### PR TITLE
[BugFix] Fix BE crash on yearweek with invalid str_to_date input

### DIFF
--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -145,7 +145,8 @@ bool TimestampValue::from_date_format_str(const char* value, int value_len, cons
     uint8_t month = month1 * 10 + month2;
     uint8_t day = day1 * 10 + day2;
 
-    if (month > 12 || (day > s_days_in_month[month] && (month != 2 || day != 29 || !date::is_leap(year)))) {
+    if (month == 0 || day == 0 || month > 12 ||
+        (day > s_days_in_month[month] && (month != 2 || day != 29 || !date::is_leap(year)))) {
         return false;
     }
 
@@ -193,7 +194,8 @@ bool TimestampValue::from_datetime_format_str(const char* value, int value_len, 
     uint8_t minute = minute1 * 10 + minute2;
     uint8_t second = second1 * 10 + second2;
 
-    if (month > 12 || (day > s_days_in_month[month] && (month != 2 || day != 29 || !date::is_leap(year))) ||
+    if (month == 0 || day == 0 || month > 12 ||
+        (day > s_days_in_month[month] && (month != 2 || day != 29 || !date::is_leap(year))) ||
         hour > 23 || minute > 59 || second > 59) {
         return false;
     }

--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -195,8 +195,8 @@ bool TimestampValue::from_datetime_format_str(const char* value, int value_len, 
     uint8_t second = second1 * 10 + second2;
 
     if (month == 0 || day == 0 || month > 12 ||
-        (day > s_days_in_month[month] && (month != 2 || day != 29 || !date::is_leap(year))) ||
-        hour > 23 || minute > 59 || second > 59) {
+        (day > s_days_in_month[month] && (month != 2 || day != 29 || !date::is_leap(year))) || hour > 23 ||
+        minute > 59 || second > 59) {
         return false;
     }
 

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/testutil/assert.h"
 #include "base/utility/defer_op.h"
 #include "column/binary_column.h"
 #include "column/column_builder.h"
@@ -1551,6 +1552,47 @@ TEST_F(TimeFunctionsTest, str_to_date_of_dateformat) {
         ASSERT_EQ(TimestampValue::create(2020, 3, 12, 0, 0, 0), nullable_col->get(4).get_timestamp());
         ASSERT_TRUE(nullable_col->is_null(5));
     }
+}
+
+TEST_F(TimeFunctionsTest, yearweek_invalid_str_to_date) {
+    FunctionContext* ctx = FunctionContext::create_test_context();
+    auto ptr = std::unique_ptr<FunctionContext>(ctx);
+
+    const char* fmt = "%Y-%m-%d";
+    const char* invalid_date = "0000-01-00";
+
+    Columns const_cols;
+    const_cols.emplace_back(nullptr);
+    const_cols.emplace_back(ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt, 1));
+    ctx->set_constant_columns(std::move(const_cols));
+    ASSERT_OK(TimeFunctions::str_to_date_prepare(ctx, FunctionContext::FRAGMENT_LOCAL));
+    DeferOp defer_close([&] { (void)TimeFunctions::str_to_date_close(ctx, FunctionContext::FRAGMENT_LOCAL); });
+
+    auto str_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(invalid_date, 1);
+    auto fmt_col = ColumnHelper::create_const_column<TYPE_VARCHAR>(fmt, 1);
+    Columns columns;
+    columns.emplace_back(str_col);
+    columns.emplace_back(fmt_col);
+
+    ColumnPtr date_result = TimeFunctions::str_to_date(ctx, columns).value();
+    if (date_result->is_constant()) {
+        date_result = ColumnHelper::as_column<ConstColumn>(date_result)->data_column();
+    }
+    ASSERT_TRUE(date_result->is_nullable());
+    auto nullable_date = ColumnHelper::as_column<NullableColumn>(date_result);
+    ASSERT_EQ(1, nullable_date->size());
+    ASSERT_TRUE(nullable_date->is_null(0));
+
+    Columns yearweek_columns;
+    yearweek_columns.emplace_back(nullable_date);
+    ColumnPtr yearweek_result = TimeFunctions::year_week_with_default_mode(ctx, yearweek_columns).value();
+    if (yearweek_result->is_constant()) {
+        yearweek_result = ColumnHelper::as_column<ConstColumn>(yearweek_result)->data_column();
+    }
+    ASSERT_TRUE(yearweek_result->is_nullable());
+    auto nullable_yearweek = ColumnHelper::as_column<NullableColumn>(yearweek_result);
+    ASSERT_EQ(1, nullable_yearweek->size());
+    ASSERT_TRUE(nullable_yearweek->is_null(0));
 }
 
 TEST_F(TimeFunctionsTest, str_to_date_of_datetimeformat) {

--- a/be/test/types/timestamp_value_test.cpp
+++ b/be/test/types/timestamp_value_test.cpp
@@ -151,4 +151,17 @@ TEST(TimestampValueTest, from_uncommon_format_str_microsecond) {
     }
 }
 
+TEST(TimestampValueTest, from_date_format_str_rejects_zero_day_or_month) {
+    TimestampValue ts;
+    const char* fmt = "%Y-%m-%d";
+    ASSERT_FALSE(ts.from_date_format_str("0000-01-00", 10, fmt));
+    ASSERT_FALSE(ts.from_date_format_str("0000-00-01", 10, fmt));
+    ASSERT_TRUE(ts.from_date_format_str("2020-01-01", 10, fmt));
+
+    TimestampValue ts2;
+    const char* dt_fmt = "%Y-%m-%d %H:%i:%s";
+    ASSERT_FALSE(ts2.from_datetime_format_str("0000-01-00 00:00:00", 19, dt_fmt));
+    ASSERT_TRUE(ts2.from_datetime_format_str("2020-01-01 00:00:00", 19, dt_fmt));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
yearweek(str_to_date('0000-01-00', '%Y-%m-%d')) can crash BE in ASAN/debug builds. The fast-path parsers in TimestampValue::from_date_format_str() and TimestampValue::from_datetime_format_str() accept month=0 or day=0, while the slow path already rejects them via check_date(). That inconsistency leads to an invalid internal date and triggers a DCHECK in TimeFunctions::compute_daynr().

## What I'm doing:

Reject month == 0 || day == 0 in the fast-path date/datetime parsers, consistent with check_date(). Invalid input such as 0000-01-00 now returns NULL instead of crashing, and yearweek() correctly propagates NULL.

Fixes https://github.com/StarRocks/starrocks/issues/78204

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
