### PR TITLE
[Feature] Support extension-based group provider

### DIFF
--- a/docs/en/_assets/user_priv/unix_file_intro.mdx
+++ b/docs/en/_assets/user_priv/unix_file_intro.mdx
@@ -1,4 +1,5 @@
-StarRocks supports three types of group providers: 
+StarRocks supports four types of group providers: 
 - **LDAP group provider**: Search and match users with groups in your LDAP service
 - **Unix group provider**: Search and match users with groups in your operating system
 - **File group provider**: Search and match users with groups defined by a file
+- **Extension group provider**: Search and match users with groups resolved by a static extension

--- a/docs/en/_assets/user_priv/unix_file_param.mdx
+++ b/docs/en/_assets/user_priv/unix_file_param.mdx
@@ -4,6 +4,7 @@ The type of the group provider to create. Valid values:
 - `ldap`: Creates an LDAP group provider. When this value is set, you need to specify `ldap_info`, `ldap_search_group_arg`, `ldap_search_user_arg`, and optionally `ldap_cache_arg`.
 - `unix`: Creates a Unix group provider.
 - `file`: Creates a File group provider. When this value is set, you need to specify `group_file_url`.
+- `extension`: Creates a group provider backed by a static extension. When this value is set, you need to specify `provider_factory_class`.
 
 #### `group_file_url`
 

--- a/docs/en/administration/user_privs/group_provider.md
+++ b/docs/en/administration/user_privs/group_provider.md
@@ -15,6 +15,8 @@ Enable Group Provider in StarRocks to authenticate, and authorize user groups fr
 
 From v3.5.0 onwards, StarRocks supports Group Provider to collect group information from external authentication systems for user group management.
 
+From v4.2 onwards, a group provider can also be supplied by a static extension. This allows a deployment to resolve groups from a system that StarRocks does not support natively, and to resolve them from the session's authentication context, for example from a claim of the token obtained during JWT or OAuth 2.0 authentication. See [Develop Static Extensions](../management/extensions.md).
+
 ## Overview
 
 To deepen its integration with external user authentication and authorization systems, such as LDAP and Apache Ranger, StarRocks supports collecting user group information for a better experience on the collective user management.
