### PR TITLE
[Enhancement] Enable the jemalloc oversize arena by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -124,10 +124,17 @@ CONF_Bool(enable_jemalloc_memory_tracker, "true");
 // changing any other option is rejected, because the corresponding `opt.*` mallctl nodes are
 // read-only; those need a restart. Note that prof_active can only be turned on when the process
 // was started with prof:true.
+// `oversize_threshold` sends every allocation of at least that many bytes to jemalloc's
+// dedicated huge arena, which is purged eagerly. Keeping the large buffers out of the
+// per-CPU arenas lets them be reused across threads and stops them from dominating the decay
+// bookkeeping of the ordinary arenas, where they otherwise drag small and medium extents into
+// being purged with them and cost a soft page fault each on the next use. It is set above
+// jemalloc's own 8MB default because the huge arena is a single shared arena, so a lower
+// threshold funnels more allocations through its lock.
 // NOTE: keep this default in sync with the normal-mode default in bin/start_backend.sh.
 CONF_mString(jemalloc_conf,
-             "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
-             "background_thread:true,prof:true,prof_active:false");
+             "percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+             "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
 
 // Whether abort the process if a large memory allocation is detected which the requested
 // size is larger than the available physical memory without wrapping with TRY_CATCH_BAD_ALLOC

--- a/be/src/common/config_memory_allocator_fwd.h
+++ b/be/src/common/config_memory_allocator_fwd.h
@@ -41,10 +41,17 @@ CONF_Bool(enable_jemalloc_memory_tracker, "true");
 // changing any other option is rejected, because the corresponding `opt.*` mallctl nodes are
 // read-only; those need a restart. Note that prof_active can only be turned on when the process
 // was started with prof:true.
+// `oversize_threshold` sends every allocation of at least that many bytes to jemalloc's
+// dedicated huge arena, which is purged eagerly. Keeping the large buffers out of the
+// per-CPU arenas lets them be reused across threads and stops them from dominating the decay
+// bookkeeping of the ordinary arenas, where they otherwise drag small and medium extents into
+// being purged with them and cost a soft page fault each on the next use. It is set above
+// jemalloc's own 8MB default because the huge arena is a single shared arena, so a lower
+// threshold funnels more allocations through its lock.
 // NOTE: keep this default in sync with the normal-mode default in bin/start_backend.sh.
 CONF_mString(jemalloc_conf,
-             "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,"
-             "background_thread:true,prof:true,prof_active:false");
+             "percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+             "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
 
 // Whether abort the process if a large memory allocation is detected which the requested
 // size is larger than the available physical memory without wrapping with TRY_CATCH_BAD_ALLOC

