### PR TITLE
[BugFix] Align TMaterializedViewStatus field ids 38/39 with the ids 4.1 shipped

### DIFF
--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -436,8 +436,9 @@ struct TMaterializedViewStatus {
     35: optional string refresh_policy
     36: optional string resource_group
     37: optional string query_rewrite_status_reason
-    38: optional string last_freshness_confirmed_at
-    39: optional string base_table_refresh_version_times
+    // Ids 38/39 must stay as branch-4.1 shipped them in 4.1.4: rolling upgrade runs new BEs against old FEs.
+    38: optional string base_table_refresh_version_times
+    39: optional string last_freshness_confirmed_at
 }
 
 struct TListPipesParams {


### PR DESCRIPTION
## Why I'm doing:

`TMaterializedViewStatus` gives the same two fields different thrift ids on `main` and on `branch-4.1`:

| id | `main` | `branch-4.1` (shipped in 4.1.4) |
|----|--------|--------------------------------|
| 38 | `last_freshness_confirmed_at` | `base_table_refresh_version_times` |
| 39 | `base_table_refresh_version_times` | `last_freshness_confirmed_at` |

On `main`, #74585 merged first and took 38, then #74717 took 39. The backports reached `branch-4.1` in the opposite order and the second one took the next free id instead of the id the field already had on `main`. 4.1.4 is released with that ordering, so `main` is the side that has to move. No other struct in `FrontendService.thrift` has a conflicting id (checked field-by-field across `branch-4.0`, `branch-4.1` and `main`).

Rolling upgrade upgrades BEs and CNs before FEs, exactly because BEs are expected to stay compatible with older FEs (`docs/en/deployment/manage_deployment/upgrade.md`), so "new BE + 4.1 FE" is a supported state — and a downgrade, which goes FE first, passes through the same state.

In that window a query on `information_schema.materialized_views` that is not FE-evaluable (`supportFeEvaluation` handles no predicate and `=TABLE_SCHEMA` / `=TABLE_NAME` in the FE; anything else is scanned on the BE) returns:

- `LAST_FRESHNESS_CONFIRMED_AT` — `NULL`, because the BE decodes field 38 into `last_freshness_confirmed_at` and the FE wrote the version-time map there, which fails `from_date_str`
- `BASE_TABLE_REFRESH_VERSION_TIMES` — a timestamp instead of the JSON map

Both columns are observability-only, nothing is persisted, and values are correct again once every FE is upgraded — but they are silently wrong until then, and the JSON column breaks any tooling that parses it.

## What I'm doing:

Swapping the two wire ids on `main` back to what 4.1.4 shipped.

Only the ids move. Both sides address these fields by name — `ShowMaterializedViewStatus.toThrift` and `MaterializedViewsSystemTable#infoToScalar` by thrift field name, `SchemaScanNode::prepare` by column name (with a type check) — so no other FE or BE code changes, and the column order of the system table is left alone.

The same class of conflict exists between `branch-4.0` (31 = `last_freshness_confirmed_at`, 32 = `last_refresh_time`) and `branch-4.1` (31 = `last_refresh_time`, 32 = `warehouse`). Both lines are released, so neither side can move and it is out of scope here.

Fixes #issue: N/A — wire-protocol id conflict found by comparing the released branches, no issue filed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
