### PR TITLE
[Enhancement] Drop JAVA_OPTS_FOR_JDK_* compatibility support

### DIFF
--- a/bin/common.sh
+++ b/bin/common.sh
@@ -42,12 +42,11 @@ jdk_version() {
     echo "$result"
 }
 
-# Print a hard-to-miss banner for a deprecated JVM options config parameter.
-# The parameter is still honored, and still overrides JAVA_OPTS, so that upgrades
-# from older versions keep working, but it will be removed in a future release.
+# Print a hard-to-miss banner for a JVM options config parameter that is no
+# longer supported. The parameter is IGNORED: only JAVA_OPTS is honored.
 # Output goes to stderr so it is not lost if the caller only redirects stdout.
-# Usage: warn_deprecated_java_opts <component> <var_name> <conf_file>
-warn_deprecated_java_opts() {
+# Usage: warn_removed_java_opts <component> <var_name> <conf_file>
+warn_removed_java_opts() {
     local component=$1
     local var_name=$2
     local conf_file=$3
@@ -55,32 +54,33 @@ warn_deprecated_java_opts() {
 
 ################################################################################
 ###                                                                          ###
-###         ACTION REQUIRED: DEPRECATED CONFIGURATION PARAMETER              ###
+###       ACTION REQUIRED: UNSUPPORTED CONFIGURATION PARAMETER IGNORED       ###
 ###                                                                          ###
 ################################################################################
 ###
-### This DEPRECATED parameter is set and is in effect right now:
+### This parameter is set but is NO LONGER SUPPORTED, and is being IGNORED:
 ###   $var_name
 ###
 ### JAVA_OPTS is the only supported place to set JVM parameters.
 ###
-### $component still honors it for this start, so that upgrades from older
-### versions keep working, but support WILL BE REMOVED in an upcoming
-### StarRocks release. After that it is IGNORED WITHOUT ANY WARNING:
-### $component falls back to JAVA_OPTS, so every JVM parameter set only
-### here (heap size, GC, add-opens, kerberos, ...) SILENTLY STOPS TAKING
-### EFFECT and the process comes up with a different heap and GC setup.
-###
+### Every JVM parameter set only here (heap size, GC, add-opens, kerberos,
+### ...) IS NOT IN EFFECT for this start. $component is starting with
 EOF
     if [ ! -z "${JAVA_OPTS}" ] ; then
         cat >&2 << EOF
-### JAVA_OPTS is also set, and this parameter OVERRIDES IT COMPLETELY.
-### The two are NOT merged, your JAVA_OPTS value is being DISCARDED.
+### JAVA_OPTS instead, so its heap and GC setup may differ from what you
+### configured here.
+###
+EOF
+    else
+        cat >&2 << EOF
+### JAVA_OPTS instead, which is EMPTY, so it falls back to the built-in
+### default heap and GC setup.
 ###
 EOF
     fi
     cat >&2 << EOF
-### HOW TO FIX (before your next StarRocks upgrade):
+### HOW TO FIX:
 ###   1. Edit $conf_file
 ###   2. Move the JVM parameters into JAVA_OPTS, merging them by hand if
 ###      JAVA_OPTS already has a value.

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -130,7 +130,7 @@ if [[ "${RUN_NUMA}" -ne "-1" ]]; then
 fi
 
 final_java_opt=${JAVA_OPTS}
-# Compatible with scenarios upgraded from jdk9~jdk16
+# JAVA_OPTS_FOR_JDK_9_AND_LATER is no longer supported, warn loudly if it is still set
 if [ ! -z "${JAVA_OPTS_FOR_JDK_9_AND_LATER}" ] ; then
     component_name="StarRocks BE"
     component_conf_file="$STARROCKS_HOME/conf/be.conf"
@@ -138,8 +138,7 @@ if [ ! -z "${JAVA_OPTS_FOR_JDK_9_AND_LATER}" ] ; then
         component_name="StarRocks CN"
         component_conf_file="$STARROCKS_HOME/conf/cn.conf"
     fi
-    warn_deprecated_java_opts "$component_name" "JAVA_OPTS_FOR_JDK_9_AND_LATER" "$component_conf_file"
-    final_java_opt=${JAVA_OPTS_FOR_JDK_9_AND_LATER}
+    warn_removed_java_opts "$component_name" "JAVA_OPTS_FOR_JDK_9_AND_LATER" "$component_conf_file"
 fi
 
 # Appending the option to avoid "process heaper" stack overflow exceptions.

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -158,10 +158,9 @@ elif [[ "$JAVA_VERSION" -lt $RECOMMENDED_JDK_VERSION ]]; then
 fi
 
 final_java_opt=${JAVA_OPTS}
-# Compatible with scenarios upgraded from jdk11
+# JAVA_OPTS_FOR_JDK_11 is no longer supported, warn loudly if it is still set
 if [ ! -z "${JAVA_OPTS_FOR_JDK_11}" ] ; then
-    warn_deprecated_java_opts "StarRocks FE" "JAVA_OPTS_FOR_JDK_11" "$STARROCKS_HOME/conf/fe.conf"
-    final_java_opt=${JAVA_OPTS_FOR_JDK_11}
+    warn_removed_java_opts "StarRocks FE" "JAVA_OPTS_FOR_JDK_11" "$STARROCKS_HOME/conf/fe.conf"
 fi
 
 if [ -z "$final_java_opt" ] ; then


### PR DESCRIPTION
JAVA_OPTS_FOR_JDK_11 (FE) and JAVA_OPTS_FOR_JDK_9_AND_LATER (BE/CN) were kept alive so that clusters upgraded from older versions would keep their JVM parameters. They took precedence over JAVA_OPTS and replaced it outright rather than merging, which made JAVA_OPTS unreliable as the single place to configure the JVM. The previous release warned loudly that the parameters were deprecated and would stop being honored.

Stop honoring them: JAVA_OPTS is now the only source of JVM parameters. An operator who still sets one of these gets a hard-to-miss startup banner instead of a silent behavior change, since the failure mode is a process coming up with a heap and GC setup that differs from what the conf file appears to configure. The banner names the JVM setup that actually took effect, distinguishing the case where JAVA_OPTS is set from the case where it is empty and the component falls back to its built-in defaults - which is what happens to an FE configured only through JAVA_OPTS_FOR_JDK_11.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
