### PR TITLE
[BugFix] Fix missing rows for Iceberg and Paimon LIKE patterns with _ or an escape

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -336,7 +336,12 @@ public class ScalarOperatorToIcebergExpr {
                     if (literal == null) {
                         return null;
                     }
-                    if (literal.indexOf("%") == literal.length() - 1) {
+                    // startsWith compares the prefix against the file bounds as a plain string, so a pattern
+                    // still holding SQL wildcards prunes data files that do hold matching rows: '_' matches
+                    // any single character, and '\' escapes the character behind it, including a trailing
+                    // '%' that is then not a wildcard at all. FlussPredicateConverter rejects the same two.
+                    if (literal.indexOf("%") == literal.length() - 1
+                            && literal.indexOf('_') < 0 && literal.indexOf('\\') < 0) {
                         return startsWith(columnName, literal.substring(0, literal.length() - 1));
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -220,7 +220,12 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, P
                     return null;
                 }
                 String literal = ((BinaryString) objectLiteral).toString();
-                if (literal.length() > 1 && literal.indexOf("%") == literal.length() - 1 && literal.charAt(0) != '%') {
+                // startsWith compares the prefix against the file statistics as a plain string, so a pattern
+                // still holding SQL wildcards prunes data files that do hold matching rows: '_' matches any
+                // single character, and '\' escapes the character behind it, including a trailing '%' that is
+                // then not a wildcard at all. FlussPredicateConverter rejects the same two.
+                if (literal.length() > 1 && literal.indexOf("%") == literal.length() - 1 && literal.charAt(0) != '%'
+                        && literal.indexOf('_') < 0 && literal.indexOf('\\') < 0) {
                     return builder.startsWith(idx, BinaryString.fromString(literal.substring(0, literal.length() - 1)));
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergExprVisitorTest.java
@@ -561,4 +561,38 @@ public class IcebergExprVisitorTest {
                 context);
         Assertions.assertEquals(Expression.Operation.TRUE, convertedExpr.op());
     }
+
+    @Test
+    public void testLikePrefixPushdownRejectsWildcardsAndEscapes() {
+        ScalarOperatorToIcebergExpr.IcebergContext context = new ScalarOperatorToIcebergExpr.IcebergContext(SCHEMA.asStruct());
+        ScalarOperatorToIcebergExpr converter = new ScalarOperatorToIcebergExpr();
+
+        // a plain prefix is still pushed down
+        Assertions.assertEquals(Expressions.startsWith("k6", "abc").toString(),
+                convertLike(converter, context, K6, "abc%").toString());
+
+        // 'a_c%' also matches abc1 and axc2, so pushing startsWith("a_c") prunes the data files whose bounds
+        // only hold those two and the rows in them go missing
+        Assertions.assertEquals(Expression.Operation.TRUE, convertLike(converter, context, K6, "a_c%").op(),
+                "A single-character wildcard has no prefix form");
+        Assertions.assertEquals(Expression.Operation.TRUE, convertLike(converter, context, K15, "a_c%").op(),
+                "The same holds for a nested column");
+
+        // '\' escapes the character behind it, so the prefix as written is not what the pattern matches
+        Assertions.assertEquals(Expression.Operation.TRUE, convertLike(converter, context, K6, "a\\_c%").op(),
+                "An escaped underscore is a literal underscore, not the two characters as written");
+        Assertions.assertEquals(Expression.Operation.TRUE, convertLike(converter, context, K6, "abc\\%").op(),
+                "An escaped trailing percent sign is a literal, not a wildcard");
+
+        // unchanged: a wildcard anywhere but the end was never a prefix match
+        Assertions.assertEquals(Expression.Operation.TRUE, convertLike(converter, context, K6, "%abc%").op());
+        Assertions.assertEquals(Expression.Operation.TRUE, convertLike(converter, context, K6, "abc").op());
+    }
+
+    private static Expression convertLike(ScalarOperatorToIcebergExpr converter,
+                                          ScalarOperatorToIcebergExpr.IcebergContext context,
+                                          ScalarOperator column, String pattern) {
+        return converter.convert(Lists.newArrayList(new LikePredicateOperator(
+                LikePredicateOperator.LikeType.LIKE, column, ConstantOperator.createVarchar(pattern))), context);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -455,4 +455,21 @@ public class PaimonPredicateConverterTest {
         Predicate convert2 = CONVERTER.convert(op52);
         Assertions.assertTrue(convert2 == null);
     }
+
+    @Test
+    public void testLikePrefixPushdownRejectsWildcardsAndEscapes() {
+        // 'a_c%' also matches abc1 and axc2, so pushing startsWith("a_c") prunes the data files whose
+        // statistics only hold those two and the rows in them go missing
+        Assertions.assertNull(CONVERTER.convert(new LikePredicateOperator(
+                        LikePredicateOperator.LikeType.LIKE, F1, ConstantOperator.createVarchar("a_c%"))),
+                "A single-character wildcard has no prefix form");
+
+        // '\' escapes the character behind it, so the prefix as written is not what the pattern matches
+        Assertions.assertNull(CONVERTER.convert(new LikePredicateOperator(
+                        LikePredicateOperator.LikeType.LIKE, F1, ConstantOperator.createVarchar("a\\_c%"))),
+                "An escaped underscore is a literal underscore, not the two characters as written");
+        Assertions.assertNull(CONVERTER.convert(new LikePredicateOperator(
+                        LikePredicateOperator.LikeType.LIKE, F1, ConstantOperator.createVarchar("abc\\%"))),
+                "An escaped trailing percent sign is a literal, not a wildcard");
+    }
 }

--- a/test/sql/test_iceberg/R/test_iceberg_like_predicate_pushdown
+++ b/test/sql/test_iceberg/R/test_iceberg_like_predicate_pushdown
@@ -1,0 +1,81 @@
+-- name: test_iceberg_like_predicate_pushdown
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}", "enable_iceberg_metadata_cache"="false");
+-- result:
+-- !result
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_like_pushdown_${uuid0}/iceberg_db/${uuid0}"
+);
+-- result:
+-- !result
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (id int, s string)", False, 5, 1000)
+-- result:
+{'status': True, 'result': '', 'msg': b''}
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (1, 'abc1');
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (2, 'axc2');
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (3, 'a_c3');
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (4, 'zzz4');
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (5, 'star%');
+-- result:
+-- !result
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'a_c%' order by id;
+-- result:
+1	abc1
+2	axc2
+3	a_c3
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'a_c%' order by id;
+-- result:
+1	abc1
+2	axc2
+3	a_c3
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'a\\_c%' order by id;
+-- result:
+3	a_c3
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'a\\_c%' order by id;
+-- result:
+3	a_c3
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'star\\%' order by id;
+-- result:
+5	star%
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'star\\%' order by id;
+-- result:
+5	star%
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'ab%' order by id;
+-- result:
+1	abc1
+-- !result
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'ab%' order by id;
+-- result:
+1	abc1
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_like_pushdown_${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_like_predicate_pushdown
+++ b/test/sql/test_iceberg/T/test_iceberg_like_predicate_pushdown
@@ -1,0 +1,41 @@
+-- name: test_iceberg_like_predicate_pushdown
+-- Test Point:
+--   1. A LIKE pattern holding the single-character wildcard `_` is not handed to Iceberg as a
+--      startsWith(), so the data files whose bounds only cover a wildcard match survive pruning.
+--   2. An escaped `\_` or a trailing `\%` is a literal character, so those patterns are not prefix
+--      matches either.
+--   3. A plain prefix pattern is still pushed down and still returns the same rows.
+-- Method: load one row per INSERT so every value gets its own data file and its own min/max bounds,
+--         then pair each predicate with the same predicate behind CONCAT(), which is never pushed
+--         down and therefore carries the answer the pruned scan has to agree with.
+-- Scope: Iceberg predicate pushdown, LIKE conversion in ScalarOperatorToIcebergExpr
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}", "enable_iceberg_metadata_cache"="false");
+
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_like_pushdown_${uuid0}/iceberg_db/${uuid0}"
+);
+
+function: retry_execute_sql("create external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (id int, s string)", False, 5, 1000)
+
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (1, 'abc1');
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (2, 'axc2');
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (3, 'a_c3');
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (4, 'zzz4');
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values (5, 'star%');
+
+refresh external table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'a_c%' order by id;
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'a_c%' order by id;
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'a\\_c%' order by id;
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'a\\_c%' order by id;
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'star\\%' order by id;
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'star\\%' order by id;
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where s like 'ab%' order by id;
+select id, s from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where concat(s, '') like 'ab%' order by id;
+
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_sql_test_${uuid0};
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_like_pushdown_${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

A `LIKE` pattern whose only `%` sits at the end is pushed down as a prefix match, and the prefix is copied straight out of the pattern. An unescaped `_` is then compared as a plain underscore, and an escape character stays inside the prefix. `startsWith` prunes data files that do hold matching rows, so the query returns fewer rows and reports no error.

Measured on 4.1.4, on an Iceberg table containing `abc1`, `axc2`, `a_c3`, `star%`, one row per data file. Each predicate is paired with the same predicate behind `concat()`, which is not pushed down, so the right column is the correct answer:

| predicate | pushed down | behind `concat()` |
|---|---|---|
| `s LIKE 'a_c%'` | 1 | 3 |
| `s LIKE 'a\_c%'` | 0 | 1 |
| `s LIKE 'star\%'` | 0 | 1 |
| `s LIKE 'ab%'` | 1 | 1 |

`FlussPredicateConverter` already skips this rewrite for both cases, and Iceberg and Paimon are the only two connectors that do not: Kudu and Delta Lake push no `LIKE`, Hive and Hudi cannot partition-prune on it, and Elasticsearch maps `_` correctly.

## What I'm doing:

Apply the Fluss condition in `ScalarOperatorToIcebergExpr` and `PaimonPredicateConverter`, so a pattern containing an unescaped `_` or a `\` is not rewritten into `startsWith`. I verified the Paimon change by reading the code and its `readBuilder.withFilter(...).newScan()` call site, not by running a Paimon table.

One more path on the Iceberg side uses the same converter: the strict conversion behind `canDeleteUsingMetadata`, where such a pattern used to become a prefix expression. A `DELETE` carrying one now falls back to the row-level path, which evaluates the pattern row by row. `executeMetadataDelete` runs only after that check passes, so the change opens no new error path. I read this path instead of running it.

Tests: unit cases in `IcebergExprVisitorTest` and `PaimonPredicateConverterTest` mirroring `FlussPredicateConverterTest#testLikePrefixPredicate`, and `test/sql/test_iceberg/{T,R}/test_iceberg_like_predicate_pushdown` for the table above. Reverting either change makes the matching unit test fail.

Fixes #78380

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
