### PR TITLE
[BugFix] (connector) Fix ClickhouseSchemaResolver varchar length to respect max_varchar_length

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -119,7 +119,7 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                 primitiveType = PrimitiveType.BOOLEAN;
                 break;
             case Types.VARCHAR:
-                return TypeFactory.createVarcharType(65533);
+                return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
             case Types.DATE:
                 primitiveType = PrimitiveType.DATE;
                 break;
@@ -145,7 +145,7 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                     return TypeFactory.createUnifiedDecimalType(precision, scale);
                 }
             case Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP_WITH_TIMEZONE:
-                return TypeFactory.createVarcharType(65533);
+                return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
@@ -22,6 +22,9 @@ import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -317,5 +320,25 @@ public class ClickhouseSchemaResolverTest {
 
         long count = resolver.getTableRowCount(connection, "testdb", "tbl1");
         Assertions.assertEquals(-1L, count, "Should return -1 when total_rows is NULL (e.g. Distributed engine)");
+    }
+
+    @Test
+    public void testConvertColumnTypeVarchar() {
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        Type type = resolver.convertColumnType(Types.VARCHAR, "String", 0, 0);
+        Assertions.assertTrue(type instanceof ScalarType);
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), ((ScalarType) type).getLength());
+    }
+
+    @Test
+    public void testConvertColumnTypeTimeWithTimezone() {
+        ClickhouseSchemaResolver resolver = new ClickhouseSchemaResolver(properties);
+        Type timeTzType = resolver.convertColumnType(Types.TIME_WITH_TIMEZONE, "DateTime64", 0, 0);
+        Assertions.assertTrue(timeTzType instanceof ScalarType);
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), ((ScalarType) timeTzType).getLength());
+
+        Type timestampTzType = resolver.convertColumnType(Types.TIMESTAMP_WITH_TIMEZONE, "DateTime64", 0, 0);
+        Assertions.assertTrue(timestampTzType instanceof ScalarType);
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), ((ScalarType) timestampTzType).getLength());
     }
 }


### PR DESCRIPTION
## Why I'm doing:
In `ClickhouseSchemaResolver.java`, type conversions for `Types.VARCHAR`, `Types.TIME_WITH_TIMEZONE`, and `Types.TIMESTAMP_WITH_TIMEZONE` hardcode `TypeFactory.createVarcharType(65533)`.

### Architectural Context & Why the Original Constraint Is No Longer Technically Valid:
1. **Legacy Constraint Origins**: The `65533` limit was originally inherited from early StarRocks / MySQL physical row-size constraints (65,535 bytes minus a 2-byte prefix) and early vectorized execution buffer assumptions where all variable-length strings were capped at 65KB.
2. **Obsolete Technical Barrier**: Since StarRocks 3.0, the core storage and vectorized execution engines support `VARCHAR(1048576)` dynamically configured via `Config.max_varchar_length` and exposed via `TypeFactory.getOlapMaxVarcharLength()`. Modern BE execution pipelines handle 1MB varchar allocations natively.
3. **Connector Parity**: Sibling JDBC connectors (`PostgresSchemaResolver`, `SqlServerSchemaResolver`) already resolve text columns using `TypeFactory.getOlapMaxVarcharLength()` and operate reliably in production. Retaining `65533` in `ClickhouseSchemaResolver` is legacy technical debt rather than a necessary architectural constraint.
4. **User Impact**: Because ClickHouse uses unbounded `String` types, the legacy `65533` constant artificially restricts ClickHouse tables to 65KB string lengths in StarRocks external catalogs, causing queries and ingestion to fail on strings between 65KB and 1MB even when clusters are configured for 1MB varchar capacity.

## What I'm doing:
1. Updated `ClickhouseSchemaResolver.java` to use `TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength())` for `Types.VARCHAR`, `Types.TIME_WITH_TIMEZONE`, and `Types.TIMESTAMP_WITH_TIMEZONE`.
2. Added unit tests in `ClickhouseSchemaResolverTest.java` verifying that `Types.VARCHAR`, `Types.TIME_WITH_TIMEZONE`, and `Types.TIMESTAMP_WITH_TIMEZONE` map dynamically to `TypeFactory.getOlapMaxVarcharLength()`.

Fixes #78209

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
