### PR TITLE
[BugFix] (connector) Support Elasticsearch 9.x cluster versions in ES connector

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsMajorVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsMajorVersion.java
@@ -50,7 +50,8 @@ public class EsMajorVersion {
     public static final EsMajorVersion V_6_X = new EsMajorVersion((byte) 6, "6.x");
     public static final EsMajorVersion V_7_X = new EsMajorVersion((byte) 7, "7.x");
     public static final EsMajorVersion V_8_X = new EsMajorVersion((byte) 8, "8.x");
-    public static final EsMajorVersion LATEST = V_7_X;
+    public static final EsMajorVersion V_9_X = new EsMajorVersion((byte) 9, "9.x");
+    public static final EsMajorVersion LATEST = V_9_X;
 
     public final byte major;
     private final String version;
@@ -85,6 +86,9 @@ public class EsMajorVersion {
     }
 
     public static EsMajorVersion parse(String version) throws StarRocksConnectorException {
+        if (version == null || version.isEmpty()) {
+            throw new StarRocksConnectorException("Elasticsearch version cannot be null or empty.");
+        }
         if (version.startsWith("0.")) {
             return new EsMajorVersion((byte) 0, version);
         }
@@ -103,9 +107,22 @@ public class EsMajorVersion {
         if (version.startsWith("7.")) {
             return new EsMajorVersion((byte) 7, version);
         }
-        // used for the next released ES version
         if (version.startsWith("8.")) {
             return new EsMajorVersion((byte) 8, version);
+        }
+        if (version.startsWith("9.")) {
+            return new EsMajorVersion((byte) 9, version);
+        }
+        try {
+            int dotIndex = version.indexOf('.');
+            if (dotIndex > 0) {
+                int major = Integer.parseInt(version.substring(0, dotIndex));
+                if (major >= 7 && major <= 127) {
+                    return new EsMajorVersion((byte) major, version);
+                }
+            }
+        } catch (NumberFormatException ignored) {
+            // fall through to exception
         }
         throw new StarRocksConnectorException("Unsupported/Unknown ES Cluster version [" + version + "]." +
                 "Highest supported version is [" + LATEST.version + "].");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsMajorVersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/elasticsearch/EsMajorVersionTest.java
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.elasticsearch;
+
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class EsMajorVersionTest {
+
+    @Test
+    public void testParseKnownVersions() {
+        Assertions.assertTrue(EsMajorVersion.parse("0.90.0").on(EsMajorVersion.V_0_X));
+        Assertions.assertTrue(EsMajorVersion.parse("1.7.0").on(EsMajorVersion.V_1_X));
+        Assertions.assertTrue(EsMajorVersion.parse("2.4.1").on(EsMajorVersion.V_2_X));
+        Assertions.assertTrue(EsMajorVersion.parse("5.6.16").on(EsMajorVersion.V_5_X));
+        Assertions.assertTrue(EsMajorVersion.parse("6.8.23").on(EsMajorVersion.V_6_X));
+        Assertions.assertTrue(EsMajorVersion.parse("7.17.0").on(EsMajorVersion.V_7_X));
+        Assertions.assertTrue(EsMajorVersion.parse("8.12.0").on(EsMajorVersion.V_8_X));
+    }
+
+    @Test
+    public void testParseEs9xVersion() {
+        EsMajorVersion v9 = EsMajorVersion.parse("9.5.2");
+        Assertions.assertEquals(9, v9.major);
+        Assertions.assertTrue(v9.on(EsMajorVersion.V_9_X));
+        Assertions.assertTrue(v9.onOrAfter(EsMajorVersion.V_7_X));
+        Assertions.assertTrue(v9.onOrAfter(EsMajorVersion.V_8_X));
+        Assertions.assertTrue(v9.after(EsMajorVersion.V_8_X));
+        Assertions.assertFalse(v9.before(EsMajorVersion.V_7_X));
+
+        EsMajorVersion v90 = EsMajorVersion.parse("9.0.0");
+        Assertions.assertEquals(9, v90.major);
+        Assertions.assertTrue(v90.on(EsMajorVersion.V_9_X));
+    }
+
+    @Test
+    public void testVersionComparisons() {
+        Assertions.assertTrue(EsMajorVersion.V_7_X.onOrAfter(EsMajorVersion.V_6_X));
+        Assertions.assertTrue(EsMajorVersion.V_8_X.onOrAfter(EsMajorVersion.V_7_X));
+        Assertions.assertTrue(EsMajorVersion.V_7_X.before(EsMajorVersion.V_8_X));
+        Assertions.assertTrue(EsMajorVersion.V_6_X.notOn(EsMajorVersion.V_7_X));
+    }
+
+    @Test
+    public void testParseInvalidVersionThrowsException() {
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> EsMajorVersion.parse("invalid_version"));
+        Assertions.assertThrows(StarRocksConnectorException.class, () -> EsMajorVersion.parse("3.0.0"));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
In `EsMajorVersion.java`, `EsMajorVersion.parse()` uses rigid prefix checks up to `8.` and pins `LATEST` to `7.x`. When connecting to an Elasticsearch 9.x cluster (such as `9.5.2`), the connector throws:
```
Unsupported/Unknown ES Cluster version [9.5.2]. Highest supported version is [7.x].
```
This causes all queries against Elasticsearch external catalog tables to fail unnecessarily.

## What I'm doing:
1. Added `V_9_X` to `EsMajorVersion.java` and updated `LATEST` to `V_9_X`.
2. Updated `EsMajorVersion.parse()` to recognize `9.x` clusters and dynamically support major versions `>= 7` so future releases do not trigger artificial version rejections.
3. Added comprehensive unit tests in `EsMajorVersionTest.java` verifying version parsing for `9.x` (`9.5.2`, `9.0.0`), comparison methods (`onOrAfter`, `before`, `after`), and invalid string handling.

Fixes #78266

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
