### PR TITLE
[BugFix] Fix avg() on DECIMAL256 returning wrong result after aggregate push down (backport #77832)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
@@ -366,9 +367,18 @@ public class AggregatePushDownUtils {
         Type argType = avgFunc.getChild(0).getType();
         if (argType.isDecimalV3()) {
             // There is not need to apply ImplicitCastRule to divide operator of decimal types.
-            // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
-            ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
-            newAvg.getChildren().set(1, new CastOperator(decimal128p38s0, newAvg.getChild(1), true));
+            // but we should cast BIGINT-typed countColRef into a decimal.
+            //
+            // The cast width must match the DIVIDE's own decimal type, not a fixed DECIMAL128: the BE
+            // dispatches division on the expression's type (VectorizedDivArithmeticExpr<TYPE_DECIMAL256>
+            // for a DECIMAL256 result) and reads BOTH operands at that width. Handing it a DECIMAL128
+            // count where it expects a DECIMAL256 one reinterprets the column's memory and silently
+            // returns garbage - avg(decimal(76,10)) came back as 0 for every row.
+            int countPrecision = avgFunc.getType().isDecimal256()
+                    ? PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL256)
+                    : PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL128);
+            ScalarType countType = ScalarType.createDecimalV3NarrowestType(countPrecision, 0);
+            newAvg.getChildren().set(1, new CastOperator(countType, newAvg.getChild(1), true));
         } else {
             final ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
             newAvg = (CallOperator) scalarRewriter.rewrite(newAvg, Lists.newArrayList(new ImplicitCastRule()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtilsTest.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.common;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AggregatePushDownUtilsTest {
+
+    private static CallOperator buildAvg(ScalarType argType, ScalarType retType) {
+        ColumnRefOperator arg = new ColumnRefOperator(1, argType, "c1", true);
+        return new CallOperator(FunctionSet.AVG, retType, Lists.newArrayList(arg));
+    }
+
+    private static CallOperator rewriteAvg(ScalarType argType, ScalarType retType) {
+        CallOperator avgFunc = buildAvg(argType, retType);
+        ColumnRefOperator sumColRef = new ColumnRefOperator(2, retType, "sum_c1", true);
+        ColumnRefOperator countColRef = new ColumnRefOperator(3, Type.BIGINT, "count_c1", true);
+        return AggregatePushDownUtils.createAvgBySumCount(avgFunc, sumColRef, countColRef);
+    }
+
+    @Test
+    public void testCreateAvgBySumCountOnDecimal128() {
+        ScalarType argType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10);
+        CallOperator newAvg = rewriteAvg(argType, argType);
+
+        Assertions.assertEquals(FunctionSet.DIVIDE, newAvg.getFnName());
+        // count is cast to the widest DECIMAL128 so that the divide's two operands share the same width
+        Assertions.assertEquals(ScalarType.createDecimalV3NarrowestType(38, 0), newAvg.getChild(1).getType());
+    }
+
+    @Test
+    public void testCreateAvgBySumCountOnDecimal256() {
+        ScalarType argType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 10);
+        CallOperator newAvg = rewriteAvg(argType, argType);
+
+        Assertions.assertEquals(FunctionSet.DIVIDE, newAvg.getFnName());
+        // BE dispatches the divide on the expression type and reads both operands at that width, so a
+        // DECIMAL256 divide must get a DECIMAL256 count - a DECIMAL128 one makes avg() return garbage.
+        Assertions.assertTrue(newAvg.getChild(1).getType().isDecimal256(),
+                "count operand should be DECIMAL256, but was " + newAvg.getChild(1).getType());
+        Assertions.assertEquals(ScalarType.createDecimalV3NarrowestType(76, 0), newAvg.getChild(1).getType());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
When an `avg()` is rewritten into `sum() / count()` — by the MV aggregate push-down rule, or by the MV `avg -> sum/count` rewriter — the BIGINT count has to be cast to a decimal so that the DIVIDE gets two decimal operands. That cast width was hardcoded to `DECIMAL128(38, 0)`, from a time when DECIMAL128 was the widest decimal there was.

DECIMAL256 broke that assumption. The BE dispatches division on the expression's own type (`VectorizedDivArithmeticExpr<TYPE_DECIMAL256>` for a DECIMAL256 result) and reads **both** operands at that width. Handing it a DECIMAL128 count where it expects a DECIMAL256 one reinterprets the column's memory — no error, no cast failure, just a wrong answer: `avg(decimal(76, 10))` came back as `0` for every row.

```
avg(decimal(76,10))  ->  DIVIDE : DECIMAL256(76,10)      <- BE reads both operands as 256-bit
                            |
                            +-- sum   : DECIMAL256(76,10)   OK
                            +-- count : DECIMAL128(38,0)    <- 128-bit payload read as 256-bit => garbage
```

## What I'm doing:
Derive the cast width from the DIVIDE's own decimal type instead of hardcoding it:

- DECIMAL256 avg -> cast count to `DECIMAL256(76, 0)`
- everything else -> cast count to `DECIMAL128(38, 0)`, i.e. unchanged behavior

Added `AggregatePushDownUtilsTest` covering both widths. The DECIMAL256 case fails on the old code with `count operand should be DECIMAL256, but was DECIMAL128(38,0)`, so it is a real regression guard rather than a tautology.

This is the same fix already merged into main as part of #77832; it is split out here on its own because it is an independent, pre-existing bug — it is reachable through the two existing callers of `createAvgBySumCount` and has nothing to do with the grouping-sets enhancement that PR was about.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

