### PR TITLE
[Doc] Add release notes for StarRocks v3.5.21

### DIFF
--- a/docs/en/release_notes/release-3.5.md
+++ b/docs/en/release_notes/release-3.5.md
@@ -27,6 +27,58 @@ description: "StarRocks 3.5 release notes: Iceberg view creation, OAuth 2.0 and 
 
 :::
 
+## 3.5.21
+
+Release date: August 28, 2026
+
+### Behavior Changes
+
+- Reverted the 3.5.20 change that cached Iceberg REST vended-credential tables and kept their credentials fresh: on `branch-3.5`, that caching caused `INSERT OVERWRITE` transactions against a slow Iceberg REST catalog to stay `COMMITTED` but not `VISIBLE` for several seconds, because a REST metadata refresh could now run while the planner held a lock that transaction publishing also needs. The caching behavior remains in place on the 4.x line. [#77039](https://github.com/StarRocks/starrocks/pull/77039)
+- GIN (inverted) indexes on Primary Key tables now read from the correct segment after a column-mode partial update, instead of serving stale index data from the unmodified base segment. [#76271](https://github.com/StarRocks/starrocks/pull/76271)
+- Audit logs for statements forwarded to the leader FE now record the leader-resolved, fully qualified table relations (with CTEs excluded), instead of the follower's unresolved names. [#76387](https://github.com/StarRocks/starrocks/pull/76387)
+- `ARRAY`/`MAP` constructor expressions now reject a result whose flattened size exceeds 4 GB instead of silently wrapping around and returning corrupted values. [#76419](https://github.com/StarRocks/starrocks/pull/76419)
+- Iceberg REST catalogs using OAuth2 client-credentials now self-heal their background token-refresh session after a prolonged failure, instead of leaving the catalog permanently unable to refresh its access token. [#76457](https://github.com/StarRocks/starrocks/pull/76457)
+- External scan contexts (for example, an abandoned Spark/Flink connector read) now properly cancel their pipeline fragments when reaped as expired, instead of leaving them running. [#76535](https://github.com/StarRocks/starrocks/pull/76535)
+- External scan plans (Spark/Flink connector reads) now set `query_delivery_timeout`, so their `QueryContext` no longer waits indefinitely for fragments that will never arrive. [#76536](https://github.com/StarRocks/starrocks/pull/76536)
+- `array_difference()` on integer arrays no longer overflows in 32-bit precision before widening to `BIGINT`, fixing incorrect results when the true difference falls outside the `INT` range. [#76569](https://github.com/StarRocks/starrocks/pull/76569)
+- Division expressions with a non-constant divisor (for example, `10 DIV c`) are no longer treated as monotonic, fixing incorrect ZoneMap-based pruning that could return an empty or wrong result. [#76744](https://github.com/StarRocks/starrocks/pull/76744)
+- The configured compression codec now applies to the synthetic null/offset sub-columns of flat JSON, `ARRAY`, `MAP`, and `STRUCT` columns, instead of always writing them as uncompressed raw pages. [#76949](https://github.com/StarRocks/starrocks/pull/76949)
+- Load quorum selection no longer picks a replica in `DECOMMISSION` state as the load primary. [#77035](https://github.com/StarRocks/starrocks/pull/77035)
+- Optimizer rules that rebuild a logical window operator now preserve its `inputIsBinary` flag, keeping the binary-input merge optimization for ranking-window pre-aggregation intact. [#77058](https://github.com/StarRocks/starrocks/pull/77058)
+
+### Improvements
+
+- Materialized views no longer force a full-partition refresh when manually set from `INACTIVE` to `ACTIVE`; only the metadata version map is cleared during a schema change. [#57371](https://github.com/StarRocks/starrocks/pull/57371)
+- Improved error messages for large-column-capacity-limit checks by removing internal diagnostics (raw pointers, operator dumps) from the user-facing error, and fixed a typo in the shared status string. [#76303](https://github.com/StarRocks/starrocks/pull/76303)
+
+### Bug fixes
+
+The following issues have been fixed:
+
+- Guarded against cyclic view definitions: an `ALTER VIEW` that closes a reference cycle (`v1` -> `v2` -> `v1`) is now rejected with a clear error instead of causing a later `SELECT` to recurse forever and crash with `StackOverflowError`. [#75033](https://github.com/StarRocks/starrocks/pull/75033)
+- Forbade pushing an aggregate down through a CASE expression that has a non-null constant ELSE branch, fixing a planning abort (`IllegalStateException`) that could occur once the rule fired. [#75037](https://github.com/StarRocks/starrocks/pull/75037)
+- `CTEAnchor` now prunes correctly when its child is a `ValueOperator`. [#64491](https://github.com/StarRocks/starrocks/pull/64491)
+- Fixed predicate conversion for Paimon: an AND-combined predicate now retains its convertible not-null branch instead of the whole conversion returning null. [#66038](https://github.com/StarRocks/starrocks/pull/66038)
+- The Arrow Flight prepared-statement schema no longer reports every view column as nullable regardless of its actual `NOT NULL` definition, and a related regression that produced wrong nullability for `GROUP BY ROLLUP`/`CUBE`/`GROUPING SETS` key columns has also been fixed. [#75684](https://github.com/StarRocks/starrocks/pull/75684) [#76149](https://github.com/StarRocks/starrocks/pull/76149)
+- Fixed two statistics bugs: an OR-predicate statistics estimate that always clamped the merged `nullsFraction` to `1` regardless of the real value, and a column-statistics cache load failure under `ERROR_IF_OVERFLOW` when a column's persisted min/max is an empty string. [#75864](https://github.com/StarRocks/starrocks/pull/75864) [#76684](https://github.com/StarRocks/starrocks/pull/76684)
+- Fixed a bRPC stub cache timer leak that leaked memory over time. [#75973](https://github.com/StarRocks/starrocks/pull/75973)
+- `UNNEST` output struct pruning now uses its input array's subfield group instead of the output's own, fixing a mismatch between the struct type BE materializes and the one FE declares. [#76002](https://github.com/StarRocks/starrocks/pull/76002)
+- Fixed Arrow Flight Prepared Statement forwarding sending the wrong action-type string when a request is forwarded to a different FE, which caused every ADBC client using prepared statements behind a load balancer to fail. [#76310](https://github.com/StarRocks/starrocks/pull/76310)
+- Hive `getTable()` now reconnects before falling back to `get_table_req()`, fixing an intermittent `out of sequence response` / `Unknown table` error when querying an Iceberg table through a Hive metastore catalog. [#76456](https://github.com/StarRocks/starrocks/pull/76456)
+- Made catalog-drop existence checks atomic under the write lock, fixing a check-then-act race that could persist a redundant drop record when two drops of the same catalog ran concurrently. [#76778](https://github.com/StarRocks/starrocks/pull/76778)
+- Fixed `PipeObservable` emitting a source event instead of a sink event on a deferred sink notification, which could leave a driver blocked on `OUTPUT_FULL` unresponsive. [#76782](https://github.com/StarRocks/starrocks/pull/76782)
+- `dictionary_get()` no longer rejects a non-NULL key when its input column's cached `has_null` flag is stale. [#76881](https://github.com/StarRocks/starrocks/pull/76881)
+- Added the missing `arrow-compression` module for Arrow Flight SQL, restoring LZ4/ZSTD codec support for compressed Arrow IPC clients. [#76921](https://github.com/StarRocks/starrocks/pull/76921)
+- Fixed an OOM in streaming pre-aggregation under memory pressure with spill enabled. [#76702](https://github.com/StarRocks/starrocks/pull/76702)
+- `Set` operators are no longer placed in colocate execution groups, fixing a hang caused by their branches being terminated by a plain local-exchange sink instead of a grouped-execution sink. [#77025](https://github.com/StarRocks/starrocks/pull/77025)
+- Stopped the query cache from storing incomplete per-tablet results for an aggregation with a `LIMIT`, which could return wrong results from the cache. [#77066](https://github.com/StarRocks/starrocks/pull/77066)
+- An insert-overwrite failure is no longer journaled against a table that was concurrently dropped, fixing an FE crash on journal replay. [#77212](https://github.com/StarRocks/starrocks/pull/77212)
+- Checkpoint-thread-created thread pools are no longer registered in the metrics registry. [#77367](https://github.com/StarRocks/starrocks/pull/77367)
+- Stopped shipping test-scope jars in the `java-extensions` reader libraries. [#77752](https://github.com/StarRocks/starrocks/pull/77752)
+- Resolved tablet backend IDs outside the `TabletInvertedIndex` write lock, fixing an FE deadlock between materialized-view refresh/insert-overwrite commit and tablet force-delete. [#78102](https://github.com/StarRocks/starrocks/pull/78102)
+- Several BE/CN crashes: a crash during graceful shutdown when a pending brpc closure ran after `SinkBuffer` was destroyed; a null-pointer crash in `SparseRangeIterator::has_more()` on an empty physical-split tablet; a `bad_weak_ptr` abort from an unscheduled global runtime-filter timer in `PipelineDriver`'s destructor; a SIGSEGV in the native Parquet reader on an incomplete nested lake schema; a heap-use-after-free with a multi-character CSV delimiter that straddles a buffer expansion; and a heap-buffer-overflow building the error message for a raw JSON value in `SimdJsonConverter`. [#73202](https://github.com/StarRocks/starrocks/pull/73202) [#75985](https://github.com/StarRocks/starrocks/pull/75985) [#76252](https://github.com/StarRocks/starrocks/pull/76252) [#76455](https://github.com/StarRocks/starrocks/pull/76455) [#76718](https://github.com/StarRocks/starrocks/pull/76718) [#76752](https://github.com/StarRocks/starrocks/pull/76752)
+- Several dependency CVEs: excluded an unused `avro-ipc` dependency that bundled a vulnerable jQuery 1.4.2; bumped Netty to 4.1.136.Final; excluded vulnerable Jetty jars and bumped pgjdbc to 42.7.12; bumped Apache Thrift to 0.24.0; and bumped Apache HttpCore to 5.4.3. [#76270](https://github.com/StarRocks/starrocks/pull/76270) [#76555](https://github.com/StarRocks/starrocks/pull/76555) [#76783](https://github.com/StarRocks/starrocks/pull/76783) [#76922](https://github.com/StarRocks/starrocks/pull/76922) [#77753](https://github.com/StarRocks/starrocks/pull/77753)
+
 ## 3.5.20
 
 Release date: July 23, 2026

--- a/docs/en/release_notes/release-3.5.md
+++ b/docs/en/release_notes/release-3.5.md
@@ -1070,8 +1070,8 @@ Release Date: June 13, 2025
 ### Data Lake Analytics
 
 - **[Beta]** Supports creating Iceberg views in the Iceberg Catalog with Hive Metastore integration. And supports adding or modifying the dialect of the Iceberg view using the ALTER VIEW statement for better syntax compatibility with external systems. [#56120](https://github.com/StarRocks/starrocks/pull/56120)
-- Supports nested namespace for [Iceberg REST Catalog](https://docs.starrocks.io/docs/data_source/catalog/iceberg/iceberg_catalog/#rest). [#58016](https://github.com/StarRocks/starrocks/pull/58016)
-- Supports using `IcebergAwsClientFactory` to create AWS clients in [Iceberg REST Catalog](https://docs.starrocks.io/docs/data_source/catalog/iceberg/iceberg_catalog/#rest) to offer vended credentials. [#58296](https://github.com/StarRocks/starrocks/pull/58296)
+- Supports nested namespace for Iceberg REST Catalog. [#58016](https://github.com/StarRocks/starrocks/pull/58016)
+- Supports using `IcebergAwsClientFactory` to create AWS clients in Iceberg REST Catalog to offer vended credentials. [#58296](https://github.com/StarRocks/starrocks/pull/58296)
 - Parquet Reader supports filtering data with Bloom Filter. [#56445](https://github.com/StarRocks/starrocks/pull/56445)
 - Supports automatically creating global dictionaries for low-cardinality columns in Parquet-formatted Hive/Iceberg tables during queries. [#55167](https://github.com/StarRocks/starrocks/pull/55167) 
 


### PR DESCRIPTION
## Why I'm doing:

StarRocks v3.5.21 has been tagged. Adding the English release notes section for it.

## What I'm doing:

Adds a `## 3.5.21` section to `docs/en/release_notes/release-3.5.md`, covering every PR
backported to `branch-3.5` between tags `3.5.20` and `3.5.21` that is user-facing
(excluding `[Doc]`/`[UT]`/`[Tool]` and behavior-neutral changes).

English only — `docs/zh` and `docs/ja` are intentionally untouched; translation will be
handled by `/translate` once a docs-maintainer checks the language boxes on the
"🌎 Translation Required?" comment that auto-posts after `markdownlint` passes.

### Notable corrections made vs. the raw PR list

While drafting, I found the automated PR-history collector had silently mis-cited or
dropped a few entries by resolving backport commits to the wrong "main PR" identity.
Verified directly against `git log 3.5.20..3.5.21` and the GitHub API:

- **#75431** ("Cache Iceberg REST vended-credential tables…") already shipped in **3.5.20**.
  It was **reverted** on `branch-3.5` by **#77039** in this window (production 3.5.20
  clusters saw `INSERT OVERWRITE` on Iceberg REST catalogs stay `COMMITTED`-but-not-`VISIBLE`
  for several seconds). The collector re-cited #75431 as if it were new to 3.5.21; the
  notes now correctly cite **#77039** under Behavior Changes instead.
- **#73391** ("Move INSERT external table auto-refresh out of the planner lock path") was
  backported to `branch-3.5` (#76969) and then reverted (#76991) in the same window — a
  mis-targeted backport (3.5 was never a selected branch for #73391). Net zero change;
  excluded entirely.
- **#76989** ("Guard legacy NGRAMBF indexes without `gram_num`") landed on `branch-3.5.21`
  after the branch was already cut (#78292) and was reverted (#78304) to keep the patch to
  its intended scope; it will ship in a later 3.5 patch. Net zero change; excluded entirely.
- **#76307/#76308** ("Honor `CREATE TABLE IF NOT EXISTS` on Iceberg REST catalogs") was a
  manual backport that bypassed `main` (main PR #76307 is still open/unmerged) and was
  reverted (#77343) for that reason. Net zero change; excluded entirely — see the separate
  PR-quality comment for follow-up.

None of these four were in the collector's own `unresolved` list, so they wouldn't have
been caught without a manual git-log diff.

### Needs reviewer confirmation

- **#77039** (Behavior Changes) — this reverts 3.5.20 behavior on `branch-3.5` only (the
  4.x line keeps the caching). Please confirm the wording matches product intent for the
  3.5 line, and that omitting #75431/#73391/#76989/#76307/#76308/#77343 entirely (all net
  zero within this window) is the right call rather than a footnote.
- **#57371** (Improvements) — changes the default behavior of manually setting an MV from
  `INACTIVE` to `ACTIVE` (no longer forces a full-partition refresh). No `behavior_changed`
  label; please confirm Improvements vs. Behavior Changes.
- **#76921** (Bug fixes) — adds a previously-missing `arrow-compression` module/codec
  support rather than fixing broken existing behav­ior; please confirm Bug fixes vs.
  Improvements.
- **#76419** (Behavior Changes), **#77212**, **#78102** (Bug fixes) — each cited PR's
  backport chain did not resolve to a merged PR on `main` (see the separate PR-quality
  comment). Included in the notes at face value; please confirm these numbers are correct
  and that the fixes exist on `main`.

## What type of PR is this:

- [x] Doc

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5