### PR TITLE
[UT] Stabilize the histogram ON ALL COLUMNS case

### DIFF
--- a/test/sql/test_analyze_statistics/R/test_histogram
+++ b/test/sql/test_analyze_statistics/R/test_histogram
@@ -681,16 +681,19 @@ PROPERTIES ('replication_num' = '1');
 -- !result
 INSERT INTO t_histogram_all_columns VALUES
     (1, 'a', '2020-01-01'),
+    (1, 'a', '2020-01-01'),
+    (1, 'a', '2020-01-01'),
     (2, 'b', '2020-01-02'),
-    (3, 'b', '2020-01-03'),
+    (2, 'b', '2020-01-02'),
+    (3, 'c', '2020-01-03'),
     (NULL, NULL, NULL);
 -- result:
 -- !result
-[UC] ANALYZE TABLE t_histogram_all_columns UPDATE HISTOGRAM ON ALL COLUMNS;
+[UC] ANALYZE TABLE t_histogram_all_columns UPDATE HISTOGRAM ON ALL COLUMNS PROPERTIES('histogram_sample_ratio' = '1.0');
 -- result:
 analyze_test_2e4abb11b7ab470b9ba904f3afeb9ed4.t_histogram_all_columns	histogram	status	OK
 -- !result
-function: assert_explain_costs_contains('select * from t_histogram_all_columns', 'MCV: [[1:10][2:10][3:10]]', 'MCV: [[b:20][a:10]] ESTIMATE', 'MCV: [[2020-01-01:10][2020-01-02:10][2020-01-03:10]]')
+function: assert_explain_costs_contains('select * from t_histogram_all_columns', 'MCV: [[1:3][2:2][3:1]]', 'MCV: [[a:3][b:2][c:1]] ESTIMATE', 'MCV: [[2020-01-01:3][2020-01-02:2][2020-01-03:1]]')
 -- result:
 None
 -- !result

--- a/test/sql/test_analyze_statistics/T/test_histogram
+++ b/test/sql/test_analyze_statistics/T/test_histogram
@@ -304,10 +304,13 @@ PROPERTIES ('replication_num' = '1');
 
 INSERT INTO t_histogram_all_columns VALUES
     (1, 'a', '2020-01-01'),
+    (1, 'a', '2020-01-01'),
+    (1, 'a', '2020-01-01'),
     (2, 'b', '2020-01-02'),
-    (3, 'b', '2020-01-03'),
+    (2, 'b', '2020-01-02'),
+    (3, 'c', '2020-01-03'),
     (NULL, NULL, NULL);
 
-[UC] ANALYZE TABLE t_histogram_all_columns UPDATE HISTOGRAM ON ALL COLUMNS;
-function: assert_explain_costs_contains('select * from t_histogram_all_columns', 'MCV: [[1:10][2:10][3:10]]', 'MCV: [[b:20][a:10]] ESTIMATE', 'MCV: [[2020-01-01:10][2020-01-02:10][2020-01-03:10]]')
+[UC] ANALYZE TABLE t_histogram_all_columns UPDATE HISTOGRAM ON ALL COLUMNS PROPERTIES('histogram_sample_ratio' = '1.0');
+function: assert_explain_costs_contains('select * from t_histogram_all_columns', 'MCV: [[1:3][2:2][3:1]]', 'MCV: [[a:3][b:2][c:1]] ESTIMATE', 'MCV: [[2020-01-01:3][2020-01-02:2][2020-01-03:1]]')
 


### PR DESCRIPTION
## Why I'm doing:

`sql/test_analyze_statistics/R/test_histogram` is flaky. The `t_histogram_all_columns` assertion added by #68290 expects MCV counts that are scaled by 10x:

```
function: assert_explain_costs_contains('select * from t_histogram_all_columns',
    'MCV: [[1:10][2:10][3:10]]', 'MCV: [[b:20][a:10]] ESTIMATE',
    'MCV: [[2020-01-01:10][2020-01-02:10][2020-01-03:10]]')
```

but the table only holds 4 rows, so the raw counts are 1/2. The 10x factor is `1 / Config.histogram_sample_ratio` (default `0.1`), and it only appears while the FE has not yet learned the table's row count:

- `AnalyzeStmtAnalyzer#visitAnalyzeHistogramStatement` corrects the sample ratio only when `totalRows != 0`. With `OlapTable#getRowCount()` still returning 0 right after the INSERT, the correction is skipped and the default ratio `0.1` survives.
- `HistogramStatisticsCollectJob#buildMostCommonValues` then scales every count by `count / sampleRatio`, i.e. x10 — which is what got recorded into the `R` file.
- Once the tablet row count is reported to the FE, `totalRows` becomes 4, `statistic_sample_collect_rows (200000) > totalRows` forces the ratio to `1`, no scaling happens, and the collected MCV is the real `[[1:1][2:1][3:1]]`.

So the recorded expectation captures a transient state rather than the intended behavior — a 4-row table should never be sampled at 0.1 — and the case passes or fails depending on whether the tablet report beats the `ANALYZE`. A recent failure showed exactly this, with `actualRows=4` in the plan confirming the FE already knew the row count:

```
AssertionError: assert expect MCV: [[1:10][2:10][3:10]] is not found in plan:
     * k1-->[1.0, 3.0, 0.25, 3.0, 3.0] MCV: [[1:1][2:1][3:1]] ESTIMATE
     * k2-->[-Infinity, Infinity, 0.25, 0.75, 2.0] MCV: [[b:2][a:1]] ESTIMATE
     * k3-->[...] MCV: [[2020-01-01:1][2020-01-02:1][2020-01-03:1]] ESTIMATE
```

There is a second latent source of flakiness in the same assertion: MCV comes from `... GROUP BY col ORDER BY count(col) DESC LIMIT topN`, and `k1`/`k3` had all three values at the same frequency, so the order of the tied entries was not guaranteed across the table's 3 tablets.

## What I'm doing:

- Pin `histogram_sample_ratio` to `1.0` on the `ON ALL COLUMNS` statement, so both timings (row count known or not) collect unscaled counts. The expectations become the real counts. Every other `ANALYZE ... UPDATE HISTOGRAM` in this file already sets the ratio explicitly for the same reason.
- Give each value a distinct frequency (3 / 2 / 1 per column) so the MCV ordering is fully determined and no longer depends on how ties come back.

The case still covers what #68290 fixed — `ON ALL COLUMNS` expanding to every column, and each column's type being resolved so the typed MCV rendering is correct for `int`, `varchar` and `date`. Only the absolute counts changed, and those reflect the sample-ratio scaling, which is unrelated to column-type resolution (and cannot be exercised meaningfully by a 4-row table anyway).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

> #68290 was not backported to branch-3.5 (the case does not exist there)
