### PR TITLE
[Refactor] Convert the partial-update and condition-update fan-outs to the runner

### DIFF
--- a/be/src/storage/lake/column_mode_partial_update_handler.cpp
+++ b/be/src/storage/lake/column_mode_partial_update_handler.cpp
@@ -39,6 +39,7 @@
 #include "storage/lake/column_mode_partial_update_handler.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/parallel_task_runner.h"
 #include "storage/lake/update_manager.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
@@ -563,8 +564,11 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
                     ThreadPool::ExecutionMode::CONCURRENT);
         }
 
+        // Declared before the runner so it outlives the join in ~ParallelTaskRunner: the tasks lock
+        // it, and reverse declaration order would otherwise destroy it first.
+        // Guards the shared dcg_* result maps only; the status is the runner's business now.
         std::mutex result_mutex;
-        Status shared_status;
+        ParallelTaskRunner runner(token.get());
 
         for (const auto& each : rss_upt_id_to_rowid_pairs) {
             uint32_t rssid = each.first;
@@ -576,16 +580,10 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
 
             auto func = [this, &params, &partial_schema, &partial_tschema, &selective_unique_update_column_ids, rssid,
                          upt_pairs_ptr, condition_idx_in_partial_schema, &dcg_column_ids,
-                         &dcg_column_file_with_encryption_metas, &dcg_column_file_sizes, &result_mutex,
-                         &shared_status]() {
+                         &dcg_column_file_with_encryption_metas, &dcg_column_file_sizes, &result_mutex]() -> Status {
                 // 3.3 prepare one DCG writer, then stream source-segment chunks through update and append.
-                auto writer_or = _prepare_delta_column_group_writer(params, partial_tschema);
-                if (!writer_or.ok()) {
-                    std::lock_guard<std::mutex> l(result_mutex);
-                    shared_status.update(writer_or.status());
-                    return;
-                }
-                auto delta_column_group_writer = std::move(writer_or.value());
+                ASSIGN_OR_RETURN(auto delta_column_group_writer,
+                                 _prepare_delta_column_group_writer(params, partial_tschema));
                 auto st = _read_from_source_segment_and_update(
                         params, partial_schema, rssid, [&](StreamChunkContainer container) {
                             const size_t source_chunk_size = container.chunk_ptr->memory_usage();
@@ -604,45 +602,31 @@ Status ColumnModePartialUpdateHandler::execute(const RowsetUpdateStateParams& pa
                             RETURN_IF_ERROR(delta_column_group_writer->append_chunk(*container.chunk_ptr));
                             return Status::OK();
                         });
-                if (!st.ok()) {
-                    std::lock_guard<std::mutex> l(result_mutex);
-                    shared_status.update(st);
-                    return;
-                }
+                RETURN_IF_ERROR(st);
 
                 uint64_t segment_file_size = 0;
                 uint64_t index_size = 0;
                 uint64_t footer_position = 0;
-                st = delta_column_group_writer->finalize(&segment_file_size, &index_size, &footer_position);
+                RETURN_IF_ERROR(delta_column_group_writer->finalize(&segment_file_size, &index_size, &footer_position));
 
                 // 3.6 collect results under lock
                 std::lock_guard<std::mutex> l(result_mutex);
-                shared_status.update(st);
-                if (shared_status.ok()) {
-                    dcg_column_ids[rssid].push_back(selective_unique_update_column_ids);
-                    dcg_column_file_with_encryption_metas[rssid].emplace_back(
-                            file_name(delta_column_group_writer->segment_path()),
-                            delta_column_group_writer->encryption_meta());
-                    dcg_column_file_sizes[rssid].push_back(static_cast<int64_t>(segment_file_size));
-                }
+                dcg_column_ids[rssid].push_back(selective_unique_update_column_ids);
+                dcg_column_file_with_encryption_metas[rssid].emplace_back(
+                        file_name(delta_column_group_writer->segment_path()),
+                        delta_column_group_writer->encryption_meta());
+                dcg_column_file_sizes[rssid].push_back(static_cast<int64_t>(segment_file_size));
                 TRACE_COUNTER_INCREMENT("pcu_handle_cnt", 1);
+                return Status::OK();
             };
 
-            if (token) {
-                auto submit_st = token->submit_func(func);
-                std::lock_guard<std::mutex> l(result_mutex);
-                shared_status.update(submit_st);
-            } else {
-                func();
-                RETURN_IF_ERROR(shared_status);
-            }
+            runner.run(func);
         }
 
-        if (token) {
+        {
             TRACE_COUNTER_SCOPE_LATENCY_US("pcu_parallel_dcg_wait_us");
-            token->wait();
+            RETURN_IF_ERROR(runner.join());
         }
-        RETURN_IF_ERROR(shared_status);
     }
     // 4 generate delta columngroup
     for (const auto& each : rss_upt_id_to_rowid_pairs) {

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -39,6 +39,7 @@
 #include "storage/lake/lake_primary_key_compaction_conflict_resolver.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/parallel_task_runner.h"
 #include "storage/lake/pk_index_utils.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
@@ -478,13 +479,13 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             std::vector<std::map<int, SegmentFileInfo>> per_seg_replace(batch_count);
             std::vector<std::vector<FileMetaPB>> per_seg_orphans(batch_count);
 
-            std::mutex status_mutex;
-            Status shared_status;
             auto token = RuntimeEnv::GetInstance()->lake_partial_update_thread_pool()->new_token(
                     ThreadPool::ExecutionMode::CONCURRENT);
+            ParallelTaskRunner runner(token.get());
 
             for (uint32_t i = batch_start; i < batch_end; i++) {
-                auto func = [&, i]() {
+                // Each task writes only its own per_seg_* element.
+                runner.run([&, i]() {
                     uint32_t idx = i - batch_start;
                     auto st = state.load_segment(i, params, base_version, true /*resolve conflict*/,
                                                  false /*no need lock*/);
@@ -492,20 +493,14 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
                     if (st.ok()) {
                         st = state.rewrite_segment(i, txn_id, params, &per_seg_replace[idx], &per_seg_orphans[idx]);
                     }
+                    // Released whether or not the above succeeded: the state cache would otherwise hold
+                    // this segment's partial state for the rest of the publish.
                     state.release_segment_partial_state(i);
                     _update_state_cache.update_object_size(state_entry, state.memory_usage());
-
-                    std::lock_guard<std::mutex> l(status_mutex);
-                    shared_status.update(st);
-                };
-                auto submit_st = token->submit_func(func);
-                if (!submit_st.ok()) {
-                    std::lock_guard<std::mutex> l(status_mutex);
-                    shared_status.update(submit_st);
-                }
+                    return st;
+                });
             }
-            token->wait();
-            RETURN_IF_ERROR(shared_status);
+            RETURN_IF_ERROR(runner.join());
 
             for (uint32_t i = batch_start; i < batch_end; i++) {
                 uint32_t idx = i - batch_start;
@@ -1517,15 +1512,10 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
         token = RuntimeEnv::GetInstance()->pk_index_execution_thread_pool()->new_token(
                 ThreadPool::ExecutionMode::CONCURRENT);
     }
-    // TRACE_COUNTER_* reads a thread-local current trace that pool worker threads do not
-    // inherit, so counters incremented inside a submitted compare task would silently drop.
-    // Capture the publish thread's trace and re-adopt it inside each worker task.
-    Trace* parent_trace = Trace::CurrentTrace();
-
-    std::mutex mutex;
-    Status status = Status::OK();
-    // Per-chunk results accumulated in iteration order; consumed after the compare barrier.
+    // Per-chunk results accumulated in iteration order; consumed after the compare barrier. Each task
+    // writes only its own result, so there is no shared state to guard.
     std::vector<std::unique_ptr<ChunkCondMergeResult>> chunk_results;
+    ParallelTaskRunner compare_runner(token.get());
 
     for (; !upsert->done(); upsert->next()) {
         auto current = upsert->current();
@@ -1533,35 +1523,17 @@ Status UpdateManager::_do_update_with_condition(const RowsetUpdateStateParams& p
         auto* result = chunk_results.back().get();
         result->chunk_physical_rowid_offset = current.physical_rowid_offset;
 
-        auto compare_func = [&, result, current]() {
-            ADOPT_TRACE(parent_trace);
-            auto st = process_single_chunk_update_with_condition_no_sst(this, params, rowset_id, upsert_idx,
-                                                                        upsert.get(), current, tablet_column,
-                                                                        read_column_ids, index, result);
-            if (!st.ok()) {
-                std::lock_guard<std::mutex> lock(mutex);
-                status.update(st);
-            }
-        };
-
-        if (token) {
-            auto submit_st = token->submit_func(compare_func);
-            if (!submit_st.ok()) {
-                std::lock_guard<std::mutex> lock(mutex);
-                status.update(submit_st);
-            }
-        } else {
-            // Single-chunk (or parallel execution disabled): compare on the publish thread.
-            compare_func();
-            RETURN_IF_ERROR(status);
-        }
+        compare_runner.run([&, result, current]() {
+            return process_single_chunk_update_with_condition_no_sst(this, params, rowset_id, upsert_idx, upsert.get(),
+                                                                     current, tablet_column, read_column_ids, index,
+                                                                     result);
+        });
     }
 
-    if (token) {
+    {
         TRACE_COUNTER_SCOPE_LATENCY_US("condition_update_compare_phase_us");
-        token->wait();
+        RETURN_IF_ERROR(compare_runner.join());
     }
-    RETURN_IF_ERROR(status);
     RETURN_IF_ERROR(upsert->status());
 
     // PHASE 2: apply index.upsert for each chunk's winners.


### PR DESCRIPTION
## Why I'm doing:

Step 2 of 3, continuing from #78343.

`lake::ParallelTaskRunner` now owns the fan-out/join shape for the six copies that live inside the PK index. Three more copies of that same shape are left outside it — each with its own local `std::mutex` + `Status` pair, and one of them still hand-rolling the trace adoption the runner does for free.

The trace part matters beyond tidiness. `TRACE_COUNTER_*` reads a thread-local current trace, pool workers do not inherit it, and the macro is a **no-op** when there is none (`be/src/base/debug/trace.h`). `ColumnModePartialUpdateHandler::execute` increments `pcu_handle_cnt` **inside** its task, so on a pool worker that counter has never landed anywhere.

## What I'm doing:

| Site | What it drops |
|---|---|
| `UpdateManager::publish_primary_key_tablet` row-mode partial-update phase 1 | mutex + Status entirely — each task writes only its own `per_seg_*` element, so no shared state remains |
| `UpdateManager::_do_update_with_condition` non-SST compare phase | mutex + Status + its hand-rolled `ADOPT_TRACE(parent_trace)` wrapper; the per-chunk `ChunkCondMergeResult` was already private to each task |
| `ColumnModePartialUpdateHandler::execute` DCG writer loop | Status plumbing; `result_mutex` is left guarding only the shared `dcg_*` result maps, which is all it was ever for |

Two details worth a reviewer's eye:

* In partial-update phase 1, `release_segment_partial_state()` stays **unconditional** — it has to run whether or not the load/rewrite succeeded, or the state cache holds that segment's partial state for the rest of the publish. It is now called out in a comment rather than being implicit in the old `if (st.ok())` shape.
* `result_mutex` in the DCG loop is declared **before** the runner rather than after. The tasks lock it, and reverse declaration order would otherwise destroy it before `~ParallelTaskRunner` joins.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Four observable differences, all internal to the publish path:

1. **`pcu_handle_cnt` starts being counted.** It is incremented inside a pool task, which had no adopted trace, so it was silently dropped. Name and meaning unchanged, so no doc update applies.
2. **Submit failure no longer fails the publish** at these sites. The runner runs the task inline instead, matching what the already-converted sites do.
3. **A failing task no longer stops the tasks after it** in the serial path. Several callers depend on side effects — releasing per-segment state, accumulating IO stats — that must still happen on a publish that is going to fail, so the runner runs everything and keeps the first error. The publish fails either way.
4. **Result collection in the DCG loop keys off the task's own success** rather than the aggregate status. A task whose siblings had failed used to skip collecting its result, which only mattered for a publish that is about to be abandoned.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

No new tests: this is a mechanical conversion of existing call sites, covered by the existing `LakePartialUpdateTest`, `ConditionUpdateTest` and column-mode partial-update suites. The runner's own behaviour is tested in `be/test/storage/lake/parallel_task_runner_test.cpp`, added in #78343.

## Follow-up

**Step 3** splits `ParallelPublishContext`, which is what unblocks the last two copies — they submit four layers below the join, inside `LakePersistentIndex::upsert`. That step touches the shared (non-lake) `primary_index` layer, so it gets its own review pass. It is parked as a draft in #78311.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport: main-only cleanup with no user-visible fix.
