### PR TITLE
[BugFix] Guard NestLoop join and ChunkAccumulator against 32-bit binary column overflow

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -15,10 +15,12 @@
 #include "exec/pipeline/nljoin/nljoin_probe_operator.h"
 
 #include "base/simd/simd.h"
+#include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
+#include "common/status.h"
 #include "exprs/expr_executor.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/current_thread.h"
@@ -27,6 +29,46 @@
 #include "storage/chunk_helper.h"
 
 namespace starrocks::pipeline {
+namespace {
+
+// Total bytes a binary column occupies. For a const column the payload is stored once but
+// logically repeats for every row, so scale it by the row count.
+size_t nljoin_binary_payload_bytes(const Column* column) {
+    const Column* data = ColumnHelper::get_data_column(column);
+    if (!data->is_binary()) {
+        return 0;
+    }
+    const size_t payload = down_cast<const BinaryColumn*>(data)->get_immutable_bytes().size();
+    if (column->is_constant()) {
+        return payload * column->size();
+    }
+    return payload;
+}
+
+// Bytes of a single row's value in a binary column.
+size_t nljoin_binary_row_bytes(const Column* column, size_t idx) {
+    const Column* data = ColumnHelper::get_data_column(column);
+    if (!data->is_binary()) {
+        return 0;
+    }
+    const auto& binary = down_cast<const BinaryColumn&>(*data);
+    const auto& offsets = binary.get_offset();
+    if (offsets.size() < 2) {
+        return 0;
+    }
+    if (column->is_constant() || idx + 1 >= offsets.size()) {
+        return static_cast<size_t>(offsets[1] - offsets[0]);
+    }
+    return static_cast<size_t>(offsets[idx + 1] - offsets[idx]);
+}
+
+// BinaryColumn addresses its bytes with uint32 offsets, so a column may hold at most
+// Column::MAX_CAPACITY_LIMIT bytes before the offsets wrap.
+bool nljoin_binary_add_exceeds(uint64_t dest_bytes, uint64_t add_bytes) {
+    return dest_bytes + add_bytes >= Column::MAX_CAPACITY_LIMIT;
+}
+
+} // namespace
 
 NLJoinProbeOperator::NLJoinProbeOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id,
                                          int32_t driver_sequence, TJoinOp::type join_op,
@@ -53,6 +95,9 @@ Status NLJoinProbeOperator::prepare(RuntimeState* state) {
     _cross_join_context->attach_probe_observer(state, observer());
 
     _output_accumulator.set_desired_size(state->chunk_size());
+    // The permute preflight keeps each permuted input chunk under the normal BinaryColumn limit.
+    // Keep the row-based accumulator from merging those chunks back past the same boundary.
+    _output_accumulator.set_pre_append_byte_limit(Column::MAX_CAPACITY_LIMIT);
 
     _unique_metrics->add_info_string("JoinType", to_string(_join_op));
     _unique_metrics->add_info_string("JoinConjuncts", _sql_join_conjuncts);
@@ -491,7 +536,55 @@ Status NLJoinProbeOperator::_probe_for_other_join(const ChunkPtr& chunk) {
     return Status::OK();
 }
 
-ChunkPtr NLJoinProbeOperator::_permute_chunk_for_inner_join(size_t chunk_size) {
+bool NLJoinProbeOperator::_next_inner_join_permute_exceeds_binary_limit(const ChunkPtr& result_chunk) const {
+    const size_t left_chunk_size = _probe_chunk->num_rows();
+    const size_t right_chunk_size = _curr_build_chunk->num_rows();
+    const bool base_left = left_chunk_size > right_chunk_size;
+    for (size_t i = 0; i < _col_types.size(); i++) {
+        const SlotId slot_id = _col_types[i]->id();
+        const Column* dest = result_chunk->get_column_by_slot_id(slot_id).get();
+        const uint64_t dest_bytes = nljoin_binary_payload_bytes(dest);
+        uint64_t add_bytes = 0;
+        if (i < _probe_column_count) {
+            const Column* src = _probe_chunk->get_column_by_slot_id(slot_id).get();
+            add_bytes = base_left ? nljoin_binary_payload_bytes(src)
+                                  : static_cast<uint64_t>(nljoin_binary_row_bytes(src, _probe_row_current)) *
+                                            right_chunk_size;
+        } else {
+            const Column* src = _curr_build_chunk->get_column_by_slot_id(slot_id).get();
+            add_bytes = base_left ? static_cast<uint64_t>(nljoin_binary_row_bytes(src, _build_row_current)) *
+                                            left_chunk_size
+                                  : nljoin_binary_payload_bytes(src);
+        }
+        if (nljoin_binary_add_exceeds(dest_bytes, add_bytes)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool NLJoinProbeOperator::_permute_probe_row_exceeds_binary_limit(const ChunkPtr& chunk) const {
+    const size_t build_rows = _curr_build_chunk->num_rows();
+    for (size_t i = 0; i < _col_types.size(); i++) {
+        const SlotId slot_id = _col_types[i]->id();
+        const Column* dest = chunk->get_column_by_slot_id(slot_id).get();
+        const uint64_t dest_bytes = nljoin_binary_payload_bytes(dest);
+        uint64_t add_bytes = 0;
+        if (i < _probe_column_count) {
+            const Column* src = _probe_chunk->get_column_by_slot_id(slot_id).get();
+            add_bytes = static_cast<uint64_t>(nljoin_binary_row_bytes(src, _probe_row_current)) * build_rows;
+        } else {
+            const Column* src = _curr_build_chunk->get_column_by_slot_id(slot_id).get();
+            add_bytes = nljoin_binary_payload_bytes(src);
+        }
+        if (nljoin_binary_add_exceeds(dest_bytes, add_bytes)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+StatusOr<ChunkPtr> NLJoinProbeOperator::_permute_chunk_for_inner_join(size_t chunk_size) {
     ChunkPtr result_chunk = _init_output_chunk(chunk_size);
 
     do {
@@ -500,6 +593,18 @@ ChunkPtr NLJoinProbeOperator::_permute_chunk_for_inner_join(size_t chunk_size) {
         size_t max_chunk_size = std::max(left_chunk_size, right_chunk_size);
         if (result_chunk->num_rows() != 0 && result_chunk->num_rows() + max_chunk_size > chunk_size) {
             // Prevent the size of a chunk from exceeding chunk size
+            break;
+        }
+
+        // BinaryColumn offsets are uint32. Repeating a large VARCHAR/JSON value across a big fan-out
+        // (e.g. CROSS JOIN TABLE(GENERATE_SERIES(...))) can exceed 4GB in a single permute even while
+        // the row count is still under chunk_size, wrapping the offsets. Stop before that happens.
+        if (_next_inner_join_permute_exceeds_binary_limit(result_chunk)) {
+            if (result_chunk->num_rows() == 0) {
+                return Status::CapacityLimitExceed(
+                        "NestLoop join output VARCHAR/binary column would exceed 4GB in a single permute. "
+                        "Extract compact fields before the cross join or reduce input row size.");
+            }
             break;
         }
 
@@ -512,6 +617,7 @@ ChunkPtr NLJoinProbeOperator::_permute_chunk_for_inner_join(size_t chunk_size) {
         }
     } while (result_chunk->num_rows() < chunk_size && _probe_chunk != nullptr && _curr_build_chunk != nullptr);
 
+    RETURN_IF_ERROR(result_chunk->upgrade_if_overflow());
     return result_chunk;
 }
 
@@ -564,6 +670,14 @@ StatusOr<ChunkPtr> NLJoinProbeOperator::_permute_chunk_for_other_join(size_t chu
         // Last build chunk must permute a chunk
         bool is_last_build_chunk = _curr_build_chunk_index == _num_build_chunks() - 1 && _num_build_chunks() > 1;
         if (!_probe_row_finished && is_last_build_chunk) {
+            if (_permute_probe_row_exceeds_binary_limit(chunk)) {
+                if (chunk->num_rows() == 0) {
+                    return Status::CapacityLimitExceed(
+                            "NestLoop join output VARCHAR/binary column would exceed 4GB in a single permute. "
+                            "Extract compact fields before the cross join or reduce input row size.");
+                }
+                return chunk;
+            }
             RETURN_IF_ERROR(_permute_probe_row(chunk));
             _reset_build_chunk_index();
             _probe_row_finished = true;
@@ -574,6 +688,14 @@ StatusOr<ChunkPtr> NLJoinProbeOperator::_permute_chunk_for_other_join(size_t chu
         // For SEMI/ANTI JOIN, the probe-row could be skipped once find matched/unmatched
         // Otherwise accumulate more build chunks into a larger chunk
         while (!_probe_row_finished && _curr_build_chunk_index < _num_build_chunks()) {
+            if (_permute_probe_row_exceeds_binary_limit(chunk)) {
+                if (chunk->num_rows() == 0) {
+                    return Status::CapacityLimitExceed(
+                            "NestLoop join output VARCHAR/binary column would exceed 4GB in a single permute. "
+                            "Extract compact fields before the cross join or reduce input row size.");
+                }
+                return chunk;
+            }
             RETURN_IF_ERROR(_permute_probe_row(chunk));
             _next_build_chunk_index_for_other_join();
             probe_row_start();
@@ -759,7 +881,7 @@ StatusOr<ChunkPtr> NLJoinProbeOperator::_pull_chunk_for_inner_join(size_t chunk_
     }
 
     while (!_is_curr_probe_chunk_finished()) {
-        ChunkPtr chunk = _permute_chunk_for_inner_join(chunk_size);
+        ASSIGN_OR_RETURN(ChunkPtr chunk, _permute_chunk_for_inner_join(chunk_size));
         DCHECK(chunk);
         RETURN_IF_ERROR(_probe_for_inner_join(chunk));
         RETURN_IF_ERROR(_eval_conjuncts(chunk));

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -90,9 +90,12 @@ private:
     void _init_build_match() const;
     Status _permute_probe_row(const ChunkPtr& chunk);
     StatusOr<ChunkPtr> _permute_chunk_for_other_join(size_t chunk_size);
-    ChunkPtr _permute_chunk_for_inner_join(size_t chunk_size);
+    StatusOr<ChunkPtr> _permute_chunk_for_inner_join(size_t chunk_size);
     void _permute_chunk_base_left(ChunkPtr* chunk);
     void _permute_chunk_base_right(ChunkPtr* chunk);
+    // Estimate whether the next permute step would push an output binary column past its uint32 range.
+    bool _next_inner_join_permute_exceeds_binary_limit(const ChunkPtr& result_chunk) const;
+    bool _permute_probe_row_exceeds_binary_limit(const ChunkPtr& chunk) const;
     Status _permute_right_join(size_t chunk_size);
     void _permute_left_join(const ChunkPtr& chunk, size_t probe_row_index, size_t probe_rows);
     bool _is_curr_probe_chunk_finished() const;

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -18,6 +18,9 @@
 
 #include <memory>
 
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "common/status.h"
 #include "common/statusor.h"
 #include "compute_env/spill/common.h"
 #include "compute_env/spill/options.h"
@@ -27,6 +30,46 @@
 #include "exprs/expr_executor.h"
 
 namespace starrocks::pipeline {
+namespace {
+
+// Total bytes a binary column occupies. For a const column the payload is stored once but
+// logically repeats for every row, so scale it by the row count.
+size_t nljoin_binary_payload_bytes(const Column* column) {
+    const Column* data = ColumnHelper::get_data_column(column);
+    if (!data->is_binary()) {
+        return 0;
+    }
+    const size_t payload = down_cast<const BinaryColumn*>(data)->get_immutable_bytes().size();
+    if (column->is_constant()) {
+        return payload * column->size();
+    }
+    return payload;
+}
+
+// Bytes of a single row's value in a binary column.
+size_t nljoin_binary_row_bytes(const Column* column, size_t idx) {
+    const Column* data = ColumnHelper::get_data_column(column);
+    if (!data->is_binary()) {
+        return 0;
+    }
+    const auto& binary = down_cast<const BinaryColumn&>(*data);
+    const auto& offsets = binary.get_offset();
+    if (offsets.size() < 2) {
+        return 0;
+    }
+    if (column->is_constant() || idx + 1 >= offsets.size()) {
+        return static_cast<size_t>(offsets[1] - offsets[0]);
+    }
+    return static_cast<size_t>(offsets[idx + 1] - offsets[idx]);
+}
+
+// BinaryColumn addresses its bytes with uint32 offsets, so a column may hold at most
+// Column::MAX_CAPACITY_LIMIT bytes before the offsets wrap.
+bool nljoin_binary_add_exceeds(uint64_t dest_bytes, uint64_t add_bytes) {
+    return dest_bytes + add_bytes >= Column::MAX_CAPACITY_LIMIT;
+}
+
+} // namespace
 
 NLJoinProber::NLJoinProber(TJoinOp::type join_op, const std::vector<ExprContext*>& join_conjuncts,
                            const std::vector<ExprContext*>& conjunct_ctxs,
@@ -56,7 +99,8 @@ StatusOr<ChunkPtr> NLJoinProber::probe_chunk(RuntimeState* state, const ChunkPtr
     // probe chunk
     auto output_chunk = _init_output_chunk(state, build_chunk);
     //
-    _permute_chunk(state, build_chunk, output_chunk);
+    RETURN_IF_ERROR(_permute_chunk(state, build_chunk, output_chunk));
+    RETURN_IF_ERROR(output_chunk->upgrade_if_overflow());
     //
     return output_chunk;
 }
@@ -89,14 +133,46 @@ ChunkPtr NLJoinProber::_init_output_chunk(RuntimeState* state, const ChunkPtr& b
     return chunk;
 }
 
-void NLJoinProber::_permute_chunk(RuntimeState* state, const ChunkPtr& build_chunk, const ChunkPtr& output) {
+Status NLJoinProber::_permute_chunk(RuntimeState* state, const ChunkPtr& build_chunk, const ChunkPtr& output) {
     for (; _probe_row_current < _probe_chunk->num_rows(); ++_probe_row_current) {
         if (output->num_rows() + build_chunk->num_rows() > state->chunk_size()) {
             DCHECK_LE(output->num_rows(), state->chunk_size());
-            return;
+            return Status::OK();
+        }
+        // BinaryColumn offsets are uint32. Repeating a large VARCHAR/JSON value across a big build
+        // chunk can exceed 4GB in a single permute, wrapping the offsets. Stop before that happens.
+        if (_permute_probe_row_exceeds_binary_limit(output.get(), build_chunk)) {
+            if (output->num_rows() == 0) {
+                return Status::CapacityLimitExceed(
+                        "NestLoop join output VARCHAR/binary column would exceed 4GB in a single permute. "
+                        "Extract compact fields before the cross join or reduce input row size.");
+            }
+            return Status::OK();
         }
         _permute_probe_row(output.get(), build_chunk);
     }
+    return Status::OK();
+}
+
+bool NLJoinProber::_permute_probe_row_exceeds_binary_limit(const Chunk* dst, const ChunkPtr& build_chunk) const {
+    const size_t build_rows = build_chunk->num_rows();
+    for (size_t i = 0; i < _col_types.size(); i++) {
+        const SlotId slot_id = _col_types[i]->id();
+        const Column* dest = dst->get_column_by_slot_id(slot_id).get();
+        const uint64_t dest_bytes = nljoin_binary_payload_bytes(dest);
+        uint64_t add_bytes = 0;
+        if (i < _probe_column_count) {
+            const Column* src = _probe_chunk->get_column_by_slot_id(slot_id).get();
+            add_bytes = static_cast<uint64_t>(nljoin_binary_row_bytes(src, _probe_row_current)) * build_rows;
+        } else {
+            const Column* src = build_chunk->get_column_by_slot_id(slot_id).get();
+            add_bytes = nljoin_binary_payload_bytes(src);
+        }
+        if (nljoin_binary_add_exceeds(dest_bytes, add_bytes)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void NLJoinProber::_permute_probe_row(Chunk* dst, const ChunkPtr& build_chunk) {

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.h
@@ -66,11 +66,13 @@ private:
     // The chunk either consists two conditions:
     // 1. Multiple probe rows and multiple build single-chunk
     // 2. One probe rows and one build chunk
-    void _permute_chunk(RuntimeState* state, const ChunkPtr& build_chunk, const ChunkPtr& output);
+    Status _permute_chunk(RuntimeState* state, const ChunkPtr& build_chunk, const ChunkPtr& output);
 
     ChunkPtr _permute_by_one_chunk(RuntimeState* state, const ChunkPtr& build_chunk);
 
     void _permute_probe_row(Chunk* dst, const ChunkPtr& build_chunk);
+    // Estimate whether permuting the current probe row would push an output binary column past its uint32 range.
+    bool _permute_probe_row_exceeds_binary_limit(const Chunk* dst, const ChunkPtr& build_chunk) const;
 
 private:
     //

--- a/be/src/runtime/chunk_accumulator.cpp
+++ b/be/src/runtime/chunk_accumulator.cpp
@@ -77,15 +77,25 @@ Status ChunkAccumulator::push(ChunkPtr&& chunk) {
                 // Schema mismatch, output current chunk and create a new one
                 _output.emplace_back(std::move(_tmp_chunk));
                 _tmp_chunk = chunk->clone_empty(_desired_size);
-                TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
-            } else {
-                TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
+            } else if (_pre_append_byte_limit != 0 && _tmp_chunk->num_rows() > 0 && need_rows > 0) {
+                // Merging these rows would grow the buffered chunk past the byte limit. Emit what is
+                // buffered and refill from scratch instead of appending across the limit. bytes_usage()
+                // over-estimates against a single column's limit, so this errs toward flushing early.
+                // The comparison is arranged to avoid unsigned underflow.
+                const uint64_t tmp_bytes = _tmp_chunk->bytes_usage();
+                const uint64_t input_bytes = chunk->bytes_usage(start, need_rows);
+                if (input_bytes >= _pre_append_byte_limit || tmp_bytes >= _pre_append_byte_limit - input_bytes) {
+                    _output.emplace_back(std::move(_tmp_chunk));
+                    continue;
+                }
             }
+            TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
             RETURN_IF_ERROR(_tmp_chunk->capacity_limit_reached());
         } else {
             need_rows = std::min(_desired_size, remain_rows);
             _tmp_chunk = chunk->clone_empty(_desired_size);
             TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
+            RETURN_IF_ERROR(_tmp_chunk->capacity_limit_reached());
         }
 
         if (_tmp_chunk->num_rows() >= _desired_size) {

--- a/be/src/runtime/chunk_accumulator.h
+++ b/be/src/runtime/chunk_accumulator.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 
 #include "column/vectorized_fwd.h"
@@ -35,6 +36,9 @@ public:
     ChunkAccumulator() = default;
     ChunkAccumulator(size_t desired_size);
     void set_desired_size(size_t desired_size);
+    // A nonzero limit emits the buffered chunk before a compatible append reaches the limit.
+    // Enable this only for materialized inputs that are already physically safe to append on their own.
+    void set_pre_append_byte_limit(uint64_t byte_limit) { _pre_append_byte_limit = byte_limit; }
     void reset();
     void finalize();
     bool empty() const;
@@ -44,6 +48,7 @@ public:
 
 private:
     size_t _desired_size;
+    uint64_t _pre_append_byte_limit = 0;
     ChunkPtr _tmp_chunk;
     std::deque<ChunkPtr> _output;
     size_t _accumulate_count = 0;

--- a/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
+++ b/be/test/exec/pipeline/nljoin_probe_operator_test.cpp
@@ -20,16 +20,23 @@
 #include <string>
 #include <vector>
 
+#include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/column_helper.h"
+#include "column/fixed_length_column.h"
 #include "common/object_pool.h"
+#include "common/runtime_profile.h"
+#include "common/status.h"
 #include "exec/pipeline/nljoin/nljoin_context.h"
+#include "exec/pipeline/nljoin/spillable_nljoin_probe_operator.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "gen_cpp/Types_types.h"
 #include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 #include "types/type_descriptor.h"
+#include "util/slice.h"
 
 // The test object library is compiled with -fno-access-control, so the test can reach the
 // private members (_init_output_chunk, _curr_build_chunk, NLJoinContext::_build_chunks) directly.
@@ -66,6 +73,53 @@ protected:
         chunk->append_column(std::move(col), slot_id);
         return chunk;
     }
+
+    // A VARCHAR SlotDescriptor. VARCHAR maps to a uint32-offset BinaryColumn, which is exactly the
+    // column type whose offsets the overflow guard protects.
+    SlotDescriptor* make_varchar_slot(int id, bool nullable) {
+        TSlotDescriptor t;
+        t.id = id;
+        t.parent = 0;
+        TTypeDesc type;
+        TTypeNode node;
+        node.__set_type(TTypeNodeType::SCALAR);
+        TScalarType scalar_type;
+        scalar_type.__set_type(TPrimitiveType::VARCHAR);
+        scalar_type.__set_len(1024 * 1024 * 1024);
+        node.__set_scalar_type(scalar_type);
+        type.types.push_back(node);
+        t.__set_slotType(type);
+        t.__set_colName("v" + std::to_string(id));
+        t.__set_slotIdx(id);
+        t.__set_isMaterialized(true);
+        t.__set_isNullable(nullable);
+        return _pool.add(new SlotDescriptor(t));
+    }
+
+    // A non-nullable INT column with `num_rows` default (0) values.
+    ChunkPtr make_int_chunk(SlotId slot_id, size_t num_rows) {
+        auto chunk = std::make_shared<Chunk>();
+        auto col = Int32Column::create();
+        col->append_default(num_rows);
+        chunk->append_column(std::move(col), slot_id);
+        return chunk;
+    }
+
+    // A non-nullable VARCHAR/binary column holding one row per value.
+    ChunkPtr make_varchar_chunk(SlotId slot_id, const std::vector<std::string>& values) {
+        auto chunk = std::make_shared<Chunk>();
+        auto col = BinaryColumn::create();
+        for (const auto& v : values) {
+            col->append_datum(Slice(v));
+        }
+        chunk->append_column(std::move(col), slot_id);
+        return chunk;
+    }
+
+    // A single VARCHAR value large enough that repeating it across `fanout` rows crosses the 4GB
+    // (2^32) BinaryColumn offset limit: 2MB * 2100 > 2^32.
+    static std::string big_value() { return std::string(2u * 1024 * 1024, 'x'); }
+    static constexpr size_t kOverflowFanout = 2100;
 
     std::shared_ptr<NLJoinContext> make_context() {
         NLJoinContextParams params;
@@ -141,6 +195,270 @@ TEST_F(NLJoinProbeOperatorTest, BuildColumnFollowsSlotWhenNoBuildChunk) {
 
     // Non-nullable slot, no build chunk, inner join -> non-nullable build-side output column.
     EXPECT_FALSE(out->is_column_nullable(build_slot->id()));
+}
+
+// ---------------------------------------------------------------------------
+// NLJoinProber permute overflow guard (spillable NestLoop path).
+// A large VARCHAR repeated across a big fan-out would push the output BinaryColumn past its uint32
+// (4GB) offset range; the guard must stop before the offsets wrap. 2MB * 2100 > 2^32.
+// ---------------------------------------------------------------------------
+
+// A single large probe row repeated across a big build chunk cannot fit into an empty output chunk,
+// so the prober reports a recoverable CapacityLimitExceed instead of wrapping the offsets.
+TEST_F(NLJoinProbeOperatorTest, ProberSingleRowOverflowReturnsError) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+
+    RuntimeState state{TQueryGlobals()};
+    state.set_chunk_size(1 << 20);
+    RuntimeProfile profile("nljoin");
+
+    NLJoinProber prober(TJoinOp::INNER_JOIN, _no_exprs, _no_exprs, _no_common_exprs, col_types,
+                        /*probe_column_count=*/1);
+    ASSERT_TRUE(prober.prepare(&state, &profile).ok());
+    ASSERT_TRUE(prober.push_probe_chunk(make_varchar_chunk(0, {big_value()})).ok());
+
+    auto res = prober.probe_chunk(&state, make_int_chunk(1, kOverflowFanout));
+    ASSERT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_capacity_limit_exceeded());
+}
+
+// When rows are already buffered, hitting the limit on a later probe row breaks early and emits what
+// has been permuted so far (the query keeps making progress) rather than failing.
+TEST_F(NLJoinProbeOperatorTest, ProberBreaksEarlyWhenRowsBuffered) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+
+    RuntimeState state{TQueryGlobals()};
+    state.set_chunk_size(1 << 20);
+    RuntimeProfile profile("nljoin");
+
+    NLJoinProber prober(TJoinOp::INNER_JOIN, _no_exprs, _no_exprs, _no_common_exprs, col_types,
+                        /*probe_column_count=*/1);
+    ASSERT_TRUE(prober.prepare(&state, &profile).ok());
+    // Row 0 is tiny (permutes fine); row 1 is large and would overflow, so the permute stops after row 0.
+    ASSERT_TRUE(prober.push_probe_chunk(make_varchar_chunk(0, {"a", big_value()})).ok());
+
+    auto res = prober.probe_chunk(&state, make_int_chunk(1, kOverflowFanout));
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(kOverflowFanout, res.value()->num_rows());
+}
+
+// A permute that stays well under the limit produces the full cross product.
+TEST_F(NLJoinProbeOperatorTest, ProberSmallPermuteSucceeds) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+
+    RuntimeState state{TQueryGlobals()};
+    state.set_chunk_size(1 << 20);
+    RuntimeProfile profile("nljoin");
+
+    NLJoinProber prober(TJoinOp::INNER_JOIN, _no_exprs, _no_exprs, _no_common_exprs, col_types,
+                        /*probe_column_count=*/1);
+    ASSERT_TRUE(prober.prepare(&state, &profile).ok());
+    ASSERT_TRUE(prober.push_probe_chunk(make_varchar_chunk(0, {"p", "q"})).ok());
+
+    auto res = prober.probe_chunk(&state, make_int_chunk(1, 4));
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(8, res.value()->num_rows()); // 2 probe rows x 4 build rows
+}
+
+// ---------------------------------------------------------------------------
+// NLJoinProbeOperator inner-join permute overflow guard.
+// ---------------------------------------------------------------------------
+
+// base-right permute (probe rows <= build rows): a single large probe value repeated across the
+// build chunk overflows an empty output chunk -> recoverable error.
+TEST_F(NLJoinProbeOperatorTest, InnerJoinBaseRightOverflowReturnsError) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_int_chunk(1, kOverflowFanout));
+
+    auto factory = make_factory(ctx, TJoinOp::INNER_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::INNER_JOIN, _no_sql, _no_exprs, _no_exprs, _no_common_exprs,
+                           col_types, /*probe_column_count=*/1, ctx);
+
+    op._probe_chunk = make_varchar_chunk(0, {big_value()});
+    op._curr_build_chunk = ctx->get_build_chunk(0);
+    op._curr_build_chunk_index = 0;
+    op._probe_row_current = 0;
+    op._build_row_current = 0;
+
+    auto res = op._permute_chunk_for_inner_join(1 << 20);
+    ASSERT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_capacity_limit_exceeded());
+}
+
+// base-left permute (probe rows > build rows) that stays under the limit: full cross product.
+TEST_F(NLJoinProbeOperatorTest, InnerJoinBaseLeftSmallPermuteSucceeds) {
+    std::vector<SlotDescriptor*> col_types = {make_int_slot(0, false), make_varchar_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_varchar_chunk(1, {"a", "b"}));
+
+    auto factory = make_factory(ctx, TJoinOp::INNER_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::INNER_JOIN, _no_sql, _no_exprs, _no_exprs, _no_common_exprs,
+                           col_types, /*probe_column_count=*/1, ctx);
+
+    op._probe_chunk = make_int_chunk(0, 3);
+    op._curr_build_chunk = ctx->get_build_chunk(0);
+    op._curr_build_chunk_index = 0;
+    op._probe_row_current = 0;
+    op._build_row_current = 0;
+
+    auto res = op._permute_chunk_for_inner_join(1 << 20);
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(6, res.value()->num_rows()); // 3 probe rows x 2 build rows
+}
+
+// base-right permute that stays under the limit: full cross product.
+TEST_F(NLJoinProbeOperatorTest, InnerJoinBaseRightSmallPermuteSucceeds) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_int_chunk(1, 3));
+
+    auto factory = make_factory(ctx, TJoinOp::INNER_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::INNER_JOIN, _no_sql, _no_exprs, _no_exprs, _no_common_exprs,
+                           col_types, /*probe_column_count=*/1, ctx);
+
+    op._probe_chunk = make_varchar_chunk(0, {"p", "q"});
+    op._curr_build_chunk = ctx->get_build_chunk(0);
+    op._curr_build_chunk_index = 0;
+    op._probe_row_current = 0;
+    op._build_row_current = 0;
+
+    auto res = op._permute_chunk_for_inner_join(1 << 20);
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(6, res.value()->num_rows()); // 2 probe rows x 3 build rows
+}
+
+// ---------------------------------------------------------------------------
+// NLJoinProbeOperator other-join (LEFT SEMI/ANTI) permute overflow guard.
+// These paths require >= 2 build chunks. A real profile counter is wired because the permute path
+// updates it; without ENABLE_COUNTERS the macro would still create a live counter.
+// ---------------------------------------------------------------------------
+
+// On the last build chunk the operator must permute; if the single probe row overflows an empty
+// output chunk it returns a recoverable error rather than wrapping the offsets.
+TEST_F(NLJoinProbeOperatorTest, OtherJoinLastBuildChunkOverflowReturnsError) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_int_chunk(1, 2));               // build chunk 0
+    ctx->_build_chunks.push_back(make_int_chunk(1, kOverflowFanout)); // build chunk 1 (last)
+
+    auto factory = make_factory(ctx, TJoinOp::LEFT_SEMI_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::LEFT_SEMI_JOIN, _no_sql, _no_exprs, _no_exprs,
+                           _no_common_exprs, col_types, /*probe_column_count=*/1, ctx);
+    RuntimeProfile profile("nljoin");
+    op._permute_rows_counter = ADD_COUNTER((&profile), "PermuteRows", TUnit::UNIT);
+
+    op._probe_chunk = make_varchar_chunk(0, {big_value()});
+    op._curr_build_chunk_index = 1; // last build chunk
+    op._curr_build_chunk = ctx->get_build_chunk(1);
+    op._probe_row_current = 0;
+    op._probe_row_finished = false;
+    op._probe_row_matched = false;
+
+    auto res = op._permute_chunk_for_other_join(1 << 20);
+    ASSERT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_capacity_limit_exceeded());
+}
+
+// While accumulating build chunks for one probe row, the operator emits the buffered rows before an
+// append that would cross the limit (progress instead of overflow).
+TEST_F(NLJoinProbeOperatorTest, OtherJoinBreaksEarlyWhenRowsBuffered) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_int_chunk(1, 1));               // build chunk 0 (permutes fine)
+    ctx->_build_chunks.push_back(make_int_chunk(1, kOverflowFanout)); // build chunk 1 (would overflow)
+
+    auto factory = make_factory(ctx, TJoinOp::LEFT_SEMI_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::LEFT_SEMI_JOIN, _no_sql, _no_exprs, _no_exprs,
+                           _no_common_exprs, col_types, /*probe_column_count=*/1, ctx);
+    RuntimeProfile profile("nljoin");
+    op._permute_rows_counter = ADD_COUNTER((&profile), "PermuteRows", TUnit::UNIT);
+
+    op._probe_chunk = make_varchar_chunk(0, {big_value()});
+    op._curr_build_chunk_index = 0; // not the last build chunk
+    op._curr_build_chunk = ctx->get_build_chunk(0);
+    op._probe_row_current = 0;
+    op._probe_row_finished = false;
+    op._probe_row_matched = false;
+
+    auto res = op._permute_chunk_for_other_join(1 << 20);
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(1, res.value()->num_rows()); // only build chunk 0 (1 row) permuted before the limit
+}
+
+// A single overflowing probe row against a non-last build chunk with an empty output -> error.
+TEST_F(NLJoinProbeOperatorTest, OtherJoinAccumulateOverflowReturnsError) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_int_chunk(1, kOverflowFanout)); // build chunk 0 (would overflow)
+    ctx->_build_chunks.push_back(make_int_chunk(1, 2));               // build chunk 1
+
+    auto factory = make_factory(ctx, TJoinOp::LEFT_SEMI_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::LEFT_SEMI_JOIN, _no_sql, _no_exprs, _no_exprs,
+                           _no_common_exprs, col_types, /*probe_column_count=*/1, ctx);
+    RuntimeProfile profile("nljoin");
+    op._permute_rows_counter = ADD_COUNTER((&profile), "PermuteRows", TUnit::UNIT);
+
+    op._probe_chunk = make_varchar_chunk(0, {big_value()});
+    op._curr_build_chunk_index = 0; // not the last build chunk
+    op._curr_build_chunk = ctx->get_build_chunk(0);
+    op._probe_row_current = 0;
+    op._probe_row_finished = false;
+    op._probe_row_matched = false;
+
+    auto res = op._permute_chunk_for_other_join(1 << 20);
+    ASSERT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_capacity_limit_exceeded());
+}
+
+// A small other-join permute across multiple build chunks stays under the limit and accumulates all rows.
+TEST_F(NLJoinProbeOperatorTest, OtherJoinSmallPermuteAccumulatesAllBuildChunks) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_int_chunk(1, 2)); // build chunk 0
+    ctx->_build_chunks.push_back(make_int_chunk(1, 3)); // build chunk 1
+
+    auto factory = make_factory(ctx, TJoinOp::LEFT_SEMI_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::LEFT_SEMI_JOIN, _no_sql, _no_exprs, _no_exprs,
+                           _no_common_exprs, col_types, /*probe_column_count=*/1, ctx);
+    RuntimeProfile profile("nljoin");
+    op._permute_rows_counter = ADD_COUNTER((&profile), "PermuteRows", TUnit::UNIT);
+
+    op._probe_chunk = make_varchar_chunk(0, {"p"});
+    op._curr_build_chunk_index = 0;
+    op._curr_build_chunk = ctx->get_build_chunk(0);
+    op._probe_row_current = 0;
+    op._probe_row_finished = false;
+    op._probe_row_matched = false;
+
+    auto res = op._permute_chunk_for_other_join(1 << 20);
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(5, res.value()->num_rows()); // 1 probe row x (2 + 3) build rows
+}
+
+// The last-build-chunk permute path (single probe row) under the limit produces one chunk.
+TEST_F(NLJoinProbeOperatorTest, OtherJoinLastBuildChunkSmallPermuteSucceeds) {
+    std::vector<SlotDescriptor*> col_types = {make_varchar_slot(0, false), make_int_slot(1, false)};
+    auto ctx = make_context();
+    ctx->_build_chunks.push_back(make_int_chunk(1, 2)); // build chunk 0
+    ctx->_build_chunks.push_back(make_int_chunk(1, 3)); // build chunk 1 (last)
+
+    auto factory = make_factory(ctx, TJoinOp::LEFT_SEMI_JOIN);
+    NLJoinProbeOperator op(factory.get(), 0, 1, 0, TJoinOp::LEFT_SEMI_JOIN, _no_sql, _no_exprs, _no_exprs,
+                           _no_common_exprs, col_types, /*probe_column_count=*/1, ctx);
+    RuntimeProfile profile("nljoin");
+    op._permute_rows_counter = ADD_COUNTER((&profile), "PermuteRows", TUnit::UNIT);
+
+    op._probe_chunk = make_varchar_chunk(0, {"p"});
+    op._curr_build_chunk_index = 1; // last build chunk
+    op._curr_build_chunk = ctx->get_build_chunk(1);
+    op._probe_row_current = 0;
+    op._probe_row_finished = false;
+    op._probe_row_matched = false;
+
+    auto res = op._permute_chunk_for_other_join(1 << 20);
+    ASSERT_TRUE(res.ok());
+    EXPECT_EQ(3, res.value()->num_rows()); // last build chunk has 3 rows
 }
 
 } // namespace starrocks::pipeline

--- a/be/test/runtime/chunk_accumulator_test.cpp
+++ b/be/test/runtime/chunk_accumulator_test.cpp
@@ -15,7 +15,11 @@
 #include "runtime/chunk_accumulator.h"
 
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
+#include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "gtest/gtest.h"
@@ -29,6 +33,20 @@ ChunkPtr make_chunk(size_t num_rows) {
     auto column = Int32Column::create();
     column->append_default(num_rows);
     chunk->append_column(std::move(column), 0);
+    return chunk;
+}
+
+// A chunk with an INT column (slot 0) and a VARCHAR/binary column (slot 1).
+ChunkPtr make_kv_chunk(const std::vector<std::pair<int32_t, std::string>>& rows) {
+    auto chunk = std::make_shared<Chunk>();
+    auto id_col = Int32Column::create();
+    auto val_col = BinaryColumn::create();
+    for (const auto& [id, val] : rows) {
+        id_col->append_datum(id);
+        val_col->append_datum(Slice(val));
+    }
+    chunk->append_column(std::move(id_col), 0);
+    chunk->append_column(std::move(val_col), 1);
     return chunk;
 }
 
@@ -75,6 +93,40 @@ TEST(ChunkAccumulatorTest, Accumulator) {
     auto output = accumulator.pull();
     EXPECT_EQ(nullptr, output);
     EXPECT_TRUE(accumulator.reach_limit());
+}
+
+// With a nonzero pre-append byte limit the accumulator emits the buffered chunk instead of merging
+// an append that would cross the limit, even when the row count is still below the desired size.
+TEST(ChunkAccumulatorTest, FlushesBeforeByteLimit) {
+    constexpr size_t kDesiredSize = 3;
+
+    auto first_input = make_kv_chunk({{1, "aaaa"}});
+    auto second_input = make_kv_chunk({{2, "bbbb"}, {3, "cccc"}});
+
+    ChunkAccumulator accumulator(kDesiredSize);
+    // Exactly the combined size of the append that would otherwise build a three-row chunk, so the
+    // second push must flush the buffered row rather than merge past the limit.
+    accumulator.set_pre_append_byte_limit(first_input->bytes_usage() + second_input->bytes_usage());
+
+    ASSERT_TRUE(accumulator.push(std::move(first_input)).ok());
+    EXPECT_EQ(nullptr, accumulator.pull());
+
+    ASSERT_TRUE(accumulator.push(std::move(second_input)).ok());
+    auto first_output = accumulator.pull();
+    ASSERT_NE(nullptr, first_output);
+    ASSERT_EQ(1, first_output->num_rows());
+    EXPECT_EQ(1, first_output->get_column_by_index(0)->get(0).get_int32());
+    EXPECT_EQ("aaaa", first_output->get_column_by_index(1)->get(0).get_slice().to_string());
+
+    accumulator.finalize();
+    auto second_output = accumulator.pull();
+    ASSERT_NE(nullptr, second_output);
+    ASSERT_EQ(2, second_output->num_rows());
+    EXPECT_EQ(2, second_output->get_column_by_index(0)->get(0).get_int32());
+    EXPECT_EQ("bbbb", second_output->get_column_by_index(1)->get(0).get_slice().to_string());
+    EXPECT_EQ(3, second_output->get_column_by_index(0)->get(1).get_int32());
+    EXPECT_EQ("cccc", second_output->get_column_by_index(1)->get(1).get_slice().to_string());
+    EXPECT_EQ(nullptr, accumulator.pull());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`BinaryColumn` addresses its byte buffer with `uint32` offsets while the buffer itself is `size_t`-indexed. A NestLoop (cross) join that repeats a large `VARCHAR`/`JSON` value across a big fan-out — for example `CROSS JOIN TABLE(GENERATE_SERIES(0, N))` over a multi-KB column — can push a single permuted output column past `2^32` bytes. The offsets then wrap silently:

- release builds later read the column out of bounds and **crash** the backend;
- debug builds abort on the `~BinaryColumnBase` destructor invariant.

Once the offsets have wrapped, the column cannot be repaired, and in a debug build it cannot even be destroyed. This is reachable from an ordinary user query, so a single ad-hoc query can take down a shared BE/CN.

## What I'm doing:

Guard the two independent, unguarded append sites where the wrap happens:

1. **NestLoop permute** (`NLJoinProbeOperator` and the spillable `NLJoinProber`). Add a byte-aware preflight that estimates the binary payload each permute step would add and stops before it crosses `Column::MAX_CAPACITY_LIMIT`. If rows are already buffered, the permute breaks early and emits what it has, so the query keeps making progress. If a single permute step cannot fit even into an empty chunk, it returns a recoverable `CapacityLimitExceed` instead of corrupting the column. The permute now finalizes with `upgrade_if_overflow()`, promoting to a large binary column when possible.

2. **`ChunkAccumulator::push` re-merge.** The accumulator merges permuted chunks by row count toward the desired size, which can again cross `2^32` in the buffered chunk. The branch that seeds a fresh `_tmp_chunk` was missing the `capacity_limit_reached()` check that the append branch already has — add it. In addition, decide *before* the append: an opt-in pre-append byte limit emits the buffered chunk and refills from scratch rather than merging across the limit, so the query keeps making progress instead of failing only after the wrap. The limit defaults to `0` (previous behavior exactly); only `NLJoinProbeOperator` enables it, set to `Column::MAX_CAPACITY_LIMIT` to match its permute preflight. Every other accumulator user is unaffected.

Net effect: this query class degrades to a clean, diagnosable error (or a promoted large binary column) instead of crashing a shared backend. Queries that stay under the 4GB-per-column limit are byte-for-byte unaffected.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
