### PR TITLE
[BugFix] Stop the heap profile toggle from writing prof.thread_active_init

### DIFF
--- a/be/src/runtime/prof/heap_prof.cpp
+++ b/be/src/runtime/prof/heap_prof.cpp
@@ -29,9 +29,16 @@ namespace starrocks {
 // detail implements for allocator
 #ifndef __APPLE__
 static int set_jemalloc_profiling(bool enable) {
-    int ret = je_mallctl("prof.active", nullptr, nullptr, &enable, 1);
-    ret |= je_mallctl("prof.thread_active_init", nullptr, nullptr, &enable, 1);
-    return ret;
+    // Only prof.active, which is also what `prof_active` in JEMALLOC_CONF maps to.
+    //
+    // prof.thread_active_init is deliberately left alone. It is not a second switch but the
+    // value copied into thread.prof.active when a thread is created, and it already defaults
+    // to true, so raising it here would change nothing -- except when an operator started the
+    // process with `prof_thread_active_init:false` to sample selected threads only, and
+    // overriding that is not ours to do. Lowering it is worse: a thread may only change its
+    // own thread.prof.active, so every thread created while the flag was down stays unsampled
+    // for the rest of its life, and re-enabling cannot repair it.
+    return je_mallctl("prof.active", nullptr, nullptr, &enable, 1);
 }
 
 static int has_enable_heap_profile() {

--- a/be/src/runtime/prof/heap_prof.cpp
+++ b/be/src/runtime/prof/heap_prof.cpp
@@ -38,7 +38,7 @@ static int set_jemalloc_profiling(bool enable) {
     // overriding that is not ours to do. Lowering it is worse: a thread may only change its
     // own thread.prof.active, so every thread created while the flag was down stays unsampled
     // for the rest of its life, and re-enabling cannot repair it.
-    return je_mallctl("prof.active", nullptr, nullptr, &enable, 1);
+    return je_mallctl("prof.active", nullptr, nullptr, &enable, sizeof(enable));
 }
 
 static int has_enable_heap_profile() {

--- a/be/test/runtime/CMakeLists.txt
+++ b/be/test/runtime/CMakeLists.txt
@@ -51,6 +51,7 @@ set(RUNTIME_TEST_FILES
     memory/counting_allocator_test.cpp
     memory/memory_allocator_test.cpp
     memory/memory_lock_test.cpp
+    prof/heap_prof_test.cpp
 )
 
 set(RUNTIME_TEST_LINK_LIBS

--- a/be/test/runtime/prof/heap_prof_test.cpp
+++ b/be/test/runtime/prof/heap_prof_test.cpp
@@ -22,6 +22,8 @@ namespace starrocks {
 
 namespace {
 
+#ifndef __APPLE__
+
 // Reading this node only needs jemalloc to be built with profiling support; writing it is
 // what additionally requires the process to have been started with `prof:true`.
 bool read_thread_active_init(bool* value) {
@@ -35,6 +37,8 @@ bool prof_enabled_at_startup() {
     return je_mallctl("opt.prof", &enabled, &size, nullptr, 0) == 0 && enabled;
 }
 
+#endif
+
 } // namespace
 
 // Toggling the heap profile must leave `prof.thread_active_init` alone. It is not a second
@@ -44,6 +48,10 @@ bool prof_enabled_at_startup() {
 // the operator, who may have started the process with `prof_thread_active_init:false` to
 // sample selected threads only.
 TEST(HeapProfTest, toggling_the_profile_keeps_thread_active_init) {
+#ifdef __APPLE__
+    GTEST_SKIP() << "HeapProf is a no-op on macOS: enable_prof() and disable_prof() do nothing and "
+                    "has_enable() always reports false, so there is no toggle to observe";
+#else
     if (!prof_enabled_at_startup()) {
         GTEST_SKIP() << "the process was not started with prof:true, so prof.thread_active_init "
                         "cannot be written and the regression cannot be reproduced";
@@ -65,6 +73,7 @@ TEST(HeapProfTest, toggling_the_profile_keeps_thread_active_init) {
     bool after = false;
     ASSERT_TRUE(read_thread_active_init(&after));
     EXPECT_EQ(before, after) << "disabling the heap profile must not touch prof.thread_active_init";
+#endif
 }
 
 } // namespace starrocks

--- a/be/test/runtime/prof/heap_prof_test.cpp
+++ b/be/test/runtime/prof/heap_prof_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include "base/utility/defer_op.h"
 #include "jemalloc/jemalloc.h"
 
 namespace starrocks {
@@ -56,6 +57,18 @@ TEST(HeapProfTest, toggling_the_profile_keeps_thread_active_init) {
         GTEST_SKIP() << "the process was not started with prof:true, so prof.thread_active_init "
                         "cannot be written and the regression cannot be reproduced";
     }
+
+    // Restore the global switch on the way out, including when an assertion returns early:
+    // the test only runs on a process started with prof:true, which is exactly a process
+    // whose remaining tests would then run with profiling silently turned off.
+    const bool was_active = HeapProf::getInstance().has_enable();
+    DeferOp restore([was_active] {
+        if (was_active) {
+            HeapProf::getInstance().enable_prof();
+        } else {
+            HeapProf::getInstance().disable_prof();
+        }
+    });
 
     bool before = false;
     ASSERT_TRUE(read_thread_active_init(&before));

--- a/be/test/runtime/prof/heap_prof_test.cpp
+++ b/be/test/runtime/prof/heap_prof_test.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/prof/heap_prof.h"
+
+#include <gtest/gtest.h>
+
+#include "jemalloc/jemalloc.h"
+
+namespace starrocks {
+
+namespace {
+
+// Reading this node only needs jemalloc to be built with profiling support; writing it is
+// what additionally requires the process to have been started with `prof:true`.
+bool read_thread_active_init(bool* value) {
+    size_t size = sizeof(*value);
+    return je_mallctl("prof.thread_active_init", value, &size, nullptr, 0) == 0;
+}
+
+bool prof_enabled_at_startup() {
+    bool enabled = false;
+    size_t size = sizeof(enabled);
+    return je_mallctl("opt.prof", &enabled, &size, nullptr, 0) == 0 && enabled;
+}
+
+} // namespace
+
+// Toggling the heap profile must leave `prof.thread_active_init` alone. It is not a second
+// switch but the value copied into thread.prof.active once, when a thread is created, and a
+// thread may only change its own -- so a thread started while the flag was down would stay
+// unsampled for the rest of its life, and re-enabling could not repair it. It also belongs to
+// the operator, who may have started the process with `prof_thread_active_init:false` to
+// sample selected threads only.
+TEST(HeapProfTest, toggling_the_profile_keeps_thread_active_init) {
+    if (!prof_enabled_at_startup()) {
+        GTEST_SKIP() << "the process was not started with prof:true, so prof.thread_active_init "
+                        "cannot be written and the regression cannot be reproduced";
+    }
+
+    bool before = false;
+    ASSERT_TRUE(read_thread_active_init(&before));
+
+    HeapProf::getInstance().enable_prof();
+    ASSERT_TRUE(HeapProf::getInstance().has_enable());
+
+    bool while_enabled = false;
+    ASSERT_TRUE(read_thread_active_init(&while_enabled));
+    EXPECT_EQ(before, while_enabled) << "enabling the heap profile must not touch prof.thread_active_init";
+
+    HeapProf::getInstance().disable_prof();
+    ASSERT_FALSE(HeapProf::getInstance().has_enable());
+
+    bool after = false;
+    ASSERT_TRUE(read_thread_active_init(&after));
+    EXPECT_EQ(before, after) << "disabling the heap profile must not touch prof.thread_active_init";
+
+}
+
+} // namespace starrocks

--- a/be/test/runtime/prof/heap_prof_test.cpp
+++ b/be/test/runtime/prof/heap_prof_test.cpp
@@ -65,7 +65,6 @@ TEST(HeapProfTest, toggling_the_profile_keeps_thread_active_init) {
     bool after = false;
     ASSERT_TRUE(read_thread_active_init(&after));
     EXPECT_EQ(before, after) << "disabling the heap profile must not touch prof.thread_active_init";
-
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`HeapProf::disable_prof()` silently damages later heap profiles.

`set_jemalloc_profiling()` (`be/src/runtime/prof/heap_prof.cpp`) writes its argument into two mallctl nodes at once:

```cpp
int ret = je_mallctl("prof.active", nullptr, nullptr, &enable, 1);
ret |= je_mallctl("prof.thread_active_init", nullptr, nullptr, &enable, 1);
```

They are not two equivalent switches. jemalloc gates sampling on **both** `prof.active` (global) and the calling thread's `thread.prof.active`: *"both must be active for the calling thread to sample"*. `prof.thread_active_init` is neither of those — it is only the value stamped into `thread.prof.active` **when a thread is created**, and `thread.prof.active` may only be changed **by the thread itself**.

So disabling the profile leaves this behind:

| time | action | `prof.active` | `thread_active_init` | threads created at this point |
|---|---|---|---|---|
| T1 | enable | true | true | `thread.prof.active = true` |
| T2 | **disable** | false | **false** | — |
| T3 | scan pool grows, brpc worker starts… | false | false | `thread.prof.active = false` — **permanent** |
| T4 | **enable** | true | true | — |
| T5 | threads created after T4 | true | true | `thread.prof.active = true` |

The T3 threads never sample again. Raising `thread_active_init` at T4 only reaches threads created afterwards, and nothing can reach back into an existing thread because that flag is per-thread and self-service. In a BE the scan pools, pipeline drivers and brpc workers all grow on demand, so every enable/disable cycle blinds another batch of them, and the next profile silently under-reports — which is exactly the wrong answer when someone is chasing a leak.

It is also inconsistent with the startup option: `prof_active` in `JEMALLOC_CONF` maps to `prof.active` alone and never touches `thread_active_init`, so `prof_active:false` at startup and a runtime disable did not mean the same thing.

## What I'm doing:

Drop the `prof.thread_active_init` write altogether, in both directions.

Lowering it on disable is what caused the damage. Raising it on enable turns out to be worth dropping too: the flag already defaults to `true` (`opt_prof_thread_active_init`, `src/prof.c`), so the write was a no-op in every normal case — the one case where it did something was an operator who started the process with `prof_thread_active_init:false` to sample selected threads only, and overriding that deliberate choice is a bug of its own.

`prof.active` is the global gate and clearing it stops all sampling by itself, so nothing is lost. `HeapProf` now touches exactly the one switch that `prof_active` in `JEMALLOC_CONF` also maps to.

Added `be/test/runtime/prof/heap_prof_test.cpp`, asserting that `prof.thread_active_init` is unchanged across both `enable_prof()` and `disable_prof()`.

**The test skips unless the process was started with `prof:true`.** Writing `prof.thread_active_init` requires `opt_prof` (`src/ctl.c`, `prof_thread_active_init_ctl`), so without it the buggy code could not change the flag either and the assertion would not discriminate. Reading the node only needs jemalloc to be built with profiling support, which is why the check itself works everywhere. CI's BE UT does not export `JEMALLOC_CONF`, so it will report the test as skipped; running a BE (or the test binary) with `prof:true` exercises it for real.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Toggling the heap profile no longer writes `prof.thread_active_init`, so profiles taken after an enable/disable cycle now cover the threads created during it, and a `prof_thread_active_init:false` set at startup is no longer overridden. There is no user-facing interface change.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
