### PR TITLE
[Enhancement] Extend 'show usage resource groups;' with mem_pool metrics (backport #66690)

### DIFF
--- a/be/src/agent/resource_group_usage_recorder.cpp
+++ b/be/src/agent/resource_group_usage_recorder.cpp
@@ -38,16 +38,26 @@ std::vector<TResourceGroupUsage> ResourceGroupUsageRecorder::get_resource_group_
                 if (it == group_to_usage.end()) {
                     TResourceGroupUsage group_usage;
                     group_usage.__set_group_id(wg.id());
+                    group_usage.__set_group_version(wg.version());
                     group_usage.__set_mem_used_bytes(wg.mem_consumption_bytes());
                     group_usage.__set_num_running_queries(wg.num_running_queries());
+                    group_usage.__set_mem_limit_bytes(wg.mem_limit_bytes());
+                    group_usage.__set_mem_pool(wg.mem_pool());
+                    group_usage.__set_mem_pool_mem_limit_bytes(wg.parent_memory_limit_bytes().value_or(0));
+                    group_usage.__set_mem_pool_mem_used_bytes(wg.parent_memory_usage_bytes().value_or(0));
                     group_to_usage.emplace(wg.id(), std::move(group_usage));
-
                     curr_group_to_cpu_runtime_ns.emplace(wg.id(), wg.cpu_runtime_ns());
                 } else {
                     TResourceGroupUsage& group_usage = it->second;
                     group_usage.__set_mem_used_bytes(group_usage.mem_used_bytes + wg.mem_consumption_bytes());
                     group_usage.__set_num_running_queries(group_usage.num_running_queries + wg.num_running_queries());
-
+                    if (wg.version() >= group_usage.group_version) {
+                        group_usage.__set_group_version(wg.version());
+                        group_usage.__set_mem_pool(wg.mem_pool());
+                        group_usage.__set_mem_limit_bytes(wg.mem_limit_bytes());
+                        group_usage.__set_mem_pool_mem_limit_bytes(wg.parent_memory_limit_bytes().value_or(0));
+                        group_usage.__set_mem_pool_mem_used_bytes(wg.parent_memory_usage_bytes().value_or(0));
+                    }
                     curr_group_to_cpu_runtime_ns[wg.id()] += wg.cpu_runtime_ns();
                 }
             });

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -190,6 +190,15 @@ public:
     int64_t num_total_queries() const { return _num_total_queries; }
     int64_t concurrency_overflow_count() const { return _concurrency_overflow_count; }
     int64_t bigquery_count() const { return _bigquery_count; }
