### PR TITLE
[BugFix] Fix unsafe Iceberg cast predicate pushdown

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -545,6 +545,11 @@ public class ScalarOperatorToIcebergExpr {
 
         @Override
         public String visitCastOperator(CastOperator operator, Void context) {
+            // Stripping a non-identity cast can change predicate semantics and incorrectly prune files.
+            // Any non-identity cast that still reaches this converter must remain a residual predicate.
+            if (!operator.getType().equals(operator.getChild(0).getType())) {
+                return null;
+            }
             return operator.getChild(0).accept(this, context);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -34,7 +34,9 @@ import com.starrocks.type.BooleanType;
 import com.starrocks.type.DateType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.StringType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expression;
@@ -71,7 +73,8 @@ public class IcebergExprVisitorTest {
                             Types.NestedField.optional(15, "k15", Types.StringType.get()),
                             Types.NestedField.optional(16, "k16", Types.FloatType.get())
                     )),
-                    Types.NestedField.optional(17, "k17.double", Types.DoubleType.get()));
+                    Types.NestedField.optional(17, "k17.double", Types.DoubleType.get()),
+                    Types.NestedField.optional(18, "k18", Types.DecimalType.of(5, 2)));
 
     private static final ColumnRefOperator K1 = new ColumnRefOperator(3, IntegerType.INT, "k1", true, false);
     private static final ColumnRefOperator K2 = new ColumnRefOperator(4, IntegerType.INT, "k2", true, false);
@@ -90,6 +93,8 @@ public class IcebergExprVisitorTest {
     private static final SubfieldOperator K15 = new SubfieldOperator(K10, StringType.STRING, ImmutableList.of("k15"));
     private static final SubfieldOperator K16 = new SubfieldOperator(K10, FloatType.FLOAT, ImmutableList.of("k16"));
     private static final ColumnRefOperator K17 = new ColumnRefOperator(17, FloatType.DOUBLE, "k17.double", true, false);
+    private static final ColumnRefOperator K18 = new ColumnRefOperator(
+            19, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 5, 2), "k18", true, false);
     private static final ColumnRefOperator LAST_UPDATED_SEQUENCE_NUMBER = new ColumnRefOperator(
             18, IntegerType.BIGINT, IcebergTable.LAST_UPDATED_SEQUENCE_NUMBER, true, false);
 
@@ -358,24 +363,19 @@ public class IcebergExprVisitorTest {
         Expression convertedExpr;
         Expression expectedExpr;
 
-        // cast string column to date
+        // Non-identity casts must remain residual predicates.
         ConstantOperator value = ConstantOperator.createDate(LocalDate.parse("2022-11-11").atTime(0, 0, 0, 0));
         CastOperator cast = new CastOperator(DateType.DATE, K6);
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.EQ, cast, value)), context);
-        expectedExpr = Expressions.equal("k6", "2022-11-11");
-        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
-                "Generated equal expression should be correct");
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
 
-        // cast date column to string
+        // The same applies even when the literal can be rendered in the source type.
         value = ConstantOperator.createVarchar("2022-11-11");
         cast = new CastOperator(VarcharType.VARCHAR, K3);
         convertedExpr = converter.convert(Lists.newArrayList(
                 new BinaryPredicateOperator(BinaryType.LT, cast, value)), context);
-        long epochDay = LocalDate.parse("2022-11-11").toEpochDay();
-        expectedExpr = Expressions.lessThan("k3", epochDay);
-        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString(),
-                "Generated lessThan expression should be correct");
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
 
         // cast string column to int
         // don't support cast string to int, different comparator
@@ -434,6 +434,24 @@ public class IcebergExprVisitorTest {
                 new BinaryPredicateOperator(BinaryType.EQ, cast, value)), context);
         Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
 
+        // DECIMAL 10.50 projects to BIGINT 10. Rewriting this as DECIMAL = 10.00 would prune matching files.
+        value = ConstantOperator.createBigint(10);
+        cast = new CastOperator(IntegerType.BIGINT, K18);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, cast, value)), context);
+        Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
+        convertedExpr = converter.convertStrict(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, cast, value)), context);
+        Assertions.assertNull(convertedExpr);
+
+        // Identity casts are safe to unwrap.
+        value = ConstantOperator.createInt(11);
+        cast = new CastOperator(IntegerType.INT, K1);
+        convertedExpr = converter.convert(Lists.newArrayList(
+                new BinaryPredicateOperator(BinaryType.EQ, cast, value)), context);
+        expectedExpr = Expressions.equal("k1", 11);
+        Assertions.assertEquals(expectedExpr.toString(), convertedExpr.toString());
+
     }
 
     @Test
