### PR TITLE
[Enhancement] correlation subquery suppert safe-equals predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -24,7 +24,6 @@ import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.DecimalV3FunctionAnalyzer;
 import com.starrocks.sql.ast.QueryRelation;
-import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/SubqueryUtils.java
@@ -123,7 +123,7 @@ public class SubqueryUtils {
     /**
      * ApplyNode doesn't need to check the number of subquery's return rows
      * when the correlation predicate meets these requirements:
-     * 1. All predicate is Binary.EQ
+     * 1. All predicate is Binary.EQ or Binary.EQ_FOR_NULL
      */
     public static boolean checkAllIsBinaryEQ(List<ScalarOperator> correlationPredicate) {
         for (ScalarOperator predicate : correlationPredicate) {
@@ -132,7 +132,7 @@ public class SubqueryUtils {
             }
 
             BinaryPredicateOperator bpo = ((BinaryPredicateOperator) predicate);
-            if (!BinaryType.EQ.equals(bpo.getBinaryType())) {
+            if (!bpo.getBinaryType().isEquivalence()) {
                 return false;
             }
         }
@@ -149,7 +149,7 @@ public class SubqueryUtils {
         }
 
         BinaryPredicateOperator bpo = ((BinaryPredicateOperator) correlationPredicate);
-        if (!BinaryType.EQ.equals(bpo.getBinaryType())) {
+        if (!bpo.getBinaryType().isEquivalence()) {
             return false;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2JoinRule.java
@@ -144,8 +144,8 @@ public class ExistentialApply2JoinRule extends TransformationRule {
     private List<OptExpression> transformCorrelation(OptExpression input, LogicalApplyOperator apply,
                                                      ExistsPredicateOperator epo) {
         boolean hasEqPredicate = Utils.extractConjuncts(apply.getCorrelationConjuncts()).stream()
-                .anyMatch(d -> OperatorType.BINARY.equals(d.getOpType()) && BinaryType.EQ
-                        .equals(((BinaryPredicateOperator) d).getBinaryType()));
+                .anyMatch(d -> OperatorType.BINARY.equals(d.getOpType())
+                        && ((BinaryPredicateOperator) d).getBinaryType().isEquivalence());
 
         if (hasEqPredicate) {
             return transformCorrelationWithEQ(input, apply, epo);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ExistentialApply2OuterJoinRule.java
@@ -78,8 +78,8 @@ public class ExistentialApply2OuterJoinRule extends TransformationRule {
     private List<OptExpression> transformCorrelation(OptExpression input, LogicalApplyOperator apply,
                                                      ExistsPredicateOperator epo, OptimizerContext context) {
         boolean hasEqPredicate = Utils.extractConjuncts(apply.getCorrelationConjuncts()).stream()
-                .anyMatch(d -> OperatorType.BINARY.equals(d.getOpType()) && BinaryType.EQ
-                        .equals(((BinaryPredicateOperator) d).getBinaryType()));
+                .anyMatch(d -> OperatorType.BINARY.equals(d.getOpType()) &&
+                        ((BinaryPredicateOperator) d).getBinaryType().isEquivalence());
 
         if (hasEqPredicate) {
             return transformCorrelationWithEQ(input, apply, epo, context);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -2063,7 +2063,6 @@ public class SubqueryTest extends PlanTestBase {
     }
 
     @Test
-<<<<<<< Updated upstream
     public void testOneRowCTE1() throws Exception {
         String sql = "WITH from_dt AS (SELECT '20250209' AS dt) "
                 + "SELECT * FROM t0 WHERE v1 > (SELECT dt FROM from_dt);";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -2063,6 +2063,7 @@ public class SubqueryTest extends PlanTestBase {
     }
 
     @Test
+<<<<<<< Updated upstream
     public void testOneRowCTE1() throws Exception {
         String sql = "WITH from_dt AS (SELECT '20250209' AS dt) "
                 + "SELECT * FROM t0 WHERE v1 > (SELECT dt FROM from_dt);";
@@ -2096,5 +2097,62 @@ public class SubqueryTest extends PlanTestBase {
                 + " left join t1 xx1 on x1.v5 = xx1.v5 and xx1.v6 = (select v8 from t2 where v9 = 1 order by v8 limit 1) ";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "ASSERT NUMBER OF ROWS");
+    }
+    
+    @Test
+    public void testNotExistSafeEqualsPushDown() throws Exception {
+        String sql = "select * from join1 where join1.dt > 1 " +
+                        "and NOT EXISTS (select * from join1 as a where a.id <=> join1.id);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "HASH JOIN\n"
+                + "  |  join op: LEFT ANTI JOIN (BROADCAST)\n"
+                + "  |  colocate: false, reason: \n"
+                + "  |  equal join conjunct: 2: id <=> 5: id");
+    }
+
+    @Test
+    public void testExistSafeEqualsPushDown() throws Exception {
+        String sql = "select * from join1 where join1.dt > 1 " +
+                "and EXISTS (select * from join1 as a where a.id <=> join1.id);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "HASH JOIN\n"
+                + "  |  join op: LEFT SEMI JOIN (BROADCAST)\n"
+                + "  |  colocate: false, reason: \n"
+                + "  |  equal join conjunct: 2: id <=> 5: id");
+    }
+
+    @Test
+    public void testInSafeEqualsPushDown() throws Exception {
+        String sql = "select * from join1 where join1.dt > 1 " +
+                "and join1.dt in (select a.dt from join1 as a where a.id <=> join1.id);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "HASH JOIN\n"
+                + "  |  join op: LEFT SEMI JOIN (BROADCAST)\n"
+                + "  |  colocate: false, reason: \n"
+                + "  |  equal join conjunct: 1: dt = 4: dt\n"
+                + "  |  equal join conjunct: 2: id <=> 5: id");
+    }
+
+    @Test
+    public void testNotInSafeEqualsPushDown() throws Exception {
+        String sql = "select * from join1 where join1.dt > 1 " +
+                "and join1.dt not in (select a.dt from join1 as a where a.id <=> join1.id);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "HASH JOIN\n"
+                + "  |  join op: NULL AWARE LEFT ANTI JOIN (BROADCAST)\n"
+                + "  |  colocate: false, reason: \n"
+                + "  |  equal join conjunct: 1: dt = 4: dt\n"
+                + "  |  other join predicates: 5: id <=> 2: id");
+    }
+
+    @Test
+    public void testScalarSafeEqualsPushDown() throws Exception {
+        String sql = "select * from join1 where join1.dt > 1 " +
+                "and join1.dt = (select a.dt from join1 as a where a.id <=> join1.id);";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "HASH JOIN\n"
+                + "  |  join op: LEFT OUTER JOIN (BROADCAST)\n"
+                + "  |  colocate: false, reason: \n"
+                + "  |  equal join conjunct: 2: id <=> 5: id");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
  When a correlated subquery uses the NULL-safe equal operator (<=>) in its correlation predicate, the optimizer does not recognize it, so the subquery cannot be decorrelated.

  To rewrite an Apply node into a Join, the optimizer must first determine whether the correlation predicates are equality predicates — only equality predicates can be safely pushed down as a join's equal conjunct. Previously that check
  was hardcoded as BinaryType.EQ.equals(bpo.getBinaryType()), which excluded <=> (EQ_FOR_NULL) outright. As a result, SubqueryUtils.checkAllIsBinaryEQ returned false, and all four rules that depend on it — ScalarApply2JoinRule,
  QuantifiedApply2OuterJoinRule, ExistentialApply2OuterJoinRule, and PushDownApplyAggFilterRule — gave up on the rewrite. The Apply node survived into the physical plan and degraded to nested-loop execution, re-running the subquery once
  per outer row, which is unusable at any real data volume.

  But <=> is semantically an equality join condition just like =; the only difference is the outcome when NULL is involved (NULL <=> NULL is true, NULL = NULL is NULL). 

```
  select * from join1 where join1.dt > 1
    and NOT EXISTS (select * from join1 as a where a.id <=> join1.id);
  -- LEFT ANTI JOIN (BROADCAST), equal join conjunct: 2: id <=> 5: id
```


## What I'm doing:

  1. SubqueryUtils — widen the equality check to accept <=>:

  - checkAllIsBinaryEQ (SubqueryUtils.java:135): the per-predicate check inside the loop now uses isEquivalence().
  - checkUniqueCorrelation (SubqueryUtils.java:152): the single-predicate check is widened the same way.

  These two methods are the rewrite preconditions for ScalarApply2JoinRule:94, QuantifiedApply2OuterJoinRule:115 and :125, ExistentialApply2OuterJoinRule:248, and PushDownApplyAggFilterRule:127. Once widened, all of those rules take
  effect for <=> correlation predicates. The javadoc on the method was updated to match.

  2. ExistentialApply2JoinRule / ExistentialApply2OuterJoinRule — in transformCorrelation, the test that decides whether to take the transformCorrelationWithEQ path also switched to isEquivalence().

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
