### PR TITLE
[BugFix] Use DecimalV2's fixed precision when building storage agg-func aggregators

### DIFF
--- a/be/src/storage_primitive/column_aggregate_func.cpp
+++ b/be/src/storage_primitive/column_aggregate_func.cpp
@@ -32,6 +32,7 @@
 #include "runtime/runtime_state.h"
 #include "storage_primitive/aggregate_type.h"
 #include "storage_primitive/column_aggregator.h"
+#include "types/decimalv2_value.h"
 #include "types/percentile_value.h"
 #include "types/type_descriptor.h"
 
@@ -501,8 +502,17 @@ StatusOr<ColumnAggregatorPtr> ColumnAggregatorFactory::create_value_column_aggre
         }
         // The storage aggregate functions above take the column type as both their argument and
         // return type.
-        auto type_desc = TypeDescriptor::from_logical_type(normalized_tpe, TypeDescriptor::MAX_VARCHAR_LENGTH,
-                                                           field->type()->precision(), field->type()->scale());
+        // DECIMALV2 has a fixed precision/scale that its scalar TypeInfo does not carry, so it
+        // reports -1 for both. Fall back to the DecimalV2 constants instead of feeding an invalid
+        // precision into TypeDescriptor.
+        auto precision = field->type()->precision();
+        auto scale = field->type()->scale();
+        if (normalized_tpe == TYPE_DECIMALV2 && precision < 0) {
+            precision = DecimalV2Value::PRECISION;
+            scale = DecimalV2Value::SCALE;
+        }
+        auto type_desc =
+                TypeDescriptor::from_logical_type(normalized_tpe, TypeDescriptor::MAX_VARCHAR_LENGTH, precision, scale);
         return std::make_unique<AggFuncBasedValueAggregator>(agg_func, type_desc,
                                                              std::vector<TypeDescriptor>{type_desc});
     }


### PR DESCRIPTION
## Why I'm doing:

`AggregateIteratorTest.agg_max` crashes in a debug build:

```
[ RUN      ] AggregateIteratorTest.agg_max
F20260829 03:18:06.632398 139629139041408 type_descriptor.h:163] Check failed: precision >= 0 (-1 vs. 0)
```

The aggregate column `c5` is a `TYPE_DECIMALV2` field. `TYPE_DECIMALV2` is a scalar field type
(`is_scalar_field_type()` returns true for it), so `get_type_info()` always hands back the
precision-less `ScalarTypeInfo` regardless of the precision/scale the `Field` was built with, and
the base `TypeInfo::precision()`/`scale()` report `-1`.

`ColumnAggregatorFactory::create_value_column_aggregator()` passed those straight into
`TypeDescriptor::from_logical_type()`, which routes `TYPE_DECIMALV2` to
`create_decimalv2_type(-1, -1)` and trips `DCHECK_GE(precision, 0)`.

This is not test-only: because the precision is dropped inside `get_type_info()`, every
`DECIMALV2` value column with a storage aggregate method (MAX/MIN/REPLACE/...) takes the same
path. Debug builds abort; release builds silently build a `TypeDescriptor` with
`precision = -1, scale = -1` and hand it to the aggregate `FunctionContext`.

Introduced by #77097, which added the `TypeDescriptor` construction to this call site. The code
only exists on main, so no release branch is affected.

## What I'm doing:

Fall back to `DecimalV2Value::PRECISION`/`SCALE` (27/9) when the field's `TypeInfo` reports no
precision for `DECIMALV2`. Those are exactly the values `from_logical_type()` already uses as its
own default arguments, so this restores the intended type descriptor instead of forwarding an
invalid precision.

`TYPE_DECIMAL` is normalized to `TYPE_DECIMALV2` just above, so it is covered too. DecimalV3
types (`DECIMAL32`/`64`/`128`/`256`) are unaffected — they use `DecimalTypeInfo`, which carries a
real precision and scale.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
  - No new test needed: the existing `AggregateIteratorTest` cases already reproduce the crash
    and cover the fix — `agg_max`, `agg_min`, `agg_sum` and `agg_replace` each declare a
    `TYPE_DECIMALV2` value column with a storage aggregate method.
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

The offending call site was added on main by #77097 and does not exist on branch-4.1, branch-4.0,
or branch-3.5, so no backport is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