@@ -72,6 +74,20 @@ ldap_cache_arg ::=
 ```
 
 <UnixFileSyntax />
+
+- Extension group provider:
+
+```SQL
+CREATE GROUP PROVIDER <group_provider_name>
+PROPERTIES (
+    "type" = "extension",
+    "provider_factory_class" = "",
+    [extension_properties]
+)
+
+extension_properties ::=
+    "<property_name>" = "<property_value>" [, ...]
+```
 
 ### Parameters
 
@@ -179,6 +195,16 @@ The argument used to define the cache behavior for the LDAP group information.
 
 Optional. The interval at which StarRocks automatically refreshes the cached LDAP group information. Unit: Seconds. Default: `900`.
 
+#### Extension group provider parameters
+
+##### `provider_factory_class`
+
+The fully qualified name of the factory class that the extension registers. StarRocks passes the remaining properties to that factory unchanged, so their names and meanings are defined by the extension, not by StarRocks.
+
+:::note
+The extension must be deployed on every FE node of the cluster. An FE that cannot resolve the factory class logs a warning and the provider resolves to an empty set of groups on that node.
+:::
+
 ### Example
 
 Suppose an LDAP server contains the following group and member information.
@@ -264,6 +290,46 @@ In this example, since `ldap_user_search_attr` is not configured, the system wil
 2. During group search, use the DN recorded during authentication as key to search user's groups.
 
 This approach is particularly suitable for Microsoft AD environments, as group members in AD may lack simple username attributes.
+
+### Extension Example
+
+An extension supplies a factory and the provider it creates:
+
+```Java
+public class MyGroupProviderFactory implements ExtensionGroupProviderFactory {
+    @Override
+    public GroupProvider create(String name, Map<String, String> properties) throws DdlException {
+        return new MyGroupProvider(name, properties);
+    }
+}
+```
+
+To resolve groups from the authentication context of the session instead of from the user name alone, the provider also implements `AccessControlContextAwareGroupProvider`.
+
+The extension registers the factory under its own class when it is loaded:
+
+```Java
+@SRModule(name = "my-groups")
+public class MyExtension implements StarRocksExtension {
+    @Override
+    public void onLoad(ExtensionContext ctx) {
+        ctx.register(MyGroupProviderFactory.class, new MyGroupProviderFactory());
+    }
+}
+```
+
+Build the extension as described in [Develop Static Extensions](../management/extensions.md), place the resulting `*-ext.jar` in the `ext_dir` directory of each FE, and restart the cluster. Then create the group provider:
+
+```SQL
+CREATE GROUP PROVIDER my_groups
+PROPERTIES (
+    "type" = "extension",
+    "provider_factory_class" = "com.example.MyGroupProviderFactory",
+    "my_property" = "my_value"
+);
+```
+
+Because the factory is named in the definition, several extensions can each register their own factory and coexist in one cluster.
 
 ## Combine group provider with a security integration
 

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AccessControlContextAwareGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AccessControlContextAwareGroupProvider.java
@@ -1,0 +1,26 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+
+import java.util.Set;
+
+public interface AccessControlContextAwareGroupProvider {
+    Set<String> getGroup(
+            UserIdentity userIdentity,
+            String distinguishedName,
+            AccessControlContext accessControlContext);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 public class AuthenticationHandler {
     private static final Logger LOG = LogManager.getLogger(AuthenticationHandler.class);
@@ -203,7 +204,7 @@ public class AuthenticationHandler {
         // Get user groups from configured group providers (e.g., LDAP groups)
         // Groups are used for role-based access control and permission management
         Set<String> groups = getGroups(context.getCurrentUserIdentity(), context.getDistinguishedName(),
-                authenticationResult.groupProviderName);
+                authenticationResult.groupProviderName, context.getAccessControlContext());
         context.setGroups(groups);
         // Set current role IDs based on the authenticated user and groups
         context.setCurrentRoleIds(authenticationResult.authenticatedUser, groups);
@@ -246,7 +247,20 @@ public class AuthenticationHandler {
         }
     }
 
+    /**
+     * Resolves groups without a session context. Kept for callers that must not pass one, e.g. EXECUTE AS
+     * resolves groups for the impersonated identity while the session context still carries the
+     * authenticating user's token, so a context-aware provider would derive groups for the wrong user.
+     */
     public static Set<String> getGroups(UserIdentity userIdentity, String distinguishedName, List<String> groupProviderList) {
+        return getGroups(userIdentity, distinguishedName, groupProviderList, null);
+    }
+
+    public static Set<String> getGroups(
+            UserIdentity userIdentity,
+            String distinguishedName,
+            List<String> groupProviderList,
+            @Nullable AccessControlContext accessControlContext) {
         AuthenticationMgr authenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
 
         HashSet<String> groups = new HashSet<>();
@@ -255,7 +269,16 @@ public class AuthenticationHandler {
             if (groupProvider == null) {
                 continue;
             }
-            groups.addAll(groupProvider.getGroup(userIdentity, distinguishedName));
+
+            if (accessControlContext != null
+                    && groupProvider instanceof AccessControlContextAwareGroupProvider awareGroupProvider) {
+                groups.addAll(awareGroupProvider.getGroup(
+                        userIdentity,
+                        distinguishedName,
+                        accessControlContext));
+            } else {
+                groups.addAll(groupProvider.getGroup(userIdentity, distinguishedName));
+            }
         }
 
         return groups;

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/ExtensionGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/ExtensionGroupProvider.java
@@ -1,0 +1,153 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.DdlException;
+import com.starrocks.extension.ExtensionManager;
+import com.starrocks.sql.analyzer.SemanticException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.Set;
+
+public class ExtensionGroupProvider extends GroupProvider
+        implements AccessControlContextAwareGroupProvider {
+    public static final String TYPE = "extension";
+    public static final String PROVIDER_FACTORY_CLASS_PROPERTY = "provider_factory_class";
+    private static final Logger LOG = LogManager.getLogger(ExtensionGroupProvider.class);
+    private transient volatile GroupProvider delegate;
+    private transient volatile boolean unresolvable;
+
+    public ExtensionGroupProvider(String name, Map<String, String> properties) {
+        super(name, properties);
+    }
+
+    private static GroupProvider createDelegate(String name, Map<String, String> properties)
+            throws DdlException {
+        String factoryClassName = properties.get(PROVIDER_FACTORY_CLASS_PROPERTY);
+        if (factoryClassName == null || factoryClassName.isBlank()) {
+            throw new DdlException(
+                    "Missing required extension group provider property: " + PROVIDER_FACTORY_CLASS_PROPERTY);
+        }
+
+        Class<?> factoryClass;
+        try {
+            factoryClass = Class.forName(factoryClassName);
+        } catch (ClassNotFoundException e) {
+            throw new DdlException(
+                    "Extension group provider factory class not found: " + factoryClassName, e);
+        }
+        if (!ExtensionGroupProviderFactory.class.isAssignableFrom(factoryClass)) {
+            throw new DdlException(
+                    "Extension component does not implement ExtensionGroupProviderFactory: "
+                            + factoryClassName);
+        }
+
+        GroupProvider provider;
+        try {
+            Object component = ExtensionManager.getComponent(factoryClass);
+            provider = ((ExtensionGroupProviderFactory) component).create(name, properties);
+        } catch (RuntimeException e) {
+            throw new DdlException(
+                    "Extension group provider factory failed: " + factoryClassName, e);
+        }
+
+        if (provider == null) {
+            throw new DdlException(
+                    "Extension group provider factory returned null: " + factoryClassName);
+        }
+        return provider;
+    }
+
+    /**
+     * Runs when the definition is applied and when metadata is replayed. DdlException is the
+     * contract of the base class and is what replayCreateGroupProvider already handles, so a
+     * frontend without the extension skips the provider instead of aborting journal replay.
+     */
+    @Override
+    public void init() throws DdlException {
+        this.delegate().init();
+    }
+
+    @Override
+    public void destroy() {
+        // A provider that was never used must not be created (using delegate()) just to be torn down.
+        GroupProvider resolved = delegate;
+        if (resolved != null) {
+            resolved.destroy();
+        }
+    }
+
+    @Override
+    public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName) {
+        return getGroup(userIdentity, distinguishedName, null);
+    }
+
+    @Override
+    public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName,
+                                AccessControlContext accessControlContext) {
+        GroupProvider resolved;
+        try {
+            resolved = delegate();
+        } catch (DdlException e) {
+            // This contract declares no checked exception, and one undeployed provider must not
+            // fail an entire login process.
+            LOG.debug("group provider [{}] resolves to no groups", getName(), e);
+            return Set.of();
+        }
+
+        if (accessControlContext != null && resolved instanceof AccessControlContextAwareGroupProvider awareGroupProvider) {
+            return awareGroupProvider.getGroup(userIdentity, distinguishedName, accessControlContext);
+        }
+        // delegate does not consume the session context
+        return resolved.getGroup(userIdentity, distinguishedName);
+    }
+
+    @Override
+    public void checkProperty() throws SemanticException {
+        try {
+            delegate().checkProperty();
+        } catch (DdlException e) {
+            throw new SemanticException(e.getMessage(), e);
+        }
+    }
+
+    private GroupProvider delegate() throws DdlException {
+        GroupProvider resolved = delegate;
+        if (resolved != null) {
+            return resolved;
+        }
+        if (unresolvable) {
+            throw new DdlException("group provider [" + getName() + "] is not available on this frontend");
+        }
+
+        synchronized (this) {
+            if (delegate == null) {
+                try {
+                    delegate = createDelegate(getName(), getProperties());
+                } catch (DdlException e) {
+                    unresolvable = true;
+                    LOG.warn("group provider [{}] is not available on this frontend: {}",
+                            getName(), e.getMessage());
+                    LOG.debug("group provider [{}] failed to resolve its delegate", getName(), e);
+                    throw e;
+                }
+            }
+            return delegate;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/ExtensionGroupProviderFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/ExtensionGroupProviderFactory.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.common.DdlException;
+
+import java.util.Map;
+
+/**
+ * Creates the {@link GroupProvider} behind a group provider of type {@code extension}.
+ * <p>
+ * An extension registers its implementation under its own class while loading:
+ *
+ * <pre>
+ * &#64;SRModule(name = "my-groups")
+ * public class MyExtension implements StarRocksExtension {
+ *     &#64;Override
+ *     public void onLoad(ExtensionContext ctx) {
+ *         ctx.register(MyGroupProviderFactory.class, new MyGroupProviderFactory());
+ *     }
+ * }
+ *
+ * public class MyGroupProviderFactory implements ExtensionGroupProviderFactory {
+ *     &#64;Override
+ *     public GroupProvider create(String name, Map&lt;String, String&gt; properties) throws DdlException {
+ *      (...)
+ *     }
+ * }
+ * </pre>
+ *
+ * and a definition then names that class, so several unrelated factories can coexist on one
+ * frontend:
+ *
+ * <pre>{@code
+ * CREATE GROUP PROVIDER my_groups PROPERTIES (
+ *     "type" = "extension",
+ *     "provider_factory_class" = "com.example.MyGroupProviderFactory",
+ *     (...)
+ * );
+ * }</pre>
+ *
+ * @see ExtensionGroupProvider
+ */
+public interface ExtensionGroupProviderFactory {
+
+    /**
+     * Creates the provider for a single group provider definition.
+     * <p>
+     * This method is not a lifecycle hook. It runs once while the {@code CREATE GROUP PROVIDER}
+     * statement is analysed and again when the definition is applied, so it may be called more than
+     * once for the same statement and must stay cheap and free of side effects. Anything that
+     * acquires a resource — opening a connection, starting a scheduler, reading remote state —
+     * belongs in {@link GroupProvider#init()}, which is paired with
+     * {@link GroupProvider#destroy()}.
+     * <p>
+     * The returned provider owns the validation of its own properties in
+     * {@link GroupProvider#checkProperty()}; {@code provider_factory_class} is consumed before this
+     * method is reached and is not the provider's concern. It may additionally implement
+     * {@link AccessControlContextAwareGroupProvider} to receive the authentication context of the
+     * session, which is the only way to reach information such as the token obtained during
+     * authentication.
+     * <p>
+     * The returned provider resolves groups on the authentication path and is therefore called
+     * concurrently by several sessions; its {@code getGroup} implementations must be thread-safe.
+     *
+     * @param name       name of the group provider being defined
+     * @param properties properties of the definition, including those specific to this factory
+     * @return the provider to delegate to, never {@code null}
+     * @throws DdlException if the provider cannot be created in this environment; reported to the
+     *                      user when a definition is created, and logged when metadata is replayed
+     *                      on a frontend where the extension is missing
+     */
+    GroupProvider create(String name, Map<String, String> properties) throws DdlException;
+}

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/GroupProviderFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/GroupProviderFactory.java
@@ -27,6 +27,7 @@ public class GroupProviderFactory {
                     .add(UnixGroupProvider.TYPE)
                     .add(FileGroupProvider.TYPE)
                     .add(LDAPGroupProvider.TYPE)
+                    .add(ExtensionGroupProvider.TYPE)
                     .build();
 
     public static void checkGroupProviderIsSupported(String groupProviderType) {
@@ -45,6 +46,8 @@ public class GroupProviderFactory {
             groupProvider = new UnixGroupProvider(name, propertyMap);
         } else if (type.equalsIgnoreCase(LDAPGroupProvider.TYPE)) {
             groupProvider = new LDAPGroupProvider(name, propertyMap);
+        } else if (type.equalsIgnoreCase(ExtensionGroupProvider.TYPE)) {
+            groupProvider = new ExtensionGroupProvider(name, propertyMap);
         }
 
         Preconditions.checkNotNull(groupProvider);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/internal/RuntimeTypeAdapterTypes.java
@@ -40,6 +40,7 @@ import com.starrocks.alter.reshard.ReshardingTablet;
 import com.starrocks.alter.reshard.SplitTabletJob;
 import com.starrocks.alter.reshard.SplittingTablet;
 import com.starrocks.alter.reshard.TabletReshardJob;
+import com.starrocks.authentication.ExtensionGroupProvider;
 import com.starrocks.authentication.FileGroupProvider;
 import com.starrocks.authentication.GroupProvider;
 import com.starrocks.authentication.JWTSecurityIntegration;
@@ -355,7 +356,8 @@ public class RuntimeTypeAdapterTypes {
                 RuntimeTypeAdapterFactory.of(GroupProvider.class, "clazz")
                         .registerSubtype(FileGroupProvider.class, "FileGroupProvider")
                         .registerSubtype(UnixGroupProvider.class, "UnixGroupProvider")
-                        .registerSubtype(LDAPGroupProvider.class, "LDAPGroupProvider");
+                        .registerSubtype(LDAPGroupProvider.class, "LDAPGroupProvider")
+                        .registerSubtype(ExtensionGroupProvider.class, "ExtensionGroupProvider");
         CLAZZ_TO_RUNTIME_TYPE_ADAPTOR_FACTORIES.put(GroupProvider.class, group_provider_runtime_type_adapter_factory);
 
         final RuntimeTypeAdapterFactory<Warehouse> warehouse_type_adapter_factory = RuntimeTypeAdapterFactory

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationHandlerTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.authentication;
 
+import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.qe.ConnectContext;
@@ -130,5 +131,41 @@ public class AuthenticationHandlerTest {
         ldapGroupProvider2.setUserToGroupCache(groups2);
         Assertions.assertEquals(Set.of("group3", "group4"),
                 ldapGroupProvider2.getGroup(authCtx.getCurrentUserIdentity(), authCtx.getDistinguishedName()));
+    }
+
+    /**
+     * Test case: Resolve groups through a group provider that consumes the session's
+     * {@link AccessControlContext}
+     * Test point: {@code getGroups} routes to the three-argument form when the provider implements
+     * {@link AccessControlContextAwareGroupProvider} and a context is available, and the
+     * pre-existing overload without a context keeps resolving through the two-argument contract.
+     * <p>
+     * The second assertion is the one that guards the change: every built-in provider and every
+     * existing caller goes through the overload without a context, so its behaviour has to stay
+     * exactly as it was.
+     */
+    @Test
+    public void testGetGroupsAcceptsContextAwareProviders() {
+        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, ExtensionGroupProvider.TYPE);
+        // Borrowed double. Returns a different group set depending on whether a context is passed,
+        // which is exactly what this test needs to tell the two dispatch paths apart.
+        properties.put(ExtensionGroupProvider.PROVIDER_FACTORY_CLASS_PROPERTY,
+                ExtensionGroupProviderTest.ContextAwareFactory.class.getName());
+
+        String groupName = "extension_group_provider";
+        authenticationMgr.replayCreateGroupProvider(groupName, properties);
+
+        UserIdentity user = new UserIdentity("test_user", "%");
+
+        Assertions.assertEquals(Set.of("context_group"),
+                AuthenticationHandler.getGroups(user, "test_user", List.of(groupName), new AccessControlContext()));
+
+        // Same provider, no context. Must fall back to the contract every built-in provider uses.
+        Assertions.assertEquals(Set.of("no_context_group"),
+                AuthenticationHandler.getGroups(user, "test_user", List.of(groupName)));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationMgrEditLogTest.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -83,6 +84,13 @@ public class AuthenticationMgrEditLogTest {
     private Map<String, String> createUnixGroupProviderProperties() {
         Map<String, String> properties = new HashMap<>();
         properties.put("type", "unix");
+        return properties;
+    }
+
+    private Map<String, String> createExtensionGroupProviderProperties(String factoryClassName) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", ExtensionGroupProvider.TYPE);
+        properties.put(ExtensionGroupProvider.PROVIDER_FACTORY_CLASS_PROPERTY, factoryClassName);
         return properties;
     }
 
@@ -889,5 +897,54 @@ public class AuthenticationMgrEditLogTest {
             masterAuthenticationMgr.dropSecurityIntegration(nonExistentName);
         });
         Assertions.assertTrue(exception.getMessage().contains("security integration '" + nonExistentName + "' not found"));
+    }
+
+    /**
+     * A frontend that does not have the extension deployed must skip the provider and carry on
+     * replaying: an exception here aborts journal replay and the frontend never starts.
+     */
+    @Test
+    public void testReplayCreateExtensionGroupProviderWithoutTheExtension() {
+        AuthenticationMgr followerAuthMgr = new AuthenticationMgr();
+
+        Assertions.assertDoesNotThrow(() -> followerAuthMgr.replayCreateGroupProvider(
+                TEST_PROVIDER_NAME, createExtensionGroupProviderProperties("com.example.NotDeployed")));
+
+        Assertions.assertNull(followerAuthMgr.getGroupProvider(TEST_PROVIDER_NAME),
+                "a provider that cannot be resolved must not be registered");
+    }
+
+    @Test
+    public void testReplayCreateExtensionGroupProviderWithTheExtension() {
+        AuthenticationMgr followerAuthMgr = new AuthenticationMgr();
+
+        followerAuthMgr.replayCreateGroupProvider(TEST_PROVIDER_NAME,
+                createExtensionGroupProviderProperties(ReplayableExtensionGroupProviderFactory.class.getName()));
+
+        GroupProvider provider = followerAuthMgr.getGroupProvider(TEST_PROVIDER_NAME);
+        Assertions.assertNotNull(provider);
+        Assertions.assertEquals(ExtensionGroupProvider.TYPE, provider.getType());
+    }
+
+    /**
+     * Minimal factory standing in for a deployed extension. The provider it returns is an anonymous
+     * subclass, which is deliberate but only safe because nothing here serialises it - subtypes of
+     * {@link GroupProvider} have to be registered in the gson runtime type adapter, and an anonymous
+     * class cannot be. Do not reuse this factory in a test that writes an image.
+     */
+    public static class ReplayableExtensionGroupProviderFactory implements ExtensionGroupProviderFactory {
+        @Override
+        public GroupProvider create(String name, Map<String, String> properties) {
+            return new GroupProvider(name, properties) {
+                @Override
+                public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName) {
+                    return Set.of("replayed_group");
+                }
+
+                @Override
+                public void checkProperty() {
+                }
+            };
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/ExtensionGroupProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/ExtensionGroupProviderTest.java
@@ -1,0 +1,287 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.DdlException;
+import com.starrocks.sql.analyzer.SemanticException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ExtensionGroupProviderTest {
+    private static final String PROVIDER_NAME = "test_extension_provider";
+    private static final UserIdentity TEST_USER = new UserIdentity("test_user", "%");
+    private static final String TEST_DN = "test_user";
+
+    @BeforeEach
+    public void resetFactoryCounters() {
+        CountingFactory.COUNTER.set(0);
+        CountingFactory.last = null;
+        FailingFactory.ATTEMPTS.set(0);
+    }
+
+    private static ExtensionGroupProvider providerFor(String factoryClassName) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, ExtensionGroupProvider.TYPE);
+        if (factoryClassName != null) {
+            properties.put(ExtensionGroupProvider.PROVIDER_FACTORY_CLASS_PROPERTY, factoryClassName);
+        }
+        return new ExtensionGroupProvider(PROVIDER_NAME, properties);
+    }
+
+    // ---------------------------------------- delegation ----------------------------------------
+
+    @Test
+    public void testGetGroupIsDelegated() throws Exception {
+        ExtensionGroupProvider provider = providerFor(CountingFactory.class.getName());
+
+        Assertions.assertEquals(Set.of("test_group"), provider.getGroup(TEST_USER, TEST_DN));
+    }
+
+    @Test
+    public void testCheckPropertyIsDelegated() {
+        ExtensionGroupProvider provider = providerFor(CountingFactory.class.getName());
+
+        Assertions.assertDoesNotThrow(provider::checkProperty);
+    }
+
+    @Test
+    public void testInitIsDelegated() throws Exception {
+        ExtensionGroupProvider provider = providerFor(CountingFactory.class.getName());
+        provider.init();
+
+        Assertions.assertNotNull(CountingFactory.last);
+        Assertions.assertTrue(CountingFactory.last.initialized, "delegate should have been initialized");
+    }
+
+    /**
+     * The delegate must not be resolved by the constructor: a definition is also reconstructed
+     * while metadata is loaded on a frontend that may not have the extension deployed.
+     */
+    @Test
+    public void testConstructorDoesNotResolveDelegate() {
+        Assertions.assertDoesNotThrow(() -> providerFor("com.example.DoesNotExist"));
+        Assertions.assertEquals(0, CountingFactory.COUNTER.get());
+    }
+
+    // ---------------------------------- failures during analysis --------------------------------
+
+    @Test
+    public void testMissingFactoryClassFailsAnalysis() {
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> providerFor(null).checkProperty());
+
+        Assertions.assertTrue(e.getMessage().contains(ExtensionGroupProvider.PROVIDER_FACTORY_CLASS_PROPERTY),
+                e.getMessage());
+    }
+
+    @Test
+    public void testUnknownFactoryClassFailsAnalysis() {
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> providerFor("com.example.DoesNotExist").checkProperty());
+
+        Assertions.assertTrue(e.getMessage().contains("class not found"), e.getMessage());
+    }
+
+    @Test
+    public void testClassThatIsNotAFactoryFailsAnalysis() {
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> providerFor(String.class.getName()).checkProperty());
+
+        Assertions.assertTrue(e.getMessage().contains("does not implement"), e.getMessage());
+    }
+
+    @Test
+    public void testFactoryReturningNullFailsAnalysis() {
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> providerFor(NullReturningFactory.class.getName()).checkProperty());
+
+        Assertions.assertTrue(e.getMessage().contains("returned null"), e.getMessage());
+    }
+
+    // -------------------------------- failures outside analysis ---------------------------------
+
+    /**
+     * The type matters, not just the failure: AuthenticationMgr.replayCreateGroupProvider catches
+     * DdlException only. A SemanticException here would abort journal replay and stop a frontend
+     * that does not have the extension deployed from starting at all.
+     */
+    @Test
+    public void testInitReportsDdlException() {
+        Assertions.assertThrows(DdlException.class,
+                () -> providerFor("com.example.DoesNotExist").init());
+    }
+
+    /**
+     * Reachable when init() failed while an image was loaded: AuthenticationMgr logs the failure
+     * but keeps the provider registered, so the next login resolves groups against it.
+     */
+    @Test
+    public void testGetGroupYieldsNoGroupsWhenUnresolvable() {
+        ExtensionGroupProvider provider = providerFor("com.example.DoesNotExist");
+
+        Assertions.assertEquals(Set.of(), provider.getGroup(TEST_USER, TEST_DN));
+        Assertions.assertEquals(Set.of(), provider.getGroup(TEST_USER, TEST_DN, new AccessControlContext()));
+    }
+
+    @Test
+    public void testResolutionFailureIsNotRetried() {
+        ExtensionGroupProvider provider = providerFor(FailingFactory.class.getName());
+
+        Assertions.assertThrows(DdlException.class, provider::init);
+        Assertions.assertThrows(DdlException.class, provider::init);
+        Assertions.assertEquals(1, FailingFactory.ATTEMPTS.get(),
+                "a provider known to be unresolvable must not be resolved again");
+    }
+
+    // ------------------------------------ context awareness -------------------------------------
+
+    @Test
+    public void testContextAwareDelegateReceivesContext() {
+        ExtensionGroupProvider provider = providerFor(ContextAwareFactory.class.getName());
+        Set<String> groups = provider.getGroup(TEST_USER, TEST_DN, new AccessControlContext());
+
+        Assertions.assertEquals(Set.of("context_group"), groups);
+    }
+
+    @Test
+    public void testContextAwareDelegateFallsBackWithoutContext() {
+        ExtensionGroupProvider provider = providerFor(ContextAwareFactory.class.getName());
+
+        Assertions.assertEquals(Set.of("no_context_group"), provider.getGroup(TEST_USER, TEST_DN));
+    }
+
+    @Test
+    public void testContextIsIgnoredByADelegateThatIsNotAware() {
+        ExtensionGroupProvider provider = providerFor(CountingFactory.class.getName());
+        Set<String> groups = provider.getGroup(TEST_USER, TEST_DN, new AccessControlContext());
+
+        Assertions.assertEquals(Set.of("test_group"), groups);
+    }
+
+    // ----------------------------------------- teardown -----------------------------------------
+
+    @Test
+    public void testDestroyDoesNotResolveDelegate() {
+        ExtensionGroupProvider provider = providerFor(CountingFactory.class.getName());
+        provider.destroy();
+
+        Assertions.assertEquals(0, CountingFactory.COUNTER.get(),
+                "a provider that was never used must not be created just to be torn down");
+    }
+
+    @Test
+    public void testDestroyIsDelegatedOnceResolved() throws Exception {
+        ExtensionGroupProvider provider = providerFor(CountingFactory.class.getName());
+        provider.init();
+        provider.destroy();
+
+        Assertions.assertTrue(CountingFactory.last.destroyed, "delegate should have been destroyed");
+    }
+
+    // ------------------------------------- test doubles ------------------------------------------
+
+    public static class CountingFactory implements ExtensionGroupProviderFactory {
+        static final AtomicInteger COUNTER = new AtomicInteger();
+        static volatile RecordingGroupProvider last;
+
+        @Override
+        public GroupProvider create(String name, Map<String, String> properties) {
+            COUNTER.incrementAndGet();
+            last = new RecordingGroupProvider(name, properties);
+            return last;
+        }
+    }
+
+    public static class ContextAwareFactory implements ExtensionGroupProviderFactory {
+        @Override
+        public GroupProvider create(String name, Map<String, String> properties) {
+            return new ContextAwareGroupProvider(name, properties);
+        }
+    }
+
+    public static class NullReturningFactory implements ExtensionGroupProviderFactory {
+        @Override
+        public GroupProvider create(String name, Map<String, String> properties) {
+            return null;
+        }
+    }
+
+    public static class FailingFactory implements ExtensionGroupProviderFactory {
+        static final AtomicInteger ATTEMPTS = new AtomicInteger();
+
+        @Override
+        public GroupProvider create(String name, Map<String, String> properties) throws DdlException {
+            ATTEMPTS.incrementAndGet();
+            throw new DdlException("factory refuses to create a provider");
+        }
+    }
+
+    public static class RecordingGroupProvider extends GroupProvider {
+        boolean initialized;
+        boolean destroyed;
+
+        public RecordingGroupProvider(String name, Map<String, String> properties) {
+            super(name, properties);
+        }
+
+        @Override
+        public void init() {
+            initialized = true;
+        }
+
+        @Override
+        public void destroy() {
+            destroyed = true;
+        }
+
+        @Override
+        public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName) {
+            return Set.of("test_group");
+        }
+
+        @Override
+        public void checkProperty() {
+        }
+    }
+
+    public static class ContextAwareGroupProvider extends GroupProvider
+            implements AccessControlContextAwareGroupProvider {
+        public ContextAwareGroupProvider(String name, Map<String, String> properties) {
+            super(name, properties);
+        }
+
+        @Override
+        public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName) {
+            return Set.of("no_context_group");
+        }
+
+        @Override
+        public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName,
+                                    AccessControlContext accessControlContext) {
+            return Set.of("context_group");
+        }
+
+        @Override
+        public void checkProperty() {
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/GroupProviderStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/GroupProviderStatementTest.java
@@ -16,6 +16,7 @@ package com.starrocks.authentication;
 
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.DdlException;
+import com.starrocks.extension.ExtensionManager;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.group.CreateGroupProviderStmt;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -54,6 +56,7 @@ public class GroupProviderStatementTest {
     private AuthenticationMgr authenticationMgr;
     private static final String TEST_PROVIDER_NAME = "test_provider";
     private static final String NON_EXISTENT_PROVIDER_NAME = "non_existent_provider";
+    private static final String TEST_EXTENSION_PROVIDER_NAME = "test_extension_provider";
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -141,6 +144,39 @@ public class GroupProviderStatementTest {
 
         Assertions.assertTrue(exception.getMessage().contains("Group provider '" + TEST_PROVIDER_NAME + "' already exists"),
                 "Error message should indicate provider already exists: " + exception.getMessage());
+    }
+
+    /**
+     * Test case: Create Group Provider from static extension
+     * Test point: Group Provider should return group test_group for user test_user
+     */
+    @Test
+    public void testCreateExtensionGroupProvider() throws Exception {
+        ExtensionManager.getInstance(); // ensure singleton is initialized
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, ExtensionGroupProvider.TYPE);
+        properties.put(
+                ExtensionGroupProvider.PROVIDER_FACTORY_CLASS_PROPERTY,
+                TestExtensionGroupProviderFactory.class.getName()
+        );
+
+        CreateGroupProviderStmt stmt = new CreateGroupProviderStmt(
+                TEST_EXTENSION_PROVIDER_NAME,
+                properties,
+                false,
+                NodePosition.ZERO
+        );
+
+        authenticationMgr.createGroupProviderStatement(stmt, ctx);
+
+        GroupProvider provider = authenticationMgr.getGroupProvider(TEST_EXTENSION_PROVIDER_NAME);
+        Assertions.assertNotNull(provider);
+        Assertions.assertEquals(TEST_EXTENSION_PROVIDER_NAME, provider.getName());
+        Assertions.assertEquals(ExtensionGroupProvider.TYPE, provider.getType());
+
+        Set<String> groups = provider.getGroup(new UserIdentity("test_user", "%"), "test_user");
+        Assertions.assertTrue(groups.contains("test_group"));
     }
 
     /**
@@ -352,6 +388,43 @@ public class GroupProviderStatementTest {
             authenticationMgr.dropGroupProviderStatement(dropStmt, ctx);
         } catch (Exception e) {
             // Ignore cleanup errors
+        }
+
+        try {
+            DropGroupProviderStmt dropStmt =
+                    new DropGroupProviderStmt(TEST_EXTENSION_PROVIDER_NAME, true, NodePosition.ZERO);
+            authenticationMgr.dropGroupProviderStatement(dropStmt, ctx);
+        } catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    /**
+     * Fake ExtensionGroupProviderFactory that simulates plugin (GroupProvider provider)
+     * provided by static extension.
+     */
+    public static class TestExtensionGroupProviderFactory implements ExtensionGroupProviderFactory {
+        @Override
+        public GroupProvider create(String name, Map<String, String> properties) {
+            return new TestExtensionGroupProvider(name, properties);
+        }
+    }
+
+    /**
+     * Fake implementation for GroupProvider provided by static extension.
+     */
+    public static class TestExtensionGroupProvider extends GroupProvider {
+        public TestExtensionGroupProvider(String name, Map<String, String> properties) {
+            super(name, properties);
+        }
+
+        @Override
+        public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName) {
+            return Set.of("test_group");
+        }
+
+        @Override
+        public void checkProperty() {
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/GroupProviderStatementAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/GroupProviderStatementAnalyzerTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.analyzer;
 
 import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.authentication.ExtensionGroupProviderFactory;
 import com.starrocks.authentication.GroupProvider;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.qe.ConnectContext;
@@ -32,6 +33,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.mockito.Mockito.when;
 
@@ -262,6 +264,38 @@ public class GroupProviderStatementAnalyzerTest {
     }
 
     /**
+     * Test case: Analyze Create Group Provider with valid extension type
+     * Test point: Should pass analysis when the factory named by the definition is deployed
+     */
+    @Test
+    public void testAnalyzeCreateGroupProviderValidExtensionType() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "extension");
+        properties.put("provider_factory_class", AnalyzableFactory.class.getName());
+        CreateGroupProviderStmt stmt = new CreateGroupProviderStmt(TEST_PROVIDER_NAME, properties, false, NodePosition.ZERO);
+
+        // Should not throw exception
+        GroupProviderStatementAnalyzer.analyze(stmt, ctx);
+    }
+
+    /**
+     * Test case: Analyze Create Group Provider of extension type without the factory class
+     * Test point: Should throw SemanticException naming the missing property
+     */
+    @Test
+    public void testAnalyzeCreateGroupProviderExtensionWithoutFactoryClass() throws Exception {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "extension");
+        CreateGroupProviderStmt stmt = new CreateGroupProviderStmt(TEST_PROVIDER_NAME, properties, false, NodePosition.ZERO);
+
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> GroupProviderStatementAnalyzer.analyze(stmt, ctx));
+
+        Assertions.assertTrue(exception.getMessage().contains("provider_factory_class"),
+                exception.getMessage());
+    }
+
+    /**
      * Test case: Test analysis with null context
      * Test point: Should handle null context gracefully
      */
@@ -313,6 +347,28 @@ public class GroupProviderStatementAnalyzerTest {
             authenticationMgr.dropGroupProviderStatement(dropStmt, ctx);
         } catch (Exception e) {
             // Ignore cleanup errors
+        }
+    }
+
+    /**
+     * Minimal factory standing in for a deployed extension, so that analysis of a valid
+     * {@code extension} definition can reach the delegate's own property validation. The returned
+     * provider is an anonymous subclass and must not be serialised, so subtypes of
+     * {@link GroupProvider} have to be registered in the gson runtime type adapter.
+     */
+    public static class AnalyzableFactory implements ExtensionGroupProviderFactory {
+        @Override
+        public GroupProvider create(String name, Map<String, String> properties) {
+            return new GroupProvider(name, properties) {
+                @Override
+                public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName) {
+                    return Set.of("analyzable_group");
+                }
+
+                @Override
+                public void checkProperty() {
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

StarRocks supports three built-in group provider types (`unix`, `file`, `ldap`). Deployments whose group source is none of those: an HTTP identity service, SCIM, a claim of the token obtained during JWT or OAuth 2.0 authentication - have to carry a patched FE, or sync groups into a `file` provider out of band and give up per-session resolution.

Rather than adding one built-in provider per identity system, this makes group resolution a
pluggable extension point, so a deployment can supply its own provider out of tree. The reasoning,
and the alternative of adding built-in types instead, are laid out in the issue.

## What I'm doing:

Fixes #78194

1. **New group provider type `extension`**, registered in `GroupProviderFactory` and in the gson runtime type adapter, so it persists in the FE image and edit log like the built-in types.

2. **`ExtensionGroupProviderFactory` SPI.** An extension registers its factory in `StarRocksExtension#onLoad` and the definition names that class through `provider_factory_class`, so several unrelated factories can coexist on one frontend.

