### PR TITLE
[BugFix] Remove AllPermission grant from UDF security policy

### DIFF
--- a/conf/udf_security.policy
+++ b/conf/udf_security.policy
@@ -1,3 +1,12 @@
+// This policy governs code loaded via UDFClassLoader (see UDFSecurityManager), i.e. Java UDFs
+// uploaded by users with CREATE FUNCTION privilege. It previously granted java.security.AllPermission,
+// which is equivalent to no sandbox at all: any UDF could read/write arbitrary files, open network
+// connections, execute system commands, and read in-process secrets via reflection.
+//
+// Grant only the minimum permissions required for ordinary UDF execution. If a specific UDF
+// legitimately needs more (e.g. reading a config file or calling an external endpoint), extend this
+// policy narrowly and explicitly for that resource rather than restoring AllPermission.
 grant {
-    permission java.security.AllPermission;
+    permission java.util.PropertyPermission "*", "read";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
 };


### PR DESCRIPTION
## Why I'm doing:
`conf/udf_security.policy` grants `java.security.AllPermission` to code  loaded through `UDFClassLoader`, which defeats the UDF sandbox entirely: a  malicious or buggy Java UDF can read/write arbitrary files, open network  connections, exec system commands, or use reflection to reach in-process  secrets — regardless of whether the security manager is enabled.
## What I'm doing:
  Replace the `AllPermission` grant with the minimum permission set ordinary  UDF execution needs (`PropertyPermission "*", "read"` and  `RuntimePermission "accessDeclaredMembers"`). Deployments with UDFs that
  legitimately need more access should extend this policy narrowly for that  specific resource instead of restoring `AllPermission`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
