### PR TITLE
[Tool] run-name quote + rebuild backport section

### DIFF
--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -1,5 +1,5 @@
 name: Repo Sync
-run-name: Repo Sync(CD PR #${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])
+run-name: "Repo Sync(CD PR #${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])"
 
 # Reverse sync executor (CD -> SR), MAIN ONLY. Cherry-pick a CelerData open-source PR's
 # commit onto StarRocks `main` and open a NATIVE-looking SR PR. Dispatched by TSP's

--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -184,24 +184,30 @@ jobs:
           labels="${labels},${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}"
           echo "BASE_LABELS=${labels}" >> $GITHUB_OUTPUT
 
-      # pr-checker.yml is authoritative for version labels: it ADDS/REMOVES `<version>` labels
-      # from the PR body's `[x]/[ ] <version>` rows and FAILS if "I have checked the version
-      # labels" is left unchecked. The copied source body has those rows unchecked, which would
-      # strip the backport labels above and fail native CI. Rewrite the body so exactly the
-      # requested versions (BACKPORT_BRANCHES) are checked and the acknowledgement row is checked.
-      - name: sync backport checkboxes in body
+      # Rebuild the "Bugfix cherry-pick branch check" section for StarRocks. The source body's
+      # section is dropped by get_pr_info's scrub (it carries CelerData-only versions like 26.2),
+      # so we append a fresh section reflecting BACKPORT_BRANCHES. pr-checker.yml is authoritative
+      # for version labels: it ADDS/REMOVES <version> labels from these rows and FAILS if
+      # "I have checked the version labels" is unchecked — so the target versions must be [x] and
+      # the acknowledgement row checked, letting native CI pass and mergify auto-backport on merge.
+      - name: rebuild backport section in body
         run: |
           F="/var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt"
           [ -f "$F" ] || exit 0
-          sed -i 's/\[ \] I have checked the version labels/[x] I have checked the version labels/' "$F"
-          for v in 4.1 4.0 3.5 3.4 3.3; do          # uncheck all known version rows first
-            vr=${v//./\\.}
-            sed -i "s/\[x\] ${vr}/[ ] ${v}/g" "$F"
-          done
-          for b in $(echo "${{ inputs.BACKPORT_BRANCHES }}" | tr ',' ' '); do
-            v="${b#branch-}"; vr=${v//./\\.}
-            [ -n "$v" ] && sed -i "s/\[ \] ${vr}/[x] ${v}/g" "$F"
-          done
+          # drop any existing section (to EOF — it is the last template section), then append a clean one
+          sed -i '/^##[[:space:]]*Bugfix cherry-pick branch check:/,$d' "$F"
+          {
+            echo ""
+            echo "## Bugfix cherry-pick branch check:"
+            echo "- [x] I have checked the version labels which the pr will be auto-backported to the target branch"
+            for v in 4.1 4.0 3.5 3.4 3.3; do
+              mark=" "
+              for b in $(echo "${{ inputs.BACKPORT_BRANCHES }}" | tr ',' ' '); do
+                [ "${b#branch-}" = "$v" ] && mark="x"
+              done
+              echo "  - [${mark}] ${v}"
+            done
+          } >> "$F"
 
       # Create the SR PR directly (no pending/ordering — native review + rebase handle
       # file-overlap ordering; the sync-based pending machinery is retired for this flow).

--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -184,30 +184,30 @@ jobs:
           labels="${labels},${{ steps.cherry-pick.outputs.LABEL }}${{ steps.cherry-pick.outputs.CONFLICT_LABEL }}"
           echo "BASE_LABELS=${labels}" >> $GITHUB_OUTPUT
 
-      # Rebuild the "Bugfix cherry-pick branch check" section for StarRocks. The source body's
-      # section is dropped by get_pr_info's scrub (it carries CelerData-only versions like 26.2),
-      # so we append a fresh section reflecting BACKPORT_BRANCHES. pr-checker.yml is authoritative
-      # for version labels: it ADDS/REMOVES <version> labels from these rows and FAILS if
-      # "I have checked the version labels" is unchecked — so the target versions must be [x] and
-      # the acknowledgement row checked, letting native CI pass and mergify auto-backport on merge.
+      # Rebuild the "Bugfix cherry-pick branch check" section for StarRocks. get_pr_info's scrub
+      # drops the source body's section (it carries CelerData-only versions like 26.2). Take the
+      # authoritative version list from StarRocks' own PR TEMPLATE (so CD-only branches never leak
+      # and the list stays in sync with SR), then check the intersection with BACKPORT_BRANCHES.
+      # pr-checker.yml syncs <version> labels from these rows and fails if the acknowledgement row
+      # is unchecked — so target versions must be [x], letting native CI pass + mergify backport.
       - name: rebuild backport section in body
         run: |
           F="/var/local/env/body/${{ github.repository }}/${{ inputs.PR_ID }}.txt"
+          TPL="${{ github.workspace }}/.github/PULL_REQUEST_TEMPLATE.md"
           [ -f "$F" ] || exit 0
-          # drop any existing section (to EOF — it is the last template section), then append a clean one
+          # drop the source body's (scrubbed/CD) section, which runs to EOF
           sed -i '/^##[[:space:]]*Bugfix cherry-pick branch check:/,$d' "$F"
-          {
-            echo ""
-            echo "## Bugfix cherry-pick branch check:"
-            echo "- [x] I have checked the version labels which the pr will be auto-backported to the target branch"
-            for v in 4.1 4.0 3.5 3.4 3.3; do
-              mark=" "
-              for b in $(echo "${{ inputs.BACKPORT_BRANCHES }}" | tr ',' ' '); do
-                [ "${b#branch-}" = "$v" ] && mark="x"
-              done
-              echo "  - [${mark}] ${v}"
+          # append StarRocks' own section (version list = the template's), then check the
+          # acknowledgement row + the versions that intersect BACKPORT_BRANCHES
+          if [ -f "$TPL" ]; then
+            echo "" >> "$F"
+            sed -n '/^##[[:space:]]*Bugfix cherry-pick branch check:/,$p' "$TPL" >> "$F"
+            sed -i 's/\[ \] I have checked the version labels/[x] I have checked the version labels/' "$F"
+            for b in $(echo "${{ inputs.BACKPORT_BRANCHES }}" | tr ',' ' '); do
+              v="${b#branch-}"; vr=${v//./\\.}
+              [ -n "$v" ] && sed -i "s/\[ \] ${vr}/[x] ${v}/g" "$F"
             done
-          } >> "$F"
+          fi
 
       # Create the SR PR directly (no pending/ordering — native review + rebase handle
       # file-overlap ordering; the sync-based pending machinery is retired for this flow).


### PR DESCRIPTION
## Why I'm doing:

Two defects in the reverse-sync executor surfaced by a test dispatch
1. `run-name` was silently truncated to `Repo Sync(` because an unquoted ` #` starts a YAML comment, dropping `#<PR_ID> [<BRANCH>]` (the scheduled dispatcher matches this run-name for in-flight de-dup).
2. `get_pr_info`'s scrub drops the whole "Bugfix cherry-pick branch check" section (it carries CelerData-only versions like `26.2`), so the synced SR PR had no backport checkboxes — not native, and it relied on the label step alone.

## What I'm doing:

1. Quote the `run-name` string so `#` is literal.
2. Rebuild the backport section: take the version list from StarRocks' own `.github/PULL_REQUEST_TEMPLATE.md` and check the intersection with `BACKPORT_BRANCHES` (CD-only versions never leak; the list stays in sync with the template). pr-checker then keeps the version labels, native CI passes, and mergify auto-backports on merge.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5