### PR TITLE
[BugFix] Skip bases without partition traits when inspecting MV refresh info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/function/MetaFunctions.java
@@ -261,6 +261,19 @@ public class MetaFunctions {
             Map<String, String> tablePartitionInfos = Maps.newHashMap();
             for (BaseTableInfo baseTableInfo : mv.getBaseTableInfos()) {
                 Table baseTable = MvUtils.getTableChecked(baseTableInfo);
+                // A base without a ConnectorPartitionTraits entry has no partition concept to inspect; the
+                // common case is a VIEW, which MvRefreshArbiter.getMvBaseTableUpdateInfo() already skips on
+                // the refresh path. Record its type and move on, so one such base no longer aborts the whole
+                // inspection via ConnectorPartitionTraits.build()'s null-check.
+                // NOTE: unlike getTablePartitionInfo() below, this guard must NOT exempt OlapTable. Both
+                // branches here need traits -- getUpdatedPartitionNamesOfOlapTable() builds them as well
+                // (MaterializedView#getUpdatedPartitionNamesOfOlapTable) -- so an OlapTable with an
+                // unregistered type (OLAP_EXTERNAL) would still trip the null-check.
+                if (!ConnectorPartitionTraits.isSupported(baseTable.getType())) {
+                    tableIdToTableNameMap.put(baseTable.getId(), baseTable.getName());
+                    tablePartitionInfos.put(baseTable.getName(), unsupportedPartitionTraitsInfo(baseTable));
+                    continue;
+                }
                 Set<String> toUpdatePartitions = null;
                 if (baseTable instanceof OlapTable) {
                     toUpdatePartitions = mv.getUpdatedPartitionNamesOfOlapTable((OlapTable) baseTable, false);
@@ -323,7 +336,21 @@ public class MetaFunctions {
         }
     }
 
+    /**
+     * Describe a base object that cannot carry partition information, instead of failing the whole inspection.
+     */
+    private static String unsupportedPartitionTraitsInfo(Table table) {
+        JsonObject obj = new JsonObject();
+        obj.addProperty("unsupportedTableType", String.valueOf(table.getType()));
+        return obj.toString();
+    }
+
     private static String getTablePartitionInfo(Table table) {
+        // Fail with an actionable message rather than letting ConnectorPartitionTraits.build() below trip its
+        // null-check, which reaches inspect_table_partition_info() callers as a bare NullPointerException.
+        if (!(table instanceof OlapTable) && !ConnectorPartitionTraits.isSupported(table.getType())) {
+            throw new SemanticException("table type does not support partition info: " + table.getType());
+        }
         JsonObject obj = new JsonObject();
         if (table instanceof OlapTable) {
             OlapTable olapTable = (OlapTable) table;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -267,6 +267,38 @@ public class MetaFunctionsTest extends MVTestBase {
     }
 
     @Test
+    public void inspectMVRefreshInfoHandlesViewBaseTable() throws Exception {
+        // An MV built on a logical VIEW is supported, but VIEW has no ConnectorPartitionTraits entry.
+        // The inspection must degrade gracefully for that base object instead of throwing.
+        starRocksAssert.withView("create view view_for_traits as select k1, v1 from test.tbl1");
+        starRocksAssert.withMaterializedView("create materialized view mv_on_view distributed by random " +
+                "as select k1, sum(v1) from test.view_for_traits group by k1");
+        ConstantOperator result = MetaFunctions.inspectMVRefreshInfo(
+                ConstantOperator.createVarchar("test.mv_on_view"));
+        Assertions.assertNotNull(result);
+        String json = result.getVarchar();
+        Assertions.assertTrue(json.contains("mvToRefreshPartitions"));
+        // The view base is reported as having no partition concept instead of aborting the inspection...
+        Assertions.assertTrue(json.contains("unsupportedTableType"));
+        // ...and the olap base behind the view still gets its real partition info reported.
+        Assertions.assertTrue(json.contains("tbl1"));
+        Assertions.assertTrue(json.contains("p1"));
+        Assertions.assertTrue(json.contains("p2"));
+        starRocksAssert.dropMaterializedView("mv_on_view");
+        starRocksAssert.dropView("view_for_traits");
+    }
+
+    @Test
+    public void inspectTablePartitionInfoThrowsSemanticExceptionForView() throws Exception {
+        // Reaching ConnectorPartitionTraits.build() with a VIEW used to surface a bare NullPointerException.
+        starRocksAssert.withView("create view view_no_partition as select k1, v1 from test.tbl1");
+        assertThrows(SemanticException.class,
+                () -> MetaFunctions.inspectTablePartitionInfo(
+                        ConstantOperator.createVarchar("test.view_no_partition")));
+        starRocksAssert.dropView("view_no_partition");
+    }
+
+    @Test
     public void inspectMVRefreshInfoHandlesEmptyBaseTables() throws Exception {
         starRocksAssert.withMaterializedView("create materialized view mv_empty distributed by random " +
                 "   as select k1 from test.tbl1 group by k1");


### PR DESCRIPTION
## Why I'm doing:

On a production cluster, every refresh of three async MVs logs a `NullPointerException` from the MV refresh trace helper on the leader FE:

```
WARN (...) [MVTaskRunProcessor.getMVRefreshTraceInfo():266]
  failed to inspect mv refresh info for mv: 
java.lang.NullPointerException: traits not supported: VIEW
```

(That log is verbatim from a 4.1.4 build, so its line number is 4.1.4's. Every code reference below points at `main`.)

The refresh itself succeeds. Only the diagnostic helper fails, but that costs two real things: the trace JSON for those MVs is empty, and the leader log is noisy.

`ConnectorPartitionTraits` is a static registry keyed by `Table.TableType`:

```java
// ConnectorPartitionTraits.java:98-100
public static ConnectorPartitionTraits build(Table.TableType tableType) {
    return Preconditions.checkNotNull(TRAITS_TABLE.get(tableType),
            "traits not supported: " + tableType).get();
}
```

`VIEW` is not one of the 12 registered types. Building an MV on top of a view is supported, so `MetaFunctions.inspectMVRefreshInfo()` walks into the `else` branch for the view base and trips that null-check, which aborts the inspection for *every* base table of that MV — not just the view.

```
MVTaskRunProcessor.getMVRefreshTraceInfo():270
  └ MetaFunctions.inspectMVRefreshInfo():262   for (BaseTableInfo : mv.getBaseTableInfos())
      ├ baseTable instanceof OlapTable  → OK
      └ else → mv.getUpdatedPartitionNamesOfExternalTable()
          └ MaterializedView.java:1350 → ConnectorPartitionTraits.build(this, baseTable)
              └ buildWithCache → buildWithoutCache → build(table.getType())  → NPE
```

Note that the refresh path already handles this exact case, in two places:

```java
// MvRefreshArbiter.getMvBaseTableUpdateInfo():174-177 (and :126-128)
if (baseTable.isView()) {
    // do nothing
    return baseTableUpdateInfo;
}
```

That guard is why the refresh succeeds. `MetaFunctions` is simply missing the equivalent one, so this PR fills in an idiom the codebase already uses rather than introducing a new one.

`getTablePartitionInfo()` has the same unguarded `build()` call. That one is reachable from the user-facing `inspect_table_partition_info()` SQL function, so passing a view returns a bare `NullPointerException` to the user.

## What I'm doing:

**1. `inspectMVRefreshInfo()` — skip bases that have no partition concept**

```java
if (!ConnectorPartitionTraits.isSupported(baseTable.getType())) {
    tableIdToTableNameMap.put(baseTable.getId(), baseTable.getName());
    tablePartitionInfos.put(baseTable.getName(), unsupportedPartitionTraitsInfo(baseTable));
    continue;
}
```

The base is recorded with its type and skipped, so the remaining base tables still get reported instead of the whole payload being lost.

Two details are deliberate:

- **`isSupported()` rather than `isView()`.** The failing precondition is registry membership itself, not view-ness. Other unregistered types (`MYSQL`, `ELASTICSEARCH`, ...) hit the same NPE when used as an MV base. The same idiom already exists at `PCTTableSnapshotInfo.java:141`.
- **This guard does not exempt `OlapTable`, while the one in `getTablePartitionInfo()` does.** The asymmetry is intentional and I left a `NOTE` in the code so it is not "cleaned up" later. `getTablePartitionInfo()` serves olap tables from `olapTable.getPartitions()` and never needs traits, so exempting `OlapTable` there is correct. In this loop, *both* branches need traits — `getUpdatedPartitionNamesOfOlapTable()` calls `ConnectorPartitionTraits.build(this, baseTable)` as well — so exempting `OlapTable` here would let `ExternalOlapTable` (`OLAP_EXTERNAL`, an `OlapTable` with no registry entry) fall straight into the olap branch and trip the same null-check.

**2. `getTablePartitionInfo()` — an actionable exception instead of an NPE**

`SemanticException("table type does not support partition info: VIEW")`. It still fails, but the caller can tell why.

I deliberately did **not** relax `ConnectorPartitionTraits.build()` into returning a null object. Several callers such as `PartitionUtil` rely on it failing fast, and silently continuing there would mask real bugs. The guards belong on the caller side.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade &amp; downgrade compatibility, etc.

For reference, what an operator sees differently: `inspect_mv_refresh_info()` now returns a populated result for MVs with a view base (previously the call threw), and each such base appears as `{"unsupportedTableType": "VIEW"}`. `inspect_table_partition_info()` on a view now raises a `SemanticException` with an explanatory message instead of a `NullPointerException`. Both are diagnostic surfaces only — no query, refresh, or planning behavior changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Two tests in `MetaFunctionsTest`:

- `inspectMVRefreshInfoHandlesViewBaseTable` — an MV over a view is inspected without throwing; the view base is reported as `unsupportedTableType`, **and the olap base behind the view still reports its real partitions (`p1`/`p2`)**. The second half is the point of the fix: skipping one base must not cost the diagnostics of the others.
- `inspectTablePartitionInfoThrowsSemanticExceptionForView` — a view yields `SemanticException`, not `NullPointerException`.

Neither test covers an `OLAP_EXTERNAL` base, since constructing an `ExternalOlapTable`-backed MV in the UT framework appears to need a live remote StarRocks cluster. That path is guarded by the `NOTE` in the code rather than by a test; happy to add one if a reviewer knows a workable fixture.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

The NPE is present on 4.0 as well — production log comparison shows it predates the 4.0.9 → 4.1.4 upgrade rather than being introduced by it.