### PR TITLE
[BugFix] Keep inferred FILES() varchar length on INSERT type push-down

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -63,7 +63,10 @@ import com.starrocks.sql.ast.expression.LiteralExprFactory;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.type.NullType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.StringType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarcharType;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.logging.log4j.LogManager;
@@ -566,6 +569,7 @@ public class InsertAnalyzer {
             // Keep original column name (BE is case-sensitive) and nullable property
             newCol.setName(oldCol.getName());
             newCol.setIsAllowNull(oldCol.isAllowNull());
+            preserveWiderInferredStringLength(oldCol, newCol);
             newFileColumns.put(oldCol.getName(), newCol);
         }
 
@@ -721,7 +725,33 @@ public class InsertAnalyzer {
         // Keep original column name (BE is case-sensitive) and nullable property
         newCol.setName(oldCol.getName());
         newCol.setIsAllowNull(oldCol.isAllowNull());
+        preserveWiderInferredStringLength(oldCol, newCol);
         fileColumns.put(oldCol.getName(), newCol);
+    }
+
+    /**
+     * Type push-down deep-copies the target column onto the FILES() scan schema so CSV/Parquet
+     * inference can use the sink type (e.g. TINYINT instead of inferred BIGINT). For strings that
+     * also copies the target length, so INSERT INTO t(STRING) rewrote a VARCHAR(1048576) FILES()
+     * slot to VARCHAR(65533). The BE scanner then rejected values that DESC/SELECT FROM FILES()
+     * accepted. Keep the wider inferred length; the INSERT sink still enforces the target type.
+     */
+    private static void preserveWiderInferredStringLength(Column fileCol, Column pushedCol) {
+        Type fileType = fileCol.getType();
+        Type pushedType = pushedCol.getType();
+        if (!fileType.isStringType() || !pushedType.isStringType()
+                || !fileType.isScalarType() || !pushedType.isScalarType()) {
+            return;
+        }
+        int fileLen = ((ScalarType) fileType).getLength();
+        int pushedLen = ((ScalarType) pushedType).getLength();
+        if (fileLen < 0) {
+            fileLen = StringType.MAX_STRING_LENGTH;
+        }
+        if (pushedLen < 0 || fileLen <= pushedLen) {
+            return;
+        }
+        pushedCol.setType(TypeFactory.createVarcharType(fileLen));
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/InsertAnalyzerFilesSchemaPushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/InsertAnalyzerFilesSchemaPushDownTest.java
@@ -9,6 +9,8 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.StringType;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,12 @@ public class InsertAnalyzerFilesSchemaPushDownTest extends PlanTestBase {
         starRocksAssert.withTable(
                 "CREATE TABLE t_sink (x BIGINT, y VARCHAR(64)) " +
                 "DISTRIBUTED BY HASH(x) BUCKETS 1 PROPERTIES('replication_num'='1')");
+        starRocksAssert.withTable(
+                "CREATE TABLE t_files_str (col_int INT, col_string STRING) " +
+                "DISTRIBUTED BY HASH(col_int) BUCKETS 1 PROPERTIES('replication_num'='1')");
+        starRocksAssert.withTable(
+                "CREATE TABLE t_files_tiny (col_int TINYINT, col_string STRING) " +
+                "DISTRIBUTED BY HASH(col_int) BUCKETS 1 PROPERTIES('replication_num'='1')");
     }
 
     @Test
@@ -96,5 +104,40 @@ public class InsertAnalyzerFilesSchemaPushDownTest extends PlanTestBase {
         assertInstanceOf(SemanticException.class, e.getCause());
         assertTrue(e.getMessage().contains("'enable_push_down_schema'")
                 && e.getMessage().contains("'schema'"));
+    }
+
+    @Test
+    public void testInsertPushDownDoesNotShrinkInferredVarcharLength() throws Exception {
+        // fake:// infers col_string as wildcard VARCHAR; STRING on the sink is VARCHAR(65533).
+        // Push-down must not shrink the FILES() slot to 65533 (issue #78208).
+        String sql = "INSERT INTO t_files_str SELECT * FROM FILES(" +
+                "  'path' = 'fake://bucket/wide.csv'," +
+                "  'format' = 'csv')";
+        InsertStmt insertStmt = (InsertStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        SelectRelation selectRelation = (SelectRelation) insertStmt.getQueryStatement().getQueryRelation();
+        FileTableFunctionRelation fileRelation = (FileTableFunctionRelation) selectRelation.getRelation();
+        TableFunctionTable fileTable = (TableFunctionTable) fileRelation.getTable();
+
+        ScalarType fileStringType = (ScalarType) fileTable.getColumn("col_string").getType();
+        assertEquals(PrimitiveType.VARCHAR, fileStringType.getPrimitiveType());
+        assertEquals(StringType.MAX_STRING_LENGTH, fileStringType.getLength(),
+                "FILES() varchar length must stay the inferred width, not the STRING sink's 65533");
+    }
+
+    @Test
+    public void testInsertPushDownStillNarrowsIntegerTypes() throws Exception {
+        String sql = "INSERT INTO t_files_tiny SELECT * FROM FILES(" +
+                "  'path' = 'fake://bucket/wide.csv'," +
+                "  'format' = 'csv')";
+        InsertStmt insertStmt = (InsertStmt) UtFrameUtils.parseStmtWithNewParser(sql, starRocksAssert.getCtx());
+        SelectRelation selectRelation = (SelectRelation) insertStmt.getQueryStatement().getQueryRelation();
+        FileTableFunctionRelation fileRelation = (FileTableFunctionRelation) selectRelation.getRelation();
+        TableFunctionTable fileTable = (TableFunctionTable) fileRelation.getTable();
+
+        assertEquals(PrimitiveType.TINYINT,
+                fileTable.getColumn("col_int").getType().getPrimitiveType(),
+                "Integer type push-down must still rewrite inferred INT to TINYINT");
+        ScalarType fileStringType = (ScalarType) fileTable.getColumn("col_string").getType();
+        assertEquals(StringType.MAX_STRING_LENGTH, fileStringType.getLength());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`INSERT INTO t SELECT * FROM FILES()` type push-down deep-copies the target column onto the FILES() scan schema. For `STRING` / short `VARCHAR` sinks that rewrites the scan slot to `VARCHAR(65533)` (or the target length), so the BE scanner rejects values that `DESC FILES()` and `SELECT FROM FILES()` still read as `varchar(1048576)`.

Same class of bug as #70621 (nullability was copied along with the type).

Fixes #78208

## What I'm doing:

When both the inferred FILES() column and the pushed-down type are strings, keep the wider inferred length instead of shrinking the scan slot. Numeric type push-down is unchanged (e.g. inferred `INT` still becomes `TINYINT`). The INSERT sink still enforces the target column type.

FE UT covers the `fake://` inferred schema vs a `STRING` sink, and checks that integer narrowing still happens.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
