### PR TITLE
[BugFix] Relax the db read lock in ViewsSystemTable to an intensive table lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -300,7 +300,6 @@ public class ViewsSystemTable extends SystemTable {
         if (db == null) {
             return true;
         }
-        String dbName = db.getFullName();
         // A DB-wide READ lock must not be used here, because this method runs in two very
         // different scopes: the thrift `listTableStatus` handler, which holds no meta lock, and
         // SchemaTableEvaluateRule during optimization, which runs inside PlannerMetaLocker and
@@ -310,111 +309,124 @@ public class ViewsSystemTable extends SystemTable {
         // the whole query, both for information_schema itself and for every user database the
         // query touches.
         //
-        // Instead this uses the split design fe/AGENTS.md prescribes for "snapshot a table list,
-        // then do per-table work": an outer database INTENTION_SHARED lock keeps the list stable,
-        // since IS conflicts with the DB WRITE that CREATE/DROP TABLE and DROP DATABASE take, and
-        // an inner per-table intensive READ lock protects each table's own state. Both are
-        // reentrant when PlannerMetaLocker already holds IS on this database, and both are
-        // acquired normally on the thrift path.
+        // Instead this follows the split design fe/AGENTS.md prescribes for "snapshot a table
+        // list, then do per-table work", in the shape TabletScheduler#getTabletBalanceTypes uses:
+        // a database INTENTION_SHARED lock scopes the snapshot only, and each table is then
+        // visited under its own intensive READ lock (IS on the database + READ on the table).
+        // Keeping the IS to the snapshot means CREATE/DROP TABLE, which take DB WRITE, are only
+        // blocked while the list is read rather than for the whole walk.
         //
-        // Everything a reported row is built from - the authorization decision, the name and
-        // pattern match, and the row itself - is read under the per-table lock. (A cheap copy of
-        // the name filters also runs outside it, purely so that a selective request does not lock
-        // and authorize every table; the two call sites explain that.) Reading under the lock
-        // matters because ALTER TABLE ... RENAME takes IX on the database plus WRITE on the table
-        // (AlterJobExecutor#visitTableRenameClause), and IS does not conflict with IX, so the
-        // outer lock alone would still let a rename land between a name check and the row being
-        // built: the row would carry the new name while having been selected by the old one, and
-        // a name-based external authorizer would have decided on the pre-rename name. The table
-        // READ lock does conflict with that WRITE, so performing every per-table read under it
-        // keeps the emitted row self-consistent.
+        // Everything a reported row is built from - the database name, the name and pattern
+        // match, the authorization decision and the row itself - is read under that per-table
+        // lock. That matters for two different renames:
+        //
+        //   ALTER TABLE ... RENAME takes IX on the database plus WRITE on the table
+        //   (AlterJobExecutor#visitTableRenameClause). IS does not conflict with IX, so only the
+        //   table READ half keeps a rename from landing between a name check and the row being
+        //   built - which would emit a row carrying the new name while it was selected by the
+        //   old one, and would let a name-based external authorizer decide on the pre-rename
+        //   name.
+        //
+        //   ALTER DATABASE ... RENAME takes DB WRITE (LocalMetastore#renameDatabase), which the
+        //   IS half does conflict with. Reading db.getFullName() before the lock would leave
+        //   TABLE_SCHEMA and that same authorization decision pointing at a stale namespace, so
+        //   the name is read inside the lock, per row.
+        //
+        // A cheap copy of the name filters also runs outside the lock, purely so that a
+        // selective request does not lock and authorize every table; that call site explains it.
+        List<Table> tables;
         Locker dbLocker = new Locker();
         dbLocker.lockDatabase(db.getId(), LockType.INTENTION_SHARED);
         try {
-            List<Table> tables = listingViews ? db.getViews() :
+            tables = listingViews ? db.getViews() :
                     GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
-            OUTER:
-            for (Table table : tables) {
-                // Cheap pre-filter, outside the lock: without it a request that names one table
-                // or a selective pattern would still take a table lock and run an authorization
-                // check for every table in the database, and with no TABLE_SCHEMA filter that is
-                // every table in the catalog. The name is read unsynchronized here, so a table
-                // renamed *into* the filter while the scan is running can be missed; that is
-                // acceptable for a concurrent metadata listing, and the evaluation under the lock
-                // below stays authoritative for everything that is reported.
+        } finally {
+            dbLocker.unLockDatabase(db.getId(), LockType.INTENTION_SHARED);
+        }
+
+        OUTER:
+        for (Table table : tables) {
+            // Cheap pre-filter, outside the lock: without it a request that names one table or a
+            // selective pattern would still take a table lock and run an authorization check for
+            // every table in the database, and with no TABLE_SCHEMA filter that is every table in
+            // the catalog. The name is read unsynchronized here, so a table renamed *into* the
+            // filter while the scan is running can be missed; that is acceptable for a concurrent
+            // metadata listing, and the evaluation under the lock below stays authoritative for
+            // everything that is reported.
+            if (!matchesNameFilters(table, paramTableName, paramPattern, matcher, caseSensitive)) {
+                continue;
+            }
+
+            Locker locker = new Locker();
+            locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+            try {
+                // The snapshot was taken under a lock that has since been released, so skip a
+                // table that a concurrent DROP removed in the meantime.
+                if (GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), table.getId()) == null) {
+                    continue;
+                }
+
+                // Stable under the IS half of this lock, which conflicts with the DB WRITE that
+                // ALTER DATABASE ... RENAME takes.
+                String dbName = db.getFullName();
+
+                // Authoritative re-evaluation: the name is stable under the table lock, so a
+                // rename that raced with the pre-filter cannot make the emitted row disagree
+                // with the filter that selected it.
                 if (!matchesNameFilters(table, paramTableName, paramPattern, matcher, caseSensitive)) {
                     continue;
                 }
 
-                Locker locker = new Locker();
-                locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
                 try {
-                    // Defensive: the outer IS lock already blocks DROP TABLE, but re-check so a
-                    // table removed through any other path is skipped rather than half-read.
-                    if (GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), table.getId()) == null) {
-                        continue;
-                    }
+                    Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
+                } catch (AccessDeniedException e) {
+                    continue;
+                }
 
-                    // Authoritative re-evaluation: the name is stable under the table lock, so a
-                    // rename that raced with the pre-filter cannot make the emitted row disagree
-                    // with the filter that selected it.
-                    if (!matchesNameFilters(table, paramTableName, paramPattern, matcher, caseSensitive)) {
-                        continue;
-                    }
+                TTableStatus status = new TTableStatus();
+                status.setName(table.getName());
+                status.setType(table.getMysqlType());
+                status.setEngine(table.getEngine());
+                status.setComment(table.getComment());
+                status.setCreate_time(table.getCreateTime());
+                status.setLast_check_time(table.getLastCheckTime());
+                if (listingViews) {
+                    View view = (View) table;
+                    String ddlSql = view.getDDLViewDef();
+
+                    ConnectContext connectContext = ConnectContext.buildInner();
+                    connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);
+                    connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+                    connectContext.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
 
                     try {
-                        Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
-                    } catch (AccessDeniedException e) {
-                        continue;
-                    }
-
-                    TTableStatus status = new TTableStatus();
-                    status.setName(table.getName());
-                    status.setType(table.getMysqlType());
-                    status.setEngine(table.getEngine());
-                    status.setComment(table.getComment());
-                    status.setCreate_time(table.getCreateTime());
-                    status.setLast_check_time(table.getLastCheckTime());
-                    if (listingViews) {
-                        View view = (View) table;
-                        String ddlSql = view.getDDLViewDef();
-
-                        ConnectContext connectContext = ConnectContext.buildInner();
-                        connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);
-                        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
-                        connectContext.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
-
-                        try {
-                            List<TableName> allTables = view.getTableRefs();
-                            for (TableName tableName : allTables) {
-                                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                        .getTable(db.getFullName(), tableName.getTbl());
-                                if (tbl != null) {
-                                    try {
-                                        Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), tbl);
-                                    } catch (AccessDeniedException e) {
-                                        continue OUTER;
-                                    }
+                        List<TableName> allTables = view.getTableRefs();
+                        for (TableName tableName : allTables) {
+                            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                    .getTable(dbName, tableName.getTbl());
+                            if (tbl != null) {
+                                try {
+                                    Authorizer.checkAnyActionOnTableLikeObject(context, dbName, tbl);
+                                } catch (AccessDeniedException e) {
+                                    continue OUTER;
                                 }
                             }
-                        } catch (SemanticException e) {
-                            // ignore semantic exception because view maybe invalid
                         }
-                        status.setDdl_sql(ddlSql);
+                    } catch (SemanticException e) {
+                        // ignore semantic exception because view maybe invalid
                     }
-
-                    result.add(new GetViewResult(dbName, status));
-                    // if user set limit, then only return limit size result
-                    if (limit > 0 && result.size() >= limit) {
-                        return false;
-                    }
-                } finally {
-                    locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                    status.setDdl_sql(ddlSql);
                 }
