### PR TITLE
[BugFix] Index page null flags by ordinal when a pushed-down predicate reads a sparse range

### DIFF
--- a/be/src/storage/rowset/binary_dict_page.cpp
+++ b/be/src/storage/rowset/binary_dict_page.cpp
@@ -301,10 +301,22 @@ Status BinaryDictPageDecoder<Type>::next_batch_with_filter(
         auto temp_data_column = temp_nullable_column->data_column_raw_ptr();
         auto& temp_null_column = temp_nullable_column->null_column_ref();
 
-        // Read data column and null column
-        ContainerResource container(_page_handle, null_data, num_rows);
-        int n = temp_null_column.append_numbers(container);
-        DCHECK_EQ(n, num_rows);
+        // Read data column and null column. null_data is indexed by the in-page ordinal (see
+        // PageDecoder::next_batch_with_filter): a contiguous range can alias the page's null flags directly, a sparse
+        // range has to pick the flags of each sub-range, otherwise the rows after the first gap would take the
+        // null flags of the skipped rows.
+        if (range.size() == 1) {
+            ContainerResource container(_page_handle, null_data + range.begin(), num_rows);
+            int n = temp_null_column.append_numbers(container);
+            DCHECK_EQ(n, num_rows);
+        } else {
+            temp_null_column.reserve(num_rows);
+            SparseRangeIterator<> iter = range.new_iterator();
+            while (iter.has_more()) {
+                Range<> r = iter.next(num_rows);
+                temp_null_column.append_numbers(null_data + r.begin(), r.span_size());
+            }
+        }
         RETURN_IF_ERROR(next_batch(range, temp_data_column));
         DCHECK(temp_null_column.size() == num_rows);
         DCHECK(temp_data_column->size() == num_rows);

--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -348,8 +348,10 @@ Status BinaryPlainPageDecoder<Type>::next_batch_with_filter(
         Range<> r = iter.next(to_read);
         size_t length = r.span_size();
         size_t end = _cur_idx + length;
+        // null_data is indexed by the in-page ordinal (see PageDecoder::next_batch_with_filter), while selection and
+        // selected_idx are packed by the rows read so far. A sparse range makes the two offsets differ.
         RETURN_IF_ERROR(next_range_with_filter(_cur_idx, end, column, compound_and_predicates,
-                                               null_data != nullptr ? null_data + index : nullptr, selection + index,
+                                               null_data != nullptr ? null_data + _cur_idx : nullptr, selection + index,
                                                selected_idx + index));
         index += length;
         to_read -= length;

--- a/be/src/storage/rowset/page_decoder.h
+++ b/be/src/storage/rowset/page_decoder.h
@@ -94,7 +94,11 @@ public:
 
     // given a set of ranges in page, apply compound and predicates on it, and only return filtered data
     // since null data is separate from actually data page, we need pass the null data by caller if this is a nullable column
-    // null_data is a uint8_t array where null_data[i] indicates whether the i-th row is null (1 for null, 0 for not null)
+    // null_data is the null-flag array of the WHOLE page, indexed by the in-page ordinal: null_data[ord] tells whether
+    // the row at ordinal `ord` is null (1 for null, 0 for not null). It is NOT relative to `range.begin()`, and it is
+    // NOT packed by the rows of `range`: `range` may be sparse (several non-adjacent sub-ranges of the same page), so
+    // the callee must look up null_data[r.begin() + i] for each sub-range `r` instead of walking null_data linearly.
+    // nullptr means the page has no null at all.
     // callee is responsible to handle null column and append null data into dst column if selected
     virtual Status next_batch_with_filter(Column* column, const SparseRange<>& range,
                                           const std::vector<const ColumnPredicate*>& compound_and_predicates,

--- a/be/src/storage/rowset/parsed_page.cpp
+++ b/be/src/storage/rowset/parsed_page.cpp
@@ -355,9 +355,10 @@ public:
             // The data_decoder will handle null predicates
             auto nc = down_cast<NullableColumn*>(column);
 
-            // Pass the null flags starting from current offset
-            // The data_decoder will handle appending null flags to the column
-            const uint8_t* null_data = _null_flags.data() + _offset_in_page;
+            // Pass the null flags of the whole page: the decoder indexes them by the in-page ordinal of each row it
+            // reads. `range` may be sparse (several sub-ranges of this page merged by the column iterator), so a
+            // pointer shifted to range.begin() and walked linearly would misalign the flags after the first gap.
+            const uint8_t* null_data = _null_flags.data();
             RETURN_IF_ERROR(_data_decoder->next_batch_with_filter(nc, range, compound_and_predicates, null_data,
                                                                   selection, selected_idx));
         }

--- a/be/test/storage/rowset/binary_dict_page_test.cpp
+++ b/be/test/storage/rowset/binary_dict_page_test.cpp
@@ -425,6 +425,62 @@ TEST_F(BinaryDictPageTest, TestNextBatchWithFilter) {
     }
 }
 
+// Same scenario as BinaryPlainPageTest.TestNextBatchWithFilterSparseRangeWithNulls for the dictionary decoder: the null
+// flags are page-level and indexed by ordinal, a sparse range must not consume them linearly.
+TEST_F(BinaryDictPageTest, TestNextBatchWithFilterSparseRangeWithNulls) {
+    std::vector<Slice> slices{"a_100", "b_200", "c_300", "d_400", "e_500"};
+
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    options.dict_page_size = 256 * 1024;
+    BinaryDictPageBuilder page_builder(options);
+    size_t count = page_builder.add(reinterpret_cast<const uint8_t*>(slices.data()), slices.size());
+    ASSERT_EQ(slices.size(), count);
+    auto s = page_builder.finish()->build();
+
+    OwnedSlice dict_slice = page_builder.get_dictionary_page()->build();
+    auto dict_page_decoder = std::make_unique<BinaryPlainPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
+    ASSERT_TRUE(dict_page_decoder->init().ok());
+
+    Slice encoded_data = s.slice();
+    PageFooterPB footer;
+    footer.set_type(DATA_PAGE);
+    footer.mutable_data_page_footer()->set_nullmap_size(0);
+    std::unique_ptr<std::vector<uint8_t>> page = nullptr;
+    Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::DICT_ENCODING, &page, &encoded_data);
+    ASSERT_TRUE(st.ok());
+
+    BinaryDictPageDecoder<TYPE_VARCHAR> page_decoder(encoded_data);
+    page_decoder.set_dict_decoder(dict_page_decoder.get());
+    ASSERT_TRUE(page_decoder.init().ok());
+
+    auto column = ChunkFactory::column_from_field_type(TYPE_VARCHAR, true);
+    std::unique_ptr<ColumnPredicate> predicate(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 0, "c_300"));
+    std::vector<const ColumnPredicate*> predicates{predicate.get()};
+
+    // read ordinal 0 and ordinals 3..4, skip 1..2
+    SparseRange<> range;
+    range.add(Range<>(0, 1));
+    range.add(Range<>(3, 5));
+    std::vector<uint8_t> selection(3, 1);
+    std::vector<uint16_t> selected_idx(3);
+
+    // ordinals 1, 2 and 4 are null; a linear walk would hand {0, 1, 1} to the 3 rows read and drop "d_400"
+    uint8_t null_data[] = {0, 1, 1, 0, 1};
+
+    st = page_decoder.next_batch_with_filter(column.get(), range, predicates, null_data, selection.data(),
+                                             selected_idx.data());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    ASSERT_EQ(0, selection[0]);
+    ASSERT_EQ(1, selection[1]);
+    ASSERT_EQ(0, selection[2]);
+
+    ASSERT_EQ(1, column->size());
+    ASSERT_FALSE(down_cast<NullableColumn*>(column.get())->has_null());
+    ASSERT_EQ("d_400", column->get(0).get_slice().to_string());
+}
+
 TEST_F(BinaryDictPageTest, TestReadByRowids) {
     std::vector<std::string> strings;
     std::vector<Slice> slices;

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -350,6 +350,53 @@ TEST_F(BinaryPlainPageTest, TestNextBatchWithFilter) {
     }
 }
 