@@ -460,7 +478,7 @@ public class IcebergExprVisitorTest {
                 BinaryType.GT, K1, ConstantOperator.createInt(10));
 
         // Build an unconvertible predicate: CAST(k6 AS INT) < 5
-        // CastOperator(INT, K6) where K6 is a string column causes getLiteralValue to return null
+        // The remaining non-identity cast cannot be converted to an Iceberg predicate.
         CastOperator cast = new CastOperator(IntegerType.INT, K6);
         BinaryPredicateOperator unconvertible = new BinaryPredicateOperator(
                 BinaryType.LT, cast, ConstantOperator.createInt(5));

--- a/test/sql/test_iceberg/R/test_iceberg_cast_predicate_pushdown
+++ b/test/sql/test_iceberg/R/test_iceberg_cast_predicate_pushdown
@@ -1,0 +1,47 @@
+-- name: test_iceberg_cast_predicate_pushdown
+create external catalog iceberg_cast_predicate_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hadoop",
+    "iceberg.catalog.warehouse" = "oss://${oss_bucket}/test_iceberg_cast_predicate_pushdown/${uuid0}/warehouse/"
+);
+-- result:
+-- !result
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_cast_predicate_pushdown/${uuid0}/warehouse/db > /dev/null
+-- result:
+0
+
+-- !result
+use iceberg_cast_predicate_${uuid0}.db;
+-- result:
+-- !result
+create table test_cast_predicate (
+    d decimal(5, 2)
+) properties (
+    "format-version" = "2"
+);
+-- result:
+-- !result
+insert into test_cast_predicate values (10.50);
+-- result:
+-- !result
+select d
+from test_cast_predicate
+where cast(d as bigint) = 10;
+-- result:
+10.50
+-- !result
+drop table test_cast_predicate force;
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog iceberg_cast_predicate_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_cast_predicate_pushdown/${uuid0}/ > /dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_cast_predicate_pushdown
+++ b/test/sql/test_iceberg/T/test_iceberg_cast_predicate_pushdown
@@ -1,0 +1,30 @@
+-- name: test_iceberg_cast_predicate_pushdown
+
+create external catalog iceberg_cast_predicate_${uuid0}
+PROPERTIES (
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hadoop",
+    "iceberg.catalog.warehouse" = "oss://${oss_bucket}/test_iceberg_cast_predicate_pushdown/${uuid0}/warehouse/"
+);
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_iceberg_cast_predicate_pushdown/${uuid0}/warehouse/db > /dev/null
+
+use iceberg_cast_predicate_${uuid0}.db;
+
+create table test_cast_predicate (
+    d decimal(5, 2)
+) properties (
+    "format-version" = "2"
+);
+
+insert into test_cast_predicate values (10.50);
+
+select d
+from test_cast_predicate
+where cast(d as bigint) = 10;
+
+drop table test_cast_predicate force;
+set catalog default_catalog;
+drop catalog iceberg_cast_predicate_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_cast_predicate_pushdown/${uuid0}/ > /dev/null


### PR DESCRIPTION
 ## Why I'm doing:

  The Iceberg predicate converter unconditionally stripped `CastOperator` when extracting a column name.

  For example:

  ```sql
  WHERE CAST(d AS BIGINT) = 10
  ```

  When d is DECIMAL(5,2), this predicate was incorrectly converted into the native Iceberg predicate d = 10.00. Iceberg file metrics could then prune a file containing 10.50, even though CAST(10.50 AS BIGINT) = 10, causing incorrect empty
  results.

## What I'm doing:

  - Keep non-identity CAST predicates as residual predicates instead of stripping the CAST.
  - Continue unwrapping identity CASTs.
  - Add FE unit tests covering non-strict conversion, strict conversion, identity CASTs, and partial AND pushdown.
  - Add an Iceberg SQL regression test using a single DECIMAL(5,2) value to deterministically reproduce the incorrect file pruning.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
