### PR TITLE
[BugFix] (mv) Enforce partition_ttl_number on incremental refresh for partitioned MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -90,14 +90,20 @@ public final class RangePartitionDiffer extends PartitionDiffer {
     public PartitionDiff diff(PCellSortedSet srcRangeMap,
                               PCellSortedSet dstRangeMap) {
         Map<String, PCell> adds = null;
+        PCellSortedSet prunedAdd;
         try {
-            PCellSortedSet prunedAdd = pruneAddedPartitions(srcRangeMap);
+            prunedAdd = pruneAddedPartitions(srcRangeMap);
             adds = diffRange(prunedAdd, dstRangeMap);
         } catch (Exception e) {
             LOG.warn("failed to prune partitions when creating");
             throw new RuntimeException(e);
         }
-        Map<String, PCell> deletes = diffRange(dstRangeMap, srcRangeMap);
+        PCellSortedSet targetDstRangeMap = dstRangeMap;
+        if (rangeToInclude != null) {
+            targetDstRangeMap = PCellSortedSet.of(dstRangeMap);
+            targetDstRangeMap.removeIf(p -> !isRangeIncluded(((PRangeCell) p.cell()).getRange(), rangeToInclude));
+        }
+        Map<String, PCell> deletes = diffRange(targetDstRangeMap, prunedAdd);
         return new PartitionDiff(PCellSortedSet.of(adds), PCellSortedSet.of(deletes));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorJdbcTest.java
@@ -415,4 +415,40 @@ public class PartitionBasedMvRefreshProcessorJdbcTest extends MVTestBase {
 
         starRocksAssert.dropMaterializedView(mvName);
     }
+
+    @Test
+    public void testRangePartitionWithPartitionTTLNumber() throws Exception {
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
+        MockedJDBCMetadata mockedJDBCMetadata =
+                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+        mockedJDBCMetadata.initPartitions();
+
+        String mvName = "mv_with_partition_ttl_number";
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW " + mvName + "\n" +
+                "PARTITION BY (`d`)\n" +
+                "DISTRIBUTED BY HASH(`a`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"partition_ttl_number\" = \"2\"\n" +
+                ")\n" +
+                "AS SELECT `a`, `b`, `c`, `d`  FROM `jdbc0`.`partitioned_db0`.`tbl0`;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(testDb.getFullName(), mvName));
+
+        // initial refresh: tbl0 has date partitions. TTL=2 keeps 2 partitions.
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " with sync mode");
+        Assertions.assertEquals(2, materializedView.getPartitions().size());
+
+        // add a new partition and refresh incrementally
+        mockedJDBCMetadata.addPartitions();
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " with sync mode");
+
+        // incremental refresh must trim the oldest partition and retain at most 2 partitions
+        Assertions.assertEquals(2, materializedView.getPartitions().size());
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
In `RangePartitionDiffer.java`, `RangePartitionDiffer.diff()` calculated `deletes` as `diffRange(dstRangeMap, srcRangeMap)`.
Because `srcRangeMap` represents un-pruned base table partitions that still contain older partition ranges, existing materialized view partitions (`dstRangeMap`) were never marked for deletion during subsequent incremental refresh passes even after exceeding `partition_ttl_number` or `partition_ttl`.

As a result, while initial MV creation correctly trimmed to the latest N partitions, incremental refresh failed to drop expired partitions, allowing the partition count to grow unbounded past `partition_ttl_number`.

## What I'm doing:
1. Updated `RangePartitionDiffer.diff()` to compute partition deletes against `prunedAdd` (the TTL-pruned partition set) rather than un-pruned `srcRangeMap`.
2. Filtered `targetDstRangeMap` by `rangeToInclude` so partial range refresh operations do not drop partitions outside the requested execution window.
3. Added unit test `testRangePartitionWithPartitionTTLNumber` in `PartitionBasedMvRefreshProcessorJdbcTest.java` verifying that subsequent incremental refreshes prune the oldest partitions down to `partition_ttl_number`.

Fixes #71972

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
