### PR TITLE
[UT] Honor nullable-child and cursor-priming contracts in BE tests

### DIFF
--- a/be/test/column/chunk_factory_test.cpp
+++ b/be/test/column/chunk_factory_test.cpp
@@ -47,7 +47,7 @@ TEST(ChunkFactoryTest, column_from_field) {
     ASSERT_TRUE(ColumnHelper::get_data_column(array_column.get())->is_array());
 
     Field map_field(2, "map_col", get_map_type_info(get_type_info(TYPE_INT), get_type_info(TYPE_VARCHAR)), true);
-    map_field.add_sub_field(Field(2, "key", TYPE_INT, false));
+    map_field.add_sub_field(Field(2, "key", TYPE_INT, true));
     map_field.add_sub_field(Field(2, "value", TYPE_VARCHAR, true));
     auto map_column = ChunkFactory::column_from_field(map_field);
     ASSERT_TRUE(map_column->is_nullable());

--- a/be/test/column/raw_data_visitor_test.cpp
+++ b/be/test/column/raw_data_visitor_test.cpp
@@ -54,8 +54,8 @@ TEST(MutableRawDataVisitorTest, VisitDecimal32Column) {
 
 TEST(MutableRawDataVisitorTest, VisitArrayColumn) {
     MutableRawDataVisitor visitor;
-    // Array of int32: [[42, 7]]
-    auto elements = ColumnTestHelper::build_column<int32_t>({42, 7});
+    // Array of int32: [[42, 7]]. ArrayColumn requires nullable elements.
+    auto elements = ColumnTestHelper::build_nullable_column<int32_t>({42, 7});
     auto offsets = ColumnTestHelper::build_column<uint32_t>({0, 2});
     auto col = ArrayColumn::create(std::move(elements), std::move(offsets));
 
@@ -200,8 +200,8 @@ TEST(RawBytesVisitorTest, VisitConstColumn) {
 
 TEST(RawBytesVisitorTest, VisitArrayColumn) {
     RawBytesVisitor visitor;
-    // Array of int32: [[42, 7]]
-    auto elements = ColumnTestHelper::build_column<int32_t>({42, 7});
+    // Array of int32: [[42, 7]]. ArrayColumn requires nullable elements.
+    auto elements = ColumnTestHelper::build_nullable_column<int32_t>({42, 7});
     auto offsets = ColumnTestHelper::build_column<uint32_t>({0, 2});
     auto col = ArrayColumn::create(std::move(elements), std::move(offsets));
 

--- a/be/test/compute_env/sorting/sorting_test.cpp
+++ b/be/test/compute_env/sorting/sorting_test.cpp
@@ -226,6 +226,9 @@ protected:
 
         CascadeChunkMerger merger(_runtime_state.get());
         CHECK_OK(merger.init(providers, &_sort_exprs, sort_desc));
+        // Priming the cursors is part of the contract: SimpleChunkSortCursor::try_get_next() requires it, and
+        // both merge_sorted_cursor_cascade() and spill::OrderedInputStream::is_ready() call it before consuming.
+        CHECK(merger.is_data_ready());
 
         std::vector<int32_t> ids;
         std::atomic<bool> eos{false};


### PR DESCRIPTION
Three backend unit tests built their fixtures in ways that violate invariants the production code asserts, so they only survived because the assertions are compiled out in release builds.

RawDataVisitor's two VisitArrayColumn cases handed ArrayColumn::create() a plain Int32Column. Both the ArrayColumn constructor and check_or_die() DCHECK that the element column is nullable, so a debug build aborts before the visitor is ever exercised. Build the elements through build_nullable_column() instead, and note the requirement in the comment so the next fixture does not repeat it.

The CascadeChunkMerger fixture in sorting_test consumed the merger without first calling is_data_ready(). Priming is part of the cursor contract: SimpleChunkSortCursor::try_get_next() DCHECKs _data_ready, and every production caller - merge_sorted_cursor_cascade() and spill::OrderedInputStream::is_ready() - primes before consuming. Add the missing CHECK(is_data_ready()) so the test drives the merger the same way production does.

Finally, declare the map key sub-field in ChunkFactoryTest as nullable. MapColumn DCHECKs that keys and values are nullable; ChunkFactory happens to wrap them via NullableColumn::wrap_if_necessary(), but a fixture that asks for a non-nullable map key describes a column that cannot exist.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
