### PR TITLE
[BugFix] Disable Poco client for AWS SDK by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1402,7 +1402,7 @@ CONF_String(aws_sdk_logging_trace_level, "trace");
 CONF_Bool(aws_sdk_enable_compliant_rfc3986_encoding, "false");
 
 // use poco client to replace default curl client
-CONF_Bool(enable_poco_client_for_aws_sdk, "true");
+CONF_Bool(enable_poco_client_for_aws_sdk, "false");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/be/src/common/config_object_storage_fwd.h
+++ b/be/src/common/config_object_storage_fwd.h
@@ -95,7 +95,7 @@ CONF_String(aws_sdk_logging_trace_level, "trace");
 CONF_Bool(aws_sdk_enable_compliant_rfc3986_encoding, "false");
 
 // use poco client to replace default curl client
-CONF_Bool(enable_poco_client_for_aws_sdk, "true");
+CONF_Bool(enable_poco_client_for_aws_sdk, "false");
 
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");

--- a/docs/en/administration/configuration/BE_parameters/query_loading.md
+++ b/docs/en/administration/configuration/BE_parameters/query_loading.md
@@ -404,6 +404,15 @@ This topic introduces the following types of BE configurations:
 - Description: Timeout duration to establish socket connections with object storage. `-1` indicates to use the default timeout duration of the SDK configurations.
 - Introduced in: v3.0.9
 
+### enable_poco_client_for_aws_sdk
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: Whether to use the Poco HTTP client for the AWS SDK. `true` replaces the AWS SDK's default curl HTTP client with Poco. `false` uses the default curl client.
+- Introduced in: -
+
 ### object_storage_request_timeout_ms
 
 - Default: -1

--- a/docs/ja/administration/configuration/BE_parameters/query_loading.md
+++ b/docs/ja/administration/configuration/BE_parameters/query_loading.md
@@ -396,6 +396,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: オブジェクトストレージとのソケット接続を確立するためのタイムアウト期間。`-1` は、SDK構成のデフォルトのタイムアウト期間を使用することを示します。
 - 導入バージョン: v3.0.9
 
+### enable_poco_client_for_aws_sdk
+
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: いいえ
+- 説明: AWS SDK で Poco HTTP クライアントを使用するかどうかを指定します。`true` の場合、AWS SDK のデフォルトの curl HTTP クライアントを Poco に置き換えます。`false` の場合、デフォルトの curl クライアントを使用します。
+- 導入バージョン: -
+
 ### object_storage_request_timeout_ms
 
 - デフォルト: -1

--- a/docs/zh/administration/configuration/BE_parameters/query_loading.md
+++ b/docs/zh/administration/configuration/BE_parameters/query_loading.md
@@ -392,6 +392,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：对象存储 Socket 连接的超时时间。`-1` 表示使用 SDK 中的默认时间。
 - 引入版本：v3.0.9
 
+### enable_poco_client_for_aws_sdk
+
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否动态：否
+- 描述：是否为 AWS SDK 使用 Poco HTTP 客户端。`true` 表示使用 Poco 替换 AWS SDK 默认的 curl HTTP 客户端；`false` 表示使用默认的 curl 客户端。
+- 引入版本：-
+
 ### object_storage_request_timeout_ms
 
 - 默认值：-1


### PR DESCRIPTION
## Why I am doing:

Use the AWS SDK default HTTP client unless Poco is explicitly enabled. This makes the safer default available in main and the supported 4.1/4.0/3.5 branches.

## What I am doing:

- Change enable_poco_client_for_aws_sdk from true to false by default.
- Regenerate config_object_storage_fwd.h from the authoritative config declaration.
- Document the parameter and HTTP client selection behavior in English, Chinese, and Japanese.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Tested with:
- python3 build-support/extract_and_diff_params.py --new-params-only --diff-base upstream/main --output github-comment
- python3 build-support/gen_config_fwd_headers.py --check
- bash build-support/check_common_config_header_includes.sh
- python3 build-support/check_be_module_boundaries.py --mode full
- python3 build-support/render_be_agents.py --check

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5