### PR TITLE
[BugFix] Resolve compute node hostnames in FE before shipping them to BE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -416,7 +416,14 @@ public class Utils {
                     publishTabletInfo.getTabletIds()));
 
             ComputeNodePB computeNodePB = new ComputeNodePB();
-            computeNodePB.setHost(entry.getKey().getHost());
+            // Send the resolved IP, not the hostname: the aggregator turns each entry into a brpc
+            // stub via LakeServiceBrpcStubCache::get_stub(), whose cache key is the resolved
+            // EndPoint, so a hostname there costs one getaddrinfo per sub-request per publish with
+            // no caching on the BE side. FE resolves through the JVM DNS cache instead. Same
+            // convention as the query/load path (see ExecutionDAG#getBrpcIpAddress, PR #32062).
+            // getIP() falls back to the hostname when resolution fails, so this only ever degrades
+            // to the previous behavior.
+            computeNodePB.setHost(entry.getKey().getIP());
             computeNodePB.setBrpcPort(entry.getKey().getBrpcPort());
             // Record the node id so that the aggregator-selection step later can prefer
             // an aggregator that already owns at least one tablet in the batch. Without

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -538,7 +538,10 @@ public class CompactionScheduler extends Daemon {
             }
             candidateAggregatorNodes.add(node);
             ComputeNodePB nodePB = new ComputeNodePB();
