### PR TITLE
be: fix whitespace in configbase

### DIFF
--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -1,3 +1,4 @@
+// poc/clang-format-probe
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
@@ -15,7 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <strings.h>
+#include   <strings.h>
 
 #include <algorithm>
 #include <cerrno>

--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -16,7 +16,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include   <strings.h>
+#include <strings.h>
 
 #include <algorithm>
 #include <cerrno>


### PR DESCRIPTION
Minor formatting cleanup in configbase.cpp.