+// A predicate pushed down to a page may come with a sparse range (several non-adjacent sub-ranges of the same page,
+// merged by ScalarColumnIterator). The null flags belong to the page and are indexed by the in-page ordinal, so the
+// rows after a gap must take their own flags, not the flags of the rows that were skipped.
+TEST_F(BinaryPlainPageTest, TestNextBatchWithFilterSparseRangeWithNulls) {
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    BinaryPlainPageBuilder builder(options);
+    Slice slices[] = {
+            "a_100", "b_200", "c_300", "d_400", "e_500",
+    };
+    ASSERT_EQ(5, builder.add((const uint8_t*)slices, 5));
+    OwnedSlice data_with_head = builder.finish()->build();
+    BinaryPlainPageDecoder<TYPE_VARCHAR> decoder(data_with_head.slice());
+    ASSERT_TRUE(decoder.init().ok());
+
+    auto column = ChunkFactory::column_from_field_type(TYPE_VARCHAR, true);
+    std::unique_ptr<ColumnPredicate> predicate(new_column_ge_predicate(get_type_info(TYPE_VARCHAR), 0, "c_300"));
+    std::vector<const ColumnPredicate*> predicates{predicate.get()};
+
+    // read ordinal 0 and ordinals 3..4, skip 1..2
+    SparseRange<> range;
+    range.add(Range<>(0, 1));
+    range.add(Range<>(3, 5));
+    ASSERT_EQ(3, range.span_size());
+    std::vector<uint8_t> selection(3, 1);
+    std::vector<uint16_t> selected_idx(3);
+
+    // page-level null flags: ordinals 1, 2 and 4 are null. Walking them linearly over the 3 rows read would take
+    // {0, 1, 1} and wrongly mark "d_400" (ordinal 3) as null.
+    uint8_t null_data[] = {0, 1, 1, 0, 1};
+
+    Status st = decoder.next_batch_with_filter(column.get(), range, predicates, null_data, selection.data(),
+                                               selected_idx.data());
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    // ordinal 0 "a_100" < "c_300" -> 0; ordinal 3 "d_400" >= "c_300" and not null -> 1; ordinal 4 is null -> 0
+    ASSERT_EQ(0, selection[0]);
+    ASSERT_EQ(1, selection[1]);
+    ASSERT_EQ(0, selection[2]);
+
+    ASSERT_EQ(1, column->size());
+    auto nullable_col = down_cast<NullableColumn*>(column.get());
+    ASSERT_FALSE(nullable_col->has_null());
+    auto binary_col = down_cast<BinaryColumn*>(nullable_col->data_column_raw_ptr());
+    ASSERT_EQ("d_400", binary_col->immutable_data()[0]);
+}
+
 TEST_F(BinaryPlainPageTest, TestReadByRowids) {
     PageBuilderOptions options;
     options.data_page_size = 256 * 1024;

--- a/test/sql/test_scan/R/test_scan_predicate_late_materialization_sparse_range_nulls
+++ b/test/sql/test_scan/R/test_scan_predicate_late_materialization_sparse_range_nulls
@@ -1,0 +1,85 @@
+-- name: test_predicate_late_materialization_sparse_range_nulls
+-- Issue #78300: the first predicate column is pushed down to the page level; when another column's zone map leaves
+-- several non-adjacent sub-ranges inside one page of that column, the null flags of the rows after a gap were taken
+-- from the skipped rows and a non-null match right after a run of NULLs was dropped.
+drop table if exists predicate_lm_sparse_nulls;
+-- result:
+-- !result
+drop table if exists predicate_lm_sparse_no_nulls;
+-- result:
+-- !result
+
+-- c2: unique 500-byte strings (never dictionary encoded, ~130 rows per page) whose prefix is the block id, so its zone
+-- map keeps block 10 of every 40-block cycle (2560 rows) and nothing else. s: plain varchar whose page holds thousands
+-- of rows, so one page of s contains at least two surviving sub-ranges; blocks 11..19 are NULL, which is exactly where
+-- a linear walk of the null flags would land for the second sub-range.
+create table predicate_lm_sparse_nulls (k bigint, c2 varchar(600), s varchar(64), v int)
+duplicate key(k) distributed by hash(k) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+
+insert into predicate_lm_sparse_nulls
+select g,
+       concat(lpad(cast((g div 64) % 40 as varchar), 4, "0"), "_", lpad(cast(g as varchar), 495, "0")),
+       case when ((g div 64) % 40) between 11 and 19 then NULL
+            when g % 2560 = 645 then "target"
+            else concat("v", g) end,
+       1
+from table(generate_series(0, 399999)) t(g);
+-- result:
+-- !result
+
+-- same layout, but no NULL at all: the page carries no null flags and never misbehaved
+create table predicate_lm_sparse_no_nulls (k bigint, c2 varchar(600), s varchar(64), v int)
+duplicate key(k) distributed by hash(k) buckets 1 properties("replication_num" = "1");
+-- result:
+-- !result
+
+insert into predicate_lm_sparse_no_nulls
+select g,
+       concat(lpad(cast((g div 64) % 40 as varchar), 4, "0"), "_", lpad(cast(g as varchar), 495, "0")),
+       case when ((g div 64) % 40) between 11 and 19 then concat("n", g)
+            when g % 2560 = 645 then "target"
+            else concat("v", g) end,
+       1
+from table(generate_series(0, 399999)) t(g);
+-- result:
+-- !result
+
+select count(*), sum(s = "target") from predicate_lm_sparse_nulls;
+-- result:
+400000	156
+-- !result
+
+-- v is referenced so the scan keeps a non-predicate output column and the predicate-column late-materialization
+-- path (rowid column + page-level pushdown of the first predicate column) is actually taken
+set enable_predicate_col_late_materialize = true;
+-- result:
+-- !result
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+-- result:
+156	156	645	397445
+-- !result
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_no_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+-- result:
+156	156	645	397445
+-- !result
+
+set enable_predicate_col_late_materialize = false;
+-- result:
+-- !result
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+-- result:
+156	156	645	397445
+-- !result
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_no_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+-- result:
+156	156	645	397445
+-- !result
+
+drop table if exists predicate_lm_sparse_nulls;
+-- result:
+-- !result
+drop table if exists predicate_lm_sparse_no_nulls;
+-- result:
+-- !result

--- a/test/sql/test_scan/T/test_scan_predicate_late_materialization_sparse_range_nulls
+++ b/test/sql/test_scan/T/test_scan_predicate_late_materialization_sparse_range_nulls
@@ -1,0 +1,50 @@
+-- name: test_predicate_late_materialization_sparse_range_nulls
+-- Issue #78300: the first predicate column is pushed down to the page level; when another column's zone map leaves
+-- several non-adjacent sub-ranges inside one page of that column, the null flags of the rows after a gap were taken
+-- from the skipped rows and a non-null match right after a run of NULLs was dropped.
+drop table if exists predicate_lm_sparse_nulls;
+drop table if exists predicate_lm_sparse_no_nulls;
+
+-- c2: unique 500-byte strings (never dictionary encoded, ~130 rows per page) whose prefix is the block id, so its zone
+-- map keeps block 10 of every 40-block cycle (2560 rows) and nothing else. s: plain varchar whose page holds thousands
+-- of rows, so one page of s contains at least two surviving sub-ranges; blocks 11..19 are NULL, which is exactly where
+-- a linear walk of the null flags would land for the second sub-range.
+create table predicate_lm_sparse_nulls (k bigint, c2 varchar(600), s varchar(64), v int)
+duplicate key(k) distributed by hash(k) buckets 1 properties("replication_num" = "1");
+
+insert into predicate_lm_sparse_nulls
+select g,
+       concat(lpad(cast((g div 64) % 40 as varchar), 4, "0"), "_", lpad(cast(g as varchar), 495, "0")),
+       case when ((g div 64) % 40) between 11 and 19 then NULL
+            when g % 2560 = 645 then "target"
+            else concat("v", g) end,
+       1
+from table(generate_series(0, 399999)) t(g);
+
+-- same layout, but no NULL at all: the page carries no null flags and never misbehaved
+create table predicate_lm_sparse_no_nulls (k bigint, c2 varchar(600), s varchar(64), v int)
+duplicate key(k) distributed by hash(k) buckets 1 properties("replication_num" = "1");
+
+insert into predicate_lm_sparse_no_nulls
+select g,
+       concat(lpad(cast((g div 64) % 40 as varchar), 4, "0"), "_", lpad(cast(g as varchar), 495, "0")),
+       case when ((g div 64) % 40) between 11 and 19 then concat("n", g)
+            when g % 2560 = 645 then "target"
+            else concat("v", g) end,
+       1
+from table(generate_series(0, 399999)) t(g);
+
+select count(*), sum(s = "target") from predicate_lm_sparse_nulls;
+
+-- v is referenced so the scan keeps a non-predicate output column and the predicate-column late-materialization
+-- path (rowid column + page-level pushdown of the first predicate column) is actually taken
+set enable_predicate_col_late_materialize = true;
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_no_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+
+set enable_predicate_col_late_materialize = false;
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+select count(*), sum(v), min(k), max(k) from predicate_lm_sparse_no_nulls where c2 >= "0010_" and c2 < "0010_~" and s = "target";
+
+drop table if exists predicate_lm_sparse_nulls;
+drop table if exists predicate_lm_sparse_no_nulls;


### PR DESCRIPTION
## Why I'm doing:

ScalarColumnIterator merges the sub-ranges that fall into one page and hands the decoder a sparse range. ParsedPageV2::read_with_filter passed the null flags as a pointer already shifted to range.begin(), and both binary decoders walked it linearly by the number of rows read, so every row after the first gap took the null flag of a skipped row. A non-null match right after a run of NULLs was treated as NULL and silently dropped by the equality predicate; which replica lost the row depended on where its page boundaries fell.

Make null_data the null-flag array of the whole page indexed by in-page ordinal, look it up per sub-range in the plain and dictionary decoders, and cover the sparse-range case in both decoder tests and a SQL test.



## What I'm doing:

Fixes #78300

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
