### PR TITLE
[BugFix] Require cluster token on BE error-log download endpoint

### DIFF
--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -98,9 +98,25 @@ void DownloadAction::handle_normal(HttpRequest* req, const std::string& file_par
 }
 
 void DownloadAction::handle_error_log(HttpRequest* req, const std::string& file_param) {
+    // need_auth() gates this on config::enable_http_auth, which defaults to false, so this
+    // path is effectively unauthenticated in a default deployment. Add the same
+    // shared-token check already used by handle_normal() as defense-in-depth so error logs
+    // (which can contain sensitive query text/data) aren't served to anyone who can reach the
+    // BE HTTP port when enable_http_auth is left at its default.
+    Status status;
+    if (config::enable_token_check) {
+        status = check_token(req);
+        if (!status.ok()) {
+            HttpChannel::send_reply(req, status.message());
+            LOG(WARNING) << "Download method:" << to_method_desc(req->method()) << " " << file_param
+                         << " error:" << status;
+            return;
+        }
+    }
+
     const std::string absolute_path = _error_log_root_dir + "/" + file_param;
 
-    Status status = check_log_path_is_allowed(absolute_path);
+    status = check_log_path_is_allowed(absolute_path);
     if (!status.ok()) {
         HttpChannel::send_reply(req, status.message());
         return;


### PR DESCRIPTION
## Why I'm doing:
`DownloadAction::handle_error_log()` relies solely on `need_auth()`   `config::enable_http_auth` for access control, and `enable_http_auth`  defaults to `false`. So in a default deployment, error-log downloads are  effectively unauthenticated. 
## What I'm doing:
  `handle_normal()` already guards its (internal) download path with the  shared cluster token via `check_token()`. Apply the same gate to  `handle_error_log()` as defense-in-depth, since error logs can contain  sensitive query text and data and shouldn't be servable to anyone who can  reach the BE HTTP port when `enable_http_auth` is left at its default.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
