### PR TITLE
[Enhancement] Support group-level query queue in query queue v2

### DIFF
--- a/docs/en/administration/management/resource_management/query_queues.md
+++ b/docs/en/administration/management/resource_management/query_queues.md
@@ -163,6 +163,24 @@ When the number of slots required by a query exceeds the current number of remai
 
 The entire queuing logic is completed on FE, including setting the total number of cluster slots, estimating the number of slots required by a query, and deciding which query's slot requirement to satisfy first. Query Queue v2 does not schedule based on the actual resource usage of BEs.
 
+### Resource group-level query queue
+
+Query Queue v2 also queues queries per resource group. In addition to the total slots of the warehouse, a query is admitted only when the number of running queries of its resource group is below the group's `concurrency_limit`; otherwise it waits in the queue instead of being rejected by BE. Queries of the other resource groups are not blocked by a group which has reached its limit.
+
+To enable it, set the global session variable `enable_group_level_query_queue` to `true` and set `concurrency_limit` on the resource group.
+
+```sql
+SET GLOBAL enable_group_level_query_queue = true;
+```
+
+The running queries are counted within each warehouse, because a queue is maintained per warehouse. `concurrency_limit` therefore means the number of queries the resource group can run concurrently within one warehouse, and the total number it can run in the cluster is the number of warehouses multiplied by `concurrency_limit`.
+
+:::note
+
+`mem_used_pct_limit` of a resource group applies only to Query Queue v1, because Query Queue v2 does not schedule based on the actual resource usage of BEs.
+
+:::
+
 ### Choose an estimation strategy
 
 #### PBE

--- a/docs/ja/administration/management/resource_management/query_queues.md
+++ b/docs/ja/administration/management/resource_management/query_queues.md
@@ -164,6 +164,24 @@ Query Queue v2 は BE リソースを論理 Slot として表現します。
 
 キューイングロジック全体は FE 上で完了します。これには、クラスタ全体の Slot 総数の設定、Query が必要とする Slot 数の見積もり、およびどの Query の Slot 要求を優先的に満たすかの決定が含まれます。Query Queue v2 は、BE の実際のリソース使用状況に基づいてスケジューリングを行いません。
 
+### リソースグループ粒度のクエリキュー
+
+Query Queue v2 もリソースグループ単位でクエリをキューイングします。Warehouse の合計 Slot に加えて、クエリが属するリソースグループの実行中クエリ数がそのグループの `concurrency_limit` を下回っている場合にのみ、クエリは実行を許可されます。そうでない場合、クエリは BE に拒否されるのではなく、キューで待機します。あるリソースグループが上限に達しても、他のリソースグループのクエリはブロックされません。
+
+有効にするには、グローバルセッション変数 `enable_group_level_query_queue` を `true` に設定し、リソースグループに `concurrency_limit` を設定します。
+
+```sql
+SET GLOBAL enable_group_level_query_queue = true;
+```
+
+キューは Warehouse ごとに管理されるため、実行中クエリ数は Warehouse ごとに個別にカウントされます。したがって `concurrency_limit` は、そのリソースグループが**単一の Warehouse 内**で同時に実行できるクエリ数を意味し、クラスタ全体で同時に実行できるクエリ数は Warehouse 数に `concurrency_limit` を掛けた値になります。
+
+:::note
+
+リソースグループの `mem_used_pct_limit` は Query Queue v1 にのみ適用されます。Query Queue v2 は BE の実際のリソース使用状況に基づいてスケジューリングを行わないためです。
+
+:::
+
 ### 推定方式を選択する
 
 #### PBE

--- a/docs/zh/administration/management/resource_management/query_queues.md
+++ b/docs/zh/administration/management/resource_management/query_queues.md
@@ -164,6 +164,24 @@ Query Queue v2 将 BE 资源表示为逻辑 Slot：
 
 整个排队逻辑都在 FE 上完成，包括设置集群总 Slot 数量、估算 Query 需要的 Slot 数量，以及决定优先满足哪个 Query 的 Slot 需求。Query Queue v2 不会根据 BE 的实际资源使用情况进行调度。
 
