### PR TITLE
[BugFix] Clean up stale column statistics after column type change

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHelper.java
@@ -17,11 +17,16 @@ package com.starrocks.alter;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.SchemaChangeTypeCompatibility;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class AlterHelper {
     static Set<String> collectDroppedOrModifiedColumns(List<Column> oldColumns, List<Column> newColumns) {
@@ -60,5 +65,76 @@ public class AlterHelper {
             }
         }
         return modifiedColumns;
+    }
+
+    /**
+     * Job-level variant used by the schema change jobs at finish time: locates the (origin, shadow)
+     * schema pair of the BASE index from the job's shadow-index mappings and diffs only that pair.
+     * Must be called before the shadow index replaces the origin one, while the old base schema is
+     * still reachable on the table.
+     * <p>
+     * Only the base pair matters because statistics are table-level and keyed by the base-schema
+     * column name, and a type change always shows up there (MODIFY has no per-rollup variant).
+     * Rollup pairs are deliberately ignored: a future per-column DROP handling must not misfire on
+     * {@code DROP COLUMN ... FROM rollup} (the column still exists on the table and its statistics
+     * stay valid), unlike the MV-inactivation collectors which do need per-index diffs.
+     *
+     * @param indexMetaIdToSchema shadow index meta id -> new schema of that shadow index
+     * @param indexMetaIdMap      shadow index meta id -> meta id of the origin index it replaces
+     */
+    static Set<String> collectStatsInvalidatedColumns(OlapTable tbl,
+                                                      Map<Long, List<Column>> indexMetaIdToSchema,
+                                                      Map<Long, Long> indexMetaIdMap) {
+        long baseIndexMetaId = tbl.getBaseIndexMetaId();
+        List<Column> originSchema = tbl.getSchemaByIndexMetaId(baseIndexMetaId);
+        if (originSchema == null) {
+            return Collections.emptySet();
+        }
+        for (Map.Entry<Long, List<Column>> entry : indexMetaIdToSchema.entrySet()) {
+            Long originIndexMetaId = indexMetaIdMap.get(entry.getKey());
+            if (originIndexMetaId != null && originIndexMetaId == baseIndexMetaId) {
+                return collectStatsInvalidatedColumns(originSchema, entry.getValue());
+            }
+        }
+        // the job does not touch the base index (e.g. a rollup-only alter): no type change possible
+        return Collections.emptySet();
+    }
+
+    /**
+     * Collect the columns whose type change invalidates their previously collected statistics.
+     * <p>
+     * Statistics store min/max as strings computed under the ordering semantics of the type at
+     * collection time; after a type change the statistics loader casts them to the NEW type. The
+     * validity condition is exactly the one of the zonemap index: the conversion must be
+     * monotonically non-decreasing so that the old min/max remain valid boundaries (e.g. the
+     * lexicographic extremes of a VARCHAR column are wrong bigint boundaries after VARCHAR->BIGINT),
+     * so {@link SchemaChangeTypeCompatibility#canReuseZonemapIndex} is reused as the predicate.
+     * Ordering-preserving widenings (INT->BIGINT, DATE->DATETIME, VARCHAR length increase, ...) keep
+     * their statistics and are not reported.
+     * <p>
+     * A type-changed column is identified by the {@link SchemaChangeHandler#SHADOW_NAME_PREFIX} on the
+     * new schema, which is applied only when the type actually changed; returned names have the prefix
+     * stripped.
+     */
+    static Set<String> collectStatsInvalidatedColumns(List<Column> oldColumns, List<Column> newColumns) {
+        Set<String> statsInvalidatedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+        Map<String, Column> oldColumnsByName = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (Column column : oldColumns) {
+            oldColumnsByName.put(column.getName(), column);
+        }
+        for (Column column : newColumns) {
+            if (!column.isNameWithPrefix(SchemaChangeHandler.SHADOW_NAME_PREFIX)) {
+                continue;
+            }
+            String originName = column.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PREFIX, column.getName());
+            Column oldColumn = oldColumnsByName.get(originName);
+            if (oldColumn == null || oldColumn.getType().equals(column.getType())) {
+                continue;
+            }
+            if (!SchemaChangeTypeCompatibility.canReuseZonemapIndex(oldColumn.getType(), column.getType())) {
+                statsInvalidatedColumns.add(originName);
+            }
+        }
+        return statsInvalidatedColumns;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -72,6 +72,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
@@ -796,6 +797,8 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         }
 
         // Replace the current index with shadow index.