--- a/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
+++ b/be/test/runtime/memory/jemalloc_conf_updater_test.cpp
@@ -35,7 +35,7 @@ namespace {
 // contains what the test itself changed.
 std::string make_conf(std::string_view dirty_decay_ms, std::string_view muzzy_decay_ms, std::string_view prof_active) {
     return fmt::format(
-            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:{},dirty_decay_ms:{},metadata_thp:auto,"
+            "percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:{},dirty_decay_ms:{},metadata_thp:auto,"
             "background_thread:true,prof:true,prof_active:{}",
             muzzy_decay_ms, dirty_decay_ms, prof_active);
 }
@@ -175,7 +175,7 @@ TEST_F(JemallocConfUpdaterTest, reject_immutable_option) {
 
     // Changed.
     Status st = updater.update(
-            "percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+            "percpu_arena:disabled,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
             "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
     EXPECT_TRUE(st.is_not_supported()) << st;
     EXPECT_TRUE(st.message().find("percpu_arena") != std::string::npos) << st;
@@ -187,14 +187,14 @@ TEST_F(JemallocConfUpdaterTest, reject_immutable_option) {
 
     // Removed.
     st = updater.update(
-            "percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
+            "percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,"
             "metadata_thp:auto,background_thread:true,prof:true");
     EXPECT_TRUE(st.is_not_supported()) << st;
     EXPECT_TRUE(st.message().find("prof_active (removed)") != std::string::npos) << st;
 
     // A mutable option changed together with an immutable one is rejected as well.
     st = updater.update(
-            "percpu_arena:disabled,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:6000,"
+            "percpu_arena:disabled,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:6000,"
             "metadata_thp:auto,background_thread:true,prof:true,prof_active:false");
     EXPECT_TRUE(st.is_not_supported()) << st;
 
@@ -222,7 +222,7 @@ TEST_F(JemallocConfUpdaterTest, update_without_change_is_a_noop) {
     // The option order does not matter either.
     ASSERT_OK(
             updater.update("prof_active:false,prof:true,background_thread:true,metadata_thp:auto,"
-                           "dirty_decay_ms:5000,muzzy_decay_ms:5000,oversize_threshold:0,percpu_arena:percpu"));
+                           "dirty_decay_ms:5000,muzzy_decay_ms:5000,oversize_threshold:134217728,percpu_arena:percpu"));
     EXPECT_EQ("5000", updater.applied_options()["muzzy_decay_ms"]);
 }
 
@@ -230,9 +230,10 @@ TEST_F(JemallocConfUpdaterTest, update_without_change_is_a_noop) {
 // arena at index narenas_auto and puts it on eager purge on purpose, and the arenas created
 // through `arenas.create` sit above that, so neither may be retuned from here.
 //
-// This process has no huge arena (`oversize_threshold:0`), but a manually created arena is
-// on the same side of narenas_auto, so it stands in for one: if the walk stopped at
-// `arenas.narenas` it would reach this arena too.
+// A manually created arena stands in for the huge one here: it sits on the same side of
+// narenas_auto, so if the walk stopped at `arenas.narenas` it would reach this arena too.
+// The test binary inherits no JEMALLOC_CONF, so whether a huge arena exists at all depends
+// on jemalloc's own `oversize_threshold` default; the assertion below holds either way.
 TEST_F(JemallocConfUpdaterTest, decay_ms_skips_the_arenas_above_narenas_auto) {
     unsigned manual_arena = 0;
     size_t size = sizeof(manual_arena);

--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -171,12 +171,12 @@ if [[ -z "$JEMALLOC_CONF" ]]; then
     if [ ${RUN_JEMALLOC_DEBUG} -eq 1 ] ; then
         export JEMALLOC_CONF="junk:true,tcache:false,prof:true"
     elif [ ${RUN_CHECK_MEM_LEAK} -eq 1 ] ; then
-        export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:true,prof_leak:true,lg_prof_sample:0,prof_final:true"
+        export JEMALLOC_CONF="percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:true,prof_leak:true,lg_prof_sample:0,prof_final:true"
     else
         # Normal mode: take the value from the `jemalloc_conf` config in be.conf/cn.conf so it is
         # observable via information_schema.be_configs. Fall back to the built-in default when unset.
         # NOTE: keep this default in sync with CONF_mString(jemalloc_conf, ...) in be/src/common/config.h.
-        jemalloc_conf="percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"
+        jemalloc_conf="percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false"
         if [ ${RUN_BE} -eq 1 ]; then
             read_var_from_conf jemalloc_conf $STARROCKS_HOME/conf/be.conf
         elif [ ${RUN_CN} -eq 1 ]; then

--- a/docs/en/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/en/administration/configuration/BE_parameters/log_server_meta.md
@@ -404,7 +404,7 @@ This topic introduces the following types of BE configurations:
 
 ### jemalloc_conf
 
-- Default: `percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
+- Default: `percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
 - Type: string
 - Unit: -
 - Is mutable: Yes (only some options)

--- a/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/ja/administration/configuration/BE_parameters/log_server_meta.md
@@ -329,7 +329,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
 ### jemalloc_conf
 
-- デフォルト: `percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
+- デフォルト: `percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
 - タイプ: string
 - 単位: -
 - 変更可能: はい (一部のオプションのみ)

--- a/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
+++ b/docs/zh/administration/configuration/BE_parameters/log_server_meta.md
@@ -425,7 +425,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 
 ### jemalloc_conf
 
-- 默认值：`percpu_arena:percpu,oversize_threshold:0,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
+- 默认值：`percpu_arena:percpu,oversize_threshold:134217728,muzzy_decay_ms:5000,dirty_decay_ms:5000,metadata_thp:auto,background_thread:true,prof:true,prof_active:false`
 - 类型：string
 - 单位：-
 - 是否动态：是（仅部分选项）


### PR DESCRIPTION
## Why I'm doing:

The default `jemalloc_conf` turns jemalloc's dedicated huge arena off with `oversize_threshold:0`, so every allocation, however large, lands in the per-CPU arena of the calling thread.

That costs on two fronts:

- **Reuse and fragmentation.** A large buffer freed on one CPU's arena is invisible to the others, so the same buffer gets allocated again per thread, and the large extents left behind are repeatedly split by smaller requests. Splitting is not reversible on its own — two neighbouring extents only coalesce when both happen to be free at the same time — so the address space ratchets towards fragmentation. This is exactly the case [jemalloc/jemalloc#1229](https://github.com/jemalloc/jemalloc/issues/1229) introduced the huge arena for.
- **Decay bookkeeping.** The purge target is computed over the arena's total dirty pages, so freeing one large extent raises it by that whole extent, while the decay walk works down the LRU one extent at a time. Small and medium extents ahead of it in the LRU are purged to reach the target — one `madvise` each — and take a soft page fault each on their next use.

jemalloc has enabled this by default (8MB) since 5.2; `0` is a non-default, explicit opt-out.

## What I'm doing:

Set `oversize_threshold` to `134217728` (128MB) in the default `jemalloc_conf`, so allocations of at least that size are routed into the huge arena, which jemalloc also keeps on eager purge.

128MB rather than jemalloc's own 8MB default because the huge arena is a single shared arena: the lower the threshold, the more allocations funnel through its lock. This is the conservative end of the range; it can be lowered later once the win is measured on a real workload.

Touched together so the value cannot drift:

- `be/src/common/config.h` and `be/src/common/config_memory_allocator_fwd.h` (the two copies of the config declaration), plus a comment explaining what the option does and why the value is above the jemalloc default
- `bin/start_backend.sh`, both the normal-mode default and the `--check_mem_leak` string that mirrors it
- the documented default in `docs/en`, `docs/zh` and `docs/ja`
- the option string `jemalloc_conf_updater_test.cpp` seeds itself with, which is meant to be the set the BE starts with

The test file's comment on `decay_ms_skips_the_arenas_above_narenas_auto` claimed the test process has no huge arena "(`oversize_threshold:0`)". That was already inaccurate — `run-be-ut.sh` sets no `JEMALLOC_CONF`, so the test binary runs on jemalloc's own default and does have one — and it does not depend on this config at all. Reworded so it no longer names a value; the assertion is `ASSERT_GE` and holds either way, no logic changed.

`oversize_threshold` is read-only after jemalloc init (`opt.oversize_threshold` is `r-`), so this takes effect on BE restart only, and the runtime `jemalloc_conf` update path continues to reject any attempt to change it.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

