### PR TITLE
[Doc] fix typo configration -> configuration

### DIFF
--- a/contrib/starrocks-python-client/README.md
+++ b/contrib/starrocks-python-client/README.md
@@ -221,7 +221,7 @@ In `alembic.ini`, set the `sqlalchemy.url` to your StarRocks connection string.
 sqlalchemy.url = starrocks://root@localhost:9030/mydatabase
 ```
 
-It's better to print the log from this `starrocks-sqlalchemy` when runing alembic command. You can add following logging configration in the `alembic.ini` file.
+It's better to print the log from this `starrocks-sqlalchemy` when runing alembic command. You can add following logging configuration in the `alembic.ini` file.
 
 ```ini
 # alembic.ini


### PR DESCRIPTION
Corrects the misspelling `configration` -> `configuration` in `contrib/starrocks-python-client/README.md`.

Documentation only, no behaviour change.


## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5