+### 资源组粒度查询队列
+
+Query Queue v2 同样支持按资源组排队。除 Warehouse 的总 Slot 之外,只有当查询所属资源组正在运行的查询数低于该组的 `concurrency_limit` 时,查询才会被放行;否则该查询会在队列中等待,而不是被 BE 拒绝。某个资源组达到上限时,其他资源组的查询不会被阻塞。
+
+如需启用,请将全局会话变量 `enable_group_level_query_queue` 设置为 `true`,并为资源组设置 `concurrency_limit`。
+
+```sql
+SET GLOBAL enable_group_level_query_queue = true;
+```
+
+正在运行的查询数在每个 Warehouse 内单独统计,因为队列是按 Warehouse 维护的。因此 `concurrency_limit` 的含义是该资源组在**单个 Warehouse 内**可以同时运行的查询数,在集群内可以同时运行的查询总数为 Warehouse 数量乘以 `concurrency_limit`。
+
+:::note
+
+资源组的 `mem_used_pct_limit` 仅适用于 Query Queue v1,因为 Query Queue v2 不会根据 BE 的实际资源使用情况进行调度。
+
+:::
+
 ### 选择估算策略
 
 #### PBE

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -522,7 +522,8 @@ public class JobSpec {
 
             instance.enableQueue = isEnableQueue(context);
             instance.needQueued = needCheckQueue();
-            instance.enableGroupLevelQueue = instance.enableQueue && GlobalVariable.isEnableGroupLevelQueryQueue();
+            instance.enableGroupLevelQueue = instance.enableQueue && instance.needQueued &&
+                    GlobalVariable.isEnableGroupLevelQueryQueue();
 
             return this;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/ShortJobFirstAlgo.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Comparator;
+import java.util.List;
 import java.util.PriorityQueue;
 import java.util.stream.Collectors;
 
@@ -58,6 +59,11 @@ class ShortJobFirstAlgo implements SlotScheduleAlgorithm {
     public void add(SlotSelectionStrategyV2.SlotContext slotContext) {
         q.add(slotContext);
         updateAgingIfNeeded();
+    }
+
+    @Override
+    public void requeue(List<SlotSelectionStrategyV2.SlotContext> slotContexts) {
+        slotContexts.forEach(this::add);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotScheduleAlgorithm.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotScheduleAlgorithm.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.qe.scheduler.slot;
 
+import java.util.List;
+
 /**
  * The algorithm/queue for slot schedule
  */
@@ -26,6 +28,8 @@ interface SlotScheduleAlgorithm {
     }
 
     void add(SlotSelectionStrategyV2.SlotContext slotContext);
+
+    void requeue(List<SlotSelectionStrategyV2.SlotContext> slotContexts);
 
     boolean remove(SlotSelectionStrategyV2.SlotContext slotContext);
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2.java
@@ -17,8 +17,12 @@ package com.starrocks.qe.scheduler.slot;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.thrift.TUniqueId;
 import org.apache.commons.compress.utils.Lists;
@@ -29,6 +33,7 @@ import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The slot resource is divided into small extra slots and normal slots.
@@ -57,6 +62,11 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
 
     private final LinkedHashMap<TUniqueId, SlotContext> requiringSmallSlots = new LinkedHashMap<>();
     private int numAllocatedSmallSlots = 0;
+
+    /**
+     * The number of running queries of each resource group within this warehouse.
+     */
+    private final Map<Long, Integer> groupIdToNumAllocatedQueries = Maps.newHashMap();
 
     private final long warehouseId;
     private final BaseSlotManager slotManager;
@@ -98,6 +108,8 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             }
         }
         requiringQueue.remove(slotContext);
+        slotContext.allocated = true;
+        groupIdToNumAllocatedQueries.merge(slot.getGroupId(), 1, Integer::sum);
 
         String category = String.valueOf(slotContext.getSubQueueIndex());
         MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING.getMetric(category).increase((long) -slot.getNumPhysicalSlots());
@@ -117,12 +129,15 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                 numAllocatedSmallSlots -= slot.getNumPhysicalSlots();
             }
         }
-        if (requiringQueue.remove(slotContext)) {
+        requiringQueue.remove(slotContext);
+        if (!slotContext.allocated) {
             MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_PENDING.getMetric(String.valueOf(slotContext.getSubQueueIndex()))
                     .increase((long) -slot.getNumPhysicalSlots());
         } else {
             MetricRepo.COUNTER_QUERY_QUEUE_CATEGORY_SLOT_RUNNING.getMetric(String.valueOf(slotContext.getSubQueueIndex()))
                     .increase((long) -slot.getNumPhysicalSlots());
+            // Mapping to null removes the entry, so groups without running queries do not accumulate.
+            groupIdToNumAllocatedQueries.computeIfPresent(slot.getGroupId(), (id, num) -> num > 1 ? num - 1 : null);
         }
     }
 
@@ -131,6 +146,7 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
         updateOptionsPeriodically();
 
         List<LogicalSlot> slotsToAllocate = Lists.newArrayList();
+        Map<Long, Integer> numQueriesToAllocateByGroup = Maps.newHashMap();
         // allocate small slots
         int curNumAllocatedSmallSlots = numAllocatedSmallSlots;
         for (SlotContext slotContext : requiringSmallSlots.values()) {
@@ -138,18 +154,32 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             if (!isSmallSlotAvailable(slotTracker, slot, curNumAllocatedSmallSlots)) {
                 break;
             }
+            if (!isGroupSlotAvailable(slot, numQueriesToAllocateByGroup)) {
+                continue;
+            }
 
             requiringQueue.remove(slotContext);
 
             slotsToAllocate.add(slot);
+            numQueriesToAllocateByGroup.merge(slot.getGroupId(), 1, Integer::sum);
             slotContext.setAllocateAsSmallSlot();
             curNumAllocatedSmallSlots += slot.getNumPhysicalSlots();
         }
 
         // allocate normal slots
         int numAllocatedSlots = slotTracker.getNumAllocatedSlots() - numAllocatedSmallSlots;