+        Set<String> statsInvalidatedColumns = Sets.newHashSet();
+        OlapTable finishedTable = null;
         try (AutoCloseableLock ignore = new AutoCloseableLock(dbId, List.of(tableId), LockType.WRITE)) {
             OlapTable table = getTable();
             if (table == null) {
@@ -805,6 +808,10 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
             // collect modified columns for inactivating mv
             // Note: should collect before visualiseShadowIndex
             Set<String> modifiedColumns = collectModifiedColumnsForRelatedMVs(table);
+            // Collect the columns whose type change invalidates their statistics
+            statsInvalidatedColumns =
+                    AlterHelper.collectStatsInvalidatedColumns(table, indexMetaIdToSchema, indexMetaIdMap);
+            finishedTable = table;
             this.finishedTimeMs = System.currentTimeMillis();
 
             persistStateChange(this, JobState.FINISHED, () -> {
@@ -819,6 +826,13 @@ public class LakeTableSchemaChangeJob extends LakeTableSchemaChangeJobBase {
         if (jobState == JobState.FINISHED) {
             AlterMetricRegistry.getInstance().updateAlterDuration(
                     AlterMetricRegistry.AlterExecutionMode.REWRITE, finishedTimeMs - createTimeMs);
+            // Leader-only cleanup of the now-invalid statistics of type-changed columns, outside the
+            // edit-log applier and after the table lock is released (issues internal DML, writes its
+            // own edit log entry, submits an async re-collection). Followers converge via the
+            // replayed OP_ADD_BASIC_STATS_META entries.
+            if (finishedTable != null) {
+                StatisticUtils.dropStatisticsAfterTypeChange(dbId, finishedTable, statsInvalidatedColumns);
+            }
         }
 
         if (span != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -88,6 +88,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
+import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -842,11 +843,14 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
          */
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(tbl.getId()), LockType.WRITE);
+        Set<String> statsInvalidatedColumns = Sets.newHashSet();
         try {
             Preconditions.checkState(tbl.getState() == OlapTableState.SCHEMA_CHANGE);
 
             // Before schema change, collect modified columns for related mvs.
             Set<String> modifiedColumns = collectModifiedColumnsForRelatedMVs(tbl);
+            // Collect the columns whose type change invalidates their statistics
+            statsInvalidatedColumns = AlterHelper.collectStatsInvalidatedColumns(tbl, indexMetaIdToSchema, indexMetaIdMap);
 
             for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
                 PhysicalPartition physicalPartition = tbl.getPhysicalPartition(physicalPartitionId);
@@ -904,6 +908,10 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
         if (jobState == JobState.FINISHED) {
             AlterMetricRegistry.getInstance().updateAlterDuration(
                     AlterMetricRegistry.AlterExecutionMode.REWRITE, finishedTimeMs - createTimeMs);
+            // Runs on the leader only, outside the edit-log applier and after the table lock is
+            // released (it issues internal DML, writes its own edit log entry, and submits an async
+            // re-collection). Followers converge via the replayed OP_ADD_BASIC_STATS_META entries.
+            StatisticUtils.dropStatisticsAfterTypeChange(dbId, tbl, statsInvalidatedColumns);
         }
 
         LOG.info("schema change job finished: {}", jobId);

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -910,11 +910,22 @@ public class EditLog {
                 }
                 case OperationType.OP_ADD_BASIC_STATS_META: {
                     BasicStatsMeta basicStatsMeta = (BasicStatsMeta) journal.data();
+                    BasicStatsMeta previousMeta =
+                            globalStateMgr.getAnalyzeMgr().getTableBasicStatsMeta(basicStatsMeta.getTableId());
                     globalStateMgr.getAnalyzeMgr().replayAddBasicStatsMeta(basicStatsMeta);
                     // The follower replays the stats meta log, indicating that the master has re-completed
                     // statistic, and the follower's should refresh cache here.
                     // We don't need to refresh statistics when checkpointing
                     if (!GlobalStateMgr.isCheckpointThread()) {
+                        // Columns removed from the meta (e.g. their statistics were invalidated by a
+                        // column type change) are not covered by the refresh below, which only reloads
+                        // the columns still listed; expire them explicitly, otherwise this FE would keep
+                        // serving their stale cached statistics until eviction.
+                        List<String> removedColumns = BasicStatsMeta.removedColumns(previousMeta, basicStatsMeta);
+                        if (!removedColumns.isEmpty()) {
+                            globalStateMgr.getAnalyzeMgr().expireTableAndColumnStatistics(basicStatsMeta.getDbId(),
+                                    basicStatsMeta.getTableId(), removedColumns);
+                        }
                         globalStateMgr.getAnalyzeMgr().refreshBasicStatisticsCache(basicStatsMeta.getDbId(),
                                 basicStatsMeta.getTableId(), basicStatsMeta.getColumns(), true);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CachedStatisticStorage.java
@@ -533,6 +533,7 @@ public class CachedStatisticStorage implements StatisticStorage, MemoryTrackable
             allKeys.add(key);
         }
         columnStatistics.synchronous().invalidateAll(allKeys);
+        partitionStatistics.synchronous().invalidateAll(allKeys);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -850,6 +850,41 @@ public class AnalyzeMgr implements Writable {
         }
     }
 
+    /**
+     * Drop the persisted statistics rows and the per-column meta entries for the given columns of a table,
+     * then invalidate the FE statistics cache for them. Used when a schema change makes the previously
+     * collected statistics of a column semantically invalid (e.g. a column type change with different
+     * ordering semantics).
+     *
+     * @return true iff the persisted rows were deleted (and the meta was updated accordingly)
+     */
+    public boolean dropColumnStatsMetaAndData(ConnectContext statsConnectCtx, long dbId, long tableId,
+                                              List<String> columns) {
+        if (columns == null || columns.isEmpty()) {
+            return true;
+        }
+        StatisticExecutor statisticExecutor = new StatisticExecutor();
+        try (var guard = statsConnectCtx.bindScope()) {
+            boolean sampleOk = statisticExecutor.dropColumnStatistics(statsConnectCtx, tableId, columns,
+                    StatsConstants.AnalyzeType.SAMPLE);
+            boolean fullOk = statisticExecutor.dropColumnStatistics(statsConnectCtx, tableId, columns,
+                    StatsConstants.AnalyzeType.FULL);
+            if (!sampleOk || !fullOk) {
+                return false;
+            }
+
+            BasicStatsMeta basicStatsMeta = basicStatsMetaMap.get(tableId);
+            if (basicStatsMeta != null && basicStatsMeta.getColumns().stream()
+                    .anyMatch(c -> columns.stream().anyMatch(c::equalsIgnoreCase))) {
+                BasicStatsMeta newMeta = basicStatsMeta.clone();
+                newMeta.removeColumnStatsMeta(columns);
+                addBasicStatsMeta(newMeta);
+            }
+            expireTableAndColumnStatistics(dbId, tableId, columns);
+            return true;
+        }
+    }
+
     public void dropHistogramStatsMetaAndData(ConnectContext statsConnectCtx, List<Long> tableIds) {
         if (tableIds == null || tableIds.isEmpty()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -885,6 +885,46 @@ public class AnalyzeMgr implements Writable {
         }
     }
 
+    /**
+     * Histogram counterpart of {@link #dropColumnStatsMetaAndData}: drop the persisted histogram rows
+     * and the per-column histogram meta for the given columns of a table, then invalidate the
+     * histogram cache. Same contract: leader-only, outside any edit-log applier, data deleted before
+     * the meta is removed.
+     *
+     * @return true iff the persisted histogram rows were deleted (and the meta was removed accordingly)
+     */
+    public boolean dropColumnHistogramMetaAndData(ConnectContext statsConnectCtx, long dbId, long tableId,
+                                                  List<String> columns) {
+        if (columns == null || columns.isEmpty()) {
+            return true;
+        }
+        StatisticExecutor statisticExecutor = new StatisticExecutor();
+        try (var guard = statsConnectCtx.bindScope()) {
+            if (!statisticExecutor.dropColumnHistogramStatistics(statsConnectCtx, tableId, columns)) {
+                return false;
+            }
+
+            List<Pair<Long, String>> keysToRemove = new ArrayList<>();
+            List<HistogramStatsMeta> metasToRemove = new ArrayList<>();
+            for (Map.Entry<Pair<Long, String>, HistogramStatsMeta> entry : histogramStatsMetaMap.entrySet()) {
+                if (entry.getKey().first == tableId
+                        && columns.stream().anyMatch(c -> c.equalsIgnoreCase(entry.getKey().second))) {
+                    keysToRemove.add(entry.getKey());
+                    metasToRemove.add(entry.getValue());
+                }
+            }
+            if (!metasToRemove.isEmpty()) {
+                GlobalStateMgr.getCurrentState().getEditLog().logRemoveHistogramStatsMetaBatch(metasToRemove, wal -> {
+                    for (Pair<Long, String> key : keysToRemove) {
+                        histogramStatsMetaMap.remove(key);
+                    }
+                });
+            }
+            GlobalStateMgr.getCurrentState().getStatisticStorage().expireHistogramStatistics(tableId, columns);
+            return true;
+        }
+    }
+
     public void dropHistogramStatsMetaAndData(ConnectContext statsConnectCtx, List<Long> tableIds) {
         if (tableIds == null || tableIds.isEmpty()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -298,6 +298,22 @@ public class BasicStatsMeta implements Writable {
         this.columnStatsMetaMap.put(columnStatsMeta.getColumnName(), columnStatsMeta);
     }
 
+    /**
+     * The columns present in {@code previous} but no longer in {@code current} (case-insensitive).
+     * Used on the edit-log replay path to invalidate the cached statistics of columns whose meta
+     * entry was revoked (e.g. by the type-change cleanup): the replay refresh only covers the
+     * columns still listed in the new meta, so removed ones must be expired explicitly.
+     */
+    public static List<String> removedColumns(BasicStatsMeta previous, BasicStatsMeta current) {
+        if (previous == null) {
+            return Collections.emptyList();
+        }
+        List<String> currentColumns = current.getColumns();
+        return previous.getColumns().stream()
+                .filter(c -> currentColumns.stream().noneMatch(c::equalsIgnoreCase))
+                .collect(Collectors.toList());
+    }
+
     public void removeColumnStatsMeta(Collection<String> columnNames) {
         for (String columnName : columnNames) {
             columnStatsMetaMap.keySet().removeIf(k -> k.equalsIgnoreCase(columnName));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -298,6 +298,21 @@ public class BasicStatsMeta implements Writable {
         this.columnStatsMetaMap.put(columnStatsMeta.getColumnName(), columnStatsMeta);
     }
 
+    public void removeColumnStatsMeta(Collection<String> columnNames) {
+        for (String columnName : columnNames) {
+            columnStatsMetaMap.keySet().removeIf(k -> k.equalsIgnoreCase(columnName));
+        }
+        // The deprecated legacy column list is still serialized for rollback compatibility and
+        // becomes authoritative again once columnStatsMetaMap is empty (see getColumns()), so it
+        // must be kept consistent, otherwise a removed entry would resurrect. Rebuild instead of
+        // removeIf: the passed-in list may be immutable.
+        if (columns != null) {
+            columns = columns.stream()
+                    .filter(c -> columnNames.stream().noneMatch(c::equalsIgnoreCase))
+                    .collect(Collectors.toList());
+        }
+    }
+
     public void resetDeltaRows() {
         this.deltaRows = 0;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -243,6 +243,16 @@ public class StatisticExecutor {
         return executeDML(statsConnectCtx, sql);
     }
 
+    public boolean dropColumnStatistics(ConnectContext statsConnectCtx, long tableId, List<String> columnNames,
+                                        StatsConstants.AnalyzeType analyzeType) {
+        if (columnNames == null || columnNames.isEmpty()) {
+            return true;
+        }
+        String sql = StatisticSQLBuilder.buildDropColumnStatisticsSQL(tableId, columnNames, analyzeType);
+        LOG.debug("Drop column statistic SQL: {}", sql);
+        return executeDML(statsConnectCtx, sql);
+    }
+
     public void dropTableMultiColumnStatistics(ConnectContext statsConnectCtx, Long tableIds) {
         String sql = StatisticSQLBuilder.buildDropMultipleStatisticsSQL(tableIds);
         LOG.debug("Expire statistic SQL: {}", sql);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -253,6 +253,16 @@ public class StatisticExecutor {
         return executeDML(statsConnectCtx, sql);
     }
 
+    public boolean dropColumnHistogramStatistics(ConnectContext statsConnectCtx, long tableId,
+                                                 List<String> columnNames) {
+        if (columnNames == null || columnNames.isEmpty()) {
+            return true;
+        }
+        String sql = StatisticSQLBuilder.buildDropHistogramSQL(tableId, columnNames);
+        LOG.debug("Drop column histogram statistic SQL: {}", sql);
+        return executeDML(statsConnectCtx, sql);
+    }
+
     public void dropTableMultiColumnStatistics(ConnectContext statsConnectCtx, Long tableIds) {
         String sql = StatisticSQLBuilder.buildDropMultipleStatisticsSQL(tableIds);
         LOG.debug("Expire statistic SQL: {}", sql);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -323,6 +323,27 @@ public class StatisticSQLBuilder {
         return "DELETE FROM " + tableName + " WHERE TABLE_ID IN (" + tids + ")";
     }
 
+    /**
+     * Delete the statistics rows of specific columns of a table, across all partitions.
+     * Both statistics tables carry (table_id, column_name) as key columns, so this predicate is
+     * legal on the UNIQUE_KEYS variants as well.
+     */
+    public static String buildDropColumnStatisticsSQL(Long tableId, List<String> columnNames,
+                                                      StatsConstants.AnalyzeType analyzeType) {
+        Preconditions.checkState(columnNames != null && !columnNames.isEmpty());
+        String tableName;
+        if (analyzeType.equals(StatsConstants.AnalyzeType.SAMPLE)) {
+            tableName = SAMPLE_STATISTICS_TABLE_NAME;
+        } else {
+            tableName = FULL_STATISTICS_TABLE_NAME;
+        }
+
+        String columnsIn = columnNames.stream()
+                .map(c -> "'" + SqlUtils.escapeSqlString(c) + "'").collect(Collectors.joining(", "));
+        return "DELETE FROM " + tableName + " WHERE TABLE_ID = " + tableId +
+                " AND COLUMN_NAME IN (" + columnsIn + ")";
+    }
+
     public static String buildDropMultipleStatisticsSQL(Long tableId) {
         return "DELETE FROM " + MULTI_COLUMN_STATISTICS_TABLE_NAME + " WHERE TABLE_ID = " + tableId;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -627,6 +627,68 @@ public class StatisticUtils {
     }
 
     /**
+     * Clean up the statistics of columns whose previously collected values became semantically invalid
+     * after a schema change, and submit an asynchronous FULL re-collection over all partitions for
+     * the columns that had been analyzed.
+     * <p>
+     * Without the cleanup, the stale rows in {@code _statistics_} keep min/max strings computed under the
+     * OLD type ordering which the statistics loader then casts to the NEW type: depending on the data
+     * this yields silently wrong estimates or, under ERROR_IF_OVERFLOW, a cast failure on every cache load.
+     * <p>
+     * Leader-only, must be called outside any edit-log applier and without holding the db/table lock.
+     * The actual work runs asynchronously on the analyze thread pool so an unhealthy statistics table
+     * can never stall the alter daemon. Best-effort: failures are logged and the loader-side
+     * robustness remains the safety net.
+     */
+    public static void dropStatisticsAfterTypeChange(long dbId, Table table, Set<String> columns) {
+        if (columns == null || columns.isEmpty()) {
+            return;
+        }
+        List<String> columnList = new ArrayList<>(columns);
+        try {
+            GlobalStateMgr.getCurrentState().getAnalyzeMgr().getAnalyzeTaskThreadPool().execute(
+                    () -> dropStatisticsAfterTypeChangeInternal(dbId, table, columnList));
+        } catch (Throwable e) {
+            LOG.warn("failed to submit statistics cleanup after column type change, table: {}, columns: {}",
+                    table.getId(), columnList, e);
+        }
+    }
+
+    private static void dropStatisticsAfterTypeChangeInternal(long dbId, Table table, List<String> columnList) {
+        try {
+            AnalyzeMgr analyzeMgr = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
+            BasicStatsMeta basicStatsMeta = analyzeMgr.getTableBasicStatsMeta(table.getId());
+            List<String> analyzedColumns = basicStatsMeta == null ? List.of() :
+                    basicStatsMeta.getColumns().stream()
+                            .filter(c -> columnList.stream().anyMatch(c::equalsIgnoreCase))
+                            .collect(Collectors.toList());
+
+            ConnectContext statsConnectCtx = buildConnectContext();
+            statsConnectCtx.setStatisticsConnection(true);
+            if (!analyzeMgr.dropColumnStatsMetaAndData(statsConnectCtx, dbId, table.getId(), columnList)) {
+                LOG.warn("failed to drop stale statistics after type change, table: {}, columns: {}",
+                        table.getId(), columnList);
+                return;
+            }
+            LOG.info("dropped stale statistics after column type change, table: {}, columns: {}",
+                    table.getId(), columnList);
+
+            if (analyzedColumns.isEmpty()) {
+                return;
+            }
+            // Cheap staleness short-circuit, not a race-free guard
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            if (db == null
+                    || GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, table.getId()) == null) {
+                return;
+            }
+            StatisticsCollectionTrigger.triggerOnSchemaChange(db, table, analyzedColumns);
+        } catch (Throwable e) {
+            LOG.warn("failed to clean up statistics after column type change, table: {}", table.getId(), e);
+        }
+    }
+
+    /**
      * Change the replication_num of system table according to cluster status
      * 1. When scale-out to greater than 3 nodes, change the replication_num to 3
      * 3. When scale-in to less than 3 node, change it to retainedBackendNum

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -657,23 +657,42 @@ public class StatisticUtils {
     private static void dropStatisticsAfterTypeChangeInternal(long dbId, Table table, List<String> columnList) {
         try {
             AnalyzeMgr analyzeMgr = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
+            // snapshot what the affected columns currently carry before the cleanup wipes the meta:
+            // only previously analyzed columns are worth re-collecting, and histograms must be
+            // rebuilt with their original collection properties
             BasicStatsMeta basicStatsMeta = analyzeMgr.getTableBasicStatsMeta(table.getId());
             List<String> analyzedColumns = basicStatsMeta == null ? List.of() :
                     basicStatsMeta.getColumns().stream()
                             .filter(c -> columnList.stream().anyMatch(c::equalsIgnoreCase))
                             .collect(Collectors.toList());
+            List<HistogramStatsMeta> histogramMetas = analyzeMgr.getHistogramMetaByTable(table.getId()).stream()
+                    .filter(m -> columnList.stream().anyMatch(c -> c.equalsIgnoreCase(m.getColumn())))
+                    .collect(Collectors.toList());
 
             ConnectContext statsConnectCtx = buildConnectContext();
             statsConnectCtx.setStatisticsConnection(true);
-            if (!analyzeMgr.dropColumnStatsMetaAndData(statsConnectCtx, dbId, table.getId(), columnList)) {
+            if (analyzeMgr.dropColumnStatsMetaAndData(statsConnectCtx, dbId, table.getId(), columnList)) {
+                LOG.info("dropped stale statistics after column type change, table: {}, columns: {}",
+                        table.getId(), columnList);
+            } else {
                 LOG.warn("failed to drop stale statistics after type change, table: {}, columns: {}",
                         table.getId(), columnList);
                 return;
             }
-            LOG.info("dropped stale statistics after column type change, table: {}, columns: {}",
-                    table.getId(), columnList);
 
-            if (analyzedColumns.isEmpty()) {
+            // a stale histogram is worse than stale basic statistics: the optimizer prefers it over
+            // the (re-collected) min/max for selectivity, so it must be dropped and rebuilt as well
+            if (analyzeMgr.dropColumnHistogramMetaAndData(statsConnectCtx, dbId, table.getId(), columnList)) {
+                LOG.info("dropped stale histogram after column type change, table: {}, columns: {}",
+                        table.getId(), columnList);
+            } else {
+                LOG.warn("failed to drop stale histogram after type change, table: {}, columns: {}",
+                        table.getId(), columnList);
+                // don't rebuild on top of rows that could not be deleted
+                histogramMetas = List.of();
+            }
+
+            if (analyzedColumns.isEmpty() && histogramMetas.isEmpty()) {
                 return;
             }
             // Cheap staleness short-circuit, not a race-free guard
@@ -682,7 +701,18 @@ public class StatisticUtils {
                     || GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbId, table.getId()) == null) {
                 return;
             }
-            StatisticsCollectionTrigger.triggerOnSchemaChange(db, table, analyzedColumns);
+            if (!analyzedColumns.isEmpty()) {
+                StatisticsCollectionTrigger.triggerOnSchemaChange(db, table, analyzedColumns);
+            }
+            for (HistogramStatsMeta histogramMeta : histogramMetas) {
+                Column column = table.getColumn(histogramMeta.getColumn());
+                if (column == null || isUnsupportedHistogramColumnType(column.getType())) {
+                    // the new type cannot carry a histogram: deletion alone is the correct end state
+                    continue;
+                }
+                StatisticsCollectionTrigger.triggerHistogramOnSchemaChange(db, table,
+                        List.of(histogramMeta.getColumn()), histogramMeta.getProperties());
+            }
         } catch (Throwable e) {
             LOG.warn("failed to clean up statistics after column type change, table: {}", table.getId(), e);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -125,7 +125,28 @@ public class StatisticsCollectionTrigger {
         if (!Config.enable_statistic_collect || StatisticUtils.statisticDatabaseBlackListCheck(db.getFullName())) {
             return trigger;
         }
-        trigger.executeCollect(null, columns);
+        trigger.executeCollect(null, columns, null);
+        return trigger;
+    }
+
+    /**
+     * Re-collect the histogram of the given columns after a schema change invalidated the previously
+     * collected one (histogram bucket bounds are stored as strings under the collection-time type
+     * ordering, exactly like the basic min/max), using the properties the original histogram was
+     * collected with.
+     */
+    public static StatisticsCollectionTrigger triggerHistogramOnSchemaChange(Database db, Table table,
+                                                                             List<String> columns,
+                                                                             Map<String, String> properties) {
+        StatisticsCollectionTrigger trigger = new StatisticsCollectionTrigger();
+        trigger.db = db;
+        trigger.table = table;
+        trigger.sync = false;
+        trigger.analyzeType = StatsConstants.AnalyzeType.HISTOGRAM;
+        if (!Config.enable_statistic_collect || StatisticUtils.statisticDatabaseBlackListCheck(db.getFullName())) {
+            return trigger;
+        }
+        trigger.executeCollect(null, columns, properties);
         return trigger;
     }
 
@@ -184,7 +205,7 @@ public class StatisticsCollectionTrigger {
             executeOverWrite();
             waitFinish();
         } else if (analyzeType != null) {
-            executeCollect(new ArrayList<>(partitionIds), null);
+            executeCollect(new ArrayList<>(partitionIds), null, null);
             waitFinish();
         }
     }
@@ -226,11 +247,13 @@ public class StatisticsCollectionTrigger {
     }
 
     // partitionIdList == null: the job factory expands it to all data-bearing partitions;
-    // columnNames == null: all collectible columns
-    private void executeCollect(List<Long> partitionIdList, List<String> columnNames) {
-        Map<String, String> properties = Maps.newHashMap();
-        if (SAMPLE == analyzeType) {
-            properties = StatsConstants.buildInitStatsProp();
+    // columnNames == null: all collectible columns;
+    // extraProperties == null: default properties derived from the analyze type
+    private void executeCollect(List<Long> partitionIdList, List<String> columnNames,
+                                Map<String, String> extraProperties) {
+        Map<String, String> properties = extraProperties;
+        if (properties == null) {
+            properties = SAMPLE == analyzeType ? StatsConstants.buildInitStatsProp() : Maps.newHashMap();
         }
         AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
                 db.getId(), table.getId(), columnNames, analyzeType,

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -107,6 +107,28 @@ public class StatisticsCollectionTrigger {
         return trigger;
     }
 
+    /**
+     * Trigger a statistics re-collection for the given columns after a schema change invalidated their
+     * previously collected statistics (e.g. MODIFY COLUMN to a type with different ordering semantics,
+     * whose stale min/max would otherwise be reinterpreted under the new type).
+     * <p>
+     * Collects FULL statistics over ALL partitions on purpose: the stale rows being replaced live in
+     * every partition, while the partition-health based incremental collection would skip the unchanged
+     * ones (a type change does not alter row counts), so this must not go through the health filter.
+     */
+    public static StatisticsCollectionTrigger triggerOnSchemaChange(Database db, Table table, List<String> columns) {
+        StatisticsCollectionTrigger trigger = new StatisticsCollectionTrigger();
+        trigger.db = db;
+        trigger.table = table;
+        trigger.sync = false;
+        trigger.analyzeType = StatsConstants.AnalyzeType.FULL;
+        if (!Config.enable_statistic_collect || StatisticUtils.statisticDatabaseBlackListCheck(db.getFullName())) {
+            return trigger;
+        }
+        trigger.executeCollect(null, columns);
+        return trigger;
+    }
+
     public static StatisticsCollectionTrigger triggerOnFirstLoad(TransactionState txnState,
                                           Database db,
                                           Table table,
@@ -162,7 +184,7 @@ public class StatisticsCollectionTrigger {
             executeOverWrite();
             waitFinish();
         } else if (analyzeType != null) {
-            executeCollect();
+            executeCollect(new ArrayList<>(partitionIds), null);
             waitFinish();
         }
     }
@@ -203,13 +225,15 @@ public class StatisticsCollectionTrigger {
         }
     }
 
-    private void executeCollect() {
+    // partitionIdList == null: the job factory expands it to all data-bearing partitions;
+    // columnNames == null: all collectible columns
+    private void executeCollect(List<Long> partitionIdList, List<String> columnNames) {
         Map<String, String> properties = Maps.newHashMap();
         if (SAMPLE == analyzeType) {
             properties = StatsConstants.buildInitStatsProp();
         }
         AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(GlobalStateMgr.getCurrentState().getNextId(),
-                db.getId(), table.getId(), null, analyzeType,
+                db.getId(), table.getId(), columnNames, analyzeType,
                 StatsConstants.ScheduleType.ONCE, properties, LocalDateTime.now());
         analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addAnalyzeStatus(analyzeStatus);
@@ -229,7 +253,7 @@ public class StatisticsCollectionTrigger {
                         statsConnectCtx.setSessionId(((OlapTable) table).getSessionId());
                     }
                     StatisticsCollectJob job = StatisticsCollectJobFactory.buildStatisticsCollectJob(db, table,
-                            new ArrayList<>(partitionIds), null, null,
+                            partitionIdList, columnNames, null,
                             analyzeType, StatsConstants.ScheduleType.ONCE,
                             analyzeStatus.getProperties(), List.of(), List.of(), false);
                     if (!partitionTabletRowCounts.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterHelperTest.java
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+public class AlterHelperTest {
+
+    private static Column shadow(String name, Type type) {
+        return new Column(SchemaChangeHandler.SHADOW_NAME_PREFIX + name, type);
+    }
+
+    @Test
+    public void testCollectStatsInvalidatedColumns() {
+        List<Column> oldColumns = List.of(
+                new Column("k1", IntegerType.INT),
+                new Column("c_str", new VarcharType(64)),
+                new Column("c_int", IntegerType.INT),
+                new Column("c_dt", DateType.DATETIME),
+                new Column("c_vc", new VarcharType(10)));
+
+        List<Column> newColumns = List.of(
+                new Column("k1", IntegerType.INT),
+                // varchar -> bigint: the stored lexicographic min/max are invalid bigint boundaries
+                shadow("c_str", IntegerType.BIGINT),
+                // int -> bigint: monotonic widening, statistics stay valid
+                shadow("c_int", IntegerType.BIGINT),
+                // datetime -> date: truncating conversion, statistics invalid
+                shadow("c_dt", DateType.DATE),
+                // varchar length increase: ordering unchanged, statistics stay valid
+                shadow("c_vc", new VarcharType(20)));
+
+        Set<String> result = AlterHelper.collectStatsInvalidatedColumns(oldColumns, newColumns);
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertTrue(result.contains("c_str"));
+        Assertions.assertTrue(result.contains("c_dt"));
+    }
+
+    @Test
+    public void testCollectStatsInvalidatedColumnsIgnoresNonTypeChanges() {
+        // columns without the shadow prefix never changed their type and are never reported
+        List<Column> oldColumns = List.of(new Column("c1", IntegerType.INT), new Column("c2", new VarcharType(8)));
+        List<Column> newColumns = List.of(new Column("c1", IntegerType.INT), new Column("c2", new VarcharType(8)));
+        Assertions.assertTrue(AlterHelper.collectStatsInvalidatedColumns(oldColumns, newColumns).isEmpty());
+
+        // a shadow column whose origin no longer exists is ignored as well
+        List<Column> onlyShadow = List.of(shadow("gone", IntegerType.BIGINT));
+        Assertions.assertTrue(AlterHelper.collectStatsInvalidatedColumns(oldColumns, onlyShadow).isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -1016,4 +1016,17 @@ public class AnalyzeStmtTest {
         Assertions.assertEquals("delete from histogram_statistics where table_id in (100)", histogramSql);
     }
 
+    @Test
+    public void testStatisticSQLBuilderDropColumnSqls() {
+        List<String> columns = List.of("c_str", "o'brien");
+        Assertions.assertEquals(
+                "DELETE FROM table_statistic_v1 WHERE TABLE_ID = 10004 AND COLUMN_NAME IN ('c_str', 'o''brien')",
+                StatisticSQLBuilder.buildDropColumnStatisticsSQL(10004L, columns, StatsConstants.AnalyzeType.SAMPLE));
+        Assertions.assertEquals(
+                "DELETE FROM column_statistics WHERE TABLE_ID = 10004 AND COLUMN_NAME IN ('c_str', 'o''brien')",
+                StatisticSQLBuilder.buildDropColumnStatisticsSQL(10004L, columns, StatsConstants.AnalyzeType.FULL));
+        Assertions.assertThrows(IllegalStateException.class, () ->
+                StatisticSQLBuilder.buildDropColumnStatisticsSQL(10004L, List.of(), StatsConstants.AnalyzeType.FULL));
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -217,6 +217,28 @@ public class BasicStatsMetaTest extends PlanTestBase {
         }
     }
 
+    @Test
+    public void testRemoveColumnStatsMeta() {
+        BasicStatsMeta meta = new BasicStatsMeta(1L, 2L, Lists.newArrayList("c1", "c2"),
+                StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), Maps.newHashMap());
+        meta.addColumnStatsMeta(new ColumnStatsMeta("c1", StatsConstants.AnalyzeType.FULL, LocalDateTime.now()));
+        meta.addColumnStatsMeta(new ColumnStatsMeta("c2", StatsConstants.AnalyzeType.FULL, LocalDateTime.now()));
+
+        // removal is case-insensitive and updates both the meta map and the deprecated legacy list
+        meta.removeColumnStatsMeta(List.of("C1"));
+        Assertions.assertEquals(List.of("c2"), meta.getColumns());
+        Assertions.assertFalse(meta.getAnalyzedColumns().containsKey("c1"));
+
+        // the removal survives the GSON round-trip used by clone()/edit log persistence
+        BasicStatsMeta cloned = meta.clone();
+        Assertions.assertEquals(List.of("c2"), cloned.getColumns());
+
+        // once the map becomes empty, getColumns() falls back to the legacy list, which must not
+        // resurrect removed entries
+        meta.removeColumnStatsMeta(List.of("c2"));
+        Assertions.assertTrue(meta.getColumns().isEmpty());
+    }
+
     @AfterEach
     public void after() {
         FeConstants.runningUnitTest = false;

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/BasicStatsMetaTest.java
@@ -239,6 +239,28 @@ public class BasicStatsMetaTest extends PlanTestBase {
         Assertions.assertTrue(meta.getColumns().isEmpty());
     }
 
+    @Test
+    public void testRemovedColumns() {
+        BasicStatsMeta oldMeta = new BasicStatsMeta(1L, 2L, Lists.newArrayList(),
+                StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), Maps.newHashMap());
+        oldMeta.addColumnStatsMeta(new ColumnStatsMeta("c1", StatsConstants.AnalyzeType.FULL, LocalDateTime.now()));
+        oldMeta.addColumnStatsMeta(new ColumnStatsMeta("c2", StatsConstants.AnalyzeType.FULL, LocalDateTime.now()));
+
+        BasicStatsMeta newMeta = oldMeta.clone();
+        newMeta.removeColumnStatsMeta(List.of("c2"));
+
+        // no previous meta: nothing to expire
+        Assertions.assertTrue(BasicStatsMeta.removedColumns(null, newMeta).isEmpty());
+        // unchanged meta: nothing removed
+        Assertions.assertTrue(BasicStatsMeta.removedColumns(oldMeta, oldMeta).isEmpty());
+        // c2 was revoked; comparison is case-insensitive
+        Assertions.assertEquals(List.of("c2"), BasicStatsMeta.removedColumns(oldMeta, newMeta));
+        BasicStatsMeta upperMeta = new BasicStatsMeta(1L, 2L, Lists.newArrayList(),
+                StatsConstants.AnalyzeType.FULL, LocalDateTime.now(), Maps.newHashMap());
+        upperMeta.addColumnStatsMeta(new ColumnStatsMeta("C1", StatsConstants.AnalyzeType.FULL, LocalDateTime.now()));
+        Assertions.assertTrue(BasicStatsMeta.removedColumns(upperMeta, oldMeta).isEmpty());
+    }
+
     @AfterEach
     public void after() {
         FeConstants.runningUnitTest = false;

--- a/test/sql/test_analyze_statistics/R/test_stats_cleanup_after_modify_column_type
+++ b/test/sql/test_analyze_statistics/R/test_stats_cleanup_after_modify_column_type
@@ -1,0 +1,51 @@
+-- name: test_stats_cleanup_after_modify_column_type
+create database sc_stats_${uuid0};
+-- result:
+-- !result
+use sc_stats_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c1` int,
+  `c_str` varchar(64)
+)
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+insert into t1 values (1, '2'), (2, '19'), (3, '30');
+-- result:
+-- !result
+analyze full table t1 with sync mode;
+-- result:
+[REGEX].*OK.*
+-- !result
+select column_name, `min`, `max` from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' order by column_name;
+-- result:
+c1	1	3
+c_str	19	30
+-- !result
+alter table t1 modify column c_str bigint;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("sc_stats_${uuid0}", "t1")
+-- result:
+FINISHED
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 120, "interval": 5, "desc": "wait stale stats cleanup and re-collection after type change"}
+  result=select count(*) from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' and column_name = 'c_str' and `min` = '2' and `max` = '30';
+  CHECK: str(to_array(${result})[0][0]) == "1"
+} END LOOP
+select column_name, `min`, `max` from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' order by column_name;
+-- result:
+c1	1	3
+c_str	2	30
+-- !result
+drop database sc_stats_${uuid0};
+-- result:
+-- !result
+CLEANUP {
+    drop database if exists sc_stats_${uuid0};
+} END CLEANUP

--- a/test/sql/test_analyze_statistics/R/test_stats_cleanup_after_modify_column_type
+++ b/test/sql/test_analyze_statistics/R/test_stats_cleanup_after_modify_column_type
@@ -18,9 +18,6 @@ insert into t1 values (1, '2'), (2, '19'), (3, '30');
 -- result:
 -- !result
 analyze full table t1 with sync mode;
--- result:
-[REGEX].*OK.*
--- !result
 select column_name, `min`, `max` from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' order by column_name;
 -- result:
 c1	1	3
@@ -38,6 +35,7 @@ LOOP {
   result=select count(*) from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' and column_name = 'c_str' and `min` = '2' and `max` = '30';
   CHECK: str(to_array(${result})[0][0]) == "1"
 } END LOOP
+
 select column_name, `min`, `max` from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' order by column_name;
 -- result:
 c1	1	3
@@ -48,4 +46,49 @@ drop database sc_stats_${uuid0};
 -- !result
 CLEANUP {
     drop database if exists sc_stats_${uuid0};
+} END CLEANUP
+
+-- name: test_histogram_cleanup_after_modify_column_type
+create database sc_hist_${uuid0};
+-- result:
+-- !result
+use sc_hist_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c1` int,
+  `c_str` varchar(64)
+)
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+insert into t1 select generate_series, cast(generate_series as varchar) from table(generate_series(1, 100));
+-- result:
+-- !result
+analyze full table t1 with sync mode;
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON c_str PROPERTIES('histogram_sample_ratio' = '1.0') WITH SYNC MODE;
+[UC]histTime=select update_time from default_catalog._statistics_.histogram_statistics where table_name = 'sc_hist_${uuid0}.t1' and column_name = 'c_str';
+-- result:
+
+-- !result
+alter table t1 modify column c_str bigint;
+-- result:
+-- !result
+function: wait_table_schema_change_finish("sc_hist_${uuid0}", "t1")
+-- result:
+FINISHED
+-- !result
+LOOP {
+  PROPERTY: {"timeout": 120, "interval": 5, "desc": "wait stale histogram cleanup and re-collection after type change"}
+  result=select count(*) from default_catalog._statistics_.histogram_statistics where table_name = 'sc_hist_${uuid0}.t1' and column_name = 'c_str' and update_time > '${histTime}';
+  CHECK: str(to_array(${result})[0][0]) == "1"
+} END LOOP
+
+drop database sc_hist_${uuid0};
+-- result:
+-- !result
+CLEANUP {
+    drop database if exists sc_hist_${uuid0};
 } END CLEANUP

--- a/test/sql/test_analyze_statistics/T/test_stats_cleanup_after_modify_column_type
+++ b/test/sql/test_analyze_statistics/T/test_stats_cleanup_after_modify_column_type
@@ -1,0 +1,31 @@
+-- name: test_stats_cleanup_after_modify_column_type
+create database sc_stats_${uuid0};
+use sc_stats_${uuid0};
+CREATE TABLE `t1` (
+  `c1` int,
+  `c_str` varchar(64)
+)
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+insert into t1 values (1, '2'), (2, '19'), (3, '30');
+analyze full table t1 with sync mode;
+-- as a varchar column, min/max are lexicographic extremes: min='19', max='30'
+select column_name, `min`, `max` from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' order by column_name;
+alter table t1 modify column c_str bigint;
+function: wait_table_schema_change_finish("sc_stats_${uuid0}", "t1")
+-- after the type change finishes, the stale varchar-era stats of c_str must be dropped and
+-- re-collected under the new type; without cleanup the lexicographic min '19' would be served
+-- as a bigint min forever (real numeric min is 2)
+LOOP {
+  PROPERTY: {"timeout": 120, "interval": 5, "desc": "wait stale stats cleanup and re-collection after type change"}
+  result=select count(*) from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' and column_name = 'c_str' and `min` = '2' and `max` = '30';
+  CHECK: str(to_array(${result})[0][0]) == "1"
+} END LOOP
+-- untouched column c1 keeps its stats; c_str now carries numeric-semantics min/max
+select column_name, `min`, `max` from default_catalog._statistics_.column_statistics where table_name = 'sc_stats_${uuid0}.t1' order by column_name;
+drop database sc_stats_${uuid0};
+
+CLEANUP {
+    drop database if exists sc_stats_${uuid0};
+} END CLEANUP

--- a/test/sql/test_analyze_statistics/T/test_stats_cleanup_after_modify_column_type
+++ b/test/sql/test_analyze_statistics/T/test_stats_cleanup_after_modify_column_type
@@ -29,3 +29,32 @@ drop database sc_stats_${uuid0};
 CLEANUP {
     drop database if exists sc_stats_${uuid0};
 } END CLEANUP
+
+-- name: test_histogram_cleanup_after_modify_column_type
+create database sc_hist_${uuid0};
+use sc_hist_${uuid0};
+CREATE TABLE `t1` (
+  `c1` int,
+  `c_str` varchar(64)
+)
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ('replication_num' = '1');
+insert into t1 select generate_series, cast(generate_series as varchar) from table(generate_series(1, 100));
+analyze full table t1 with sync mode;
+[UC] ANALYZE TABLE t1 UPDATE HISTOGRAM ON c_str PROPERTIES('histogram_sample_ratio' = '1.0') WITH SYNC MODE;
+histTime=select update_time from default_catalog._statistics_.histogram_statistics where table_name = 'sc_hist_${uuid0}.t1' and column_name = 'c_str';
+alter table t1 modify column c_str bigint;
+function: wait_table_schema_change_finish("sc_hist_${uuid0}", "t1")
+-- the varchar-era histogram (lexicographically bucketed) must be dropped and re-collected under the
+-- new type: a rebuilt histogram carries a newer update_time, a stale leftover keeps the old one forever
+LOOP {
+  PROPERTY: {"timeout": 120, "interval": 5, "desc": "wait stale histogram cleanup and re-collection after type change"}
+  result=select count(*) from default_catalog._statistics_.histogram_statistics where table_name = 'sc_hist_${uuid0}.t1' and column_name = 'c_str' and update_time > '${histTime}';
+  CHECK: str(to_array(${result})[0][0]) == "1"
+} END LOOP
+drop database sc_hist_${uuid0};
+
+CLEANUP {
+    drop database if exists sc_hist_${uuid0};
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

Statistics store per-column min/max as **strings**, computed under the ordering semantics of the column type **at collection time**. After `ALTER TABLE ... MODIFY COLUMN` changes a column to a type with different ordering semantics (e.g. `VARCHAR -> BIGINT`), nothing cleans up or re-collects the old rows in `_statistics_.column_statistics` / `table_statistic_v1`, and the statistics cache loader keeps casting the stale strings to the **new** type. Depending on the data this yields:

- **silently wrong estimates**: for values {2, 19, 30} collected as varchar, the stored lexicographic extremes are min="19"/max="30"; after the change to bigint both cast successfully and the optimizer believes min=19 (real min is 2), so e.g. `WHERE c < 10` is estimated at zero selectivity with no warning;
- **cast failures on every cache load** when the stale string cannot be cast under the new type (or under `ERROR_IF_OVERFLOW` in sql_mode), failing the whole batched load.

The residue is effectively **permanent**: a type change alters neither row counts nor partition health, so the health-based auto collection never re-collects the column, and even when the table is later re-collected for other reasons the collection is partition-incremental and never overwrites the rows of unchanged historical partitions. The schema change finish path already invalidates related materialized views and low-cardinality global dictionaries, but statistics were the one subscriber missing from that cleanup chain.

## What I'm doing:

When a rewrite schema change job finishes, clean up the statistics of the columns whose type change invalidated them, then re-collect:

- **identify** the affected columns by reusing `SchemaChangeTypeCompatibility.canReuseZonemapIndex`: the zonemap-reuse condition is exactly the min/max-validity condition for statistics, so ordering-preserving conversions (`INT -> BIGINT`, varchar length increase, ...) are left untouched;
- **clean up** asynchronously on the leader: delete the columns' statistics rows and histogram rows (a stale histogram is worse than stale basic statistics: the optimizer prefers it for selectivity), drop their meta entries from `BasicStatsMeta`, and invalidate the FE statistics caches; followers expire the removed columns when replaying the meta update;
- **re-collect** the affected columns with an async FULL collection over all partitions (the health-based incremental collection would never overwrite the stale rows on its own), and rebuild their histograms with the properties they were originally collected with.

The pipeline is best-effort: any failure is logged and leaves the system no worse than today.

Verified end-to-end on a local cluster and covered by a new SQL test: stats for {'2','19','30'} go from lexicographic min=19/max=30 to numeric min=2/max=30 shortly after the schema change finishes, while untouched columns keep their statistics.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