3. **Opt-in context-aware resolution.** `AccessControlContextAwareGroupProvider` lets a provider receive the session's `AccessControlContext`, which is the only way to reach the token obtained during authentication. `AuthenticationHandler.getGroups(...)` dispatches to it when the provider implements it and a context is available. 

The pre-existing three-argument overload is kept deliberately, not by omission: `EXECUTE AS` resolves groups for the impersonated identity while the session context still carries the authenticating user's token, so passing the context there would derive groups for the wrong user.

4. **Failures never break a frontend.** Resolution is lazy and reported as `DdlException`, which `replayCreateGroupProvider` already handles, so a frontend without the extension deployed skips the provider instead of aborting journal replay. On the authentication path an unresolvable provider logs once and yields no groups rather than failing the login.

5. **Tests.** All three call sites of `GroupProviderFactory.createGroupProvider` are covered: analysis (`GroupProviderStatementAnalyzerTest`), DDL execution (`GroupProviderStatementTest`) and edit-log replay (`AuthenticationMgrEditLogTest`, including replay on a frontend without the extension). `ExtensionGroupProviderTest` covers delegation, lazy resolution, the context-aware dispatch and its fallback, and teardown. `AuthenticationHandlerTest` covers the dispatch in `getGroups` and asserts the overload without a context is unchanged.

6. **Documentation.** `docs/en/administration/user_privs/group_provider.md` gains the new type, its property and an example, cross-referencing `docs/en/administration/management/extensions.md`.

Two things I would still like your call on, both raised in the issue:
- whether the plugin-facing interfaces should live in `fe/fe-spi` rather than `fe-core`, given that `GroupProvider` is an abstract class in `fe-core` and an extension has to compile against it anyway;
- whether you would rather see built-in provider types added upstream instead of this extension point.

I also guessed `v4.2` for the version note in the documentation. Please correct it if that is wrong.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The change is additive: a new accepted value of the `type` property, a new opt-in interface, and one new overload. Existing providers, images and edit logs are unaffected.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