+    std::optional<int64_t> parent_memory_limit_bytes() const {
+        return _mem_tracker != nullptr && _mem_tracker->parent() ? std::make_optional(_mem_tracker->parent()->limit())
+                                                                 : std::nullopt;
+    }
+    std::optional<int64_t> parent_memory_usage_bytes() const {
+        return _mem_tracker != nullptr && _mem_tracker->parent()
+                       ? std::make_optional(_mem_tracker->parent()->consumption())
+                       : std::nullopt;
+    }
 
     int64_t big_query_mem_limit() const { return _big_query_mem_limit; }
     bool use_big_query_mem_limit() const {

--- a/be/test/agent/resource_group_usage_recorder_test.cpp
+++ b/be/test/agent/resource_group_usage_recorder_test.cpp
@@ -42,6 +42,9 @@ TEST(ResourceGroupUsageRecorderTest, test_get_resource_group_usages) {
     ASSERT_EQ(group_usages.size(), 1);
     ASSERT_EQ(group_usages[0].group_id, default_wg->id());
     ASSERT_EQ(group_usages[0].cpu_core_used_permille, num_cores * 1000);
+    ASSERT_EQ(group_usages[0].mem_pool, workgroup::WorkGroup::DEFAULT_MEM_POOL);
+    ASSERT_EQ(group_usages[0].mem_limit_bytes, default_wg->mem_limit_bytes());
+    ASSERT_EQ(group_usages[0].mem_pool_mem_limit_bytes, default_wg->mem_limit_bytes());
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowResourceGroupUsageStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowResourceGroupUsageStmt.java
@@ -43,7 +43,15 @@ public class ShowResourceGroupUsageStmt extends ShowStmt {
                     Pair.create(new Column("BEInUseMemBytes", ScalarType.createVarchar(64)),
                             item -> Long.toString(item.usage.getMemUsageBytes())),
                     Pair.create(new Column("BERunningQueries", ScalarType.createVarchar(64)),
-                            item -> Integer.toString(item.usage.getNumRunningQueries()))
+                            item -> Integer.toString(item.usage.getNumRunningQueries())),
+                    Pair.create(new Column("BEMemLimitBytes", ScalarType.createVarchar(64)),
+                            item -> Long.toString(item.usage.getMemLimitBytes())),
+                    Pair.create(new Column("BEMemPool", ScalarType.createVarchar(64)),
+                            item -> item.usage.getMemPool()),
+                    Pair.create(new Column("BEMemPoolInUseMemBytes", ScalarType.createVarchar(64)),
+                            item -> Long.toString(item.usage.getMemPoolMemUsageBytes())),
+                    Pair.create(new Column("BEMemPoolMemLimitBytes", ScalarType.createVarchar(64)),
+                            item -> Long.toString(item.usage.getMemPoolMemLimitBytes()))
             );
 
     private static final ShowResultSetMetaData COLUMN_META_DATA;

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -779,17 +779,33 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
         private final int cpuCoreUsagePermille;
         private final long memUsageBytes;
         private final int numRunningQueries;
+        private final long memLimitBytes;
+        private final String memPool;
+        private final long memPoolMemUsageBytes;
+        private final long memPoolMemLimitBytes;
 
-        private ResourceGroupUsage(ResourceGroup group, int cpuCoreUsagePermille, long memUsageBytes, int numRunningQueries) {
+        private ResourceGroupUsage(ResourceGroup group,
+                                   int cpuCoreUsagePermille,
+                                   long memUsageBytes,
+                                   int numRunningQueries,
+                                   long memLimitBytes,
+                                   String memPool,
+                                   long memPoolMemUsageBytes,
+                                   long memPoolMemLimitBytes) {
             this.group = group;
             this.cpuCoreUsagePermille = cpuCoreUsagePermille;
             this.memUsageBytes = memUsageBytes;
             this.numRunningQueries = numRunningQueries;
+            this.memLimitBytes = memLimitBytes;
+            this.memPool = memPool;
+            this.memPoolMemUsageBytes = memPoolMemUsageBytes;
+            this.memPoolMemLimitBytes = memPoolMemLimitBytes;
         }
 
         private static ResourceGroupUsage fromThrift(TResourceGroupUsage tUsage, ResourceGroup group) {
             return new ResourceGroupUsage(group, tUsage.getCpu_core_used_permille(), tUsage.getMem_used_bytes(),
-                    tUsage.getNum_running_queries());
+                    tUsage.getNum_running_queries(), tUsage.getMem_limit_bytes(), tUsage.getMem_pool(),
+                    tUsage.getMem_pool_mem_used_bytes(), tUsage.getMem_pool_mem_limit_bytes());
         }
 
         public boolean isCpuCoreUsagePermilleEffective() {
@@ -811,5 +827,22 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
         public int getNumRunningQueries() {
             return numRunningQueries;
         }
+
+        public long getMemLimitBytes() {
+            return memLimitBytes;
+        }
+
+        public String getMemPool() {
+            return memPool;
+        }
+
+        public long getMemPoolMemUsageBytes() {
+            return memPoolMemUsageBytes;
+        }
+
+        public long getMemPoolMemLimitBytes() {
+            return memPoolMemLimitBytes;
+        }
+
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -1557,68 +1557,170 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
 
         {
             String res = starRocksAssert.executeShowResourceUsageSql("SHOW USAGE RESOURCE GROUPS;");
-            assertThat(res).isEqualTo("Name|Id|Backend|BEInUseCpuCores|BEInUseMemBytes|BERunningQueries\n");
+            assertThat(res).isEqualTo("Name|Id|Backend|BEInUseCpuCores|BEInUseMemBytes|BERunningQueries" +
+                    "|BEMemLimitBytes|BEMemPool|BEMemPoolInUseMemBytes|BEMemPoolMemLimitBytes\n");
         }
 
-        List<TResourceGroupUsage> groupUsages = ImmutableList.of(
-                new TResourceGroupUsage().setGroup_id(ResourceGroup.DEFAULT_WG_ID).setCpu_core_used_permille(3112)
-                        .setMem_used_bytes(39).setNum_running_queries(38),
-                new TResourceGroupUsage().setGroup_id(10L).setCpu_core_used_permille(112).setMem_used_bytes(9)
-                        .setNum_running_queries(8),
-                new TResourceGroupUsage().setGroup_id(11L).setCpu_core_used_permille(100),
-                new TResourceGroupUsage().setGroup_id(12L).setCpu_core_used_permille(120).setMem_used_bytes(7)
-                        .setNum_running_queries(6),
-                new TResourceGroupUsage().setGroup_id(13L).setCpu_core_used_permille(30)
-        );
-        backends.get(0).setMemLimitBytes(100L);
-        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(0L, 0, 30, 0, groupUsages);
-        groupUsages = ImmutableList.of(
-                new TResourceGroupUsage().setGroup_id(ResourceGroup.DEFAULT_MV_WG_ID).setCpu_core_used_permille(4110)
-                        .setMem_used_bytes(49).setNum_running_queries(48),
-                new TResourceGroupUsage().setGroup_id(10L).setCpu_core_used_permille(1110).setMem_used_bytes(19)
-                        .setNum_running_queries(18),
-                new TResourceGroupUsage().setGroup_id(11L).setCpu_core_used_permille(1100),
-                new TResourceGroupUsage().setGroup_id(12L).setCpu_core_used_permille(1120).setMem_used_bytes(17)
-                        .setNum_running_queries(16),
-                new TResourceGroupUsage().setGroup_id(13L).setCpu_core_used_permille(130)
-        );
-        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(1L, 0, 30, 0, groupUsages);
-
         {
-            String res = starRocksAssert.executeShowResourceUsageSql("SHOW USAGE RESOURCE GROUPS;");
-            assertThat(res).isEqualTo("Name|Id|Backend|BEInUseCpuCores|BEInUseMemBytes|BERunningQueries\n" +
-                    "default_wg|2|be0-host|3.112|39|38\n" +
-                    "default_mv_wg|3|be1-host|4.11|49|48\n" +
-                    "wg0|10|be0-host|0.112|9|8\n" +
-                    "wg0|10|be1-host|1.11|19|18\n" +
-                    "wg1|11|be0-host|0.1|0|0\n" +
-                    "wg1|11|be1-host|1.1|0|0\n" +
-                    "wg2|12|be0-host|0.12|7|6\n" +
-                    "wg2|12|be1-host|1.12|17|16\n" +
-                    "wg3|13|be0-host|0.03|0|0\n" +
-                    "wg3|13|be1-host|0.13|0|0");
+            {
+                final List<TResourceGroupUsage> groupUsages = ImmutableList.of(
+                        new TResourceGroupUsage()
+                                .setGroup_id(ResourceGroup.DEFAULT_WG_ID)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(3112)
+                                .setMem_used_bytes(39)
+                                .setMem_limit_bytes(40)
+                                .setNum_running_queries(38),
+                        new TResourceGroupUsage()
+                                .setGroup_id(10L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(112)
+                                .setMem_used_bytes(9)
+                                .setMem_limit_bytes(10)
+                                .setNum_running_queries(8),
+                        new TResourceGroupUsage()
+                                .setGroup_id(11L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(100),
+                        new TResourceGroupUsage()
+                                .setGroup_id(12L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(120)
+                                .setMem_used_bytes(7)
+                                .setMem_limit_bytes(10)
+                                .setNum_running_queries(6),
+                        new TResourceGroupUsage()
+                                .setGroup_id(13L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(30)
+                );
+
+                backends.get(0).setMemLimitBytes(100L);
+                final long memPoolMemLimitBytes = 100;
+                final long memPoolMemUsedBytes = groupUsages.stream().mapToLong(TResourceGroupUsage::getMem_used_bytes).sum();
+                groupUsages.forEach(usage -> {
+                    usage.setMem_pool_mem_used_bytes(memPoolMemUsedBytes);
+                    usage.setMem_pool_mem_limit_bytes(memPoolMemLimitBytes);
+                });
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(0L, 0, 30, 0, groupUsages);
+            }
+            {
+                final List<TResourceGroupUsage> groupUsages = ImmutableList.of(
+                        new TResourceGroupUsage()
+                                .setGroup_id(ResourceGroup.DEFAULT_MV_WG_ID)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(4110)
+                                .setMem_used_bytes(49)
+                                .setMem_limit_bytes(50)
+                                .setNum_running_queries(48),
+                        new TResourceGroupUsage()
+                                .setGroup_id(10L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(1110)
+                                .setMem_used_bytes(19)
+                                .setMem_limit_bytes(20)
+                                .setNum_running_queries(18),
+                        new TResourceGroupUsage()
+                                .setGroup_id(11L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(1100),
+                        new TResourceGroupUsage()
+                                .setGroup_id(12L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(1120)
+                                .setMem_used_bytes(17)
+                                .setMem_limit_bytes(20)
+                                .setNum_running_queries(16),
+                        new TResourceGroupUsage()
+                                .setGroup_id(13L)
+                                .setMem_pool(ResourceGroup.DEFAULT_MEM_POOL)
+                                .setCpu_core_used_permille(130)
+                );
+
+                backends.get(1).setMemLimitBytes(200L);
+                final long memPoolMemLimitBytes = 200;
+                final long memPoolMemUsedBytes = groupUsages.stream().mapToLong(TResourceGroupUsage::getMem_used_bytes).sum();
+                groupUsages.forEach(usage -> {
+                    usage.setMem_pool_mem_used_bytes(memPoolMemUsedBytes);
+                    usage.setMem_pool_mem_limit_bytes(memPoolMemLimitBytes);
+                });
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(1L, 0, 30, 0, groupUsages);
+            }
+
+            final String result = starRocksAssert.executeShowResourceUsageSql("SHOW USAGE RESOURCE GROUPS;");
+            assertThat(result).isEqualTo("Name|Id|Backend|BEInUseCpuCores|BEInUseMemBytes|BERunningQueries" +
+                    "|BEMemLimitBytes|BEMemPool|BEMemPoolInUseMemBytes|BEMemPoolMemLimitBytes\n" +
+                    "default_wg|2|be0-host|3.112|39|38|40|default_mem_pool|55|100\n" +
+                    "default_mv_wg|3|be1-host|4.11|49|48|50|default_mem_pool|85|200\n" +
+                    "wg0|10|be0-host|0.112|9|8|10|default_mem_pool|55|100\n" +
+                    "wg0|10|be1-host|1.11|19|18|20|default_mem_pool|85|200\n" +
+                    "wg1|11|be0-host|0.1|0|0|0|default_mem_pool|55|100\n" +
+                    "wg1|11|be1-host|1.1|0|0|0|default_mem_pool|85|200\n" +
+                    "wg2|12|be0-host|0.12|7|6|10|default_mem_pool|55|100\n" +
+                    "wg2|12|be1-host|1.12|17|16|20|default_mem_pool|85|200\n" +
+                    "wg3|13|be0-host|0.03|0|0|0|default_mem_pool|55|100\n" +
+                    "wg3|13|be1-host|0.13|0|0|0|default_mem_pool|85|200"
+            );
         }
 
-        groupUsages = ImmutableList.of(
-                new TResourceGroupUsage().setGroup_id(10L).setCpu_core_used_permille(210).setMem_used_bytes(29)
-                        .setNum_running_queries(28),
-                new TResourceGroupUsage().setGroup_id(11L).setCpu_core_used_permille(200)
-        );
-        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(0L, 0, 30, 0, groupUsages);
-        groupUsages = ImmutableList.of(
-                new TResourceGroupUsage().setGroup_id(12L).setCpu_core_used_permille(1220).setMem_used_bytes(27)
-                        .setNum_running_queries(26),
-                new TResourceGroupUsage().setGroup_id(13L).setCpu_core_used_permille(230)
-        );
-        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(1L, 0, 30, 0, groupUsages);
-
         {
-            String res = starRocksAssert.executeShowResourceUsageSql("SHOW USAGE RESOURCE GROUPS;");
-            assertThat(res).isEqualTo("Name|Id|Backend|BEInUseCpuCores|BEInUseMemBytes|BERunningQueries\n" +
-                    "wg0|10|be0-host|0.21|29|28\n" +
-                    "wg1|11|be0-host|0.2|0|0\n" +
-                    "wg2|12|be1-host|1.22|27|26\n" +
-                    "wg3|13|be1-host|0.23|0|0");
+            {
+                final List<TResourceGroupUsage> groupUsages = ImmutableList.of(
+                        new TResourceGroupUsage()
+                                .setGroup_id(10L)
+                                .setMem_pool("mem_pool_0")
+                                .setCpu_core_used_permille(210)
+                                .setMem_used_bytes(29)
+                                .setMem_limit_bytes(30)
+                                .setNum_running_queries(28),
+                        new TResourceGroupUsage()
+                                .setGroup_id(11L)
+                                .setMem_pool("mem_pool_0")
+                                .setMem_limit_bytes(30)
+                                .setCpu_core_used_permille(200)
+                );
+                backends.get(0).setMemLimitBytes(100L);
+                final long memPoolMemLimitBytes = 100;
+                final long memPoolMemUsedBytes = groupUsages.stream().mapToLong(TResourceGroupUsage::getMem_used_bytes).sum();
+                groupUsages.forEach(usage -> {
+                    usage.setMem_pool_mem_used_bytes(memPoolMemUsedBytes);
+                    usage.setMem_pool_mem_limit_bytes(memPoolMemLimitBytes);
+                });
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(0L, 0, 30, 0, groupUsages);
+            }
+            {
+                final List<TResourceGroupUsage> groupUsages = ImmutableList.of(
+                        new TResourceGroupUsage()
+                                .setGroup_id(12L)
+                                .setMem_pool("mem_pool_1")
+                                .setCpu_core_used_permille(1220)
+                                .setMem_used_bytes(27)
+                                .setMem_limit_bytes(50)
+                                .setNum_running_queries(26),
+                        new TResourceGroupUsage()
+                                .setGroup_id(13L)
+                                .setMem_pool("mem_pool_1")
+                                .setMem_limit_bytes(50)
+                                .setCpu_core_used_permille(230)
+                );
+                backends.get(1).setMemLimitBytes(200L);
+                final long memPoolMemLimitBytes = 200;
+                final long memPoolMemUsedBytes = groupUsages.stream().mapToLong(TResourceGroupUsage::getMem_used_bytes).sum();
+                groupUsages.forEach(usage -> {
+                    usage.setMem_pool_mem_used_bytes(memPoolMemUsedBytes);
+                    usage.setMem_pool_mem_limit_bytes(memPoolMemLimitBytes);
+                });
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().updateResourceUsage(1L, 0, 30, 0, groupUsages);
+            }
+
+            final String res = starRocksAssert.executeShowResourceUsageSql("SHOW USAGE RESOURCE GROUPS;");
+            assertThat(res).isEqualTo("Name|Id|Backend|BEInUseCpuCores|BEInUseMemBytes|BERunningQueries" +
+                    "|BEMemLimitBytes|BEMemPool|BEMemPoolInUseMemBytes|BEMemPoolMemLimitBytes\n" +
+                    "wg0|10|be0-host|0.21|29|28|30|mem_pool_0|29|100\n" +
+                    "wg1|11|be0-host|0.2|0|0|30|mem_pool_0|29|100\n" +
+                    "wg2|12|be1-host|1.22|27|26|50|mem_pool_1|27|200\n" +
+                    "wg3|13|be1-host|0.23|0|0|50|mem_pool_1|27|200"
+            );
         }
     }
 

--- a/gensrc/thrift/ResourceUsage.thrift
+++ b/gensrc/thrift/ResourceUsage.thrift
@@ -22,6 +22,11 @@ struct TResourceGroupUsage {
     2: optional i32 cpu_core_used_permille
     3: optional i64 mem_used_bytes;
     4: optional i32 num_running_queries;
+    5: optional i64 mem_limit_bytes
+    6: optional string mem_pool
+    7: optional i64 mem_pool_mem_limit_bytes
+    8: optional i64 mem_pool_mem_used_bytes
+    9: optional i64 group_version
 }
 
 struct TResourceUsage {


### PR DESCRIPTION
Backport of #66690 to `branch-3.5-cc`.

Original commit: f4a8df573a1140c8fbfbdf43551f62b6debdc4d1
Original PR: https://github.com/StarRocks/starrocks/pull/66690

---

<!-- Original PR description below -->

## Why I'm doing:

The `mem_pool` property for resource groups was recently introduced. See related pull requests below:

- https://github.com/StarRocks/starrocks/pull/64111
- https://github.com/StarRocks/starrocks/pull/64112
- https://github.com/StarRocks/starrocks/pull/65859
- https://github.com/StarRocks/starrocks/pull/66104

Currently, there is no way to display the usage metrics of the memory pools. 

## What I'm doing:

This pull request extends the result of `show usage resource groups;` command with the following:

| Column | Description |
| --------- | ------------ |
| Id | |
| Backend | |
| BEInUseCpuCores | |
| BEInUseMemBytes | |
| BERunningQueries | |
| + BEMemLimitBytes | Memory limit of the resource group.
| + BEMemPool | Name of the memory pool the resource group belongs to.
| + BEMemPoolInUseMemBytes | Current total memory usage of the mem_pool.
| + BEMemPoolMemLimitBytes | Specified memory limit of the mem_pool.

- The current implementation of memory pools requires configuring the memory limit of all resource groups (`BEMemLimitBytes`) under the same memory pool to the same value. This value also corresponds to the memory limit of the memory pool (`BEMemPoolMemLimitBytes`). The displayed values in these two columns will coincide due to this restriction, but it might change in the future. 
- The value of `BEMemPoolInUseMemBytes` is the sum of memory usages of each resource group that belongs to that memory pool. See the screenshots below for an example scenario.

### Notes/Discussion
- If two workgroups with the same id but different versions exist at the same time, the metrics to be reported for memory pools must belong to the latest version of that workgroup. This necessitates knowing which `group_version` a `TResourceGroupUsage` object belongs to. I tried two different approaches:
  - In `resorce_group_usage_recorder.cpp`, I added an auxillary `VersionedResourceGroupUsage` struct which had a group_version and a `TResourceGroupUsage` object as a pair. This solution worked, but it is just too messy for something as simple as this. See b9c41413de827d7de078225c3b109617dd67c3b0
 - (Preferred) I added a `group_version` field to the `ResourceUsage.thrift` file and directly use it. This is much cleaner. See bba21655103744e3117988e33f5880d7e11a668b
   - The `group_version` is only used by `resorce_group_usage_recorder.cpp` in the backend, and is not read from the thrift file on the front end side.

## Demo
![demo-0](https://github.com/user-attachments/assets/962eec89-233a-445d-8808-aeef1f2a87ca)
![demo-1](https://github.com/user-attachments/assets/8a46083c-0815-4ae4-8cd2-80ae59f0c14a) 
![demo-2](https://github.com/user-attachments/assets/5061e07c-956d-4193-889e-85a55d1c02e1)
![demo-3](https://github.com/user-attachments/assets/a34f1f02-aef3-47d8-90c8-f7b9b654b099)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances resource group usage reporting with memory‑pool metrics end-to-end.
> 
> - FE: Extends `SHOW USAGE RESOURCE GROUPS` with `BEMemLimitBytes`, `BEMemPool`, `BEMemPoolInUseMemBytes`, `BEMemPoolMemLimitBytes`; updates metadata, rendering, and tests
> - BE: `ResourceGroupUsageRecorder` now includes `group_version`, `mem_limit_bytes`, `mem_pool`, and mem‑pool limit/usage; merges per‑group stats preferring latest `group_version`
> - BE: `WorkGroup` exposes parent memory limit/usage helpers used for mem‑pool values
> - FE runtime: `ComputeNode.ResourceGroupUsage` extended to carry new fields and map from thrift
> - Thrift: adds fields to `TResourceGroupUsage` for mem limits/pool and `group_version`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a07cc5e5c6aeacd1f9602d4795052fdb458a6559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