-            nodePB.setHost(node.getHost());
+            // Resolved IP rather than hostname, for the same reason as the aggregate publish path:
+            // the aggregator feeds this straight into LakeServiceBrpcStubCache::get_stub(), which
+            // must resolve before it can even look up its cache. See Utils#createSubRequestForAggregatePublish.
+            nodePB.setHost(node.getIP());
             nodePB.setBrpcPort(node.getBrpcPort());
             nodePB.setId(entry.getKey());
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DictionaryCacheSink.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Dictionary;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.util.DnsCache;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TColumn;
@@ -44,7 +45,15 @@ public class DictionaryCacheSink extends DataSink {
     private final long txnId;
 
     public DictionaryCacheSink(List<TNetworkAddress> nodes, Dictionary dictionary, long txnId) {
-        this.nodes = nodes;
+        // Resolve here, at the boundary where the node list crosses over to a BE. The BE turns every
+        // entry into a stub via HttpBrpcStubCache::get_http_stub(), whose cache is keyed by the resolved
+        // EndPoint -- so a hostname costs one uncached getaddrinfo per node per refresh, since the BE has
+        // no DNS cache of its own. Doing it here rather than in the caller keeps the shared node-list
+        // helper single-behavior: FE-originated RPC and the hostname SHOW DICTIONARY prints stay untouched.
+        // DnsCache passes IP literals through unchanged and falls back to the hostname on failure.
+        this.nodes = nodes.stream()
+                .map(node -> new TNetworkAddress(DnsCache.tryLookup(node.getHostname()), node.getPort()))
+                .collect(Collectors.toList());
         this.dictionary = dictionary;
         this.txnId = txnId;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
@@ -15,22 +15,32 @@
 
 package com.starrocks.lake;
 
+import com.google.common.collect.Lists;
+import com.starrocks.alter.reshard.PublishTabletsInfo;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.DnsCache;
+import com.starrocks.proto.AggregatePublishVersionRequest;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.NodeSelector;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class UtilsTest {
 
@@ -133,5 +143,62 @@ public class UtilsTest {
 
         Assertions.assertFalse(Utils.publishesUnshareCompaction(null, null),
                 "an empty request publishes no unshare compaction");
+    }
+
+    // The aggregator turns every ComputeNodePB into a brpc stub via
+    // LakeServiceBrpcStubCache::get_stub(), which has to resolve the host before it can look up its
+    // (EndPoint-keyed) cache. Shipping a hostname there therefore costs one uncached getaddrinfo per
+    // sub-request per publish on the CN. Pin that FE sends the resolved IP instead.
+    @Test
+    public void testAggregatePublishSubRequestCarriesResolvedIp() throws Exception {
+        ComputeNode node = new ComputeNode(1001L, "cn-0.starrocks-cn-search.svc.cluster.local", 9040);
+        node.setBrpcPort(9050);
+
+        PublishTabletsInfo tabletsInfo = new PublishTabletsInfo();
+        tabletsInfo.addTabletId(101L);
+
+        new MockUp<DnsCache>() {
+            @Mock
+            public String tryLookup(String hostname) {
+                return "cn-0.starrocks-cn-search.svc.cluster.local".equals(hostname) ? "10.0.0.7" : hostname;
+            }
+        };
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public WarehouseManager getWarehouseMgr() {
+                return new WarehouseManager();
+            }
+        };
+
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public boolean isResourceAvailable(ComputeResource computeResource) {
+                return true;
+            }
+        };
+
+        new MockUp<Utils>() {
+            @Mock
+            public Map<ComputeNode, PublishTabletsInfo> processTablets(List<Tablet> tablets,
+                                                                      ComputeResource computeResource,
+                                                                      WarehouseManager warehouseManager,
+                                                                      List<Long> rebuildPindexTabletIds,
+                                                                      long baseVersion, long newVersion)
+                    throws NoAliveBackendException {
+                return Collections.singletonMap(node, tabletsInfo);
+            }
+        };
+
+        AggregatePublishVersionRequest request = new AggregatePublishVersionRequest();
+        Utils.createSubRequestForAggregatePublish(Lists.newArrayList(), Lists.newArrayList(new TxnInfoPB()),
+                1L, 2L, null, WarehouseManager.DEFAULT_RESOURCE, request);
+
+        Assertions.assertEquals(1, request.getComputeNodes().size());
+        Assertions.assertEquals("10.0.0.7", request.getComputeNodes().get(0).getHost());
+        Assertions.assertEquals(9050, (int) request.getComputeNodes().get(0).getBrpcPort());
+        // The node id must still be the real id: FE matches PBs back to ComputeNode objects by id
+        // when choosing an aggregator.
+        Assertions.assertEquals(1001L, (long) request.getComputeNodes().get(0).getId());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -27,6 +27,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.util.DnsCache;
 import com.starrocks.lake.LakeAggregator;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
@@ -608,6 +609,79 @@ public class CompactionSchedulerTest {
 
         Assertions.assertTrue(foundNode1);
         Assertions.assertTrue(foundNode2);
+    }
+
+    // The aggregator feeds every ComputeNodePB straight into LakeServiceBrpcStubCache::get_stub(),
+    // which must resolve the host before it can look up its EndPoint-keyed cache -- so a hostname
+    // there is one uncached getaddrinfo per sub-request per compaction on the CN. Pin that FE ships
+    // the resolved IP. Note the aggregator's own address stays a hostname: that call goes through
+    // BrpcProxy, which resolves on the FE side.
+    @Test
+    public void testCreateAggregateCompactionTaskResolvesHostnameToIp() throws Exception {
+        Map<Long, List<Long>> beToTablets = new HashMap<>();
+        beToTablets.put(1001L, Lists.newArrayList(101L));
+
+        CompactionMgr compactionManager = new CompactionMgr();
+
+        ComputeNode node1 = new ComputeNode(1001L, "cn-0.starrocks-cn.svc.cluster.local", 9040);
+        node1.setBrpcPort(9050);
+        ComputeNode aggregatorNode = new ComputeNode(1003L, "cn-2.starrocks-cn.svc.cluster.local", 9040);
+        aggregatorNode.setBrpcPort(9050);
+
+        new MockUp<DnsCache>() {
+            @Mock
+            public String tryLookup(String hostname) {
+                return hostname.startsWith("cn-0.") ? "10.0.0.7" : hostname;
+            }
+        };
+
+        new Expectations() {
+            {
+                systemInfoService.getBackendOrComputeNode(1001L);
+                result = node1;
+            }
+        };
+
+        new MockUp<LakeAggregator>() {
+            @Mock
+            public ComputeNode chooseAggregatorNode(ComputeResource computeResource,
+                                                    java.util.Collection<ComputeNode> candidateNodes) {
+                return aggregatorNode;
+            }
+        };
+
+        new Expectations() {
+            {
+                BrpcProxy.getLakeService("cn-2.starrocks-cn.svc.cluster.local", 9050);
+                result = lakeService;
+            }
+        };
+
+        CompactionScheduler scheduler = new CompactionScheduler(compactionManager, systemInfoService,
+                globalTransactionMgr, globalStateMgr, "");
+
+        // A real LakeTable with an injected TableProperty rather than Mockito.mock(OlapTable.class):
+        // createAggregateCompactionTask only reads getTableProperty(), and inline-mocking OlapTable
+        // fails under JDK 21 ("Could not modify all classes") once JMockit has instrumented it.
+        LakeTable table = new LakeTable();
+        table.setTableProperty(new TableProperty(new HashMap<>()));
+
+        Method method = CompactionScheduler.class.getDeclaredMethod("createAggregateCompactionTask",
+                long.class, Map.class, long.class, PartitionStatistics.CompactionPriority.class, ComputeResource.class,
+                long.class, OlapTable.class);
+        method.setAccessible(true);
+        CompactionTask task = (CompactionTask) method.invoke(scheduler, 1000L, beToTablets, 2000L,
+                PartitionStatistics.CompactionPriority.DEFAULT, WarehouseManager.DEFAULT_RESOURCE, 99L, table);
+
+        Field requestField = AggregateCompactionTask.class.getDeclaredField("request");
+        requestField.setAccessible(true);
+        AggregateCompactRequest aggRequest = (AggregateCompactRequest) requestField.get(task);
+
+        Assertions.assertEquals(1, aggRequest.computeNodes.size());
+        ComputeNodePB nodePB = aggRequest.computeNodes.get(0);
+        Assertions.assertEquals("10.0.0.7", nodePB.getHost());
+        Assertions.assertEquals(9050, (int) nodePB.getBrpcPort());
+        Assertions.assertEquals(1001L, (long) nodePB.getId());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/DictionaryCacheSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/DictionaryCacheSinkTest.java
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.util.DnsCache;
+import com.starrocks.thrift.TNetworkAddress;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class DictionaryCacheSinkTest {
+
+    // The node list in this sink is shipped to a BE, which turns every entry into a stub via
+    // HttpBrpcStubCache::get_http_stub(). That cache is keyed by the resolved EndPoint, so it cannot
+    // suppress the lookup -- a hostname here means one uncached getaddrinfo per node per refresh on the
+    // BE, which has no DNS cache. The sink must therefore carry resolved addresses. It is done here
+    // rather than in DictionaryMgr#fillBackendsOrComputeNodes on purpose: that helper also feeds
+    // SHOW DICTIONARY, which must keep printing the hostname the user configured.
+    @Test
+    public void testSinkCarriesResolvedAddresses() {
+        new MockUp<DnsCache>() {
+            @Mock
+            public String tryLookup(String hostname) {
+                if ("be-0.starrocks-be.svc.cluster.local".equals(hostname)) {
+                    return "10.0.0.11";
+                } else if ("cn-0.starrocks-cn.svc.cluster.local".equals(hostname)) {
+                    return "10.0.0.12";
+                }
+                return hostname;
+            }
+        };
+
+        List<TNetworkAddress> nodes = Lists.newArrayList(
+                new TNetworkAddress("be-0.starrocks-be.svc.cluster.local", 8060),
+                new TNetworkAddress("cn-0.starrocks-cn.svc.cluster.local", 8060));
+
+        DictionaryCacheSink sink = new DictionaryCacheSink(nodes, null, 1L);
+
+        Assertions.assertEquals(
+                Lists.newArrayList(new TNetworkAddress("10.0.0.11", 8060), new TNetworkAddress("10.0.0.12", 8060)),
+                sink.getNodes());
+        // The caller's list must not be mutated: DictionaryMgr reuses it for the BEGIN/COMMIT/CLEAR RPCs
+        // it issues itself, and those are expected to keep going through BrpcProxy by hostname.
+        Assertions.assertEquals("be-0.starrocks-be.svc.cluster.local", nodes.get(0).getHostname());
+    }
+
+    // An address that is already an IP literal must survive untouched, and an unresolvable hostname must
+    // fall back to itself rather than becoming null or empty -- so the change can only ever degrade to
+    // the previous behavior.
+    @Test
+    public void testResolutionIsIdempotentAndFallsBack() {
+        List<TNetworkAddress> nodes = Lists.newArrayList(
+                new TNetworkAddress("10.0.0.11", 8060),
+                new TNetworkAddress("no-such-host.invalid", 8060));
+
+        DictionaryCacheSink sink = new DictionaryCacheSink(nodes, null, 1L);
+
+        Assertions.assertEquals(new TNetworkAddress("10.0.0.11", 8060), sink.getNodes().get(0));
+        Assertions.assertEquals(new TNetworkAddress("no-such-host.invalid", 8060), sink.getNodes().get(1));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Since #32062 / #33189 the FE resolves compute-node hostnames before handing an address to a
BE, so that a BE never has to call `getaddrinfo()` for a peer. #32062 states the reason
explicitly: *"Because compute node has no DNS cache in container, it may cause resolving
flooding for DNS server ... After applying this patch, Compute node doesn't need to resolve
hostname anymore."*

Three paths added after that ship a raw hostname instead:

| FE site | consumed by |
| --- | --- |
| `Utils#createSubRequestForAggregatePublish` | `LakeServiceImpl::aggregate_publish_version` |
| `CompactionScheduler#createAggregateCompactionTask` | `LakeServiceImpl::aggregate_compact` |
| `DictionaryMgr#fillBackendsOrComputeNodes` &rarr; `DictionaryCacheSink` | `DictionaryCacheWriter` |

On the BE all three end up in a brpc stub cache keyed by the *resolved* `butil::EndPoint`, so
the cache structurally cannot suppress the lookup — `hostname_to_ip()` runs before the map is
consulted, on every call, and the BE has no DNS cache and no retry at all
(`be/src/common/brpc/brpc_stub_cache.cpp`). For aggregate publish that is one `getaddrinfo()`
per sub-request per publish batch, issued by whichever node is acting as the aggregator, so the
DNS query rate scales with `publish rate x compute nodes` rather than being bounded by the
number of nodes. `Config.enable_file_bundling` defaults to true, which makes this the default
path for shared-data tables.

## What I'm doing:

Send the resolved IP on exactly those three paths, matching what the query and load paths
already do (`ExecutionDAG#getBrpcIpAddress`, `GlobalStateMgr` `TNodeInfo`). The FE resolves
through the JVM DNS cache.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
