### PR TITLE
[UT] Restore JIT verification in expr_test and fix JITCacheTest.cache

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -218,11 +218,7 @@ endif ()
 
 add_library(starrocks_test_objs OBJECT ${EXEC_FILES})
 target_link_libraries(starrocks_test_objs PRIVATE StarRocksPCH)
-if (NOT STARROCKS_JIT_ENABLE)
-    SET_TARGET_PROPERTIES(starrocks_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control -DSTARROCKS_EXPR_TEST_NO_JIT")
-else()
-    SET_TARGET_PROPERTIES(starrocks_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
-endif ()
+SET_TARGET_PROPERTIES(starrocks_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
 add_executable(starrocks_test test_main.cpp $<TARGET_OBJECTS:starrocks_test_objs> ${TEST_EXTRA_SOURCES})
 
 set(STARROCKS_TEST_LINK_LIBS ${TEST_LINK_LIBS})

--- a/be/test/data_sink/CMakeLists.txt
+++ b/be/test/data_sink/CMakeLists.txt
@@ -99,12 +99,7 @@ set(DATA_SINK_RESULT_TEST_FILES
 
 add_library(starrocks_data_sink_result_test_objs OBJECT ${DATA_SINK_RESULT_TEST_FILES})
 target_link_libraries(starrocks_data_sink_result_test_objs PRIVATE StarRocksPCH)
-if (NOT STARROCKS_JIT_ENABLE)
-    set_target_properties(starrocks_data_sink_result_test_objs PROPERTIES
-        COMPILE_FLAGS "-fno-access-control -DSTARROCKS_EXPR_TEST_NO_JIT")
-else()
-    set_target_properties(starrocks_data_sink_result_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
-endif()
+set_target_properties(starrocks_data_sink_result_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
 add_executable(data_sink_result_test
     ../test_main.cpp

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -100,6 +100,9 @@ set(EXPR_TEST_FILES
     unary_function_test.cpp
     vectorized_literal_test.cpp
 )
+if (STARROCKS_JIT_ENABLE)
+    list(APPEND EXPR_TEST_FILES jit_cache_test.cpp)
+endif()
 
 set(EXPR_JAVA_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
@@ -136,24 +139,14 @@ set(EXPR_TEST_LINK_LIBS
 
 add_library(starrocks_expr_test_objs OBJECT ${EXPR_TEST_FILES})
 target_link_libraries(starrocks_expr_test_objs PRIVATE StarRocksPCH)
-set_target_properties(starrocks_expr_test_objs PROPERTIES
-    COMPILE_FLAGS "-fno-access-control -DSTARROCKS_EXPR_TEST_NO_JIT")
+set_target_properties(starrocks_expr_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
-set(EXPR_TEST_OBJECTS $<TARGET_OBJECTS:starrocks_expr_test_objs>)
-if (STARROCKS_JIT_ENABLE)
-    add_library(starrocks_expr_jit_test_objs OBJECT jit_cache_test.cpp)
-    target_link_libraries(starrocks_expr_jit_test_objs PRIVATE StarRocksPCH)
-    set_target_properties(starrocks_expr_jit_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
-    list(APPEND EXPR_TEST_OBJECTS $<TARGET_OBJECTS:starrocks_expr_jit_test_objs>)
-endif()
-
-add_executable(expr_test expr_test_main.cpp ${EXPR_TEST_OBJECTS})
+add_executable(expr_test expr_test_main.cpp $<TARGET_OBJECTS:starrocks_expr_test_objs>)
 target_link_libraries(expr_test ${EXPR_TEST_LINK_LIBS})
 
 add_library(starrocks_expr_java_test_objs OBJECT ${EXPR_JAVA_TEST_FILES})
 target_link_libraries(starrocks_expr_java_test_objs PRIVATE StarRocksPCH)
-set_target_properties(starrocks_expr_java_test_objs PROPERTIES
-    COMPILE_FLAGS "-fno-access-control -DSTARROCKS_EXPR_TEST_NO_JIT")
+set_target_properties(starrocks_expr_java_test_objs PROPERTIES COMPILE_FLAGS "-fno-access-control")
 
 add_executable(expr_java_test expr_test_main.cpp $<TARGET_OBJECTS:starrocks_expr_java_test_objs>)
 target_link_libraries(expr_java_test ${EXPR_TEST_LINK_LIBS})

--- a/be/test/exprs/expr_test_main.cpp
+++ b/be/test/exprs/expr_test_main.cpp
@@ -25,6 +25,7 @@
 #include "common/system/cpu_info.h"
 #ifdef STARROCKS_JIT_ENABLE
 #include "common/system/mem_info.h"
+#include "exprs/jit/jit_engine.h"
 #include "runtime/runtime_env.h"
 #endif
 #include "types/time_types.h"
@@ -90,6 +91,13 @@ int main(int argc, char** argv) {
     auto runtime_env_status = starrocks::RuntimeEnv::GetInstance()->init(nullptr);
     if (!runtime_env_status.ok()) {
         fprintf(stderr, "failed to initialize RuntimeEnv: %s\n", runtime_env_status.to_string().c_str());
+        return 1;
+    }
+    // Production initializes the JIT engine in ExecEnv::init(). Without it support_jit() is
+    // false and every ExprsTestHelper::verify_with_jit() call silently skips the JIT path.
+    auto jit_status = starrocks::JITEngine::get_instance()->init();
+    if (!jit_status.ok()) {
+        fprintf(stderr, "failed to initialize JIT engine: %s\n", jit_status.to_string().c_str());
         return 1;
     }
 #endif

--- a/be/test/exprs/exprs_test_helper.h
+++ b/be/test/exprs/exprs_test_helper.h
@@ -20,7 +20,7 @@
 #include "column/chunk.h"
 #include "exprs/array_expr.h"
 #include "exprs/expr_executor.h"
-#ifndef STARROCKS_EXPR_TEST_NO_JIT
+#ifdef STARROCKS_JIT_ENABLE
 #include "exprs/jit/jit_expr.h"
 #endif
 #include "gen_cpp/Descriptors_types.h"
@@ -160,7 +160,7 @@ public:
         // Verify the original result.
         test_func(ptr);
 
-#ifdef STARROCKS_EXPR_TEST_NO_JIT
+#ifndef STARROCKS_JIT_ENABLE
         (void)expr;
         (void)runtime_state;
         (void)need_jit;
@@ -194,7 +194,7 @@ public:
     }
 
     static bool should_verify_with_jit(const Expr* expr, RuntimeState* runtime_state) {
-#ifdef STARROCKS_EXPR_TEST_NO_JIT
+#ifndef STARROCKS_JIT_ENABLE
         (void)expr;
         (void)runtime_state;
         return false;
@@ -204,7 +204,7 @@ public:
     }
 
     static void verify_result_with_jit(const ColumnPtr& ptr, Expr* expr, RuntimeState* runtime_state) {
-#ifdef STARROCKS_EXPR_TEST_NO_JIT
+#ifndef STARROCKS_JIT_ENABLE
         (void)ptr;
         (void)expr;
         (void)runtime_state;

--- a/be/test/exprs/jit_cache_test.cpp
+++ b/be/test/exprs/jit_cache_test.cpp
@@ -38,6 +38,12 @@ public:
         expr_node.type = gen_type_desc(TPrimitiveType::INT);
         engine = JITEngine::get_instance();
         engine->init();
+        // Other suites in this binary may have compiled the same expressions already;
+        // the test asserts on cache misses, so start from an empty callable cache.
+        auto* cache = engine->get_callable_cache();
+        auto capacity = cache->get_capacity();
+        cache->set_capacity(0);
+        cache->set_capacity(capacity);
     }
 
 public:


### PR DESCRIPTION
JITCacheTest.cache has failed since #75772 moved jit_cache_test.cpp into expr_test (then expr_core_test). ExprsTestHelper::verify_with_jit() is an inline header function whose body is selected by a per-target macro, STARROCKS_EXPR_TEST_NO_JIT. The main expr_test object library was built with that macro and jit_cache_test.cpp without it, so two different bodies of the same weak symbol were linked into one binary and the linker kept the no-op stub. Nothing was ever JIT-compiled, engine->lookup() found no cached callable, and the test failed at its "cached" assertion. The same stub also silently disabled the JIT-vs-interpreter cross-checks in the arithmetic, binary predicate, case, cast and compound predicate tests.

Gate the helper on the build-wide STARROCKS_JIT_ENABLE instead, which is what decides whether the JIT sources are compiled into Expr at all, and drop the per-target macro everywhere so every translation unit in a binary agrees. Fold jit_cache_test.cpp back into EXPR_TEST_FILES under the same condition and remove the separate object library.

expr_test_main.cpp never initialized JITEngine, unlike ExecEnv::init() in production, so support_jit() was false and verify_with_jit() still returned early for every suite except JITCacheTest. Initialize it in main() so the cross-checks actually exercise the JIT path.

JITCacheTest asserts on cache misses, and the arithmetic tests JIT the same TINYINT ADD expression earlier in the run, so flush the callable cache in SetUp() to make the test independent of ordering.

Verified with a DEBUG shared-data build: expr_test passes 2073/2073, with 57 distinct expressions now JIT-compiled where previously there were none, and a revived translation unit still compiles with STARROCKS_JIT_ENABLE undefined.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