+        List<SlotContext> groupBlockedSlots = Lists.newArrayList();
         while (!requiringQueue.isEmpty()) {
             SlotContext slotContext = requiringQueue.peak();
+            if (!isGroupSlotAvailable(slotContext.getSlot(), numQueriesToAllocateByGroup)) {
+                requiringQueue.poll();
+                groupBlockedSlots.add(slotContext);
+                continue;
+            }
+            // Skipping a group at its concurrency limit, which lets the slots of the other groups behind it
+            // proceed, requires taking the slot out because peak() keeps returning the same head. The slots
+            // taken out are requeued once the loop ends: ShortJobFirstAlgo orders by score and only adds them,
+            // while WeightedRoundRobinQueue orders by insertion and puts them back in front.
             if (!isGlobalSlotAvailable(slotTracker, numAllocatedSlots, slotContext.getSlot())) {
                 break;
             }
@@ -157,8 +187,10 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             requiringQueue.poll();
 
             slotsToAllocate.add(slotContext.getSlot());
+            numQueriesToAllocateByGroup.merge(slotContext.getSlot().getGroupId(), 1, Integer::sum);
             numAllocatedSlots += slotContext.getSlot().getNumPhysicalSlots();
         }
+        requiringQueue.requeue(groupBlockedSlots);
 
         return slotsToAllocate;
     }
@@ -188,16 +220,26 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             } else {
                 Preconditions.checkState(false, "unknown schedule policy: " + opts.getPolicy());
             }
+            // Both the migration and the supplement below go through migratedSlotIds, so that a slot is
+            // enqueued once even if it is in the old queue more than once or is also supplemented.
+            Set<TUniqueId> migratedSlotIds = Sets.newHashSet();
             if (requiringQueue != null) {
                 while (!requiringQueue.isEmpty()) {
-                    newQueue.add(requiringQueue.poll());
+                    SlotContext slotContext = requiringQueue.poll();
+                    if (migratedSlotIds.add(slotContext.getSlotId())) {
+                        newQueue.add(slotContext);
+                    }
                 }
             }
             requiringQueue = newQueue;
 
-            slotContexts.values().stream()
-                    .filter(slotContext -> slotContext.getSlot().getState() == LogicalSlot.State.REQUIRING)
-                    .forEach(slotContext -> requiringQueue.add(slotContext));
+            // Supplement the pending slots which the migration above did not cover, in no particular order.
+            for (SlotContext slotContext : slotContexts.values()) {
+                if (slotContext.getSlot().getState() == LogicalSlot.State.REQUIRING
+                        && migratedSlotIds.add(slotContext.getSlotId())) {
+                    requiringQueue.add(slotContext);
+                }
+            }
 
             LOG.info("updated SlotSelectionStrategy to {}", newOpts.toString());
         }
@@ -237,6 +279,20 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
             return true;
         }
         return slotTracker.getCurrentCurrency() < queryQueueConcurrencyLimit;
+    }
+
+    private boolean isGroupSlotAvailable(LogicalSlot slot, Map<Long, Integer> numQueriesToAllocateByGroup) {
+        if (!GlobalVariable.isEnableGroupLevelQueryQueue()) {
+            return true;
+        }
+        long groupId = slot.getGroupId();
+        ResourceGroup group = GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup(groupId);
+        if (group == null || !group.isConcurrencyLimitEffective()) {
+            return true;
+        }
+        int numRunningQueries = groupIdToNumAllocatedQueries.getOrDefault(groupId, 0)
+                + numQueriesToAllocateByGroup.getOrDefault(groupId, 0);
+        return numRunningQueries < group.getConcurrencyLimit();
     }
 
     private static boolean isSmallSlot(LogicalSlot slot) {
@@ -338,6 +394,40 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
                     nextSlotToPeak = slotContext;
                     subQueue.incrState(-totalWeight);
                     prevPeakSubQueue.incrState(totalWeight);
+                }
+            }
+        }
+
+        @Override
+        public void requeue(List<SlotContext> slotContexts) {
+            if (slotContexts.isEmpty()) {
+                return;
+            }
+
+            Map<Integer, List<SlotContext>> queueIndexToSlots = Maps.newLinkedHashMap();
+            for (SlotContext slotContext : slotContexts) {
+                int queueIndex = getSubQueueIndex(slotContext);
+                queueIndexToSlots.computeIfAbsent(queueIndex, k -> Lists.newArrayList()).add(slotContext);
+            }
+
+            for (Map.Entry<Integer, List<SlotContext>> entry : queueIndexToSlots.entrySet()) {
+                int queueIndex = entry.getKey();
+                SlotSubQueue subQueue = subQueues[queueIndex];
+
+                LinkedHashMap<TUniqueId, SlotContext> rebuilt = Maps.newLinkedHashMap();
+                for (SlotContext slotContext : entry.getValue()) {
+                    rebuilt.put(slotContext.getSlotId(), slotContext);
+                }
+                rebuilt.putAll(subQueue.slots);
+
+                // A slot may have been requeued already, so count the ones actually added.
+                size += rebuilt.size() - subQueue.slots.size();
+                subQueue.slots.clear();
+                subQueue.slots.putAll(rebuilt);
+
+                // Otherwise the cached peak would hide the slots put back in front of it.
+                if (nextSlotToPeak != null && nextSlotToPeak.getSubQueueIndex() == queueIndex) {
+                    nextSlotToPeak = subQueue.peak();
                 }
             }
         }
