### PR TITLE
[BugFix] Wrap map/array children in NullableColumn in ChunkFactory::column_from_field

### DIFF
--- a/be/src/column/chunk_factory.cpp
+++ b/be/src/column/chunk_factory.cpp
@@ -156,13 +156,15 @@ MutableColumnPtr ChunkFactory::column_from_field(const Field& field) {
     case TYPE_DECIMAL256:
         return NullableIfNeed(Decimal256Column::create(field.type()->precision(), field.type()->scale()));
     case TYPE_ARRAY: {
-        return NullableIfNeed(
-                ArrayColumn::create(ChunkFactory::column_from_field(field.sub_field(0)), UInt32Column::create()));
+        // ArrayColumn/MapColumn require nullable children, no matter how the sub-fields are declared.
+        auto elements = NullableColumn::wrap_if_necessary(ChunkFactory::column_from_field(field.sub_field(0)));
+        return NullableIfNeed(ArrayColumn::create(std::move(elements), UInt32Column::create()));
     }
-    case TYPE_MAP:
-        return NullableIfNeed(MapColumn::create(ChunkFactory::column_from_field(field.sub_field(0)),
-                                                ChunkFactory::column_from_field(field.sub_field(1)),
-                                                UInt32Column::create()));
+    case TYPE_MAP: {
+        auto keys = NullableColumn::wrap_if_necessary(ChunkFactory::column_from_field(field.sub_field(0)));
+        auto values = NullableColumn::wrap_if_necessary(ChunkFactory::column_from_field(field.sub_field(1)));
+        return NullableIfNeed(MapColumn::create(std::move(keys), std::move(values), UInt32Column::create()));
+    }
     case TYPE_STRUCT: {
         std::vector<std::string> names;
         MutableColumns fields;

--- a/be/test/column/chunk_factory_test.cpp
+++ b/be/test/column/chunk_factory_test.cpp
@@ -17,11 +17,14 @@
 #include <memory>
 #include <utility>
 
+#include "column/array_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/field.h"
+#include "column/map_column.h"
 #include "column/schema.h"
 #include "gtest/gtest.h"
+#include "gutil/casts.h"
 #include "types/type_info.h"
 
 namespace starrocks {
@@ -45,13 +48,27 @@ TEST(ChunkFactoryTest, column_from_field) {
     auto array_column = ChunkFactory::column_from_field(array_field);
     ASSERT_TRUE(array_column->is_nullable());
     ASSERT_TRUE(ColumnHelper::get_data_column(array_column.get())->is_array());
+    array_column->check_or_die();
 
+    // The element sub-field is declared NOT NULL, but the elements column must still be nullable.
+    Field array_field_with_not_null_element(1, "array_col2", get_array_type_info(get_type_info(TYPE_INT)), true);
+    array_field_with_not_null_element.add_sub_field(Field(1, "item", TYPE_INT, false));
+    auto array_column2 = ChunkFactory::column_from_field(array_field_with_not_null_element);
+    auto* array_data2 = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(array_column2.get()));
+    ASSERT_TRUE(array_data2->elements_column()->is_nullable());
+    array_column2->check_or_die();
+
+    // Map keys are always declared NOT NULL in the tablet schema, but the keys column must still be nullable.
     Field map_field(2, "map_col", get_map_type_info(get_type_info(TYPE_INT), get_type_info(TYPE_VARCHAR)), true);
     map_field.add_sub_field(Field(2, "key", TYPE_INT, false));
     map_field.add_sub_field(Field(2, "value", TYPE_VARCHAR, true));
     auto map_column = ChunkFactory::column_from_field(map_field);
     ASSERT_TRUE(map_column->is_nullable());
     ASSERT_TRUE(ColumnHelper::get_data_column(map_column.get())->is_map());
+    auto* map_data = down_cast<MapColumn*>(ColumnHelper::get_data_column(map_column.get()));
+    ASSERT_TRUE(map_data->keys_column()->is_nullable());
+    ASSERT_TRUE(map_data->values_column()->is_nullable());
+    map_column->check_or_die();
 
     Field struct_field(3, "struct_col", get_struct_type_info({get_type_info(TYPE_INT), get_type_info(TYPE_VARCHAR)}),
                        true);


### PR DESCRIPTION
## Why I'm doing:

`MapColumn` and `ArrayColumn` require their children to be nullable columns; both constructors assert it (`map_column.cpp`: `DCHECK(_keys->is_nullable())` / `DCHECK(_values->is_nullable())`, `array_column.cpp`: `DCHECK(_elements->is_nullable())`), and `check_or_die()` re-checks it.

`ChunkFactory::column_from_field()` passed the child columns straight into `MapColumn::create()` / `ArrayColumn::create()`, so a sub-field declared NOT NULL produced a non-nullable child and broke that invariant. Map keys are always NOT NULL in the tablet schema (`StorageSchemaHelper::convert_field` derives sub-field nullability from the sub-column), so this is reachable from real schemas, not just tests.

The pooled construction path in the same file (`ColumnPtrBuilder`) already wraps the children with `NullableColumn::wrap_if_necessary()` — that wrapping was added together with the assertions in #17483, but `column_from_field` was missed at the time, and the helper was later moved verbatim into `ChunkFactory`. The two construction paths have disagreed ever since.

Symptom in a DCHECK-enabled (DEBUG/ASAN) build:

```
[ RUN      ] ChunkFactoryTest.column_from_field
F map_column.cpp:72] Check failed: _keys->is_nullable()
```

Release builds compile the DCHECKs out (`-DNDEBUG`), so there the invariant was violated silently.

## What I'm doing:

- `ChunkFactory::column_from_field()`: wrap map keys/values and array elements with `NullableColumn::wrap_if_necessary()`, matching `ColumnPtrBuilder`. The ARRAY branch had the same latent defect; it is fixed too.
- Strengthen `ChunkFactoryTest.column_from_field` to assert the children really are nullable and to call `check_or_die()`, plus a new case for an array whose element sub-field is declared NOT NULL.

No user-visible behavior change: this only restores the column-shape invariant that the rest of the code (and the other construction path) already assumes.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport labels checked: the failure only shows up in DCHECK-enabled builds, and on release branches the same code still lives in `ChunkHelper::column_from_field`, so a backport would not apply cleanly. Happy to add labels and a manual backport if reviewers want it.
