### PR TITLE
[BugFix] Prevent incorrect Variant pruning for cross-type predicates

### DIFF
--- a/be/src/formats/parquet/complex_column_reader.cpp
+++ b/be/src/formats/parquet/complex_column_reader.cpp
@@ -2254,6 +2254,15 @@ bool VariantVirtualZoneMapReader::_prepare_delegate_predicates(
                   << " because leaf reader/type is unavailable";
         return false;
     }
+    // ColumnPredicate::convert_to() converts only the literal; it does not derive the inverse
+    // predicate of CAST(leaf AS virtual_type). For a lossy cross-type projection, delegating
+    // the converted predicate to leaf statistics can incorrectly prune matching rows.
+    if (*leaf_type != _virtual_slot_type) {
+        VLOG_FILE << "skip cross-type variant virtual predicate pushdown for path="
+                  << _leaf_path.to_shredded_path().value_or("") << ", leaf type=" << leaf_type->debug_string()
+                  << ", virtual slot type=" << _virtual_slot_type.debug_string();
+        return false;
+    }
     // Variant shredding only permits data skipping on typed_value statistics when the paired
     // fallback `value` column is null for the entire row group. Otherwise min/max/bloom on
     // typed_value cover only the typed subset, while the engine may still match fallback rows

--- a/be/test/formats/parquet/complex_column_reader_test.cpp
+++ b/be/test/formats/parquet/complex_column_reader_test.cpp
@@ -904,7 +904,7 @@ TEST(VariantZoneMapTest, ZoneMapReaderDoesNotFilterWhenPredicateInStatRange) {
     EXPECT_FALSE(result.value()); // row group should NOT be filtered
 }
 
