### PR TITLE
[BugFix] Report DecimalV2's fixed precision and scale from its TypeInfo

### DIFF
--- a/be/src/types/type_info.cpp
+++ b/be/src/types/type_info.cpp
@@ -144,6 +144,12 @@ public:
 
     LogicalType type() const override { return _field_type; }
 
+    // DECIMALV2's precision and scale are fixed by the type itself rather than carried per column,
+    // so report them here. Every other scalar type has none of its own and keeps the base's -1.
+    int precision() const override { return _field_type == TYPE_DECIMALV2 ? DecimalV2Value::PRECISION : -1; }
+
+    int scale() const override { return _field_type == TYPE_DECIMALV2 ? DecimalV2Value::SCALE : -1; }
+
 protected:
     int _datum_cmp_impl(const Datum& left, const Datum& right) const override { return _datum_cmp(left, right); }
 


### PR DESCRIPTION
## Why I'm doing:

`AggregateIteratorTest.agg_max` aborts in a debug/ASAN build (which is what `run-be-ut.sh` uses by
default):

```
[ RUN      ] AggregateIteratorTest.agg_max
F20260829 03:18:06.632398 139629139041408 type_descriptor.h:163] Check failed: precision >= 0 (-1 vs. 0)
```

**Root cause.** `TYPE_DECIMALV2` is a scalar field type, so `get_type_info(type, precision, scale)`
takes the `is_scalar_field_type()` branch and returns the shared `ScalarTypeInfo` singleton,
discarding the precision/scale the caller passed. `ScalarTypeInfo` carried no precision of its own,
so `TypeInfo::precision()`/`scale()` fell through to the base class and reported `-1` for every
`DECIMALV2` column — in production as well as in tests. The `Field` constructor's `-1` default is
not the source: `StorageSchemaHelper::convert_field()` passes the real `TabletColumn` precision and
it is dropped just the same.

Callers that forward those values into a `TypeDescriptor` then reach
`create_decimalv2_type(-1, -1)`, which trips `DCHECK_GE(precision, 0)`. Two call sites do this:

- `ColumnAggregatorFactory::create_value_column_aggregator()` — aborts `AggregateIteratorTest`
  `agg_max` / `agg_min` / `agg_sum` today. (`agg_replace` takes the earlier `STORAGE_AGGREGATE_REPLACE`
  branch and is unaffected; `agg_decimal_key` uses DECIMALV2 as a key, so no value aggregator is built.)
- `TypeDescriptor::from_storage_type_info()` — reached from `ColumnExprPredicate`, i.e. predicate
  pushdown on a DECIMALV2 column fails the same way.

Introduced by #77097, which added the `TypeDescriptor` construction to the first call site. The
code only exists on main, so no release branch is affected.

**Severity, stated honestly.** DECIMALV2 is no longer the default — `Config.enable_decimal_v3` is
`true`, so `TypeFactory.createUnifiedDecimalType()` produces DecimalV3 for new columns. DECIMALV2
remains only in tables created before that default, or with `enable_decimal_v3` turned off. And in
a release build the invalid `TypeDescriptor` is currently inert: nothing on the storage aggregate
path reads precision (only `avg`/`distinct` do, and neither is a `StorageAggregateType`), and
DECIMALV2 is not in `lt_is_decimal`, so it never reaches the column builders that consume
precision. So the concrete damage today is the UT abort; the invalid state is a latent trap for
whoever next reads precision off that `FunctionContext`.

## What I'm doing:

Override `precision()`/`scale()` in `ScalarTypeInfo` to report
`DecimalV2Value::PRECISION`/`SCALE` for DECIMALV2 instead of inheriting the base's "not
applicable" `-1`. DecimalV2's precision and scale are properties of the type itself, not of the
column, so they belong in the type's own `TypeInfo`. Every other scalar type keeps the `-1`
default.

This fixes both call sites at the source rather than patching each one. Patching only
`column_aggregate_func.cpp` would leave the `from_storage_type_info()` path broken.

The values are derived from `_field_type` rather than stored in new members on purpose:
`ScalarTypeInfoResolver::get_type_info()` copy-constructs a fresh `ScalarTypeInfo` on the heap for
every `Field`, and `TabletSchema::_schema` keeps one per column for the lifetime of the schema, so
widening the object would grow resident memory that no `MemTracker` currently accounts for. This
way the object size is unchanged and the cost is a single comparison.

**Compatibility.** Checked, and this is a no-op for stored data and for existing logic:

- No code branches on `TypeInfo::precision()` as a sentinel (no `precision() == / < / > / !=`
  comparisons anywhere in `be/src`), so nothing keys off the `-1`.
- DecimalV3-only consumers are unreachable for DECIMALV2: `chunk_factory`'s decimal branches,
  `DecimalV3TypeConverter` (registered only for v3 type pairs — DECIMALV2 uses
  `DecimalTypeConverter`/`DecimalToDecimal12TypeConverter`, which ignore precision),
  `default_value_column_iterator` (dispatched only for DECIMAL32/64/128/256), and the precision
  comparison in `schema_change_utils.cpp` (guarded by `is_decimalv3_field_type`).
- The one persistence path, `DatumVariant::to_proto()` (lake tablet range / segment metadata), will
  write `precision = 27` instead of `-1` for DECIMALV2 keys. Round-trip is insensitive to it:
  `from_proto()` rebuilds the `TypeInfo` through `get_type_info()`, which drops precision again, and
  `tablet_range_helper` compares only `TypeDescriptor::type`, not precision. Rolling upgrade and
  downgrade both read either value identically.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
  - No new test needed: `AggregateIteratorTest.agg_max` / `agg_min` / `agg_sum` already reproduce
    the abort and cover the fix.
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

The offending call site was added on main by #77097 and does not exist on branch-4.1, branch-4.0,
or branch-3.5, so no backport is required.

---

Supersedes #78369, which patched only the `column_aggregate_func.cpp` call site. I will close that
one if this approach is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