@@ -538,6 +628,7 @@ public class SlotSelectionStrategyV2 implements SlotSelectionStrategy {
     @VisibleForTesting
     static class SlotContext {
         private final LogicalSlot slot;
+        private boolean allocated = false;
         private boolean allocatedAsSmallSlot = false;
         private int subQueueIndex = 0;
         private long createTime;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/dag/JobSpecGroupLevelQueueFlagTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/dag/JobSpecGroupLevelQueueFlagTest.java
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.dag;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.ResourceGroupClassifier;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.CoordinatorPreprocessor;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.qe.scheduler.slot.ResourceUsageMonitor;
+import com.starrocks.qe.scheduler.slot.SlotManager;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TQueryOptions;
+import com.starrocks.thrift.TQueryType;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.thrift.TWorkGroup;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The enable_group_level_query_queue flag sent to BE makes it skip its own resource-group
+ * concurrency-limit check, on the premise that the FE queue enforces the limit by group-level
+ * queueing. It must therefore be set only for queries that actually go through the FE queue, that is,
+ * when the queue is enabled AND the query is not exempted from queueing.
+ */
+public class JobSpecGroupLevelQueueFlagTest {
+    private boolean prevEnableGroupLevelQueryQueue = false;
+
+    @Mocked
+    private ScanNode scanNode;
+
+    @BeforeEach
+    public void before() {
+        prevEnableGroupLevelQueryQueue = GlobalVariable.isEnableGroupLevelQueryQueue();
+    }
+
+    @AfterEach
+    public void after() {
+        GlobalVariable.setEnableGroupLevelQueryQueue(prevEnableGroupLevelQueryQueue);
+    }
+
+    @Test
+    public void testFlagRequiresQueueEnabledNeedQueuedAndVariableOn(@Mocked GlobalStateMgr globalStateMgr,
+                                                                   @Mocked ConnectContext connectContext) {
+        new MockUp<CoordinatorPreprocessor>() {
+            @Mock
+            public TWorkGroup prepareResourceGroup(ConnectContext connect,
+                                                   ResourceGroupClassifier.QueryType queryType) {
+                return null;
+            }
+        };
+
+        boolean[] queueEnabled = {true};
+        SlotManager stubSlotManager = new SlotManager(new ResourceUsageMonitor()) {
+            @Override
+            public boolean isEnableQueryQueue(ConnectContext connect, JobSpec instance) {
+                return queueEnabled[0];
+            }
+        };
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getSlotManager();
+                result = stubSlotManager;
+                minTimes = 0;
+
+                connectContext.isNeedQueued();
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        // A queued query with the variable on: the flag is propagated, FE enforces the limit by queueing.
+        GlobalVariable.setEnableGroupLevelQueryQueue(true);
+        JobSpec jobSpec = buildJobSpec(connectContext, ImmutableList.of(scanNode));
+        assertThat(jobSpec.isEnableQueue()).isTrue();
+        assertThat(jobSpec.isNeedQueued()).isTrue();
+        assertThat(jobSpec.isEnableGroupLevelQueue()).isTrue();
+
+        // A query exempted from queueing (no scan node, likewise schema-only): it never reaches the FE queue,
+        // so the flag must not be propagated, otherwise BE would skip its check for a query FE does not queue.
+        jobSpec = buildJobSpec(connectContext, Collections.emptyList());
+        assertThat(jobSpec.isEnableQueue()).isTrue();
+        assertThat(jobSpec.isNeedQueued()).isFalse();
+        assertThat(jobSpec.isEnableGroupLevelQueue()).isFalse();
+
+        // The variable is off: group-level queueing is not requested at all.
+        GlobalVariable.setEnableGroupLevelQueryQueue(false);
+        jobSpec = buildJobSpec(connectContext, ImmutableList.of(scanNode));
+        assertThat(jobSpec.isEnableGroupLevelQueue()).isFalse();
+
+        // The queue is disabled: nothing is queued on FE, so BE must keep enforcing the limit.
+        queueEnabled[0] = false;
+        GlobalVariable.setEnableGroupLevelQueryQueue(true);
+        jobSpec = buildJobSpec(connectContext, ImmutableList.of(scanNode));
+        assertThat(jobSpec.isEnableQueue()).isFalse();
+        assertThat(jobSpec.isEnableGroupLevelQueue()).isFalse();
+    }
+
+    private static JobSpec buildJobSpec(ConnectContext connectContext, List<ScanNode> scanNodes) {
+        TQueryOptions queryOptions = new TQueryOptions();
+        queryOptions.setQuery_type(TQueryType.SELECT);
+        return new JobSpec.Builder()
+                .queryId(new TUniqueId(1, 2))
+                .fragments(Collections.emptyList())
+                .scanNodes(scanNodes)
+                .queryOptions(queryOptions)
+                .commonProperties(connectContext)
+                .build();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2GroupQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2GroupQueueTest.java
@@ -1,0 +1,344 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.ResourceGroup;
+import com.starrocks.catalog.ResourceGroupMgr;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.metric.MetricRepo;
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.system.BackendResourceStat;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Group-level queueing in {@link SlotSelectionStrategyV2}: when {@code enable_group_level_query_queue} is on,
+ * queries beyond their resource group's {@code concurrency_limit} stay pending instead of being allocated,
+ * without blocking the queries of other groups behind them in the queue.
+ */
+public class SlotSelectionStrategyV2GroupQueueTest {
+    private static final int NUM_CORES = 16;
+    private static final long GROUP_LIMITED = 10L;
+    private static final long GROUP_UNLIMITED = 20L;
+
+    private boolean prevEnableQueryQueueV2 = false;
+    private int prevQueryQueueV2ConcurrencyLevel = 0;
+    private String prevQueryQueueV2ScheduleStrategy;
+    private int prevQueryQueueConcurrencyLimit = -1;
+    private boolean prevEnableGroupLevelQueryQueue = false;
+
+    private SlotManager slotManager;
+    private final Map<Long, ResourceGroup> groups = new HashMap<>();
+
+    @BeforeAll
+    public static void beforeClass() {
+        MetricRepo.init();
+    }
+
+    @BeforeEach
+    public void before() {
+        prevEnableQueryQueueV2 = Config.enable_query_queue_v2;
+        prevQueryQueueV2ConcurrencyLevel = Config.query_queue_v2_concurrency_level;
+        prevQueryQueueV2ScheduleStrategy = Config.query_queue_v2_schedule_strategy;
+        prevQueryQueueConcurrencyLimit = GlobalVariable.getQueryQueueConcurrencyLimit();
+        prevEnableGroupLevelQueryQueue = GlobalVariable.isEnableGroupLevelQueryQueue();
+
+        Config.enable_query_queue_v2 = true;
+        Config.query_queue_v2_concurrency_level = 0;
+        Config.query_queue_v2_schedule_strategy = QueryQueueOptions.SchedulePolicy.SWRR.name();
+        GlobalVariable.setQueryQueueConcurrencyLimit(-1);
+        GlobalVariable.setEnableGroupLevelQueryQueue(true);
+
+        slotManager = new SlotManager(new ResourceUsageMonitor());
+        BackendResourceStat.getInstance().setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1, NUM_CORES);
+
+        groups.clear();
+        ResourceGroup limitedGroup = new ResourceGroup();
+        limitedGroup.setConcurrencyLimit(2);
+        groups.put(GROUP_LIMITED, limitedGroup);
+        groups.put(GROUP_UNLIMITED, new ResourceGroup());
+
+        Map<Long, ResourceGroup> localGroups = groups;
+        new MockUp<ResourceGroupMgr>() {
+            @Mock
+            public ResourceGroup getResourceGroup(long id) {
+                return localGroups.get(id);
+            }
+        };
+    }
+
+    @AfterEach
+    public void after() {
+        Config.enable_query_queue_v2 = prevEnableQueryQueueV2;
+        Config.query_queue_v2_concurrency_level = prevQueryQueueV2ConcurrencyLevel;
+        Config.query_queue_v2_schedule_strategy = prevQueryQueueV2ScheduleStrategy;
+        GlobalVariable.setQueryQueueConcurrencyLimit(prevQueryQueueConcurrencyLimit);
+        GlobalVariable.setEnableGroupLevelQueryQueue(prevEnableGroupLevelQueryQueue);
+
+        BackendResourceStat.getInstance().reset();
+    }
+
+    @Test
+    public void testOverLimitQueriesWaitAndResumeOnRelease() {
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot2 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot3 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot1);
+        slotTracker.requireSlot(slot2);
+        slotTracker.requireSlot(slot3);
+
+        List<LogicalSlot> peaked = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peaked).containsExactly(slot1, slot2);
+        peaked.forEach(slotTracker::allocateSlot);
+
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        slotTracker.releaseSlot(slot1.getSlotId());
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot3);
+    }
+
+    @Test
+    public void testBlockedGroupDoesNotBlockOtherGroups() {
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot limited1 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot limited2 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot limited3 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot unlimited1 = generateSlot(1, GROUP_UNLIMITED);
+        LogicalSlot noGroup1 = generateSlot(1, 0);
+        slotTracker.requireSlot(limited1);
+        slotTracker.requireSlot(limited2);
+        slotTracker.requireSlot(limited3);
+        slotTracker.requireSlot(unlimited1);
+        slotTracker.requireSlot(noGroup1);
+
+        List<LogicalSlot> peaked = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peaked).containsExactly(limited1, limited2, unlimited1, noGroup1);
+        peaked.forEach(slotTracker::allocateSlot);
+
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        slotTracker.releaseSlot(limited2.getSlotId());
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(limited3);
+    }
+
+    @Test
+    public void testDisabledVariableKeepsCurrentBehavior() {
+        GlobalVariable.setEnableGroupLevelQueryQueue(false);
+
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot2 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot3 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot1);
+        slotTracker.requireSlot(slot2);
+        slotTracker.requireSlot(slot3);
+
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot1, slot2, slot3);
+    }
+
+    @Test
+    public void testCancelPendingSlotKeepsGroupCountsIntact() {
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot2 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot3 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot1);
+        slotTracker.requireSlot(slot2);
+        slotTracker.requireSlot(slot3);
+
+        List<LogicalSlot> peaked = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peaked).containsExactly(slot1, slot2);
+        peaked.forEach(slotTracker::allocateSlot);
+
+        // Cancel the pending query: releasing it must not decrement the group's running count.
+        slotTracker.releaseSlot(slot3.getSlotId());
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        LogicalSlot slot4 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot4);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        slotTracker.releaseSlot(slot1.getSlotId());
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot4);
+    }
+
+    /**
+     * The count of a group whose queries have all finished must go back to zero, otherwise the group would
+     * permanently lose part of its concurrency_limit.
+     */
+    @Test
+    public void testGroupCountReturnsToZeroWhenAllQueriesFinish() {
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot1);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot1);
+        slotTracker.allocateSlot(slot1);
+        slotTracker.releaseSlot(slot1.getSlotId());
+
+        // The whole limit of 2 is available again.
+        LogicalSlot slot2 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot3 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot2);
+        slotTracker.requireSlot(slot3);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot2, slot3);
+    }
+
+    /**
+     * Group-level queueing has to work the same under the short-job-first policy, whose queue orders slots by
+     * score instead of by insertion.
+     */
+    @Test
+    public void testOverLimitQueriesWaitUnderShortJobFirst() {
+        Config.query_queue_v2_schedule_strategy = QueryQueueOptions.SchedulePolicy.SJF.name();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot slot1 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot2 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot3 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot1);
+        slotTracker.requireSlot(slot2);
+        slotTracker.requireSlot(slot3);
+
+        List<LogicalSlot> peaked = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peaked).hasSize(2);
+        peaked.forEach(slotTracker::allocateSlot);
+
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).isEmpty();
+
+        slotTracker.releaseSlot(peaked.get(0).getSlotId());
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).hasSize(1);
+    }
+
+    /**
+     * Every options change moves the pending slots into a new queue and then supplements them from the known
+     * contexts. A slot must not end up in the queue more than once, otherwise it would be allocated twice.
+     */
+    @Test
+    public void testOptionsChangesDoNotDuplicateSlotsUnderShortJobFirst() throws InterruptedException {
+        Config.query_queue_v2_schedule_strategy = QueryQueueOptions.SchedulePolicy.SJF.name();
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot slot = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot);
+
+        for (int concurrencyLevel : new int[] {8, 16}) {
+            // The options are refreshed at most once per UPDATE_OPTIONS_INTERVAL_MS.
+            Thread.sleep(1100);
+            Config.query_queue_v2_concurrency_level = concurrencyLevel;
+            strategy.updateOptionsPeriodically();
+        }
+
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(slot);
+    }
+
+    /**
+     * A slot held back by its group keeps its place when the round ends early because the warehouse ran out of
+     * capacity, so it is scheduled before the slots which were still waiting behind it.
+     */
+    @Test
+    public void testBlockedSlotKeepsItsPlaceWhenCapacityEndsTheRound() {
+        // 1 worker of 16 cores at concurrency level 2 gives 16 * 2 / 4 = 8 total slots.
+        Config.query_queue_v2_concurrency_level = 2;
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        // Fill the group up to its limit of 2, which takes 4 of the 8 total slots.
+        LogicalSlot running1 = generateSlot(2, GROUP_LIMITED);
+        LogicalSlot running2 = generateSlot(2, GROUP_LIMITED);
+        slotTracker.requireSlot(running1);
+        slotTracker.requireSlot(running2);
+        strategy.peakSlotsToAllocate(slotTracker).forEach(slotTracker::allocateSlot);
+
+        LogicalSlot blocked = generateSlot(2, GROUP_LIMITED);
+        LogicalSlot pass1 = generateSlot(2, GROUP_UNLIMITED);
+        LogicalSlot pass2 = generateSlot(2, GROUP_UNLIMITED);
+        LogicalSlot behind = generateSlot(2, GROUP_UNLIMITED);
+        slotTracker.requireSlot(blocked);
+        slotTracker.requireSlot(pass1);
+        slotTracker.requireSlot(pass2);
+        slotTracker.requireSlot(behind);
+
+        // `blocked` is held back by its group, `pass1` and `pass2` exhaust the total slots, so `behind` is never
+        // reached in this round.
+        List<LogicalSlot> peaked = strategy.peakSlotsToAllocate(slotTracker);
+        assertThat(peaked).containsExactly(pass1, pass2);
+        peaked.forEach(slotTracker::allocateSlot);
+
+        // Free the group and the capacity taken by the two running queries.
+        slotTracker.releaseSlot(running1.getSlotId());
+        slotTracker.releaseSlot(running2.getSlotId());
+
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(blocked, behind);
+    }
+
+    /**
+     * A slot which was peaked but never allocated has taken no seat of its group, so releasing it must not give
+     * back a seat which another query is still holding.
+     */
+    @Test
+    public void testReleasingASlotWhichWasNeverAllocatedKeepsTheGroupCount() {
+        SlotSelectionStrategyV2 strategy = new SlotSelectionStrategyV2(slotManager, DEFAULT_WAREHOUSE_ID);
+        SlotTracker slotTracker = new SlotTracker(slotManager, ImmutableList.of(strategy));
+
+        LogicalSlot running = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(running);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(running);
+        slotTracker.allocateSlot(running);
+
+        LogicalSlot peakedOnly = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(peakedOnly);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).containsExactly(peakedOnly);
+        slotTracker.releaseSlot(peakedOnly.getSlotId());
+
+        // `running` still holds one of the two seats of the group.
+        LogicalSlot slot3 = generateSlot(1, GROUP_LIMITED);
+        LogicalSlot slot4 = generateSlot(1, GROUP_LIMITED);
+        slotTracker.requireSlot(slot3);
+        slotTracker.requireSlot(slot4);
+        assertThat(strategy.peakSlotsToAllocate(slotTracker)).hasSize(1);
+    }
+
+    private static LogicalSlot generateSlot(int numSlots, long groupId) {
+        return new LogicalSlot(UUIDUtil.genTUniqueId(), "fe", WarehouseManager.DEFAULT_WAREHOUSE_ID,
+                groupId, numSlots, 0, 0, 0, 0, 0);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2WeightedRoundRobinQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/slot/SlotSelectionStrategyV2WeightedRoundRobinQueueTest.java
@@ -334,4 +334,115 @@ public class SlotSelectionStrategyV2WeightedRoundRobinQueueTest {
         }
     }
 