-TEST(VariantZoneMapTest, ZoneMapReaderRewritesPredicatesToLeafType) {
+TEST(VariantZoneMapTest, ZoneMapReaderDelegatesPredicatesWhenTypesMatch) {
     auto file_meta = make_minimal_file_meta();
     ASSERT_NE(file_meta, nullptr);
 
@@ -919,11 +919,11 @@ TEST(VariantZoneMapTest, ZoneMapReaderRewritesPredicatesToLeafType) {
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));
     ASSERT_OK(path);
-    VariantVirtualZoneMapReader zm_reader(vr, *path, TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT));
+    VariantVirtualZoneMapReader zm_reader(vr, *path, TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
 
     ObjectPool pool;
-    TypeInfoPtr ti = get_type_info(LogicalType::TYPE_BIGINT);
-    auto* pred = pool.add(new_column_gt_predicate_from_datum(ti, 0, Datum(int64_t(100))));
+    TypeInfoPtr ti = get_type_info(LogicalType::TYPE_INT);
+    auto* pred = pool.add(new_column_gt_predicate_from_datum(ti, 0, Datum(int32_t(100))));
 
     auto row_group_result = zm_reader.row_group_zone_map_filter({pred}, CompoundNodeType::AND, 0, 5);
     ASSERT_OK(row_group_result);
@@ -940,7 +940,7 @@ TEST(VariantZoneMapTest, ZoneMapReaderRewritesPredicatesToLeafType) {
     EXPECT_FALSE(bloom_result.value());
 }
 
-TEST(VariantZoneMapTest, ZoneMapReaderRewritesDecimalPredicatesToLeafType) {
+TEST(VariantZoneMapTest, ZoneMapReaderDelegatesDecimalPredicatesWhenLayoutsMatch) {
     auto file_meta = make_minimal_file_meta();
     ASSERT_NE(file_meta, nullptr);
 
@@ -955,13 +955,13 @@ TEST(VariantZoneMapTest, ZoneMapReaderRewritesDecimalPredicatesToLeafType) {
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("price"));
     ASSERT_OK(path);
-    auto virtual_slot_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL64, 10, 2);
+    auto virtual_slot_type = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL32, 5, 2);
     VariantVirtualZoneMapReader zm_reader(vr, *path, virtual_slot_type);
 
     ObjectPool pool;
     TypeInfoPtr ti = get_type_info(virtual_slot_type);
     ASSERT_NE(ti, nullptr);
-    auto* pred = pool.add(new_column_gt_predicate_from_datum(ti, 0, Datum(int64_t(2000))));
+    auto* pred = pool.add(new_column_gt_predicate_from_datum(ti, 0, Datum(int32_t(2000))));
 
     auto row_group_result = zm_reader.row_group_zone_map_filter({pred}, CompoundNodeType::AND, 0, 5);
     ASSERT_OK(row_group_result);
@@ -972,6 +972,38 @@ TEST(VariantZoneMapTest, ZoneMapReaderRewritesDecimalPredicatesToLeafType) {
     ASSERT_OK(page_result);
     EXPECT_FALSE(page_result.value());
     EXPECT_TRUE(row_ranges.empty());
+}
+
+TEST(VariantZoneMapTest, ZoneMapReaderSkipsDecimalToBigintPredicateDelegation) {
+    auto file_meta = make_minimal_file_meta();
+    ASSERT_NE(file_meta, nullptr);
+
+    tparquet::RowGroup rg;
+    ColumnReaderOptions opts;
+    opts.file_meta_data = file_meta.get();
+    ParquetField root_field;
+    ASSIGN_OR_ABORT(auto reader,
+                    make_shredded_decimal_variant_reader(rg, opts, root_field, /*stats_on_leaf_chunk=*/true,
+                                                         /*leaf_value_all_null=*/true, /*include_leaf_value=*/true));
+    auto* vr = down_cast<VariantColumnReader*>(reader.get());
+
+    auto path = VariantPathParser::parse_shredded_path(std::string_view("price"));
+    ASSERT_OK(path);
+    VariantVirtualZoneMapReader zm_reader(vr, *path, TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT));
+
+    ObjectPool pool;
+    TypeInfoPtr ti = get_type_info(LogicalType::TYPE_BIGINT);
+    auto* pred = pool.add(new_column_eq_predicate_from_datum(ti, 0, Datum(int64_t(10))));
+
+    const ColumnReader* leaf_reader = nullptr;
+    std::vector<const ColumnPredicate*> rewritten_predicates;
+    EXPECT_FALSE(zm_reader._prepare_delegate_predicates({pred}, &pool, 5, &leaf_reader, &rewritten_predicates));
+    EXPECT_NE(leaf_reader, nullptr);
+    EXPECT_TRUE(rewritten_predicates.empty());
+
+    auto row_group_result = zm_reader.row_group_zone_map_filter({pred}, CompoundNodeType::AND, 0, 5);
+    ASSERT_OK(row_group_result);
+    EXPECT_FALSE(row_group_result.value());
 }
 
 TEST(VariantZoneMapTest, ZoneMapReaderSkipsPushdownWhenPredicateRewriteFails) {
@@ -989,9 +1021,9 @@ TEST(VariantZoneMapTest, ZoneMapReaderSkipsPushdownWhenPredicateRewriteFails) {
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));
     ASSERT_OK(path);
