### PR TITLE
[Refactor] Reserve the tags and enum values downstream distributions already occupy

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -373,7 +373,9 @@ message TabletDataSnapshotPB {
     repeated string new_data_files = 2;
     repeated string new_metadata_files = 3;
     repeated string new_schema_files = 4;
-    optional TabletDataSnapshotExtPB ext = 5;
+    // Tag 5 is occupied by downstream distributions; never allocate an upstream field here.
+    optional bytes placeholder_5 = 5;
+    optional TabletDataSnapshotExtPB ext = 6;
 }
 
 // Placeholder for external cluster snapshot feature.

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -408,7 +408,9 @@ message MetadataUpdateInfoPB {
     optional CompactionStrategyPB compaction_strategy = 5;
     optional FlatJsonConfigPB flat_json_config = 6;
     optional TabletRangePB tablet_range = 7;
-    optional MetadataUpdateInfoExtPB ext = 8;
+    // Tag 8 is occupied by downstream distributions; never allocate an upstream field here.
+    optional bytes placeholder_8 = 8;
+    optional MetadataUpdateInfoExtPB ext = 9;
 }
 
 message BundleTabletMetadataPB {

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -411,5 +411,7 @@ message BuiltinInvertedIndexPB {
     optional int32 placeholder_2 = 2;
     optional bytes placeholder_3 = 3;
     optional bytes placeholder_4 = 4;
-    optional BuiltinInvertedIndexExtPB ext = 5;
+    // Tag 5 is occupied by downstream distributions; never allocate an upstream field here.
+    optional bytes placeholder_5 = 5;
+    optional BuiltinInvertedIndexExtPB ext = 6;
 }

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -411,7 +411,5 @@ message BuiltinInvertedIndexPB {
     optional int32 placeholder_2 = 2;
     optional bytes placeholder_3 = 3;
     optional bytes placeholder_4 = 4;
-    // Tag 5 is occupied by downstream distributions; never allocate an upstream field here.
-    optional bytes placeholder_5 = 5;
-    optional BuiltinInvertedIndexExtPB ext = 6;
+    optional BuiltinInvertedIndexExtPB ext = 5;
 }

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -564,9 +564,7 @@ enum TTabletMetaType {
     BASE_COMPACTION_FORBIDDEN_TIME_RANGES = 12,
     FLAT_JSON_CONFIG = 13,
     ENABLE_FILE_BUNDLING = 14,
-    COMPACTION_STRATEGY = 15,
-    // Value 16 is taken by a downstream distribution.
-    PLACEHOLDER_16 = 16
+    COMPACTION_STRATEGY = 15
 }
 
 // Extension point for TTabletMetaInfo. DO NOT MODIFY: do not add fields here,

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -149,11 +149,13 @@ struct TCreateTabletReq {
     25: optional TFlatJsonConfig flat_json_config;
     26: optional TCompactionStrategy compaction_strategy;
     27: optional Types.TTabletRange range;
+    // Tag 28 is occupied by downstream distributions; never allocate an upstream field here.
+    28: optional bool placeholder_28;
 
     // New fields should be added above this comment.
     // NOTE: If you add a new field here that ends up in tablet metadata,
     // also update TCloudTabletMeta in FrontendService.thrift to keep the two paths in sync.
-    28: optional TCreateTabletReqExt ext
+    29: optional TCreateTabletReqExt ext
 }
 
 struct TDropTabletReq {
@@ -562,7 +564,9 @@ enum TTabletMetaType {
     BASE_COMPACTION_FORBIDDEN_TIME_RANGES = 12,
     FLAT_JSON_CONFIG = 13,
     ENABLE_FILE_BUNDLING = 14,
-    COMPACTION_STRATEGY = 15
+    COMPACTION_STRATEGY = 15,
+    // Value 16 is taken by a downstream distribution.
+    PLACEHOLDER_16 = 16
 }
 
 // Extension point for TTabletMetaInfo. DO NOT MODIFY: do not add fields here,
@@ -590,7 +594,9 @@ struct TTabletMetaInfo {
     13: optional bool bundle_tablet_metadata;
     14: optional TCompactionStrategy compaction_strategy;
     15: optional Types.TTabletRange tablet_range;
-    16: optional TTabletMetaInfoExt ext;
+    // Tag 16 is occupied by downstream distributions; never allocate an upstream field here.
+    16: optional bool placeholder_16;
+    17: optional TTabletMetaInfoExt ext;
 }
 
 struct TUpdateTabletMetaInfoReq {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -69,9 +69,7 @@ enum TDataSinkType {
     SPLIT_DATA_STREAM_SINK = 15,
     NOOP_SINK = 16,
     ICEBERG_DELETE_SINK = 17,
-    ICEBERG_ROW_DELTA_SINK = 18,
-    // Value 19 is taken by a downstream distribution.
-    PLACEHOLDER_19 = 19
+    ICEBERG_ROW_DELTA_SINK = 18
 }
 
 enum TResultSinkType {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -69,7 +69,9 @@ enum TDataSinkType {
     SPLIT_DATA_STREAM_SINK = 15,
     NOOP_SINK = 16,
     ICEBERG_DELETE_SINK = 17,
-    ICEBERG_ROW_DELTA_SINK = 18
+    ICEBERG_ROW_DELTA_SINK = 18,
+    // Value 19 is taken by a downstream distribution.
+    PLACEHOLDER_19 = 19
 }
 
 enum TResultSinkType {
@@ -80,7 +82,9 @@ enum TResultSinkType {
     HTTP_PROTOCAL,
     METADATA_ICEBERG,
     CUSTOMIZED,
-    ARROW_FLIGHT_PROTOCAL
+    ARROW_FLIGHT_PROTOCAL,
+    // Value 8 is taken by a downstream distribution.
+    PLACEHOLDER_8 = 8
 }
 
 enum TResultSinkFormatType {
@@ -302,6 +306,9 @@ struct TIcebergTableSink {
     //   IcebergRowDeltaSink (both)        → both
     11: optional Types.TCompressionType delete_compression_type
     12: optional TIcebergTableSinkExt ext
+    // Tags 50, 51 are occupied by downstream distributions; never allocate an upstream field here.
+    50: optional bool placeholder_50
+    51: optional bool placeholder_51
 }
 
 struct THiveTableSink {
@@ -353,4 +360,6 @@ struct TDataSink {
   16: optional i64 sink_id
   17: optional TSplitDataStreamSink split_stream_sink
   18: optional TDataSinkExt ext
+  // Tag 30 is occupied by downstream distributions; never allocate an upstream field here.
+  30: optional bool placeholder_30
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2475,7 +2475,9 @@ struct TCloudTabletMeta {
     8: optional i64 gtid;
     9: optional Types.TCompressionType compression_type;
     10: optional i32 compression_level;
-    11: optional TCloudTabletMetaExt ext;
+    // Tag 11 is occupied by downstream distributions; never allocate an upstream field here.
+    11: optional bool placeholder_11;
+    12: optional TCloudTabletMetaExt ext;
 }
 
 struct TGetTabletMetadataResponse {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -557,6 +557,9 @@ struct TScanRange {
 
   40: optional TBenchmarkScanRange benchmark_scan_range
   41: optional TScanRangeExt ext
+  // Tags 50, 51 are occupied by downstream distributions; never allocate an upstream field here.
+  50: optional bool placeholder_50
+  51: optional bool placeholder_51
 }
 
 struct TMySQLScanNode {
@@ -664,7 +667,10 @@ struct TSchemaScanNode {
   26: optional list<TFrontend> frontends;
 
   101: optional string catalog_name;
-  102: optional TSchemaScanNodeExt ext;
+  // Tags 102, 103 are occupied by downstream distributions; never allocate an upstream field here.
+  102: optional bool placeholder_102;
+  103: optional bool placeholder_103;
+  104: optional TSchemaScanNodeExt ext;
 }
 
 enum TAccessPathType {
@@ -761,6 +767,8 @@ struct TOlapScanNode {
 
   40: optional TVectorSearchOptions vector_search_options
   41: optional TTableSampleOptions sample_options;
+  // Tag 42 is occupied by downstream distributions; never allocate an upstream field here.
+  42: optional bool placeholder_42;
 
   //back pressure
   50: optional bool enable_topn_filter_back_pressure
@@ -842,6 +850,8 @@ struct TLakeScanNode {
   56: optional bool enable_global_late_materialization
 
   57: optional TVectorSearchOptions vector_search_options
+  // Tag 58 is occupied by downstream distributions; never allocate an upstream field here.
+  58: optional bool placeholder_58
 
   60: optional list<Exprs.TExpr> partition_conjuncts
 
@@ -1711,6 +1721,9 @@ struct TPlanNode {
   86: optional TEnforceUniqueRowLocatorNode enforce_unique_row_locator_node
   87: optional TPlanNodeExt ext
   88: optional TAIProjectNode ai_project_node
+  // Tags 150, 151 are occupied by downstream distributions; never allocate an upstream field here.
+  150: optional bool placeholder_150;
+  151: optional bool placeholder_151;
 }
 
 // A flattened representation of a tree of PlanNodes, obtained by depth-first

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -468,9 +468,7 @@ enum TTableType {
     BENCHMARK_TABLE = 34,
     ICEBERG_PROPERTIES_TABLE = 35,
     LANCE_TABLE = 36,
-    FLUSS_TABLE = 37,
-    // Value 38 is taken by a downstream distribution.
-    PLACEHOLDER_38 = 38
+    FLUSS_TABLE = 37
 }
 
 enum TKeysType {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -468,7 +468,9 @@ enum TTableType {
     BENCHMARK_TABLE = 34,
     ICEBERG_PROPERTIES_TABLE = 35,
     LANCE_TABLE = 36,
-    FLUSS_TABLE = 37
+    FLUSS_TABLE = 37,
+    // Value 38 is taken by a downstream distribution.
+    PLACEHOLDER_38 = 38
 }
 
 enum TKeysType {
@@ -644,6 +646,10 @@ struct TIcebergDataFile {
     9: optional TIcebergFileContent file_content;
     10: optional string referenced_data_file;
     11: optional TIcebergDataFileExt ext;
+    // Tags 50, 51, 52 are occupied by downstream distributions; never allocate an upstream field here.
+    50: optional bool placeholder_50;
+    51: optional bool placeholder_51;
+    52: optional bool placeholder_52;
 }
 
 struct THiveFileInfo {
@@ -670,6 +676,8 @@ struct TSinkCommitInfo {
     101: optional string staging_dir
     102: optional bool is_rewrite;
     103: optional TSinkCommitInfoExt ext;
+    // Tag 150 is occupied by downstream distributions; never allocate an upstream field here.
+    150: optional bool placeholder_150;
 }
 
 struct TSnapshotInfo {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

#78108 added an `ext` extension point to a set of shared containers, and picked for each one the next tag free *in this tree*. Seven of those tags are already in use by a downstream distribution, and three of them are persisted: TabletDataSnapshotPB 5, MetadataUpdateInfoPB 8, BuiltinInvertedIndexPB 5, TTabletMetaInfo 16, TCreateTabletReq 28, TCloudTabletMeta 11 and TSchemaScanNode 102. A fork syncing #78108 therefore cannot take the extension point as written -- it has to renumber it locally, which is exactly the drift the extension point exists to avoid.

Move those seven `ext` fields to the next tag free on both sides, and declare a placeholder on each tag downstream occupies, in the same form this repo already uses for BuiltinInvertedIndexPB tags 2-4 and TabletMetadataPB tags 50-51.

Also reserve the downstream tags in the containers where `ext` happens not to collide today but the surrounding numbers are still growing: TDataSink 30, TOlapScanNode 42 and TLakeScanNode 58 sit below or beside the tag `ext` was given, so they are the next ones an upstream field would land on.

The same hazard exists for four enums, and there it is worse because the collision would be silent -- nothing fails to compile, both sides simply believe they own the value. TTabletMetaType 16, TDataSinkType 19, TResultSinkType 8 and TTableType 38 are each exactly one past this repo's current maximum, so the very next member appended to any of them lands on a value downstream already ships.

Nothing here changes a value that is in use upstream. The seven `ext` fields were introduced by #78108, are on `main` only, their containers are all still empty, and no code reads or writes them yet, so moving them is a rename of an unused number; the four enum placeholders are appended past the current maximum and shift nothing.

Two enums are beyond help from this side and are left alone: downstream inserted a member mid-enum in TSchemaTableType and TPlanNodeType, so its values from SYS_USERS and CHANGES_SCAN_NODE onward are already one off from this repo's. Realigning those would mean renumbering values upstream has long shipped.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
