### PR TITLE
[BugFix] (privilege) Apply Ranger column masking and row filtering to PREPARE and PIVOT queries

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -28,6 +28,14 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
         return null;
     }
 
+    @Override
+    public R visitPrepareStatement(PrepareStmt statement, C context) {
+        if (statement.getInnerStmt() != null) {
+            visit(statement.getInnerStmt(), context);
+        }
+        return null;
+    }
+
     // ------------------------------------------- DML Statement -------------------------------------------------------
 
     @Override
@@ -198,6 +206,14 @@ public class AstTraverser<R, C> implements AstVisitorExtendInterface<R, C> {
     @Override
     public R visitView(ViewRelation node, C context) {
         return visit(node.getQueryStatement(), context);
+    }
+
+    @Override
+    public R visitPivotRelation(PivotRelation node, C context) {
+        if (node.getQuery() != null) {
+            visit(node.getQuery(), context);
+        }
+        return null;
     }
 
     // ------------------------------------------- Expression --------------------------------==------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/ranger/RangerInterfaceTest.java
@@ -902,4 +902,44 @@ public class RangerInterfaceTest {
         Assertions.assertFalse(scanColumns.containsKey(null),
                 "scanColumns must NOT contain a null key (silent drop guard). Got: " + scanColumns);
     }
+
+    @Test
+    public void testAstTraverserSetsNeedRewrittenByPolicyOnPrepareStmt() throws Exception {
+        String sql = "PREPARE p1 FROM 'SELECT v1, v2 FROM db.t1 WHERE k1 = ?'";
+        StatementBase stmt = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+
+        List<Relation> relations = Lists.newArrayList();
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitRelation(Relation relation, Void context) {
+                relation.setNeedRewrittenByPolicy(true);
+                relations.add(relation);
+                return null;
+            }
+        }.visit(stmt);
+
+        Assertions.assertFalse(relations.isEmpty(), "AstTraverser must visit relations inside PrepareStmt");
+        Assertions.assertTrue(relations.get(0).isNeedRewrittenByPolicy(),
+                "Relations inside PrepareStmt must have needRewrittenByPolicy set to true");
+    }
+
+    @Test
+    public void testAstTraverserSetsNeedRewrittenByPolicyOnPivot() throws Exception {
+        String sql = "SELECT * FROM db.t1 PIVOT (SUM(v1) FOR v2 IN (1, 2))";
+        StatementBase stmt = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+
+        List<Relation> relations = Lists.newArrayList();
+        new AstTraverser<Void, Void>() {
+            @Override
+            public Void visitRelation(Relation relation, Void context) {
+                relation.setNeedRewrittenByPolicy(true);
+                relations.add(relation);
+                return null;
+            }
+        }.visit(stmt);
+
+        Assertions.assertFalse(relations.isEmpty(), "AstTraverser must visit relations inside Pivot");
+        Assertions.assertTrue(relations.stream().allMatch(Relation::isNeedRewrittenByPolicy),
+                "Relations inside Pivot must have needRewrittenByPolicy set to true");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
In `ConnectProcessor.java`, `AstTraverser` traverses the statement AST to set `relation.setNeedRewrittenByPolicy(true)` so that `SecurityPolicyRewriteRule` can apply Ranger column masking and row-level access control filters.

However, `AstTraverser` did not override `visitPrepareStatement` or `visitPivotRelation`. As a result:
1. When queries ran through `PREPARE / EXECUTE` (including standard JDBC connections with `useServerPrepStmts=true`), the traversal stopped at `PrepareStmt` without descending into `innerStmt`.
2. When queries contained `PIVOT`, the traversal stopped at `PivotRelation` without descending into `query`.

Because `needRewrittenByPolicy` remained `false`, `SecurityPolicyRewriteRule` was bypassed, returning clear-text unmasked data and unfiltered rows to prepared statement clients.

## What I'm doing:
1. Overrode `visitPrepareStatement` in `AstTraverser.java` to traverse `statement.getInnerStmt()`.
2. Overrode `visitPivotRelation` in `AstTraverser.java` to traverse `node.getQuery()`.
3. Added unit tests `testAstTraverserSetsNeedRewrittenByPolicyOnPrepareStmt` and `testAstTraverserSetsNeedRewrittenByPolicyOnPivot` in `RangerInterfaceTest.java` verifying that relations inside `PREPARE` statements and `PIVOT` clauses are properly marked for security policy evaluation.

Fixes #78176
Fixes #78174

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