-    VariantVirtualZoneMapReader zm_reader(vr, *path, TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT));
+    VariantVirtualZoneMapReader zm_reader(vr, *path, TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
 
-    FailingConvertPredicate pred(get_type_info(LogicalType::TYPE_BIGINT));
+    FailingConvertPredicate pred(get_type_info(LogicalType::TYPE_INT));
 
     auto row_group_result = zm_reader.row_group_zone_map_filter({&pred}, CompoundNodeType::AND, 0, 5);
     ASSERT_OK(row_group_result);
@@ -1022,11 +1054,11 @@ TEST(VariantZoneMapTest, ZoneMapReaderSkipsWhenFallbackValueMayContainNonNullRow
 
     auto path = VariantPathParser::parse_shredded_path(std::string_view("age"));
     ASSERT_OK(path);
-    VariantVirtualZoneMapReader zm_reader(vr, *path, TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT));
+    VariantVirtualZoneMapReader zm_reader(vr, *path, TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
 
     ObjectPool pool;
-    TypeInfoPtr ti = get_type_info(LogicalType::TYPE_BIGINT);
-    auto* pred = pool.add(new_column_gt_predicate_from_datum(ti, 0, Datum(int64_t(100))));
+    TypeInfoPtr ti = get_type_info(LogicalType::TYPE_INT);
+    auto* pred = pool.add(new_column_gt_predicate_from_datum(ti, 0, Datum(int32_t(100))));
 
     auto row_group_result = zm_reader.row_group_zone_map_filter({pred}, CompoundNodeType::AND, 0, 5);
     ASSERT_OK(row_group_result);

--- a/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/R/test_iceberg_variant_virtual_column_rewrite
@@ -237,6 +237,24 @@ order by id;
 1003
 1004
 -- !result
+-- Cross-type predicate correctness: DECIMAL(5,2) 10.50 projects to BIGINT 10.
+-- The virtual predicate must not be delegated as DECIMAL leaf = 10.00.
+set cbo_variant_path_rewrite = false;
+-- result:
+-- !result
+select count(*) from test_variant_virtual_column
+where get_variant_int(data, '$.profile.price') = 10;
+-- result:
+1
+-- !result
+set cbo_variant_path_rewrite = true;
+-- result:
+-- !result
+select count(*) from test_variant_virtual_column
+where get_variant_int(data, '$.profile.price') = 10;
+-- result:
+1
+-- !result
 -- DECIMAL read correctness: all three precision tiers (DECIMAL4/8/16), with virtual-column rewrite
 select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) as price
 from test_variant_virtual_column

--- a/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
+++ b/test/sql/test_iceberg/T/test_iceberg_variant_virtual_column_rewrite
@@ -130,6 +130,16 @@ from test_variant_virtual_column
 where get_variant_int(data, '$.profile.salary') >= 52000
 order by id;
 
+-- Cross-type predicate correctness: DECIMAL(5,2) 10.50 projects to BIGINT 10.
+-- The virtual predicate must not be delegated as DECIMAL leaf = 10.00.
+set cbo_variant_path_rewrite = false;
+select count(*) from test_variant_virtual_column
+where get_variant_int(data, '$.profile.price') = 10;
+
+set cbo_variant_path_rewrite = true;
+select count(*) from test_variant_virtual_column
+where get_variant_int(data, '$.profile.price') = 10;
+
 -- DECIMAL read correctness: all three precision tiers (DECIMAL4/8/16), with virtual-column rewrite
 select cast(variant_query(data, '$.profile.price') as decimal(5, 2)) as price
 from test_variant_virtual_column


### PR DESCRIPTION
  ## Why I'm doing:

  Variant virtual-column predicates are evaluated using the virtual slot type, while the corresponding shredded Parquet leaf may use a different type.

  The current delegation logic calls `ColumnPredicate::convert_to()` to convert only the predicate literal to the leaf type. This is not equivalent to deriving the inverse predicate of `CAST(leaf AS virtual_type)` when the conversion is lossy or
  many-to-one.

  For example, an Iceberg Variant file contains a shredded `DECIMAL(5,2)` leaf with value `10.50`:

  ```sql
  SELECT COUNT(*)
  FROM test_variant_virtual_column
  WHERE get_variant_int(data, '$.profile.price') = 10;
  ```

  Without Variant path rewrite, the query correctly returns 1. With rewrite enabled, the predicate is incorrectly delegated as DECIMAL leaf = 10.00, causing the row-group zone map [10.50, 12.50] to skip the entire row group and return 0.

  This is a silent wrong-result issue rather than a performance-only problem.

  This fix provides the following value:

  - Prevents false-negative pruning and silent missing rows.
  - Protects row-group zone maps, page-index zone maps, and bloom filters through their shared delegation path.
  - Preserves existing statistics pruning when the leaf and virtual slot have identical type descriptors.
  - Falls back to post-read predicate evaluation for cross-type projections, prioritizing correctness.
  - Adds both focused BE unit tests and an end-to-end Iceberg SQL regression test.

  ## What I'm doing:

  - Delegate Variant virtual predicates to shredded leaf statistics only when the leaf and virtual slot TypeDescriptors are identical.
  - Log skipped cross-type predicate delegation through VLOG_FILE.
  - Keep existing same-type statistics pushdown and fallback-value safety checks unchanged.
  - Add a BE regression test for DECIMAL(5,2) -> BIGINT.
  - Add an Iceberg SQL regression that compares rewrite-disabled and rewrite-enabled results.

  Validation:

  - VariantZoneMapTest.*: 13/13 passed.
  - Release BE build passed.
  - Before the fix, the SQL regression failed with expected 1, actual 0.
  - After the fix, both rewrite-disabled and rewrite-enabled queries return 1.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