+    /**
+     * A slot taken out of the queue and put back keeps its place, so that a scheduling round which polls a slot
+     * without allocating it does not push that slot behind the slots it arrived before.
+     */
+    @Test
+    public void testPolledSlotKeepsItsPlaceWhenAddedBack() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        // All of them require the same number of slots, so they land in the same sub-queue.
+        SlotContext first = generateSlotContext(1);
+        SlotContext second = generateSlotContext(1);
+        SlotContext third = generateSlotContext(1);
+        queue.add(first);
+        queue.add(second);
+        queue.add(third);
+
+        assertThat(queue.poll()).isSameAs(first);
+        // Caches `second` as the peak before `first` is put back in front of it.
+        assertThat(queue.peak()).isSameAs(second);
+
+        queue.requeue(ImmutableList.of(first));
+        assertThat(queue.size()).isEqualTo(3);
+        assertThat(queue.peak()).isSameAs(first);
+        assertThat(queue.poll()).isSameAs(first);
+        assertThat(queue.poll()).isSameAs(second);
+        assertThat(queue.poll()).isSameAs(third);
+    }
+
+    /**
+     * Slots requeued together keep the order they had, both among themselves and against the slots which stayed
+     * in the queue.
+     */
+    @Test
+    public void testRequeueKeepsTheOrderOfSlotsOfTheSameSubQueue() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        SlotContext first = generateSlotContext(1);
+        SlotContext second = generateSlotContext(1);
+        SlotContext third = generateSlotContext(1);
+        SlotContext behind = generateSlotContext(1);
+        queue.add(first);
+        queue.add(second);
+        queue.add(third);
+        queue.add(behind);
+
+        assertThat(queue.poll()).isSameAs(first);
+        assertThat(queue.poll()).isSameAs(second);
+        assertThat(queue.poll()).isSameAs(third);
+
+        queue.requeue(ImmutableList.of(first, second, third));
+
+        assertThat(queue.size()).isEqualTo(4);
+        assertThat(queue.poll()).isSameAs(first);
+        assertThat(queue.poll()).isSameAs(second);
+        assertThat(queue.poll()).isSameAs(third);
+        assertThat(queue.poll()).isSameAs(behind);
+    }
+
+    /**
+     * Slots requeued together may belong to different sub-queues, and each of them has to go back in front of
+     * its own sub-queue.
+     */
+    @Test
+    public void testRequeueRestoresSlotsToTheirOwnSubQueue() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        SlotContext big = generateSlotContext(1024);
+        SlotContext bigNext = generateSlotContext(1024);
+        SlotContext small = generateSlotContext(1);
+        SlotContext smallNext = generateSlotContext(1);
+        queue.add(big);
+        queue.add(bigNext);
+        queue.add(small);
+        queue.add(smallNext);
+        assertThat(big.getSubQueueIndex()).isNotEqualTo(small.getSubQueueIndex());
+
+        assertThat(queue.remove(big)).isTrue();
+        assertThat(queue.remove(small)).isTrue();
+        assertThat(queue.size()).isEqualTo(2);
+
+        queue.requeue(ImmutableList.of(big, small));
+
+        assertThat(queue.size()).isEqualTo(4);
+        assertThat(queue.getSubQueues()[big.getSubQueueIndex()].peak()).isSameAs(big);
+        assertThat(queue.getSubQueues()[small.getSubQueueIndex()].peak()).isSameAs(small);
+    }
+
+    /**
+     * A slot already put back, as {@link SlotSelectionStrategyV2#updateOptionsPeriodically} does when it refills
+     * the queue, must not be counted twice, otherwise the queue reports slots it no longer holds and peaking
+     * never terminates.
+     */
+    @Test
+    public void testRequeueDoesNotCountAnAlreadyAddedSlotTwice() {
+        WeightedRoundRobinQueue queue = new WeightedRoundRobinQueue(1024, 1);
+
+        SlotContext first = generateSlotContext(1);
+        SlotContext second = generateSlotContext(1);
+        queue.add(first);
+        queue.add(second);
+
+        assertThat(queue.poll()).isSameAs(first);
+        queue.add(first);
+        queue.requeue(ImmutableList.of(first));
+
+        assertThat(queue.size()).isEqualTo(2);
+        assertThat(queue.poll()).isNotNull();
+        assertThat(queue.poll()).isNotNull();
+        assertThat(queue.isEmpty()).isTrue();
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

Query queue V2 has no notion of resource groups — SlotSelectionStrategyV2 contains no resource-group logic at all.

A resource group's concurrency_limit is therefore enforced only by the rejection check on the BE side: an over-limit query fails immediately with Exceed concurrency limit instead of waiting in the queue. Since enable_query_queue_v2 defaults to true from v4.1, users upgrading from 3.x lose group-level queueing without any notice.

Worse, once enable_group_level_query_queue is on, FE tells BE to skip its group concurrency check, on the premise that FE queues per group — which V2 never does. The concurrency_limit is then enforced neither on FE nor on BE, and the resource group runs unbounded without any error.

## What I'm doing:
Implement group-level queueing in SlotSelectionStrategyV2, aligning with the V1 semantics.

Counting granularity: per warehouse. A strategy instance is created per warehouse, so concurrency_limit means "at most N queries of this resource group run concurrently within each warehouse". When the queries of one resource group are spread over several warehouses, the total number the group can run in the cluster is the number of warehouses × concurrency_limit.

Two existing issues are fixed along the way:

Require needQueued before propagating enable_group_level_query_queue. A query exempted from queueing (schema-only, see JobSpec#isJobNeedCheckQueue) never reaches the FE queue but still runs on BE, yet the flag was propagated for it, letting it bypass the group concurrency limit. The condition now matches the one QueryQueueOptions#createFromEnvAndQuery already uses.

Deduplicate by slot ID when the queue is rebuilt on an options change. The old queue was migrated and then every pending slot was supplemented again, so a slot was enqueued twice; WeightedRoundRobinQueue happens to be safe because it deduplicates by key, while ShortJobFirstAlgo keeps both copies in its PriorityQueue. A duplicated slot can be selected twice in one round and get two completion notifications, and the failure of the second one triggers releaseSlotAsync(), releasing the slot of a query that is still running.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5