### PR TITLE
[BugFix] Require cluster token on BE /api/_stop_be endpoint

### DIFF
--- a/be/src/http/action/stop_be_action.cpp
+++ b/be/src/http/action/stop_be_action.cpp
@@ -20,6 +20,8 @@
 #include "base/utility/defer_op.h"
 #include "common/config_http_fwd.h"
 #include "common/process_exit.h"
+#include "common/status.h"
+#include "common/system/master_info.h"
 #include "platform/http/http_channel.h"
 #include "platform/http/http_request.h"
 #include "platform/http/http_status.h"
@@ -29,6 +31,23 @@
 #endif
 
 namespace starrocks {
+
+namespace {
+// stop_be shuts the process down for any caller that can reach this HTTP endpoint.
+// config::enable_stop_be_action is only a feature toggle (default true), not a credential,
+// so gate it behind the same cluster-internal shared token already used for other
+// admin/internal BE HTTP endpoints (see DownloadAction::check_token).
+Status check_internal_token(HttpRequest* req) {
+    const std::string& token_str = req->param("token");
+    if (token_str.empty()) {
+        return Status::InternalError("token is not specified.");
+    }
+    if (token_str != get_master_token()) {
+        return Status::InternalError("invalid token.");
+    }
+    return Status::OK();
+}
+} // namespace
 
 std::string StopBeAction::construct_response_message(const std::string& msg) {
     std::stringstream ss;
@@ -48,6 +67,16 @@ void StopBeAction::handle(HttpRequest* req) {
         HttpChannel::send_reply(req, HttpStatus::FORBIDDEN,
                                 construct_response_message("stop_be action is disabled by config"));
         return;
+    }
+
+    if (config::enable_token_check) {
+        Status token_st = check_internal_token(req);
+        if (!token_st.ok()) {
+            LOG(WARNING) << "Rejected stop_be request: " << token_st;
+            HttpChannel::send_reply(req, HttpStatus::UNAUTHORIZED,
+                                    construct_response_message(std::string(token_st.message())));
+            return;
+        }
     }
 
     DeferOp defer([&]() {


### PR DESCRIPTION
## Why I'm doing:
StopBeAction::handle() only checks config::enable_stop_be_action, a feature  toggle that defaults to `true`. It performs no caller authentication, so any  request that can reach a BE's HTTP port can shut the process down therefore no  credential required.

## What I'm doing:

Gate the endpoint behind the same cluster-internal shared token  (`get_master_token()`) already used to protect other BE-internal HTTP admin  endpoints, following the existing `DownloadAction::check_token()` pattern.  The check is itself gated by `config::enable_token_check` (default `true`)  for consistency with the rest of the codebase, and only runs after the existing `enable_stop_be_action` toggle passes.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