+
+                result.add(new GetViewResult(dbName, status));
+                // if user set limit, then only return limit size result
+                if (limit > 0 && result.size() >= limit) {
+                    return false;
+                }
+            } finally {
+                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
             }
-        } finally {
-            dbLocker.unLockDatabase(db.getId(), LockType.INTENTION_SHARED);
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -278,6 +278,19 @@ public class ViewsSystemTable extends SystemTable {
     }
 
     /**
+     * Whether the table passes the TABLE_NAME and pattern filters of the request. Evaluated twice
+     * per table - once as a cheap pre-filter outside the table lock and once under it - so it is
+     * kept in one place to make sure the two never drift apart.
+     */
+    private static boolean matchesNameFilters(Table table, String paramTableName, String paramPattern,
+                                              PatternMatcher matcher, boolean caseSensitive) {
+        if (!PatternMatcher.matchPattern(paramPattern, table.getName(), matcher, caseSensitive)) {
+            return false;
+        }
+        return Strings.isNullOrEmpty(paramTableName) || table.getName().equalsIgnoreCase(paramTableName);
+    }
+
+    /**
      * if the limit is reached, false is returned, otherwise true will be returned.
      */
     private static boolean collectViewsInDb(ConnectContext context, Database db,
@@ -288,11 +301,6 @@ public class ViewsSystemTable extends SystemTable {
             return true;
         }
         String dbName = db.getFullName();
-        // Snapshot the table list without holding any lock: Database#getViews and
-        // LocalMetastore#getTables both copy out of the idToTable ConcurrentHashMap. Each table
-        // is then locked individually below with an intensive table lock (IS on the db + READ on
-        // the table), as InformationSchemaDataSource has done since #73936.
-        //
         // A DB-wide READ lock must not be used here, because this method runs in two very
         // different scopes: the thrift `listTableStatus` handler, which holds no meta lock, and
         // SchemaTableEvaluateRule during optimization, which runs inside PlannerMetaLocker and
@@ -300,80 +308,113 @@ public class ViewsSystemTable extends SystemTable {
         // query. Hierarchical locking forbids requesting a plain database READ lock inside an
         // intention scope - MultiUserLock#tryLock throws NotSupportLockException - which fails
         // the whole query, both for information_schema itself and for every user database the
-        // query touches. The intensive lock is reentrant in that scope, and it still conflicts
-        // with the table WRITE lock taken by ALTER VIEW, so the view definition read below is
-        // actually protected.
-        List<Table> tables = listingViews ? db.getViews() :
-                GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
-        OUTER:
-        for (Table table : tables) {
-            try {
-                Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
-            } catch (AccessDeniedException e) {
-                continue;
-            }
-
-            if (!PatternMatcher.matchPattern(paramPattern, table.getName(), matcher, caseSensitive)) {
-                continue;
-            }
-            if (!Strings.isNullOrEmpty(paramTableName) &&
-                    !table.getName().equalsIgnoreCase(paramTableName)) {
-                continue;
-            }
-
-            Locker locker = new Locker();
-            locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-            try {
-                // The list above was snapshotted unlocked; skip if a concurrent DROP removed
-                // the table before we acquired the lock.
-                if (GlobalStateMgr.getCurrentState().getLocalMetastore()
-                        .getTable(db.getId(), table.getId()) == null) {
+        // query touches.
+        //
+        // Instead this uses the split design fe/AGENTS.md prescribes for "snapshot a table list,
+        // then do per-table work": an outer database INTENTION_SHARED lock keeps the list stable,
+        // since IS conflicts with the DB WRITE that CREATE/DROP TABLE and DROP DATABASE take, and
+        // an inner per-table intensive READ lock protects each table's own state. Both are
+        // reentrant when PlannerMetaLocker already holds IS on this database, and both are
+        // acquired normally on the thrift path.
+        //
+        // Everything a reported row is built from - the authorization decision, the name and
+        // pattern match, and the row itself - is read under the per-table lock. (A cheap copy of
+        // the name filters also runs outside it, purely so that a selective request does not lock
+        // and authorize every table; the two call sites explain that.) Reading under the lock
+        // matters because ALTER TABLE ... RENAME takes IX on the database plus WRITE on the table
+        // (AlterJobExecutor#visitTableRenameClause), and IS does not conflict with IX, so the
+        // outer lock alone would still let a rename land between a name check and the row being
+        // built: the row would carry the new name while having been selected by the old one, and
+        // a name-based external authorizer would have decided on the pre-rename name. The table
+        // READ lock does conflict with that WRITE, so performing every per-table read under it
+        // keeps the emitted row self-consistent.
+        Locker dbLocker = new Locker();
+        dbLocker.lockDatabase(db.getId(), LockType.INTENTION_SHARED);
+        try {
+            List<Table> tables = listingViews ? db.getViews() :
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
+            OUTER:
+            for (Table table : tables) {
+                // Cheap pre-filter, outside the lock: without it a request that names one table
+                // or a selective pattern would still take a table lock and run an authorization
+                // check for every table in the database, and with no TABLE_SCHEMA filter that is
+                // every table in the catalog. The name is read unsynchronized here, so a table
+                // renamed *into* the filter while the scan is running can be missed; that is
+                // acceptable for a concurrent metadata listing, and the evaluation under the lock
+                // below stays authoritative for everything that is reported.
+                if (!matchesNameFilters(table, paramTableName, paramPattern, matcher, caseSensitive)) {
                     continue;
                 }
 
-                TTableStatus status = new TTableStatus();
-                status.setName(table.getName());
-                status.setType(table.getMysqlType());
-                status.setEngine(table.getEngine());
-                status.setComment(table.getComment());
-                status.setCreate_time(table.getCreateTime());
-                status.setLast_check_time(table.getLastCheckTime());
-                if (listingViews) {
-                    View view = (View) table;
-                    String ddlSql = view.getDDLViewDef();
+                Locker locker = new Locker();
+                locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                try {
+                    // Defensive: the outer IS lock already blocks DROP TABLE, but re-check so a
+                    // table removed through any other path is skipped rather than half-read.
+                    if (GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), table.getId()) == null) {
+                        continue;
+                    }
 
-                    ConnectContext connectContext = ConnectContext.buildInner();
-                    connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);
-                    connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
-                    connectContext.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+                    // Authoritative re-evaluation: the name is stable under the table lock, so a
+                    // rename that raced with the pre-filter cannot make the emitted row disagree
+                    // with the filter that selected it.
+                    if (!matchesNameFilters(table, paramTableName, paramPattern, matcher, caseSensitive)) {
+                        continue;
+                    }
 
                     try {
-                        List<TableName> allTables = view.getTableRefs();
-                        for (TableName tableName : allTables) {
-                            Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTable(db.getFullName(), tableName.getTbl());
-                            if (tbl != null) {
-                                try {
-                                    Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), tbl);
-                                } catch (AccessDeniedException e) {
-                                    continue OUTER;
+                        Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
+                    } catch (AccessDeniedException e) {
+                        continue;
+                    }
+
+                    TTableStatus status = new TTableStatus();
+                    status.setName(table.getName());
+                    status.setType(table.getMysqlType());
+                    status.setEngine(table.getEngine());
+                    status.setComment(table.getComment());
+                    status.setCreate_time(table.getCreateTime());
+                    status.setLast_check_time(table.getLastCheckTime());
+                    if (listingViews) {
+                        View view = (View) table;
+                        String ddlSql = view.getDDLViewDef();
+
+                        ConnectContext connectContext = ConnectContext.buildInner();
+                        connectContext.setQualifiedUser(AuthenticationMgr.ROOT_USER);
+                        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+                        connectContext.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+
+                        try {
+                            List<TableName> allTables = view.getTableRefs();
+                            for (TableName tableName : allTables) {
+                                Table tbl = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getFullName(), tableName.getTbl());
+                                if (tbl != null) {
+                                    try {
+                                        Authorizer.checkAnyActionOnTableLikeObject(context, db.getFullName(), tbl);
+                                    } catch (AccessDeniedException e) {
+                                        continue OUTER;
+                                    }
                                 }
                             }
+                        } catch (SemanticException e) {
+                            // ignore semantic exception because view maybe invalid
                         }
-                    } catch (SemanticException e) {
-                        // ignore semantic exception because view maybe invalid
+                        status.setDdl_sql(ddlSql);
                     }
-                    status.setDdl_sql(ddlSql);
-                }
 
-                result.add(new GetViewResult(dbName, status));
-                // if user set limit, then only return limit size result
-                if (limit > 0 && result.size() >= limit) {
-                    return false;
+                    result.add(new GetViewResult(dbName, status));
+                    // if user set limit, then only return limit size result
+                    if (limit > 0 && result.size() >= limit) {
+                        return false;
+                    }
+                } finally {
+                    locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
                 }
-            } finally {
-                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
             }
+        } finally {
+            dbLocker.unLockDatabase(db.getId(), LockType.INTENTION_SHARED);
         }
         return true;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -287,25 +287,47 @@ public class ViewsSystemTable extends SystemTable {
         if (db == null) {
             return true;
         }
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
         String dbName = db.getFullName();
-        try {
-            List<Table> tables = listingViews ? db.getViews() :
-                    GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
-            OUTER:
-            for (Table table : tables) {
-                try {
-                    Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
-                } catch (AccessDeniedException e) {
-                    continue;
-                }
+        // Snapshot the table list without holding any lock: Database#getViews and
+        // LocalMetastore#getTables both copy out of the idToTable ConcurrentHashMap. Each table
+        // is then locked individually below with an intensive table lock (IS on the db + READ on
+        // the table), as InformationSchemaDataSource has done since #73936.
+        //
+        // A DB-wide READ lock must not be used here, because this method runs in two very
+        // different scopes: the thrift `listTableStatus` handler, which holds no meta lock, and
+        // SchemaTableEvaluateRule during optimization, which runs inside PlannerMetaLocker and
+        // therefore already holds an INTENTION_SHARED lock on every database referenced by the
+        // query. Hierarchical locking forbids requesting a plain database READ lock inside an
+        // intention scope - MultiUserLock#tryLock throws NotSupportLockException - which fails
+        // the whole query, both for information_schema itself and for every user database the
+        // query touches. The intensive lock is reentrant in that scope, and it still conflicts
+        // with the table WRITE lock taken by ALTER VIEW, so the view definition read below is
+        // actually protected.
+        List<Table> tables = listingViews ? db.getViews() :
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTables(db.getId());
+        OUTER:
+        for (Table table : tables) {
+            try {
+                Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
+            } catch (AccessDeniedException e) {
+                continue;
+            }
 
-                if (!PatternMatcher.matchPattern(paramPattern, table.getName(), matcher, caseSensitive)) {
-                    continue;
-                }
-                if (!Strings.isNullOrEmpty(paramTableName) &&
-                        !table.getName().equalsIgnoreCase(paramTableName)) {
+            if (!PatternMatcher.matchPattern(paramPattern, table.getName(), matcher, caseSensitive)) {
+                continue;
+            }
+            if (!Strings.isNullOrEmpty(paramTableName) &&
+                    !table.getName().equalsIgnoreCase(paramTableName)) {
+                continue;
+            }
+
+            Locker locker = new Locker();
+            locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+            try {
+                // The list above was snapshotted unlocked; skip if a concurrent DROP removed
+                // the table before we acquired the lock.
+                if (GlobalStateMgr.getCurrentState().getLocalMetastore()
+                        .getTable(db.getId(), table.getId()) == null) {
                     continue;
                 }
 
@@ -349,9 +371,9 @@ public class ViewsSystemTable extends SystemTable {
                 if (limit > 0 && result.size() >= limit) {
                     return false;
                 }
+            } finally {
+                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
             }
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
         }
         return true;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -956,13 +956,15 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
     @Test
     public void testViewsSystemViewUnderWholePhaseLock() throws Exception {
         starRocksAssert.withDatabase("test_views_lock_db").useDatabase("test_views_lock_db");
-        starRocksAssert.withTable("CREATE TABLE test_views_lock_db.`lock_tbl1` (\n" +
-                "  `k1` date COMMENT \"\",\n" +
-                "  `k2` varchar(20) COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "DUPLICATE KEY(`k1`)\n" +
-                "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
-                "PROPERTIES ('replication_num' = '1');");
+        starRocksAssert.withTable("""
+                CREATE TABLE test_views_lock_db.`lock_tbl1` (
+                  `k1` date COMMENT "",
+                  `k2` varchar(20) COMMENT ""
+                ) ENGINE=OLAP
+                DUPLICATE KEY(`k1`)
+                DISTRIBUTED BY HASH(k1) BUCKETS 1
+                PROPERTIES ('replication_num' = '1');
+                """);
         starRocksAssert.withView("CREATE VIEW test_views_lock_db.lock_view1 AS " +
                 "SELECT k1, k2 FROM test_views_lock_db.lock_tbl1");
 
@@ -1003,6 +1005,23 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
         TListTableStatusResult result = ViewsSystemTable.query(params, connectContext);
         Assertions.assertEquals(1, result.getTables().size());
         Assertions.assertEquals("lock_view1", result.getTables().get(0).getName());
+
+        // The name and pattern filters run inside the per-table lock so that a concurrent rename
+        // cannot make the emitted row disagree with the filter that selected it. Guard that the
+        // reordering did not change what the filters actually accept.
+        params.setPattern("lock_view%");
+        result = ViewsSystemTable.query(params, connectContext);
+        Assertions.assertEquals(1, result.getTables().size());
+        Assertions.assertEquals("lock_view1", result.getTables().get(0).getName());
+
+        params.setPattern("no_such_view%");
+        Assertions.assertEquals(0, ViewsSystemTable.query(params, connectContext).getTables().size());
+
+        params.unsetPattern();
+        params.setTable_name("lock_view1");
+        Assertions.assertEquals(1, ViewsSystemTable.query(params, connectContext).getTables().size());
+        params.setTable_name("lock_view_missing");
+        Assertions.assertEquals(0, ViewsSystemTable.query(params, connectContext).getTables().size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/InformationSchemaDataSourceTest.java
@@ -28,6 +28,9 @@ import com.starrocks.catalog.system.information.ViewsSystemTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.common.util.concurrent.lock.LockManager;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.scheduler.slot.BaseSlotManager;
@@ -929,6 +932,77 @@ public class InformationSchemaDataSourceTest extends StarRocksTestBase {
             Assertions.assertEquals(0, result.getTables().size(),
                     "Should return empty result for non-existing db");
         }
+    }
+
+    /**
+     * Regression test for the hierarchical-lock violation in {@link ViewsSystemTable}: scanning
+     * information_schema.views used to request a database READ lock while the planner already
+     * held an INTENTION_SHARED lock on the very same database, which MultiUserLock rejects with
+     * "Can't request Database READ Lock ... in the scope of Database INTENTION_SHARED Lock".
+     * <p>
+     * In production the optimizer reaches this state through authorization, not through the
+     * session variable used below. When a catalog is served by an {@code ExternalAccessController}
+     * (Ranger), {@code ColumnPrivilege.check} runs a nested RULE_BASED optimizer to compute the
+     * pruned column list, and it does so from {@code Authorizer.check} in
+     * {@code StatementPlanner.plan} - which still runs inside the PlannerMetaLocker scope, well
+     * before the lock-free path would have released it. Every query touching
+     * information_schema.views therefore failed on such clusters with default session variables.
+     * <p>
+     * Reproducing that here would need a permissive 34-method ExternalAccessController stub, so
+     * the test instead sets cbo_use_lock_db, which keeps the planner lock held for the whole
+     * planning phase and so puts SchemaTableEvaluateRule -> ViewsSystemTable#evaluate in exactly
+     * the same lock state: INTENTION_SHARED held on every database the query references.
+     */
+    @Test
+    public void testViewsSystemViewUnderWholePhaseLock() throws Exception {
+        starRocksAssert.withDatabase("test_views_lock_db").useDatabase("test_views_lock_db");
+        starRocksAssert.withTable("CREATE TABLE test_views_lock_db.`lock_tbl1` (\n" +
+                "  `k1` date COMMENT \"\",\n" +
+                "  `k2` varchar(20) COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(k1) BUCKETS 1\n" +
+                "PROPERTIES ('replication_num' = '1');");
+        starRocksAssert.withView("CREATE VIEW test_views_lock_db.lock_view1 AS " +
+                "SELECT k1, k2 FROM test_views_lock_db.lock_tbl1");
+
+        boolean originCboUseDBLock = connectContext.getSessionVariable().isCboUseDBLock();
+        connectContext.getSessionVariable().setCboUseDBLock(true);
+        try {
+            // (a) the planner holds INTENTION_SHARED on information_schema itself.
+            starRocksAssert.query("select count(1) from information_schema.views")
+                    .explainContains("     constant exprs: ");
+
+            // (b) the planner additionally holds INTENTION_SHARED on the user database, because
+            //     the query joins a table from it. TABLE_SCHEMA pins the scan to that one
+            //     database, so information_schema is never enumerated here - this used to fail
+            //     purely on the user database, which is why skipping the lock only for system
+            //     databases would not have fixed it. Planning just has to succeed; the constant rows
+            //     are folded away by the join, so no "constant exprs: " survives in the plan.
+            String joinPlan = starRocksAssert.query("select count(1) from information_schema.views v, " +
+                    "test_views_lock_db.lock_tbl1 t where v.TABLE_SCHEMA = 'test_views_lock_db'")
+                    .explainQuery();
+            Assertions.assertTrue(joinPlan.contains("lock_tbl1"), joinPlan);
+        } finally {
+            connectContext.getSessionVariable().setCboUseDBLock(originCboUseDBLock);
+        }
+
+        // Everything must be unwound afterwards: a missing release in the new per-table finally
+        // block would leave a lock behind here.
+        long dbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test_views_lock_db").getId();
+        LockManager lockManager = GlobalStateMgr.getCurrentState().getLockManager();
+        Locker locker = new Locker();
+        Assertions.assertFalse(lockManager.isOwner(dbId, locker, LockType.INTENTION_SHARED));
+        Assertions.assertFalse(lockManager.isOwner(dbId, locker, LockType.READ));
+
+        // The thrift path holds no planner lock and must keep behaving exactly as before.
+        TGetTablesParams params = new TGetTablesParams();
+        params.setCurrent_user_ident(UserIdentityUtils.toThrift(connectContext.getCurrentUserIdentity()));
+        params.setDb("test_views_lock_db");
+        params.setType(TTableType.VIEW);
+        TListTableStatusResult result = ViewsSystemTable.query(params, connectContext);
+        Assertions.assertEquals(1, result.getTables().size());
+        Assertions.assertEquals("lock_view1", result.getTables().get(0).getName());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

On clusters where a catalog is served by an `ExternalAccessController` (i.e. Ranger authorization is enabled), **every query that touches `information_schema.views` fails**, with default session variables:

```
ERROR 5300 (55P03): Failed to query views .
  Failed to acquire lock: Can't request Database READ Lock (...) in the scope of Database INTENTION_SHARED Lock (...)
```

`ViewsSystemTable.collectViewsInDb()` takes a **database-wide READ lock**, but it runs in two very different lock scopes:

1. the thrift `FrontendServiceImpl.listTableStatus` handler, which holds no meta lock — this path works today;
2. `SchemaTableEvaluateRule` during optimization, where `PlannerMetaLocker` already holds an `INTENTION_SHARED` lock on **every database referenced by the query**.

Hierarchical locking forbids requesting a plain database READ lock inside an intention-lock scope, so `MultiUserLock#tryLock` throws `NotSupportLockException`. `Locker` equality is thread-id based, so the `Locker` created inside `collectViewsInDb` is the same owner as the planner's.

**Why Ranger makes this always reproducible.** The optimizer normally runs outside the planner lock (`StatementPlanner` releases it at the lock-free path before `createQueryPlanWithReTry`). But with an `ExternalAccessController`, `ColumnPrivilege.check` runs a nested RULE_BASED optimizer to compute the pruned column list, and it is called from `Authorizer.check` in `StatementPlanner.plan` — which is still **inside** the `PlannerMetaLocker` scope, well before that release. Stack captured on a live cluster:

```
StatementPlanner.plan:138  ->  Authorizer.check()
  AuthorizerStmtVisitor.checkSelectTableAction:377
  ColumnPrivilege.check:119  ->  QueryOptimizer.optimize()
    SchemaTableEvaluateRule.transform:84
    ViewsSystemTable.evaluate -> collectViewsInDb:291 -> lockDatabase -> NotSupportLockException
```

With native access control the nested optimizer does not run, so the failure does not reproduce — which is why this has gone unnoticed.

**This is not limited to `information_schema` itself.** The planner takes `INTENTION_SHARED` on every internal database in the query, so a query that joins a user table fails on that user database too. Measured on a live cluster (before this fix, default session variables):

| Query | Result |
| --- | --- |
| `SELECT COUNT(*) FROM information_schema.views` | fails |
| `... WHERE TABLE_SCHEMA = 'information_schema'` | fails |
| `... WHERE TABLE_SCHEMA = 'mydb'` (each of the 14 user databases) | ok |
| `FROM information_schema.views v, mydb.tbl t WHERE v.TABLE_SCHEMA = 'mydb'` | **fails — on the user database** |
| `SELECT COUNT(*) FROM information_schema.tables WHERE TABLE_TYPE = 'VIEW'` | ok |

The last-but-one row matters: skipping the lock only for system databases would look like a fix but would leave the bug in place. Both cases are pinned by the regression test.

`SET enable_evaluate_schema_scan_rule = false` avoids the failure, but that variable defaults to `true`, so the **default configuration is broken** for these clusters. It is also hard to apply in practice, because the queries that hit this are typically metadata introspection issued by BI tools and JDBC drivers on connections the application does not control — working around it means disabling the optimization globally for all FE-evaluable system tables.

**Scope.** I swept all 66 system tables on a live cluster, both with the planner holding `INTENTION_SHARED` on `information_schema` only and with it also holding one on a user database: `information_schema.views` is the only one that fails. That matches the code — of the tables that override `supportFeEvaluation`, `ViewsSystemTable` is the only one whose evaluation path takes a non-intention lock.

## What I'm doing:

Replacing the database-wide READ lock in `ViewsSystemTable.collectViewsInDb()` with the split design `fe/AGENTS.md` prescribes for "snapshot a table list, then do per-table work", in the shape `TabletScheduler#getTabletBalanceTypes` uses: a database `INTENTION_SHARED` lock scopes the **snapshot only**, and each table is then visited under its own intensive `READ` lock (IS on the database + READ on the table). This is the same direction #73936 already took across `InformationSchemaDataSource` for the same reason — `ViewsSystemTable.collectViewsInDb` is the one site that PR did not cover, so this finishes that work rather than introducing a new pattern.

Keeping the IS to the snapshot matters: IS conflicts with the DB WRITE that `CREATE`/`DROP TABLE` take, so holding it across the whole per-table walk would block those for the entire listing rather than just while the list is read.

```
IS on the database -> snapshot the table list -> release IS
cheap pre-filter on name / pattern   (no lock)
lock (IS-on-db + READ-on-table)
  -> re-check existence
  -> read the database name           <- stable under the IS half
  -> name / pattern filter            <- authoritative
  -> authorization check
  -> build the row
finally -> unlock
```

Everything a reported row is built from — the database name, the name and pattern match, the authorization decision and the row itself — is read under that per-table lock. That matters for two different renames:

- `ALTER TABLE ... RENAME` takes IX on the database plus WRITE on the table (`AlterJobExecutor#visitTableRenameClause`). IS does not conflict with IX, so only the table READ half keeps a rename from landing between a name check and the row being built — which would emit a row carrying the new name while it was selected by the old one, and would let a name-based external authorizer decide on the pre-rename name.
- `ALTER DATABASE ... RENAME` takes DB WRITE (`LocalMetastore#renameDatabase`), which the IS half does conflict with. Reading `db.getFullName()` before the lock would leave `TABLE_SCHEMA` — and that same authorization decision, which `RangerStarRocksAccessController` makes on the database name — pointing at a stale namespace, so the name is read inside the lock, per row. The two inline `db.getFullName()` calls in the view-reference block use that same local, so one row cannot mix a pre- and post-rename name.

The name and pattern checks additionally run as a cheap pre-filter before the lock. Without it, a request naming one table or using a selective pattern would still take a table lock and run an authorization check for every table in the database — and with no `TABLE_SCHEMA` filter, for every table in the catalog. Both call sites go through one `matchesNameFilters` helper so they cannot drift apart. The pre-filter reads the name unsynchronized, so a table renamed *into* the filter while the scan runs can be missed; that is acceptable for a concurrent metadata listing, and it cannot produce a row that disagrees with the filter that selected it — the locked re-check guarantees that.

Both locks are safe in both scopes:

| Request | Planner holds IS on the db | No planner lock (thrift) |
| --- | --- | --- |
| `lockDatabase(dbId, INTENTION_SHARED)` for the snapshot | same locker, same type -> reentrant, refcount++ | newly acquired |
| `lockTableWithIntensiveDbLock(dbId, tableId, READ)` | IS reentrant, table READ new (or reentrant on the same rid) | newly acquired |

Neither path can throw. Notes on the resulting lock behaviour:

- The thrift path keeps locking; only the granularity narrows, from "one DB READ for the whole walk" to "DB IS for the snapshot plus one table READ at a time".
- Contention decreases where it matters: IS does not block IX, so a views listing no longer stalls concurrent `ALTER` on other tables in the database — which the old database-wide READ lock did.
- Protection improves for the view definition read: the table `READ` lock conflicts with the table `WRITE` that `ALTER VIEW` takes.
- The snapshot is a copied list, so a table dropped after the IS is released is skipped by the existence re-check under the per-table lock.

Not filing a separate issue — the root cause and the fix are both described here. Related: #73936 (the precedent this completes) and #63482 (the umbrella enhancement to move database locks to intensive table locks).

**Test.** `InformationSchemaDataSourceTest#testViewsSystemViewUnderWholePhaseLock`, placed next to the existing `testTablesSystemView`, covers (a) `information_schema` itself, (b) a user database reached through a join — the case a system-database-only skip would not fix — plus the thrift path, four assertions pinning that neither evaluating the name and pattern filters under the lock nor adding the pre-filter changed what they accept, and a check that no lock is left held afterwards. Reproducing the Ranger path in a unit test would need a permissive 34-method `ExternalAccessController` stub, so the test sets `cbo_use_lock_db` instead, which keeps the planner lock held for the whole planning phase and produces the identical lock state; the reasoning is recorded in the test javadoc.

Verified on this branch: full `fe-core` build passes, the `information_schema` set passes (44 tests across `InformationSchemaDataSourceTest`, `SetRoleInformationSchemaTest`, `LakeInformationSchemaDataSourceTest`, `InformationSchemaBeFeTableTest`), checkstyle is clean, and with the production change reverted to unpatched `main` the new test **fails** with exactly the reported error (`Can't request Database READ Lock (main|1) in the scope of Database INTENTION_SHARED Lock (main|1)` at `collectViewsInDb:291`), so it is a genuine regression test.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

No interface, parameter, or policy change. Queries that previously failed now return their intended result. The only internal change is lock granularity, described above; it narrows the lock and therefore reduces DDL contention rather than adding any.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

`branch-3.5` is not affected: `ViewsSystemTable` there has no `supportFeEvaluation`/`evaluate()` override, so the FE-evaluation path that triggers this does not exist. `branch-4.1` and `branch-4.0` both carry the all-databases scan and the database-wide READ lock, and their `ColumnPrivilege` has the same nested-optimizer call, so both are affected.

cc/ @kevincai