### PR TITLE
[BugFix] Fail closed on Arrow Flight bearer auth (hardcoded token)

### DIFF
--- a/be/src/service/service_be/arrow_flight_auth_server_middleware.cpp
+++ b/be/src/service/service_be/arrow_flight_auth_server_middleware.cpp
@@ -39,6 +39,15 @@ void NoOpBearerAuthServerMiddleware::SendingHeaders(arrow::flight::AddCallHeader
 arrow::Status NoOpBearerAuthServerMiddlewareFactory::StartCall(
         const arrow::flight::CallInfo& info, const arrow::flight::ServerCallContext& context,
         std::shared_ptr<arrow::flight::ServerMiddleware>* middleware) {
+    std::string bearer_token = FindKeyValPrefixInCallHeaders(context.incoming_headers(), kAuthHeader, kBearerPrefix);
+    _is_valid = (bearer_token == std::string(kBearerDefaultToken));
+    if (!_is_valid) {
+        // Previously this factory admitted every call unconditionally and only recorded the
+        // token comparison in _is_valid, a field nothing ever read (CWE-287: the call was
+        // effectively unauthenticated). Fail closed instead of falling back to an implicitly
+        // authenticated state so a missing/incorrect bearer token actually rejects the call.
+        return arrow::Status::IOError("Unauthenticated: missing or invalid bearer token");
+    }
     *middleware = std::make_shared<NoOpBearerAuthServerMiddleware>(context.incoming_headers(), &_is_valid);
     return arrow::Status::OK();
 }


### PR DESCRIPTION
## Why I'm doing:
`NoOpBearerAuthServerMiddlewareFactory::StartCall()` computes the bearer  token comparison into `_is_valid` but never checks it before admitting the  call — every Arrow Flight RPC is accepted regardless of the Authorization
  header, and `_is_valid` is never read by anything. This is CWE-287  (Improper Authentication): the middleware only *appears* to gate access.
## What I'm doing:
Reject the call outright when the bearer token doesn't match the expected  value, instead of constructing the middleware and unconditionally returning  `OK`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
