### PR TITLE
[Enhancement] Compress tablet merge RSSID intervals

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -521,10 +521,18 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
         std::string declaration_key;
         std::vector<SegmentMetadataPB*> references;
     };
+    std::map<std::string, bool> bundled_by_filename;
     std::map<std::pair<std::string, int64_t>, PhysicalSliceDeclaration> declarations_by_physical_slice;
     for (auto& canonical : *canonicals) {
         RETURN_IF_ERROR(validate_physical_rowset_shape(canonical.source_form_rowset));
         for (auto& segment : *canonical.source_form_rowset.mutable_segment_metas()) {
+            auto [form, form_inserted] =
+                    bundled_by_filename.try_emplace(segment.filename(), segment.has_bundle_file_offset());
+            if (!form_inserted && form->second != segment.has_bundle_file_offset()) {
+                return Status::Corruption(
+                        fmt::format("tablet merge physical segment file {} mixes bundled and standalone forms",
+                                    segment.filename()));
+            }
             const auto slice = std::pair{segment.filename(),
                                          segment.has_bundle_file_offset() ? segment.bundle_file_offset() : int64_t{0}};
             const auto declaration_key = normalized_physical_base_key(segment);
@@ -3235,10 +3243,6 @@ Status validate_source_rssid_domain(const TabletMetadataPB& metadata) {
         const uint64_t segment_span = rowset.segment_metas_size() == 0 ? 1 : max_segment_idx + 1;
         if (uint64_t{rowset.id()} + segment_span > kSourceRssidExclusiveLimit) {
             return Status::InvalidArgument("tablet merge source rowset extent exceeds the uint32 RSSID domain");
-        }
-        if (rowset.has_max_compact_input_rowset_id() &&
-            uint64_t{rowset.max_compact_input_rowset_id()} + 1 > kSourceRssidExclusiveLimit) {
-            return Status::InvalidArgument("tablet merge source recovery key exceeds the uint32 RSSID domain");
         }
         for (const auto& del : rowset.del_files()) {
             const uint64_t replay_offset = del.has_op_offset() ? uint64_t{del.op_offset()} : max_segment_idx;

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -430,6 +430,9 @@ std::string normalized_physical_base_key(const SegmentMetadataPB& segment) {
 }
 
 Status validate_physical_segment_shape(const SegmentMetadataPB& segment) {
+    if (!segment.has_filename() || segment.filename().empty()) {
+        return Status::Corruption("tablet merge segment has a missing or empty filename");
+    }
     if (segment.has_bundle_file_offset() && segment.bundle_file_offset() < 0) {
         return Status::Corruption(fmt::format("tablet merge segment {} has negative bundle_file_offset {}",
                                               segment.filename(), segment.bundle_file_offset()));
@@ -441,6 +444,15 @@ Status validate_physical_segment_shape(const SegmentMetadataPB& segment) {
     if (segment.has_bundle_file_offset() && !segment.has_size()) {
         return Status::Corruption(fmt::format("tablet merge segment {} has bundle_file_offset {} but no size",
                                               segment.filename(), segment.bundle_file_offset()));
+    }
+    if (segment.has_bundle_file_offset()) {
+        const uint64_t bundle_end =
+                static_cast<uint64_t>(segment.bundle_file_offset()) + static_cast<uint64_t>(segment.size());
+        if (bundle_end > std::numeric_limits<int64_t>::max()) {
+            return Status::Corruption(
+                    fmt::format("tablet merge segment {} bundle_file_offset {} plus size {} exceeds int64 range",
+                                segment.filename(), segment.bundle_file_offset(), segment.size()));
+        }
     }
     return Status::OK();
 }
@@ -2256,32 +2268,84 @@ Status project_non_shared_legacy_sstable(const PersistentIndexSstablePB& sst, in
     return Status::OK();
 }
 
-bool legacy_sstable_occurrence_agrees(const RssidProjection& projection,
-                                      const std::unordered_set<uint32_t>& source_live_rssids,
+struct LegacySstableLiveRssidIndex {
+    struct Entry {
+        uint32_t source_rssid = 0;
+        std::optional<int64_t> target_delta;
+        size_t agreement_run = 0;
+    };
+
+    std::unordered_set<uint32_t> source_live_rssids;
+    std::vector<Entry> entries;
+};
+
+struct SstableLiveRssidIndex {
+    std::unordered_set<uint32_t> target_live_rssids;
+    std::vector<LegacySstableLiveRssidIndex> sources;
+};
+
+// Build the live occurrence mapping once after source PK flush has installed the current rowsets. A missing/dead target
+// is represented by no delta; adjacent sorted live RSSIDs with the same valid delta share one agreement run. The
+// existing affine proof plus one bounded run lookup then proves each legacy SST without rescanning all live RSSIDs.
+SstableLiveRssidIndex build_sstable_live_rssid_index(const std::vector<TabletMergeContext>& contexts,
+                                                     const TabletMergeAllocationPlan& allocation_plan,
+                                                     const TabletMetadataPB& target) {
+    SstableLiveRssidIndex result;
+    result.target_live_rssids = collect_live_rssids(target);
+    result.sources.reserve(contexts.size());
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        TEST_SYNC_POINT_CALLBACK("legacy_sstable_liveness_index:precompute_context", nullptr);
+        LegacySstableLiveRssidIndex source_index;
+        source_index.source_live_rssids = collect_live_rssids(*contexts[context_index].metadata());
+        source_index.entries.reserve(source_index.source_live_rssids.size());
+        for (uint32_t source : source_index.source_live_rssids) {
+            TEST_SYNC_POINT_CALLBACK("legacy_sstable_liveness_index:visited_live_rssid", nullptr);
+            LegacySstableLiveRssidIndex::Entry entry{.source_rssid = source};
+            auto mapped = allocation_plan.projections[context_index].map_occurrence_rssid(source);
+            if (mapped.ok() && mapped.value() < allocation_plan.target_next_rowset_id &&
+                result.target_live_rssids.contains(mapped.value())) {
+                entry.target_delta = static_cast<int64_t>(mapped.value()) - source;
+            }
+            source_index.entries.emplace_back(std::move(entry));
+        }
+        std::sort(source_index.entries.begin(), source_index.entries.end(),
+                  [](const auto& left, const auto& right) { return left.source_rssid < right.source_rssid; });
+        for (size_t i = 1; i < source_index.entries.size(); ++i) {
+            source_index.entries[i].agreement_run = source_index.entries[i - 1].agreement_run;
+            if (source_index.entries[i].target_delta != source_index.entries[i - 1].target_delta) {
+                ++source_index.entries[i].agreement_run;
+            }
+        }
+        result.sources.emplace_back(std::move(source_index));
+    }
+    return result;
+}
+
+bool legacy_sstable_occurrence_agrees(const LegacySstableLiveRssidIndex& source_index,
                                       const std::unordered_set<uint32_t>& target_live_rssids, uint64_t source_begin,
                                       uint32_t source_high, int64_t delta, uint32_t target_end) {
-    if (!source_live_rssids.contains(source_high)) return false;
+    TEST_SYNC_POINT_CALLBACK("legacy_sstable_liveness_index:bounded_lookup", nullptr);
+    if (!source_index.source_live_rssids.contains(source_high)) return false;
     const int64_t projected_begin = static_cast<int64_t>(source_begin) + delta;
     const int64_t projected_high = static_cast<int64_t>(source_high) + delta;
     if (projected_begin < 0 || projected_begin > std::numeric_limits<int32_t>::max() || projected_high < 0 ||
         projected_high >= target_end || !target_live_rssids.contains(static_cast<uint32_t>(projected_high))) {
         return false;
     }
-    for (uint32_t source : source_live_rssids) {
-        if (source < source_begin || source > source_high) continue;
-        auto mapped = projection.map_occurrence_rssid(source);
-        const int64_t expected = static_cast<int64_t>(source) + delta;
-        if (!mapped.ok() || expected < 0 || expected >= target_end || mapped.value() != expected ||
-            !target_live_rssids.contains(mapped.value())) {
-            return false;
-        }
-    }
-    return true;
+    auto find_source = [&](uint64_t source) {
+        return std::lower_bound(source_index.entries.begin(), source_index.entries.end(), source,
+                                [](const auto& entry, uint64_t value) { return entry.source_rssid < value; });
+    };
+    auto first = find_source(source_begin);
+    auto high = find_source(source_high);
+    return first != source_index.entries.end() && high != source_index.entries.end() &&
+           high->source_rssid == source_high && first->agreement_run == high->agreement_run &&
+           first->target_delta == delta;
 }
 
 std::optional<int64_t> prove_legacy_sstable_affine_domain(const PersistentIndexSstablePB& sst,
                                                           const RssidProjection& projection,
-                                                          const std::unordered_set<uint32_t>& source_live_rssids,
+                                                          const LegacySstableLiveRssidIndex& source_index,
                                                           const std::unordered_set<uint32_t>& target_live_rssids,
                                                           uint32_t target_end) {
     if (sst.rssid_offset() < 0) return std::optional<int64_t>{};
@@ -2289,8 +2353,8 @@ std::optional<int64_t> prove_legacy_sstable_affine_domain(const PersistentIndexS
     const uint32_t source_high = extract_rss_rowid_high(sst.max_rss_rowid());
     if (source_high < source_begin) return std::optional<int64_t>{};
     auto delta = projection.affine_delta(source_begin, uint64_t{source_high} + 1);
-    if (!delta.has_value() || !legacy_sstable_occurrence_agrees(projection, source_live_rssids, target_live_rssids,
-                                                                source_begin, source_high, *delta, target_end)) {
+    if (!delta.has_value() || !legacy_sstable_occurrence_agrees(source_index, target_live_rssids, source_begin,
+                                                                source_high, *delta, target_end)) {
         return std::optional<int64_t>{};
     }
     return delta;
@@ -2762,25 +2826,25 @@ void order_and_assign_singleton_filesets(PersistentIndexSstableMetaPB* metadata)
 
 StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std::vector<TabletMergeContext>& contexts,
                                                                        const TabletMergeAllocationPlan& allocation_plan,
-                                                                       const TabletMetadataPB& target) {
+                                                                       const TabletMetadataPB& target,
+                                                                       const SstableLiveRssidIndex& live_rssids) {
     ASSIGN_OR_RETURN(auto range_proof, validate_metadata_reuse_source_ranges(contexts, target));
     if (range_proof != MergeSourceRangeProof::kReusable) {
         return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
     }
 
-    const auto target_live_rssids = collect_live_rssids(target);
     std::unordered_set<std::string> filenames;
     MergeSstableMetaResult result;
     result.mode = MergeSstableMetaMode::kPrivate;
     for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
         const auto& context = contexts[context_index];
         const auto& projection = allocation_plan.projections[context_index];
+        const auto& source_live_rssids = live_rssids.sources[context_index];
         for (const auto& rowset : context.metadata()->rowsets()) {
             if (rowset.has_uid() && rowset.uid().hi() == 0 && rowset.uid().lo() == 0) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
             }
         }
-        const auto source_live_rssids = collect_live_rssids(*context.metadata());
         for (const auto& source_sstable : context.metadata()->sstable_meta().sstables()) {
             if (source_sstable.shared()) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kSharedOrMixed);
@@ -2803,11 +2867,11 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
                 if (extract_rss_rowid_high(source_sstable.max_rss_rowid()) != *source_rssid ||
-                    !source_live_rssids.contains(*source_rssid)) {
+                    !source_live_rssids.source_live_rssids.contains(*source_rssid)) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
                 auto mapped_rssid = projection.map_occurrence_rssid(*source_rssid);
-                if (!mapped_rssid.ok() || !target_live_rssids.contains(mapped_rssid.value())) {
+                if (!mapped_rssid.ok() || !live_rssids.target_live_rssids.contains(mapped_rssid.value())) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
                 const auto projection_status =
@@ -2821,9 +2885,9 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
                     source_sstable.rssid_offset() < 0) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
                 }
-                auto domain_delta =
-                        prove_legacy_sstable_affine_domain(source_sstable, projection, source_live_rssids,
-                                                           target_live_rssids, allocation_plan.target_next_rowset_id);
+                auto domain_delta = prove_legacy_sstable_affine_domain(source_sstable, projection, source_live_rssids,
+                                                                       live_rssids.target_live_rssids,
+                                                                       allocation_plan.target_next_rowset_id);
                 if (!domain_delta.has_value()) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
                 }
@@ -2896,7 +2960,8 @@ bool semantic_sstable_equal(const PersistentIndexSstablePB& left, const Persiste
 
 StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std::vector<TabletMergeContext>& contexts,
                                                                        const TabletMergeAllocationPlan& allocation_plan,
-                                                                       const TabletMetadataPB& target) {
+                                                                       const TabletMetadataPB& target,
+                                                                       const SstableLiveRssidIndex& live_rssids) {
     ASSIGN_OR_RETURN(auto range_proof, validate_metadata_reuse_source_ranges(contexts, target));
     if (range_proof != MergeSourceRangeProof::kReusable) {
         return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
@@ -2932,12 +2997,6 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
         }
     }
 
-    const auto target_live_rssids = collect_live_rssids(target);
-    std::vector<std::unordered_set<uint32_t>> source_live_rssids;
-    source_live_rssids.reserve(contexts.size());
-    for (const auto& context : contexts) {
-        source_live_rssids.emplace_back(collect_live_rssids(*context.metadata()));
-    }
     MergeSstableMetaResult result;
     result.mode = MergeSstableMetaMode::kIdentical;
     for (const auto& canonical_sstable : canonical_sstables) {
@@ -2953,7 +3012,7 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
             }
             std::optional<uint32_t> common_target;
             for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
-                if (!source_live_rssids[context_index].contains(*source_rssid)) {
+                if (!live_rssids.sources[context_index].source_live_rssids.contains(*source_rssid)) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
                 ASSIGN_OR_RETURN(auto mapped,
@@ -2967,7 +3026,7 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
             }
             const uint32_t mapped_rssid = *common_target;
-            if (!target_live_rssids.contains(mapped_rssid)) {
+            if (!live_rssids.target_live_rssids.contains(mapped_rssid)) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
             }
             const auto projection_status =
@@ -2984,16 +3043,15 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
             const uint64_t source_begin = static_cast<uint32_t>(canonical_sstable.rssid_offset());
             const uint32_t source_high = extract_rss_rowid_high(canonical_sstable.max_rss_rowid());
             auto common_delta = prove_legacy_sstable_affine_domain(
-                    canonical_sstable, allocation_plan.projections.front(), source_live_rssids.front(),
-                    target_live_rssids, allocation_plan.target_next_rowset_id);
+                    canonical_sstable, allocation_plan.projections.front(), live_rssids.sources.front(),
+                    live_rssids.target_live_rssids, allocation_plan.target_next_rowset_id);
             if (!common_delta.has_value()) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
             }
             for (size_t context_index = 1; context_index < contexts.size(); ++context_index) {
-                if (!legacy_sstable_occurrence_agrees(allocation_plan.projections[context_index],
-                                                      source_live_rssids[context_index], target_live_rssids,
-                                                      source_begin, source_high, *common_delta,
-                                                      allocation_plan.target_next_rowset_id)) {
+                if (!legacy_sstable_occurrence_agrees(live_rssids.sources[context_index],
+                                                      live_rssids.target_live_rssids, source_begin, source_high,
+                                                      *common_delta, allocation_plan.target_next_rowset_id)) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
                 }
             }
@@ -3119,20 +3177,21 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
         new_metadata->clear_sstable_meta();
         return Status::OK();
     }
+    const auto live_rssids = build_sstable_live_rssid_index(merge_contexts, allocation_plan, *new_metadata);
 
     TEST_SYNC_POINT_CALLBACK("merge_sstables:metadata_classifier_entry", nullptr);
     DeferOp classifier_exit([] { TEST_SYNC_POINT_CALLBACK("merge_sstables:metadata_classifier_exit", nullptr); });
 
-    ASSIGN_OR_RETURN(auto private_result,
-                     try_project_complete_private_sstables(merge_contexts, allocation_plan, *new_metadata));
+    ASSIGN_OR_RETURN(auto private_result, try_project_complete_private_sstables(merge_contexts, allocation_plan,
+                                                                                *new_metadata, live_rssids));
     if (private_result.mode == MergeSstableMetaMode::kPrivate) {
         new_metadata->mutable_sstable_meta()->Swap(&private_result.metadata);
         record_merge_sstable_meta_result(private_result);
         return Status::OK();
     }
 
-    ASSIGN_OR_RETURN(auto identical_result,
-                     try_reuse_complete_identical_sstables(merge_contexts, allocation_plan, *new_metadata));
+    ASSIGN_OR_RETURN(auto identical_result, try_reuse_complete_identical_sstables(merge_contexts, allocation_plan,
+                                                                                  *new_metadata, live_rssids));
     if (identical_result.mode == MergeSstableMetaMode::kIdentical) {
         new_metadata->mutable_sstable_meta()->Swap(&identical_result.metadata);
         record_merge_sstable_meta_result(identical_result);

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -260,16 +260,15 @@ public:
         return Status::OK();
     }
 
-    Status finalize_aliases() {
+    void finalize_aliases() {
         _divergent_alias_keys.clear();
         for (const auto& [source, target] : _occurrence_aliases) {
             auto primary = map_primary_rssid(source);
             if (primary.ok() && primary.value() != target) _divergent_alias_keys.emplace_back(source);
         }
-        return Status::OK();
     }
 
-    StatusOr<std::optional<int64_t>> affine_delta(uint64_t begin, uint64_t end) const {
+    std::optional<int64_t> affine_delta(uint64_t begin, uint64_t end) const {
         if (begin >= end || end > uint64_t{std::numeric_limits<uint32_t>::max()} + 1) {
             return std::optional<int64_t>{};
         }
@@ -423,7 +422,15 @@ std::optional<int64_t> rowset_schema_id(const TabletMergeContext& context, uint3
     return iter->second;
 }
 
+SegmentMetadataPB normalized_physical_base(const SegmentMetadataPB& segment) {
+    SegmentMetadataPB normalized(segment);
+    normalized.clear_segment_idx();
+    normalized.clear_shared();
+    return normalized;
+}
+
 Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* occurrence) {
+    const bool overlapped = canonical->overlapped() || (occurrence != nullptr && occurrence->overlapped());
     std::map<uint32_t, SegmentMetadataPB> by_index;
     auto ingest = [&](const RowsetMetadataPB& source) -> Status {
         for (int position = 0; position < source.segment_metas_size(); ++position) {
@@ -458,8 +465,22 @@ Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* o
         (void)index;
         canonical->add_segment_metas()->Swap(&segment);
     }
-    if (segment_union_expanded) canonical->set_overlapped(true);
+    if (overlapped || segment_union_expanded) canonical->set_overlapped(true);
     return Status::OK();
+}
+
+void normalize_cross_target_physical_ownership(std::vector<CanonicalAllocationPlan>* canonicals) {
+    std::map<std::string, std::vector<SegmentMetadataPB*>> references_by_physical_base;
+    for (auto& canonical : *canonicals) {
+        for (auto& segment : *canonical.source_form_rowset.mutable_segment_metas()) {
+            references_by_physical_base[normalized_physical_base(segment).SerializeAsString()].emplace_back(&segment);
+        }
+    }
+    for (auto& [physical_base, references] : references_by_physical_base) {
+        (void)physical_base;
+        if (references.size() < 2) continue;
+        for (auto* segment : references) segment->set_shared(true);
+    }
 }
 
 Status validate_del_replay_span(uint32_t origin, uint32_t offset) {
@@ -513,7 +534,7 @@ Status union_canonical_range(CanonicalAllocationPlan* canonical, const TabletRan
 
 Status validate_primary_affine_span(const RssidProjection& projection, uint64_t begin, uint64_t end,
                                     std::string_view description) {
-    ASSIGN_OR_RETURN(auto delta, projection.affine_delta(begin, end));
+    auto delta = projection.affine_delta(begin, end);
     if (!delta.has_value()) {
         return Status::Corruption(fmt::format("tablet merge {} is not primary-affine", description));
     }
@@ -602,11 +623,14 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
         }
     }
 
+    normalize_cross_target_physical_ownership(&result.canonicals);
+
     std::vector<std::vector<std::pair<uint64_t, uint64_t>>> atoms(contexts.size());
     std::vector<std::vector<std::pair<uint64_t, uint64_t>>> extents(contexts.size());
     for (const auto& canonical : result.canonicals) {
         const auto& rowset = canonical.source_form_rowset;
-        const uint64_t segment_span = rowset.segment_metas_size() == 0 ? 1 : uint64_t{get_max_segment_idx(rowset)} + 1;
+        const uint32_t final_max = get_max_segment_idx(rowset);
+        const uint64_t segment_span = rowset.segment_metas_size() == 0 ? 1 : uint64_t{final_max} + 1;
         const uint64_t extent_end = uint64_t{rowset.id()} + segment_span;
         if (extent_end > kSourceRssidExclusiveLimit) {
             return Status::InvalidArgument("tablet merge rowset extent exceeds the supported RSSID domain");
@@ -618,7 +642,6 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
             context_atoms.emplace_back(rowset.max_compact_input_rowset_id(),
                                        uint64_t{rowset.max_compact_input_rowset_id()} + 1);
         }
-        const uint32_t final_max = get_max_segment_idx(rowset);
         for (const auto& del : rowset.del_files()) {
             const uint32_t offset = del.has_op_offset() ? del.op_offset() : final_max;
             RETURN_IF_ERROR(validate_del_replay_span(del.origin_rowset_id(), offset));
@@ -675,14 +698,15 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
                 RETURN_IF_ERROR(add_alias(static_cast<uint32_t>(source), uint64_t{canonical_target} + index));
             }
         }
-        RETURN_IF_ERROR(result.projections[context_index].finalize_aliases());
+        result.projections[context_index].finalize_aliases();
     }
 
     for (const auto& canonical : result.canonicals) {
         const auto& rowset = canonical.source_form_rowset;
         const auto& projection = result.projections[canonical.selected_context_index];
-        const uint64_t extent_end = uint64_t{rowset.id()} +
-                                    (rowset.segment_metas_size() == 0 ? 1 : uint64_t{get_max_segment_idx(rowset)} + 1);
+        const uint32_t final_max = get_max_segment_idx(rowset);
+        const uint64_t extent_end =
+                uint64_t{rowset.id()} + (rowset.segment_metas_size() == 0 ? 1 : uint64_t{final_max} + 1);
         RETURN_IF_ERROR(validate_primary_affine_span(projection, rowset.id(), extent_end, "canonical extent"));
         ASSIGN_OR_RETURN(auto mapped_id, projection.map_primary_rssid(rowset.id()));
         if (mapped_id >= cursor) return Status::Corruption("tablet merge canonical target is outside cursor");
@@ -690,7 +714,6 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
             ASSIGN_OR_RETURN(auto mapped, projection.map_primary_rssid(rowset.max_compact_input_rowset_id()));
             (void)mapped;
         }
-        const uint32_t final_max = get_max_segment_idx(rowset);
         for (const auto& del : rowset.del_files()) {
             const uint32_t offset = del.has_op_offset() ? del.op_offset() : final_max;
             RETURN_IF_ERROR(validate_primary_affine_span(projection, del.origin_rowset_id(),
@@ -914,10 +937,21 @@ DeltaColumnGroupVerPB make_single_entry_dcg(const DeltaColumnGroupVerPB& source,
     return out;
 }
 
+std::unordered_map<uint32_t, bool> collect_target_rssid_ownership(const TabletMetadataPB& metadata) {
+    std::unordered_map<uint32_t, bool> result;
+    for (const auto& rowset : metadata.rowsets()) {
+        for (int position = 0; position < rowset.segment_metas_size(); ++position) {
+            result[get_rssid(rowset, position)] = rowset.segment_metas(position).shared();
+        }
+    }
+    return result;
+}
+
 // Pass 1 — walk each old tablet's dcg_meta and rowsets, dedup by filename across
 // old tablets, and accumulate source-rowset refs per target T.
 Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContext>& merge_contexts,
                                              const TabletMergeAllocationPlan& allocation_plan,
+                                             const std::unordered_map<uint32_t, bool>& target_rssid_ownership,
                                              std::map<uint32_t, DcgTargetWorkItem>* work_by_target) {
     // Track which .cols filenames we have already observed per target so that
     // subsequent old tablets with the same filename are deduped (and verified).
@@ -964,12 +998,18 @@ Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContex
         for (const auto& [segment_id, dcg_value] : context.metadata()->dcg_meta().dcgs()) {
             ASSIGN_OR_RETURN(uint32_t target_rssid,
                              allocation_plan.projections[old_tablet_index].map_occurrence_rssid(segment_id));
+            auto target_ownership = target_rssid_ownership.find(target_rssid);
+            if (target_ownership == target_rssid_ownership.end()) {
+                return Status::Corruption(fmt::format("tablet merge source-live DCG RSSID {} maps to missing target {}",
+                                                      segment_id, target_rssid));
+            }
 
             DeltaColumnGroupVerPB normalized = dcg_value;
             RETURN_IF_ERROR(validate_dcg_shape(normalized));
             normalize_dcg_optional_fields(&normalized);
 
             for (int entry_index = 0; entry_index < normalized.column_files_size(); ++entry_index) {
+                normalized.set_shared_files(entry_index, target_ownership->second);
                 const std::string& file_name = normalized.column_files(entry_index);
 
                 auto& target_work = (*work_by_target)[target_rssid];
@@ -1432,7 +1472,9 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
                       const TabletMergeAllocationPlan& allocation_plan, int64_t new_tablet_id, int64_t new_version,
                       int64_t txn_id, const std::vector<CanonicalGapSpec>& gap_specs, TabletMetadataPB* new_metadata) {
     std::map<uint32_t, DcgTargetWorkItem> work_by_target;
-    RETURN_IF_ERROR(dcg_pass1_collect_entries_and_sources(merge_contexts, allocation_plan, &work_by_target));
+    const auto target_rssid_ownership = collect_target_rssid_ownership(*new_metadata);
+    RETURN_IF_ERROR(dcg_pass1_collect_entries_and_sources(merge_contexts, allocation_plan, target_rssid_ownership,
+                                                          &work_by_target));
 
     // Index synthesized gap bitmaps by target rssid so a rebuild can short-circuit
     // its coverage check for rowids that merge_delvecs masks. Empty for non-PK
@@ -1607,12 +1649,7 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
     // agree. Preserving a source flag would carry a stale value (e.g. a tablet split before
     // this fix has segment.shared=true but idg.shared_file=false, because the old split marked
     // segments shared but not idg) and later mis-route the .idx at vacuum time.
-    std::unordered_map<uint32_t, bool> target_rssid_shared;
-    for (const auto& rowset : new_metadata->rowsets()) {
-        for (int i = 0; i < rowset.segment_metas_size(); ++i) {
-            target_rssid_shared[get_rssid(rowset, i)] = rowset.segment_metas(i).shared();
-        }
-    }
+    const auto target_rssid_shared = collect_target_rssid_ownership(*new_metadata);
 
     std::map<uint32_t, std::vector<IndexDeltaGroupEntryPB>> work_by_target;
     // target rssid -> (.idx filename -> index into work_by_target[target]).
@@ -2204,15 +2241,16 @@ bool legacy_sstable_occurrence_agrees(const RssidProjection& projection,
     return true;
 }
 
-StatusOr<std::optional<int64_t>> prove_legacy_sstable_affine_domain(
-        const PersistentIndexSstablePB& sst, const RssidProjection& projection,
-        const std::unordered_set<uint32_t>& source_live_rssids, const std::unordered_set<uint32_t>& target_live_rssids,
-        uint32_t target_end) {
+std::optional<int64_t> prove_legacy_sstable_affine_domain(const PersistentIndexSstablePB& sst,
+                                                          const RssidProjection& projection,
+                                                          const std::unordered_set<uint32_t>& source_live_rssids,
+                                                          const std::unordered_set<uint32_t>& target_live_rssids,
+                                                          uint32_t target_end) {
     if (sst.rssid_offset() < 0) return std::optional<int64_t>{};
     const uint64_t source_begin = static_cast<uint32_t>(sst.rssid_offset());
     const uint32_t source_high = extract_rss_rowid_high(sst.max_rss_rowid());
     if (source_high < source_begin) return std::optional<int64_t>{};
-    ASSIGN_OR_RETURN(auto delta, projection.affine_delta(source_begin, uint64_t{source_high} + 1));
+    auto delta = projection.affine_delta(source_begin, uint64_t{source_high} + 1);
     if (!delta.has_value() || !legacy_sstable_occurrence_agrees(projection, source_live_rssids, target_live_rssids,
                                                                 source_begin, source_high, *delta, target_end)) {
         return std::optional<int64_t>{};
@@ -2351,20 +2389,13 @@ StatusOr<bool> sstable_range_within_tablet(const PersistentIndexSstablePB& sst, 
     return true;
 }
 
-SegmentMetadataPB normalized_physical_base(const SegmentMetadataPB& segment) {
-    SegmentMetadataPB normalized(segment);
-    normalized.clear_segment_idx();
-    normalized.clear_shared();
-    return normalized;
-}
-
 struct PreflightTargetSegment {
     SegmentMetadataPB physical_base;
+    bool shared = false;
 };
 
 struct PreflightSourceSegment {
     uint32_t target_rssid = 0;
-    SegmentMetadataPB physical_base;
 };
 
 StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_segments(
@@ -2380,7 +2411,8 @@ StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_se
                 target_rssid > std::numeric_limits<uint32_t>::max()) {
                 return Status::Corruption("tablet merge planned target segment exceeds its authoritative cursor");
             }
-            PreflightTargetSegment candidate{normalized_physical_base(rowset.segment_metas(position))};
+            PreflightTargetSegment candidate{normalized_physical_base(rowset.segment_metas(position)),
+                                             rowset.segment_metas(position).shared()};
             auto [iter, inserted] = result.try_emplace(static_cast<uint32_t>(target_rssid), std::move(candidate));
             if (!inserted) {
                 return Status::Corruption(
@@ -2412,11 +2444,9 @@ StatusOr<std::vector<std::map<uint32_t, PreflightSourceSegment>>> collect_prefli
                             fmt::format("tablet merge source-live RSSID {} disagrees with target {} physical base",
                                         source_rssid, target_rssid));
                 }
-                auto [iter, inserted] = result[context_index].try_emplace(
-                        source_rssid, PreflightSourceSegment{target_rssid, std::move(physical_base)});
-                if (!inserted && (iter->second.target_rssid != target_rssid ||
-                                  iter->second.physical_base.SerializeAsString() !=
-                                          target->second.physical_base.SerializeAsString())) {
+                auto [iter, inserted] =
+                        result[context_index].try_emplace(source_rssid, PreflightSourceSegment{target_rssid});
+                if (!inserted && iter->second.target_rssid != target_rssid) {
                     return Status::Corruption(
                             fmt::format("tablet merge source RSSID {} has conflicting physical bases", source_rssid));
                 }
@@ -2477,10 +2507,54 @@ Status register_preflight_sidecar(std::string_view kind, const std::string& file
     return Status::OK();
 }
 
-Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& contexts,
-                               const TabletMergeAllocationPlan& allocation_plan, int64_t target_tablet_id,
-                               int64_t target_version) {
-    (void)tablet_manager;
+Status validate_preflight_sstable_declaration(const PersistentIndexSstablePB& sstable) {
+    if (!sstable.has_filename() || sstable.filename().empty()) {
+        return Status::Corruption("tablet merge source SST has a missing or empty filename");
+    }
+    if (sstable.has_filesize() && sstable.filesize() < 0) {
+        return Status::Corruption(fmt::format("tablet merge source SST {} has a negative size", sstable.filename()));
+    }
+    if (sstable.has_shared_rssid()) {
+        auto effective = effective_shared_rssid(sstable);
+        if (!effective.ok()) {
+            return Status::Corruption(fmt::format("tablet merge source SST {} has an invalid shared form: {}",
+                                                  sstable.filename(), effective.status().message()));
+        }
+    } else {
+        auto legacy_status = validate_non_shared_legacy_sstable_form(sstable);
+        if (!legacy_status.ok()) {
+            return Status::Corruption(fmt::format("tablet merge source SST {} has an invalid legacy form: {}",
+                                                  sstable.filename(), legacy_status.message()));
+        }
+    }
+    if (sstable.has_range()) {
+        if (!sstable.range().has_start_key() || !sstable.range().has_end_key()) {
+            return Status::Corruption(
+                    fmt::format("tablet merge source SST {} has an incomplete range", sstable.filename()));
+        }
+        if (::starrocks::sstable::BytewiseComparator()->Compare(Slice(sstable.range().start_key()),
+                                                                Slice(sstable.range().end_key())) > 0) {
+            return Status::Corruption(
+                    fmt::format("tablet merge source SST {} has a reversed range", sstable.filename()));
+        }
+    }
+    return Status::OK();
+}
+
+PersistentIndexSstablePB normalized_preflight_sstable_form(const PersistentIndexSstablePB& sstable) {
+    PersistentIndexSstablePB normalized(sstable);
+    normalized.clear_version();
+    normalized.clear_filename();
+    normalized.clear_filesize();
+    normalized.clear_encryption_meta();
+    normalized.clear_shared();
+    normalized.clear_fileset_id();
+    normalized.clear_generation_version();
+    return normalized;
+}
+
+Status preflight_merge_sources(const std::vector<TabletMergeContext>& contexts,
+                               const TabletMergeAllocationPlan& allocation_plan, const TabletMetadataPB& target) {
     ASSIGN_OR_RETURN(const auto target_segments, collect_preflight_target_segments(allocation_plan));
     ASSIGN_OR_RETURN(const auto source_segments,
                      collect_preflight_source_segments(contexts, allocation_plan, target_segments));
@@ -2504,6 +2578,7 @@ Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<
                     return Status::Corruption(
                             fmt::format("tablet merge source-live DCG RSSID {} target was omitted", source_rssid));
                 }
+                const auto& target_segment = target_segments.at(source_segment->second.target_rssid);
                 DeltaColumnGroupVerPB normalized(source_dcg);
                 RETURN_IF_ERROR(validate_dcg_shape(normalized));
                 normalize_dcg_optional_fields(&normalized);
@@ -2515,10 +2590,11 @@ Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<
                         return Status::Corruption(fmt::format("tablet merge DCG file {} has a negative size",
                                                               normalized.column_files(entry_index)));
                     }
+                    normalized.set_shared_files(entry_index, target_segment.shared);
                     const auto single = make_single_entry_dcg(normalized, entry_index);
                     RETURN_IF_ERROR(register_preflight_sidecar("DCG", normalized.column_files(entry_index),
-                                                               single.SerializeAsString(),
-                                                               source_segment->second.physical_base, &dcg_files));
+                                                               single.SerializeAsString(), target_segment.physical_base,
+                                                               &dcg_files));
                 }
             }
         }
@@ -2533,13 +2609,14 @@ Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<
                     return Status::Corruption(
                             fmt::format("tablet merge source-live IDG RSSID {} target was omitted", source_rssid));
                 }
+                const auto& target_segment = target_segments.at(source_segment->second.target_rssid);
                 for (const auto& entry : source_idg.entries()) {
                     RETURN_IF_ERROR(validate_idg_entry_shape(entry));
                     IndexDeltaGroupEntryPB stable(entry);
                     stable.clear_dropped_keys();
                     stable.clear_shared_file();
                     RETURN_IF_ERROR(register_preflight_sidecar("IDG", entry.index_file(), stable.SerializeAsString(),
-                                                               source_segment->second.physical_base, &idg_files));
+                                                               target_segment.physical_base, &idg_files));
                 }
             }
         }
@@ -2594,15 +2671,6 @@ Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<
     }
     if (!has_source_sstable) return Status::OK();
 
-    TabletMetadataPB target(*contexts.front().metadata());
-    target.set_id(target_tablet_id);
-    target.set_version(target_version);
-    TabletRangePB target_range = contexts.front().metadata()->range();
-    for (size_t i = 1; i < contexts.size(); ++i) {
-        ASSIGN_OR_RETURN(target_range,
-                         tablet_reshard_helper::union_range(target_range, contexts[i].metadata()->range()));
-    }
-    target.mutable_range()->CopyFrom(target_range);
     if (target.schema().column_size() > 0) {
         auto range_proof = validate_metadata_reuse_source_ranges(contexts, target);
         if (!range_proof.ok()) {
@@ -2616,13 +2684,7 @@ Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<
     std::map<std::string, PersistentIndexSstablePB> physical_sstables;
     for (const auto& context : contexts) {
         for (const auto& sstable : context.metadata()->sstable_meta().sstables()) {
-            if (!sstable.has_filename() || sstable.filename().empty()) {
-                return Status::Corruption("tablet merge source SST has a missing or empty filename");
-            }
-            if (sstable.has_filesize() && sstable.filesize() < 0) {
-                return Status::Corruption(
-                        fmt::format("tablet merge source SST {} has a negative size", sstable.filename()));
-            }
+            RETURN_IF_ERROR(validate_preflight_sstable_declaration(sstable));
             auto [iter, inserted] = physical_sstables.try_emplace(sstable.filename(), sstable);
             if (!inserted) {
                 const auto& existing = iter->second;
@@ -2634,6 +2696,11 @@ Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<
                 if (!size_matches || !encryption_matches) {
                     return Status::Corruption(fmt::format(
                             "tablet merge source SST {} has conflicting physical metadata", sstable.filename()));
+                }
+                if (normalized_preflight_sstable_form(existing).SerializeAsString() !=
+                    normalized_preflight_sstable_form(sstable).SerializeAsString()) {
+                    return Status::Corruption(fmt::format("tablet merge source SST {} has conflicting form or range",
+                                                          sstable.filename()));
                 }
             }
         }
@@ -2711,9 +2778,9 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
                     source_sstable.rssid_offset() < 0) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
                 }
-                ASSIGN_OR_RETURN(auto domain_delta, prove_legacy_sstable_affine_domain(
-                                                            source_sstable, projection, source_live_rssids,
-                                                            target_live_rssids, allocation_plan.target_next_rowset_id));
+                auto domain_delta =
+                        prove_legacy_sstable_affine_domain(source_sstable, projection, source_live_rssids,
+                                                           target_live_rssids, allocation_plan.target_next_rowset_id);
                 if (!domain_delta.has_value()) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
                 }
@@ -2870,10 +2937,9 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
             }
             const uint64_t source_begin = static_cast<uint32_t>(canonical_sstable.rssid_offset());
             const uint32_t source_high = extract_rss_rowid_high(canonical_sstable.max_rss_rowid());
-            ASSIGN_OR_RETURN(auto common_delta,
-                             prove_legacy_sstable_affine_domain(canonical_sstable, allocation_plan.projections.front(),
-                                                                source_live_rssids.front(), target_live_rssids,
-                                                                allocation_plan.target_next_rowset_id));
+            auto common_delta = prove_legacy_sstable_affine_domain(
+                    canonical_sstable, allocation_plan.projections.front(), source_live_rssids.front(),
+                    target_live_rssids, allocation_plan.target_next_rowset_id);
             if (!common_delta.has_value()) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
             }
@@ -3229,8 +3295,7 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     }
     new_tablet_metadata->mutable_range()->CopyFrom(merged_range);
 
-    RETURN_IF_ERROR(preflight_merge_sources(tablet_manager, merge_contexts, allocation_plan,
-                                            merging_tablet.new_tablet_id(), new_version));
+    RETURN_IF_ERROR(preflight_merge_sources(merge_contexts, allocation_plan, *new_tablet_metadata));
 
     FAIL_POINT_TRIGGER_RETURN_ERROR(tablet_merge_after_rssid_reassign);
 

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -469,18 +469,35 @@ Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* o
     return Status::OK();
 }
 
-void normalize_cross_target_physical_ownership(std::vector<CanonicalAllocationPlan>* canonicals) {
-    std::map<std::string, std::vector<SegmentMetadataPB*>> references_by_physical_base;
+Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocationPlan>* canonicals) {
+    struct PhysicalSliceDeclaration {
+        std::string declaration_key;
+        std::vector<SegmentMetadataPB*> references;
+    };
+    std::map<std::pair<std::string, int64_t>, PhysicalSliceDeclaration> declarations_by_physical_slice;
     for (auto& canonical : *canonicals) {
         for (auto& segment : *canonical.source_form_rowset.mutable_segment_metas()) {
-            references_by_physical_base[normalized_physical_base_key(segment)].emplace_back(&segment);
+            const auto slice = std::pair{segment.filename(),
+                                         segment.has_bundle_file_offset() ? segment.bundle_file_offset() : int64_t{0}};
+            const auto declaration_key = normalized_physical_base_key(segment);
+            auto [iter, inserted] = declarations_by_physical_slice.try_emplace(slice);
+            if (inserted) {
+                iter->second.declaration_key = declaration_key;
+            } else if (iter->second.declaration_key != declaration_key) {
+                return Status::Corruption(
+                        fmt::format("tablet merge physical segment slice {} at bundle offset {} has conflicting "
+                                    "declarations",
+                                    slice.first, slice.second));
+            }
+            iter->second.references.emplace_back(&segment);
         }
     }
-    for (auto& [physical_base, references] : references_by_physical_base) {
-        (void)physical_base;
-        if (references.size() < 2) continue;
-        for (auto* segment : references) segment->set_shared(true);
+    for (auto& [slice, declaration] : declarations_by_physical_slice) {
+        (void)slice;
+        if (declaration.references.size() < 2) continue;
+        for (auto* segment : declaration.references) segment->set_shared(true);
     }
+    return Status::OK();
 }
 
 Status validate_del_replay_span(uint32_t origin, uint32_t offset) {
@@ -623,7 +640,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
         }
     }
 
-    normalize_cross_target_physical_ownership(&result.canonicals);
+    RETURN_IF_ERROR(normalize_cross_target_physical_ownership(&result.canonicals));
 
     std::vector<std::vector<std::pair<uint64_t, uint64_t>>> atoms(contexts.size());
     std::vector<std::vector<std::pair<uint64_t, uint64_t>>> extents(contexts.size());

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -286,12 +286,6 @@ public:
                                       static_cast<int64_t>(iter->source_begin)};
     }
 
-    StatusOr<std::optional<int64_t>> conservative_context_delta() const {
-        if (_runs.size() != 1 || !_occurrence_aliases.empty()) return std::optional<int64_t>{};
-        return std::optional<int64_t>{static_cast<int64_t>(_runs.front().target_begin) -
-                                      static_cast<int64_t>(_runs.front().source_begin)};
-    }
-
     bool has_divergent_occurrence_alias(uint32_t source) const {
         return std::binary_search(_divergent_alias_keys.begin(), _divergent_alias_keys.end(), source);
     }
@@ -337,10 +331,10 @@ struct PlannedCanonicalRowset {
     int output_index = -1;
 };
 
-// Plan the exact rowsets merge_rowsets will emit in (version, old-tablet-index)
-// order. This is the single source of truth for duplicate decisions: offset
-// preparation uses it to ignore discarded sibling copies, and merge_rowsets
-// uses the recorded canonical index instead of recomputing dedup independently.
+// Plan the exact rowsets that materialization will emit in (version, old-tablet-index)
+// order. This is the single source of truth for duplicate decisions: allocation
+// planning reconciles sibling occurrences into canonical atoms and occurrence
+// aliases, then materialization uses the recorded canonical index directly.
 StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<TabletMergeContext>& merge_contexts,
                                                         bool discard_empty_rowsets) {
     RowsetEmissionPlan plan(merge_contexts.size());
@@ -465,13 +459,15 @@ Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* o
         return Status::OK();
     };
     RETURN_IF_ERROR(ingest(*canonical));
+    const size_t canonical_segment_count = by_index.size();
     if (occurrence != nullptr) RETURN_IF_ERROR(ingest(*occurrence));
+    const bool segment_union_expanded = by_index.size() > canonical_segment_count;
     canonical->clear_segment_metas();
     for (auto& [index, segment] : by_index) {
         (void)index;
         canonical->add_segment_metas()->Swap(&segment);
     }
-    if (canonical->segment_metas_size() > 1) canonical->set_overlapped(true);
+    if (segment_union_expanded) canonical->set_overlapped(true);
     return Status::OK();
 }
 
@@ -2842,6 +2838,11 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
     }
 
     const auto target_live_rssids = collect_live_rssids(target);
+    std::vector<std::unordered_set<uint32_t>> source_live_rssids;
+    source_live_rssids.reserve(contexts.size());
+    for (const auto& context : contexts) {
+        source_live_rssids.emplace_back(collect_live_rssids(*context.metadata()));
+    }
     MergeSstableMetaResult result;
     result.mode = MergeSstableMetaMode::kIdentical;
     for (const auto& canonical_sstable : canonical_sstables) {
@@ -2854,8 +2855,7 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
             }
             std::optional<uint32_t> common_target;
             for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
-                const auto source_live = collect_live_rssids(*contexts[context_index].metadata());
-                if (!source_live.contains(*source_rssid)) {
+                if (!source_live_rssids[context_index].contains(*source_rssid)) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
                 ASSIGN_OR_RETURN(auto mapped,
@@ -2885,18 +2885,17 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
             }
             const uint64_t source_begin = static_cast<uint32_t>(canonical_sstable.rssid_offset());
             const uint32_t source_high = extract_rss_rowid_high(canonical_sstable.max_rss_rowid());
-            const auto canonical_live = collect_live_rssids(canonical_metadata);
             ASSIGN_OR_RETURN(auto common_delta,
                              prove_legacy_sstable_affine_domain(canonical_sstable, allocation_plan.projections.front(),
-                                                                canonical_live, target_live_rssids,
+                                                                source_live_rssids.front(), target_live_rssids,
                                                                 allocation_plan.target_next_rowset_id));
             if (!common_delta.has_value()) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
             }
             for (size_t context_index = 1; context_index < contexts.size(); ++context_index) {
-                const auto source_live = collect_live_rssids(*contexts[context_index].metadata());
-                if (!legacy_sstable_occurrence_agrees(allocation_plan.projections[context_index], source_live,
-                                                      target_live_rssids, source_begin, source_high, *common_delta,
+                if (!legacy_sstable_occurrence_agrees(allocation_plan.projections[context_index],
+                                                      source_live_rssids[context_index], target_live_rssids,
+                                                      source_begin, source_high, *common_delta,
                                                       allocation_plan.target_next_rowset_id)) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
                 }

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -193,6 +193,9 @@ struct RssidTranslationRun {
     uint32_t target_begin;
 };
 
+constexpr uint64_t kSourceRssidExclusiveLimit = uint64_t{std::numeric_limits<uint32_t>::max()} + 1;
+constexpr uint64_t kTargetRssidExclusiveLimit = static_cast<uint64_t>(std::numeric_limits<int32_t>::max());
+
 class RssidProjection {
 public:
     Status build(std::vector<std::pair<uint64_t, uint64_t>> atoms, uint32_t target_begin) {
@@ -203,7 +206,7 @@ public:
         std::sort(atoms.begin(), atoms.end());
         std::vector<std::pair<uint64_t, uint64_t>> merged;
         for (const auto& [begin, end] : atoms) {
-            if (begin >= end || end > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+            if (begin >= end || end > kSourceRssidExclusiveLimit) {
                 return Status::InvalidArgument("tablet merge source RSSID interval is outside the supported domain");
             }
             if (merged.empty() || begin > merged.back().second) {
@@ -215,7 +218,7 @@ public:
         uint64_t cursor = target_begin;
         for (const auto& [begin, end] : merged) {
             const uint64_t length = end - begin;
-            if (cursor + length > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+            if (cursor + length > kTargetRssidExclusiveLimit) {
                 return Status::InvalidArgument("tablet merge exhausts the supported rssid allocation domain");
             }
             _runs.emplace_back(RssidTranslationRun{begin, end, static_cast<uint32_t>(cursor)});
@@ -473,7 +476,7 @@ Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* o
 
 Status validate_del_replay_span(uint32_t origin, uint32_t offset) {
     const uint64_t end = static_cast<uint64_t>(origin) + static_cast<uint64_t>(offset) + 1;
-    if (end > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+    if (end > kSourceRssidExclusiveLimit) {
         return Status::InvalidArgument("tablet merge delete replay span exceeds the supported RSSID domain");
     }
     return Status::OK();
@@ -621,7 +624,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
         const auto& rowset = canonical.source_form_rowset;
         const uint64_t segment_span = rowset.segment_metas_size() == 0 ? 1 : uint64_t{get_max_segment_idx(rowset)} + 1;
         const uint64_t extent_end = uint64_t{rowset.id()} + segment_span;
-        if (extent_end > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+        if (extent_end > kSourceRssidExclusiveLimit) {
             return Status::InvalidArgument("tablet merge rowset extent exceeds the supported RSSID domain");
         }
         auto& context_atoms = atoms[canonical.selected_context_index];
@@ -2697,6 +2700,27 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
     return Status::OK();
 }
 
+Status validate_source_rssid_domain(const TabletMetadataPB& metadata) {
+    for (const auto& rowset : metadata.rowsets()) {
+        const uint64_t max_segment_idx = get_max_segment_idx(rowset);
+        const uint64_t segment_span = rowset.segment_metas_size() == 0 ? 1 : max_segment_idx + 1;
+        if (uint64_t{rowset.id()} + segment_span > kSourceRssidExclusiveLimit) {
+            return Status::InvalidArgument("tablet merge source rowset extent exceeds the uint32 RSSID domain");
+        }
+        if (rowset.has_max_compact_input_rowset_id() &&
+            uint64_t{rowset.max_compact_input_rowset_id()} + 1 > kSourceRssidExclusiveLimit) {
+            return Status::InvalidArgument("tablet merge source recovery key exceeds the uint32 RSSID domain");
+        }
+        for (const auto& del : rowset.del_files()) {
+            const uint64_t replay_offset = del.has_op_offset() ? uint64_t{del.op_offset()} : max_segment_idx;
+            if (uint64_t{del.origin_rowset_id()} + replay_offset + 1 > kSourceRssidExclusiveLimit) {
+                return Status::InvalidArgument("tablet merge source delete span exceeds the uint32 RSSID domain");
+            }
+        }
+    }
+    return Status::OK();
+}
+
 StatusOr<uint32_t> compute_supported_next_rowset_id(const TabletMetadataPB& metadata) {
     uint64_t next = 1;
     for (const auto& rowset : metadata.rowsets()) {
@@ -2818,17 +2842,10 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
         if (old_tablet_metadata == nullptr) {
             return Status::InvalidArgument("old tablet metadata is null");
         }
-        // The read-only alias path retains the historical source-SST domain
-        // check. A real writable MERGE may deliberately omit an uncertain SST,
-        // so only its rowset/delete recovery domain is authoritative here; the
-        // installed fast-path SST cohort is checked again after classification.
-        if (skip_sstable_merge) {
-            RETURN_IF_ERROR(compute_supported_next_rowset_id(*old_tablet_metadata));
-        } else {
-            TabletMetadataPB recovery_visible_source(*old_tablet_metadata);
-            recovery_visible_source.clear_sstable_meta();
-            RETURN_IF_ERROR(compute_supported_next_rowset_id(recovery_visible_source));
-        }
+        // Source RSSIDs occupy the full uint32 domain. Only the packed target
+        // cursor is restricted to INT32_MAX; source SST reuse is proved later
+        // by the modern/legacy classifiers against the packed projection.
+        RETURN_IF_ERROR(validate_source_rssid_domain(*old_tablet_metadata));
         if (!skip_sstable_merge && is_primary_key(*old_tablet_metadata)) {
             for (const auto& rowset : old_tablet_metadata->rowsets()) {
                 const uint64_t source_rowset_id = static_cast<uint64_t>(rowset.id());

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -141,7 +141,7 @@ inline uint64_t encode_rss_rowid(uint32_t rssid_high, uint64_t rowid_low) {
 // BEFORE update_canonical's union_range mutates the canonical's stored range
 // — otherwise the convex hull would swallow gaps and the coverage / gap
 // detection would fail.
-using CanonicalContribMap = std::unordered_map<int, std::vector<TabletRangePB>>;
+using CanonicalContribMap = std::unordered_map<size_t, std::vector<TabletRangePB>>;
 
 struct DelvecSourceRef {
     const TabletMergeContext* ctx;
@@ -300,7 +300,6 @@ private:
 
 struct CanonicalAllocationPlan {
     size_t selected_context_index = 0;
-    int output_index = -1;
     RowsetMetadataPB source_form_rowset;
     std::optional<int64_t> schema_id;
     std::vector<TabletRangePB> contributor_ranges;
@@ -430,6 +429,7 @@ std::string normalized_physical_base_key(const SegmentMetadataPB& segment) {
 }
 
 Status validate_physical_segment_shape(const SegmentMetadataPB& segment) {
+    constexpr int64_t kSegmentFooterTrailerSize = 12;
     if (!segment.has_filename() || segment.filename().empty()) {
         return Status::Corruption("tablet merge segment has a missing or empty filename");
     }
@@ -446,12 +446,31 @@ Status validate_physical_segment_shape(const SegmentMetadataPB& segment) {
                                               segment.filename(), segment.bundle_file_offset()));
     }
     if (segment.has_bundle_file_offset()) {
+        if (segment.size() < kSegmentFooterTrailerSize) {
+            return Status::Corruption(
+                    fmt::format("tablet merge bundled segment {} size {} is smaller than the {}-byte footer trailer",
+                                segment.filename(), segment.size(), kSegmentFooterTrailerSize));
+        }
         const uint64_t bundle_end =
                 static_cast<uint64_t>(segment.bundle_file_offset()) + static_cast<uint64_t>(segment.size());
         if (bundle_end > std::numeric_limits<int64_t>::max()) {
             return Status::Corruption(
                     fmt::format("tablet merge segment {} bundle_file_offset {} plus size {} exceeds int64 range",
                                 segment.filename(), segment.bundle_file_offset(), segment.size()));
+        }
+    }
+    return Status::OK();
+}
+
+Status validate_physical_rowset_shape(const RowsetMetadataPB& rowset) {
+    std::optional<bool> bundled;
+    for (const auto& segment : rowset.segment_metas()) {
+        RETURN_IF_ERROR(validate_physical_segment_shape(segment));
+        if (!bundled.has_value()) {
+            bundled = segment.has_bundle_file_offset();
+        } else if (*bundled != segment.has_bundle_file_offset()) {
+            return Status::Corruption(
+                    fmt::format("tablet merge rowset {} mixes bundled and standalone segments", rowset.id()));
         }
     }
     return Status::OK();
@@ -504,8 +523,8 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
     };
     std::map<std::pair<std::string, int64_t>, PhysicalSliceDeclaration> declarations_by_physical_slice;
     for (auto& canonical : *canonicals) {
+        RETURN_IF_ERROR(validate_physical_rowset_shape(canonical.source_form_rowset));
         for (auto& segment : *canonical.source_form_rowset.mutable_segment_metas()) {
-            RETURN_IF_ERROR(validate_physical_segment_shape(segment));
             const auto slice = std::pair{segment.filename(),
                                          segment.has_bundle_file_offset() ? segment.bundle_file_offset() : int64_t{0}};
             const auto declaration_key = normalized_physical_base_key(segment);
@@ -617,7 +636,6 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
             }
             auto& canonical = result.canonicals[decision.canonical_index];
             canonical.selected_context_index = context_index;
-            canonical.output_index = decision.canonical_index;
             canonical.source_form_rowset.CopyFrom(rowset);
             RETURN_IF_ERROR(
                     tablet_reshard_helper::update_rowset_range(&canonical.source_form_rowset, metadata.range()));
@@ -806,8 +824,9 @@ Status materialize_planned_rowsets(const TabletMergeAllocationPlan& plan, Tablet
             if (decision.emit && decision.non_pk_skip_dedup_fired) g_tablet_merge_non_pk_skip_dedup_total << 1;
         }
     }
-    for (const auto& canonical : plan.canonicals) {
-        if (canonical.output_index != target->rowsets_size()) {
+    for (size_t canonical_index = 0; canonical_index < plan.canonicals.size(); ++canonical_index) {
+        const auto& canonical = plan.canonicals[canonical_index];
+        if (canonical_index != static_cast<size_t>(target->rowsets_size())) {
             return Status::InternalError("tablet merge canonical plan is out of materialization order");
         }
         RowsetMetadataPB output(canonical.source_form_rowset);
@@ -828,7 +847,7 @@ Status materialize_planned_rowsets(const TabletMergeAllocationPlan& plan, Tablet
             (*target->mutable_rowset_to_schema())[mapped_id] = *canonical.schema_id;
         }
         if (canonical_contribs != nullptr && !canonical.source_form_rowset.has_delete_predicate()) {
-            (*canonical_contribs)[canonical.output_index] = canonical.contributor_ranges;
+            (*canonical_contribs)[canonical_index] = canonical.contributor_ranges;
         }
     }
     return Status::OK();
@@ -1809,11 +1828,11 @@ StatusOr<std::vector<CanonicalGapSpec>> compute_synthesized_gap_specs(TabletMana
     const TabletSchemaCSPtr current_schema =
             new_metadata.has_schema() ? TabletSchema::create(new_metadata.schema()) : nullptr;
     for (const auto& [canonical_index, contrib] : canonical_contribs) {
-        if (canonical_index < 0 || canonical_index >= new_metadata.rowsets_size()) {
+        if (canonical_index >= static_cast<size_t>(new_metadata.rowsets_size())) {
             return Status::InternalError(
                     fmt::format("compute_synthesized_gap_specs: invalid canonical_index {}", canonical_index));
         }
-        const auto& canonical = new_metadata.rowsets(canonical_index);
+        const auto& canonical = new_metadata.rowsets(static_cast<int>(canonical_index));
         // segment_metas_size() alone is insufficient because a rowset can own only
         // non-shared segments. Only synthesize gap bits when at least one segment is
         // actually shared.

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -429,6 +429,22 @@ std::string normalized_physical_base_key(const SegmentMetadataPB& segment) {
     return normalized.SerializeAsString();
 }
 
+Status validate_physical_segment_shape(const SegmentMetadataPB& segment) {
+    if (segment.has_bundle_file_offset() && segment.bundle_file_offset() < 0) {
+        return Status::Corruption(fmt::format("tablet merge segment {} has negative bundle_file_offset {}",
+                                              segment.filename(), segment.bundle_file_offset()));
+    }
+    if (segment.has_size() && segment.size() < 0) {
+        return Status::Corruption(
+                fmt::format("tablet merge segment {} has negative size {}", segment.filename(), segment.size()));
+    }
+    if (segment.has_bundle_file_offset() && !segment.has_size()) {
+        return Status::Corruption(fmt::format("tablet merge segment {} has bundle_file_offset {} but no size",
+                                              segment.filename(), segment.bundle_file_offset()));
+    }
+    return Status::OK();
+}
+
 Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* occurrence) {
     const bool overlapped = canonical->overlapped() || (occurrence != nullptr && occurrence->overlapped());
     std::map<uint32_t, SegmentMetadataPB> by_index;
@@ -477,6 +493,7 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
     std::map<std::pair<std::string, int64_t>, PhysicalSliceDeclaration> declarations_by_physical_slice;
     for (auto& canonical : *canonicals) {
         for (auto& segment : *canonical.source_form_rowset.mutable_segment_metas()) {
+            RETURN_IF_ERROR(validate_physical_segment_shape(segment));
             const auto slice = std::pair{segment.filename(),
                                          segment.has_bundle_file_offset() ? segment.bundle_file_offset() : int64_t{0}};
             const auto declaration_key = normalized_physical_base_key(segment);

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -299,21 +299,12 @@ private:
     uint32_t _target_end = 1;
 };
 
-struct ValidationOnlyDelOccurrence {
-    size_t context_index;
-    int rowset_index;
-    int del_index;
-    uint32_t current_max_segment_idx;
-};
-
 struct CanonicalAllocationPlan {
     size_t selected_context_index = 0;
-    int selected_rowset_index = -1;
     int output_index = -1;
     RowsetMetadataPB source_form_rowset;
     std::optional<int64_t> schema_id;
     std::vector<TabletRangePB> contributor_ranges;
-    std::vector<ValidationOnlyDelOccurrence> validation_only_dels;
 };
 
 struct TabletMergeAllocationPlan {
@@ -479,8 +470,7 @@ Status validate_del_replay_span(uint32_t origin, uint32_t offset) {
     return Status::OK();
 }
 
-Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, size_t context_index, int rowset_index,
-                                const RowsetMetadataPB& occurrence) {
+Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, const RowsetMetadataPB& occurrence) {
     auto* selected = &canonical->source_form_rowset;
     if (selected->del_files_size() != occurrence.del_files_size()) {
         return Status::Corruption("tablet merge duplicate rowset del-file count differs");
@@ -506,8 +496,6 @@ Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, size_t conte
         selected_del->set_shared(selected_del->shared() || occurrence_del.shared());
         const uint32_t local_offset = occurrence_del.has_op_offset() ? occurrence_del.op_offset() : current_max;
         RETURN_IF_ERROR(validate_del_replay_span(occurrence_del.origin_rowset_id(), local_offset));
-        canonical->validation_only_dels.emplace_back(
-                ValidationOnlyDelOccurrence{context_index, rowset_index, del_index, current_max});
     }
     return Status::OK();
 }
@@ -562,7 +550,6 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
             }
             auto& canonical = result.canonicals[decision.canonical_index];
             canonical.selected_context_index = context_index;
-            canonical.selected_rowset_index = rowset_index;
             canonical.output_index = decision.canonical_index;
             canonical.source_form_rowset.CopyFrom(rowset);
             RETURN_IF_ERROR(
@@ -611,7 +598,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
                                                        occurrence.data_size());
             canonical.source_form_rowset.set_num_dels(canonical.source_form_rowset.num_dels() + occurrence.num_dels());
             RETURN_IF_ERROR(reconcile_segments(&canonical.source_form_rowset, &occurrence));
-            RETURN_IF_ERROR(reconcile_duplicate_dels(&canonical, context_index, rowset_index, occurrence));
+            RETURN_IF_ERROR(reconcile_duplicate_dels(&canonical, occurrence));
         }
     }
 
@@ -742,8 +729,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
     return result;
 }
 
-Status materialize_planned_rowsets(const std::vector<TabletMergeContext>& contexts,
-                                   const TabletMergeAllocationPlan& plan, TabletMetadataPB* target,
+Status materialize_planned_rowsets(const TabletMergeAllocationPlan& plan, TabletMetadataPB* target,
                                    CanonicalContribMap* canonical_contribs) {
     TEST_SYNC_POINT_CALLBACK("materialize_planned_rowsets:entry", nullptr);
     for (const auto& decisions : plan.emission) {
@@ -776,7 +762,6 @@ Status materialize_planned_rowsets(const std::vector<TabletMergeContext>& contex
             (*canonical_contribs)[canonical.output_index] = canonical.contributor_ranges;
         }
     }
-    (void)contexts;
     return Status::OK();
 }
 
@@ -3254,8 +3239,7 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // old tablets' old-tablet-local ranges; consumed by the PK fail-fast coverage
     // check below and by gap-delvec synthesis.
     CanonicalContribMap canonical_contribs;
-    RETURN_IF_ERROR(materialize_planned_rowsets(merge_contexts, allocation_plan, new_tablet_metadata.get(),
-                                                &canonical_contribs));
+    RETURN_IF_ERROR(materialize_planned_rowsets(allocation_plan, new_tablet_metadata.get(), &canonical_contribs));
 
     // Phase 2.5: Merge schemas (must run before gap synthesis + merge_dcg_meta,
     // which need historical_schemas to locate rebuild schemas for shared-segment

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -306,10 +306,10 @@ struct CanonicalAllocationPlan {
 };
 
 struct TabletMergeAllocationPlan {
-    RowsetEmissionPlan emission;
     std::vector<CanonicalAllocationPlan> canonicals;
     std::vector<RssidProjection> projections;
     uint32_t target_next_rowset_id = 1;
+    int64_t non_pk_skip_dedup_count = 0;
 };
 
 DEFINE_FAIL_POINT(tablet_merge_before_delete_predicate_range);
@@ -464,13 +464,25 @@ Status validate_physical_segment_shape(const SegmentMetadataPB& segment) {
 
 Status validate_physical_rowset_shape(const RowsetMetadataPB& rowset) {
     std::optional<bool> bundled;
-    for (const auto& segment : rowset.segment_metas()) {
+    std::map<std::pair<std::string, int64_t>, uint32_t> segment_index_by_physical_slice;
+    for (int position = 0; position < rowset.segment_metas_size(); ++position) {
+        const auto& segment = rowset.segment_metas(position);
         RETURN_IF_ERROR(validate_physical_segment_shape(segment));
         if (!bundled.has_value()) {
             bundled = segment.has_bundle_file_offset();
         } else if (*bundled != segment.has_bundle_file_offset()) {
             return Status::Corruption(
                     fmt::format("tablet merge rowset {} mixes bundled and standalone segments", rowset.id()));
+        }
+        const auto slice = std::pair{segment.filename(),
+                                     segment.has_bundle_file_offset() ? segment.bundle_file_offset() : int64_t{0}};
+        const uint32_t segment_index = get_segment_idx(rowset, position);
+        auto [iter, inserted] = segment_index_by_physical_slice.try_emplace(slice, segment_index);
+        if (!inserted && iter->second != segment_index) {
+            return Status::Corruption(fmt::format(
+                    "tablet merge rowset {} references physical segment slice {} at bundle offset {} from multiple "
+                    "segment indices",
+                    rowset.id(), slice.first, slice.second));
         }
     }
     return Status::OK();
@@ -480,8 +492,13 @@ Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* o
     const bool overlapped = canonical->overlapped() || (occurrence != nullptr && occurrence->overlapped());
     std::map<uint32_t, SegmentMetadataPB> by_index;
     auto ingest = [&](const RowsetMetadataPB& source) -> Status {
+        std::unordered_set<uint32_t> source_indices;
         for (int position = 0; position < source.segment_metas_size(); ++position) {
             const uint32_t index = get_segment_idx(source, position);
+            if (!source_indices.insert(index).second) {
+                return Status::Corruption(
+                        fmt::format("tablet merge source rowset has duplicate effective segment index {}", index));
+            }
             SegmentMetadataPB candidate(source.segment_metas(position));
             candidate.set_segment_idx(index);
             const bool candidate_shared = candidate.shared();
@@ -521,15 +538,18 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
         std::string declaration_key;
         std::vector<SegmentMetadataPB*> references;
     };
-    std::map<std::string, bool> bundled_by_filename;
-    std::map<std::string, std::map<int64_t, int64_t>> bundled_intervals_by_filename;
+    struct PhysicalFilenameDeclaration {
+        bool bundled = false;
+        std::map<int64_t, int64_t> bundled_intervals;
+    };
+    std::map<std::string, PhysicalFilenameDeclaration> declarations_by_filename;
     std::map<std::pair<std::string, int64_t>, PhysicalSliceDeclaration> declarations_by_physical_slice;
     for (auto& canonical : *canonicals) {
         RETURN_IF_ERROR(validate_physical_rowset_shape(canonical.source_form_rowset));
         for (auto& segment : *canonical.source_form_rowset.mutable_segment_metas()) {
-            auto [form, form_inserted] =
-                    bundled_by_filename.try_emplace(segment.filename(), segment.has_bundle_file_offset());
-            if (!form_inserted && form->second != segment.has_bundle_file_offset()) {
+            auto [file, file_inserted] = declarations_by_filename.try_emplace(
+                    segment.filename(), PhysicalFilenameDeclaration{.bundled = segment.has_bundle_file_offset()});
+            if (!file_inserted && file->second.bundled != segment.has_bundle_file_offset()) {
                 return Status::Corruption(
                         fmt::format("tablet merge physical segment file {} mixes bundled and standalone forms",
                                     segment.filename()));
@@ -537,7 +557,7 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
             if (segment.has_bundle_file_offset()) {
                 const int64_t bundle_end = static_cast<int64_t>(static_cast<uint64_t>(segment.bundle_file_offset()) +
                                                                 static_cast<uint64_t>(segment.size()));
-                bundled_intervals_by_filename[segment.filename()].try_emplace(segment.bundle_file_offset(), bundle_end);
+                file->second.bundled_intervals.try_emplace(segment.bundle_file_offset(), bundle_end);
             }
             const auto slice = std::pair{segment.filename(),
                                          segment.has_bundle_file_offset() ? segment.bundle_file_offset() : int64_t{0}};
@@ -554,9 +574,9 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
             iter->second.references.emplace_back(&segment);
         }
     }
-    for (const auto& [filename, intervals] : bundled_intervals_by_filename) {
+    for (const auto& [filename, declaration] : declarations_by_filename) {
         std::optional<std::pair<int64_t, int64_t>> previous;
-        for (const auto& [begin, end] : intervals) {
+        for (const auto& [begin, end] : declaration.bundled_intervals) {
             if (previous.has_value() && begin < previous->second) {
                 return Status::Corruption(fmt::format(
                         "tablet merge physical segment file {} has overlapping bundled slices [{}, {}) and [{}, {})",
@@ -639,18 +659,20 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
     TEST_SYNC_POINT_CALLBACK("tablet_merge_test:drop_primary_atom", &drop_primary_atom);
 
     TabletMergeAllocationPlan result;
-    ASSIGN_OR_RETURN(result.emission, build_rowset_emission_plan(contexts, discard_empty_rowsets));
+    ASSIGN_OR_RETURN(auto emission, build_rowset_emission_plan(contexts, discard_empty_rowsets));
     int canonical_count = 0;
-    for (const auto& decisions : result.emission) {
-        for (const auto& decision : decisions)
+    for (const auto& decisions : emission) {
+        for (const auto& decision : decisions) {
             canonical_count = std::max(canonical_count, decision.canonical_index + 1);
+            result.non_pk_skip_dedup_count += decision.emit && decision.non_pk_skip_dedup_fired;
+        }
     }
     result.canonicals.resize(canonical_count);
 
     for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
         const auto& metadata = *contexts[context_index].metadata();
         for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
-            const auto& decision = result.emission[context_index][rowset_index];
+            const auto& decision = emission[context_index][rowset_index];
             if (!decision.emit) continue;
             const auto& rowset = metadata.rowsets(rowset_index);
             DCHECK(tablet_reshard_helper::has_valid_uid(rowset))
@@ -676,7 +698,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
     for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
         const auto& metadata = *contexts[context_index].metadata();
         for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
-            const auto& decision = result.emission[context_index][rowset_index];
+            const auto& decision = emission[context_index][rowset_index];
             if (decision.discard || decision.emit) continue;
             const auto& occurrence = metadata.rowsets(rowset_index);
             DCHECK(tablet_reshard_helper::has_valid_uid(occurrence))
@@ -759,7 +781,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
     for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
         const auto& metadata = *contexts[context_index].metadata();
         for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
-            const auto& decision = result.emission[context_index][rowset_index];
+            const auto& decision = emission[context_index][rowset_index];
             const auto& occurrence = metadata.rowsets(rowset_index);
             if (decision.discard || decision.emit || occurrence.has_delete_predicate()) continue;
             const auto& canonical = result.canonicals[decision.canonical_index];
@@ -844,11 +866,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
 Status materialize_planned_rowsets(const TabletMergeAllocationPlan& plan, TabletMetadataPB* target,
                                    CanonicalContribMap* canonical_contribs) {
     TEST_SYNC_POINT_CALLBACK("materialize_planned_rowsets:entry", nullptr);
-    for (const auto& decisions : plan.emission) {
-        for (const auto& decision : decisions) {
-            if (decision.emit && decision.non_pk_skip_dedup_fired) g_tablet_merge_non_pk_skip_dedup_total << 1;
-        }
-    }
+    g_tablet_merge_non_pk_skip_dedup_total << plan.non_pk_skip_dedup_count;
     for (size_t canonical_index = 0; canonical_index < plan.canonicals.size(); ++canonical_index) {
         const auto& canonical = plan.canonicals[canonical_index];
         if (canonical_index != static_cast<size_t>(target->rowsets_size())) {
@@ -1032,6 +1050,16 @@ std::unordered_map<uint32_t, bool> collect_target_rssid_ownership(const TabletMe
     for (const auto& rowset : metadata.rowsets()) {
         for (int position = 0; position < rowset.segment_metas_size(); ++position) {
             result[get_rssid(rowset, position)] = rowset.segment_metas(position).shared();
+        }
+    }
+    return result;
+}
+
+std::unordered_map<uint32_t, std::string> collect_target_rssid_physical_bases(const TabletMetadataPB& metadata) {
+    std::unordered_map<uint32_t, std::string> result;
+    for (const auto& rowset : metadata.rowsets()) {
+        for (int position = 0; position < rowset.segment_metas_size(); ++position) {
+            result[get_rssid(rowset, position)] = normalized_physical_base_key(rowset.segment_metas(position));
         }
     }
     return result;
@@ -1740,6 +1768,7 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
     // this fix has segment.shared=true but idg.shared_file=false, because the old split marked
     // segments shared but not idg) and later mis-route the .idx at vacuum time.
     const auto target_rssid_shared = collect_target_rssid_ownership(*new_metadata);
+    const auto target_rssid_physical_bases = collect_target_rssid_physical_bases(*new_metadata);
 
     std::map<uint32_t, std::vector<IndexDeltaGroupEntryPB>> work_by_target;
     // target rssid -> (.idx filename -> index into work_by_target[target]).
@@ -1782,6 +1811,26 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
     }
 
     if (work_by_target.empty()) return Status::OK();
+
+    // DROP INDEX is table-wide monotonic. Co-referenced target RSSIDs that resolve to the same normalized physical base
+    // and .idx file must therefore see the union of every tombstone before active/dead and orphan decisions.
+    std::map<std::pair<std::string, std::string>, IndexDeltaGroupEntryPB> global_tombstones;
+    for (const auto& [target_rssid, entries] : work_by_target) {
+        auto base = target_rssid_physical_bases.find(target_rssid);
+        if (base == target_rssid_physical_bases.end()) {
+            return Status::Corruption(
+                    fmt::format("tablet merge IDG target RSSID {} has no physical base", target_rssid));
+        }
+        for (const auto& entry : entries) {
+            union_idg_dropped_keys(&global_tombstones[{base->second, entry.index_file()}], entry);
+        }
+    }
+    for (auto& [target_rssid, entries] : work_by_target) {
+        const auto& base = target_rssid_physical_bases.at(target_rssid);
+        for (auto& entry : entries) {
+            union_idg_dropped_keys(&entry, global_tombstones.at({base, entry.index_file()}));
+        }
+    }
 
     auto* merged_idgs = new_metadata->mutable_idg_meta()->mutable_idgs();
     // Fully-tombstoned entries' .idx files are orphan candidates. Collect them first and only
@@ -2871,9 +2920,9 @@ void order_and_assign_singleton_filesets(PersistentIndexSstableMetaPB* metadata)
 StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std::vector<TabletMergeContext>& contexts,
                                                                        const TabletMergeAllocationPlan& allocation_plan,
                                                                        const TabletMetadataPB& target,
+                                                                       MergeSourceRangeProof source_range_proof,
                                                                        const SstableLiveRssidIndex& live_rssids) {
-    ASSIGN_OR_RETURN(auto range_proof, validate_metadata_reuse_source_ranges(contexts, target));
-    if (range_proof != MergeSourceRangeProof::kReusable) {
+    if (source_range_proof != MergeSourceRangeProof::kReusable) {
         return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
     }
 
@@ -3005,9 +3054,9 @@ bool semantic_sstable_equal(const PersistentIndexSstablePB& left, const Persiste
 StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std::vector<TabletMergeContext>& contexts,
                                                                        const TabletMergeAllocationPlan& allocation_plan,
                                                                        const TabletMetadataPB& target,
+                                                                       MergeSourceRangeProof source_range_proof,
                                                                        const SstableLiveRssidIndex& live_rssids) {
-    ASSIGN_OR_RETURN(auto range_proof, validate_metadata_reuse_source_ranges(contexts, target));
-    if (range_proof != MergeSourceRangeProof::kReusable) {
+    if (source_range_proof != MergeSourceRangeProof::kReusable) {
         return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
     }
 
@@ -3225,17 +3274,21 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
 
     TEST_SYNC_POINT_CALLBACK("merge_sstables:metadata_classifier_entry", nullptr);
     DeferOp classifier_exit([] { TEST_SYNC_POINT_CALLBACK("merge_sstables:metadata_classifier_exit", nullptr); });
+    ASSIGN_OR_RETURN(const auto source_range_proof,
+                     validate_metadata_reuse_source_ranges(merge_contexts, *new_metadata));
 
-    ASSIGN_OR_RETURN(auto private_result, try_project_complete_private_sstables(merge_contexts, allocation_plan,
-                                                                                *new_metadata, live_rssids));
+    ASSIGN_OR_RETURN(auto private_result,
+                     try_project_complete_private_sstables(merge_contexts, allocation_plan, *new_metadata,
+                                                           source_range_proof, live_rssids));
     if (private_result.mode == MergeSstableMetaMode::kPrivate) {
         new_metadata->mutable_sstable_meta()->Swap(&private_result.metadata);
         record_merge_sstable_meta_result(private_result);
         return Status::OK();
     }
 
-    ASSIGN_OR_RETURN(auto identical_result, try_reuse_complete_identical_sstables(merge_contexts, allocation_plan,
-                                                                                  *new_metadata, live_rssids));
+    ASSIGN_OR_RETURN(auto identical_result,
+                     try_reuse_complete_identical_sstables(merge_contexts, allocation_plan, *new_metadata,
+                                                           source_range_proof, live_rssids));
     if (identical_result.mode == MergeSstableMetaMode::kIdentical) {
         new_metadata->mutable_sstable_meta()->Swap(&identical_result.metadata);
         record_merge_sstable_meta_result(identical_result);

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/tablet_merger.h"
 
 #include <bvar/bvar.h>
+#include <google/protobuf/unknown_field_set.h>
 
 #include <algorithm>
 #include <limits>
@@ -897,6 +898,9 @@ Status materialize_planned_rowsets(const TabletMergeAllocationPlan& plan, Tablet
 }
 
 Status validate_dcg_shape(const DeltaColumnGroupVerPB& dcg) {
+    if (dcg.GetReflection()->GetUnknownFields(dcg).field_count() != 0) {
+        return Status::Corruption("DCG message has unknown fields that cannot be attributed to an entry");
+    }
     // Required fields must be equal length
     if (dcg.unique_column_ids_size() != dcg.column_files_size() || dcg.versions_size() != dcg.column_files_size()) {
         return Status::Corruption("DCG shape invalid: column_files/unique_column_ids/versions size mismatch");

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -1033,6 +1033,11 @@ struct DcgTargetWorkItem {
     std::vector<DcgSourceRowsetReference> source_refs;
 };
 
+struct TargetSegmentDeclaration {
+    std::string physical_base_key;
+    bool shared = false;
+};
+
 DeltaColumnGroupVerPB make_single_entry_dcg(const DeltaColumnGroupVerPB& source, int entry_index) {
     DeltaColumnGroupVerPB out;
     out.add_column_files(source.column_files(entry_index));
@@ -1055,11 +1060,14 @@ std::unordered_map<uint32_t, bool> collect_target_rssid_ownership(const TabletMe
     return result;
 }
 
-std::unordered_map<uint32_t, std::string> collect_target_rssid_physical_bases(const TabletMetadataPB& metadata) {
-    std::unordered_map<uint32_t, std::string> result;
+std::unordered_map<uint32_t, TargetSegmentDeclaration> collect_target_segment_declarations(
+        const TabletMetadataPB& metadata) {
+    std::unordered_map<uint32_t, TargetSegmentDeclaration> result;
     for (const auto& rowset : metadata.rowsets()) {
         for (int position = 0; position < rowset.segment_metas_size(); ++position) {
-            result[get_rssid(rowset, position)] = normalized_physical_base_key(rowset.segment_metas(position));
+            const auto& segment = rowset.segment_metas(position);
+            result[get_rssid(rowset, position)] =
+                    TargetSegmentDeclaration{normalized_physical_base_key(segment), segment.shared()};
         }
     }
     return result;
@@ -1760,17 +1768,20 @@ std::unordered_set<uint32_t> collect_live_rssids(const TabletMetadataPB& metadat
 // partial-write cleanup to do.
 Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
                       const TabletMergeAllocationPlan& allocation_plan, TabletMetadataPB* new_metadata) {
-    // Every segment present after merge_rowsets, mapped to its shared flag. An IDG entry is
+    // Every segment present after merge_rowsets, mapped to its physical-base declaration. An IDG entry is
     // kept only if its remapped target is here (target-live), and its .idx shared_file is
     // DERIVED from the target segment's shared flag (see the emit loop) rather than preserved
     // from the source: an .idx is shared iff the segment it indexes is shared, so the two must
     // agree. Preserving a source flag would carry a stale value (e.g. a tablet split before
     // this fix has segment.shared=true but idg.shared_file=false, because the old split marked
     // segments shared but not idg) and later mis-route the .idx at vacuum time.
-    const auto target_rssid_shared = collect_target_rssid_ownership(*new_metadata);
-    const auto target_rssid_physical_bases = collect_target_rssid_physical_bases(*new_metadata);
+    const auto target_segments = collect_target_segment_declarations(*new_metadata);
 
-    std::map<uint32_t, std::vector<IndexDeltaGroupEntryPB>> work_by_target;
+    struct TargetWorkItem {
+        const TargetSegmentDeclaration* declaration = nullptr;
+        std::vector<IndexDeltaGroupEntryPB> entries;
+    };
+    std::map<uint32_t, TargetWorkItem> work_by_target;
     // target rssid -> (.idx filename -> index into work_by_target[target]).
     std::map<uint32_t, std::unordered_map<std::string, size_t>> seen_files_by_target;
 
@@ -1790,11 +1801,14 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
                 return Status::Corruption(
                         fmt::format("tablet merge source-live IDG RSSID {} target was omitted", segment_id));
             }
-            if (!target_rssid_shared.contains(target_rssid)) {
+            auto target_segment = target_segments.find(target_rssid);
+            if (target_segment == target_segments.end()) {
                 return Status::Corruption(fmt::format("tablet merge source-live IDG RSSID {} maps to missing target {}",
                                                       segment_id, target_rssid));
             }
-            auto& entries = work_by_target[target_rssid];
+            auto& target_work = work_by_target[target_rssid];
+            target_work.declaration = &target_segment->second;
+            auto& entries = target_work.entries;
             auto& seen = seen_files_by_target[target_rssid];
             for (const auto& entry : idg_ver.entries()) {
                 if (!entry.has_index_file() || entry.index_file().empty()) continue;
@@ -1815,20 +1829,20 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
     // DROP INDEX is table-wide monotonic. Co-referenced target RSSIDs that resolve to the same normalized physical base
     // and .idx file must therefore see the union of every tombstone before active/dead and orphan decisions.
     std::map<std::pair<std::string, std::string>, IndexDeltaGroupEntryPB> global_tombstones;
-    for (const auto& [target_rssid, entries] : work_by_target) {
-        auto base = target_rssid_physical_bases.find(target_rssid);
-        if (base == target_rssid_physical_bases.end()) {
-            return Status::Corruption(
-                    fmt::format("tablet merge IDG target RSSID {} has no physical base", target_rssid));
-        }
-        for (const auto& entry : entries) {
-            union_idg_dropped_keys(&global_tombstones[{base->second, entry.index_file()}], entry);
+    for (const auto& [target_rssid, target_work] : work_by_target) {
+        (void)target_rssid;
+        DCHECK(target_work.declaration != nullptr);
+        for (const auto& entry : target_work.entries) {
+            union_idg_dropped_keys(&global_tombstones[{target_work.declaration->physical_base_key, entry.index_file()}],
+                                   entry);
         }
     }
-    for (auto& [target_rssid, entries] : work_by_target) {
-        const auto& base = target_rssid_physical_bases.at(target_rssid);
-        for (auto& entry : entries) {
-            union_idg_dropped_keys(&entry, global_tombstones.at({base, entry.index_file()}));
+    for (auto& [target_rssid, target_work] : work_by_target) {
+        (void)target_rssid;
+        DCHECK(target_work.declaration != nullptr);
+        for (auto& entry : target_work.entries) {
+            union_idg_dropped_keys(
+                    &entry, global_tombstones.at({target_work.declaration->physical_base_key, entry.index_file()}));
         }
     }
 
@@ -1840,13 +1854,14 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
     // practice, but resolving against the full surviving set keeps the orphan set provably safe.)
     std::unordered_set<std::string> surviving_files;
     std::map<std::string, FileMetaPB> orphan_candidates;
-    for (auto& [target_rssid, entries] : work_by_target) {
+    for (auto& [target_rssid, target_work] : work_by_target) {
         // Derive the .idx shared flag from the merged segment's ownership: an .idx is shared
         // iff the segment it indexes is shared. This corrects a stale source flag (e.g. from a
         // tablet split before this fix) instead of preserving it, and matches how vacuum treats
         // the segment/.cols for the same rssid.
-        auto shared_it = target_rssid_shared.find(target_rssid);
-        const bool tgt_shared = shared_it != target_rssid_shared.end() && shared_it->second;
+        DCHECK(target_work.declaration != nullptr);
+        const bool tgt_shared = target_work.declaration->shared;
+        auto& entries = target_work.entries;
         std::sort(entries.begin(), entries.end(), [](const IndexDeltaGroupEntryPB& a, const IndexDeltaGroupEntryPB& b) {
             return a.version() > b.version();
         });
@@ -2584,14 +2599,9 @@ StatusOr<bool> sstable_range_within_tablet(const PersistentIndexSstablePB& sst, 
     return true;
 }
 
-struct PreflightTargetSegment {
-    std::string physical_base_key;
-    bool shared = false;
-};
-
-StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_segments(
+StatusOr<std::map<uint32_t, TargetSegmentDeclaration>> collect_preflight_target_segments(
         const TabletMergeAllocationPlan& allocation_plan) {
-    std::map<uint32_t, PreflightTargetSegment> result;
+    std::map<uint32_t, TargetSegmentDeclaration> result;
     for (const auto& canonical : allocation_plan.canonicals) {
         const auto& rowset = canonical.source_form_rowset;
         const auto& projection = allocation_plan.projections[canonical.selected_context_index];
@@ -2602,8 +2612,8 @@ StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_se
                 target_rssid > std::numeric_limits<uint32_t>::max()) {
                 return Status::Corruption("tablet merge planned target segment exceeds its authoritative cursor");
             }
-            PreflightTargetSegment candidate{normalized_physical_base_key(rowset.segment_metas(position)),
-                                             rowset.segment_metas(position).shared()};
+            TargetSegmentDeclaration candidate{normalized_physical_base_key(rowset.segment_metas(position)),
+                                               rowset.segment_metas(position).shared()};
             auto [iter, inserted] = result.try_emplace(static_cast<uint32_t>(target_rssid), std::move(candidate));
             if (!inserted) {
                 return Status::Corruption(
@@ -2616,7 +2626,7 @@ StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_se
 
 StatusOr<std::vector<std::map<uint32_t, uint32_t>>> collect_preflight_source_segments(
         const std::vector<TabletMergeContext>& contexts, const TabletMergeAllocationPlan& allocation_plan,
-        const std::map<uint32_t, PreflightTargetSegment>& target_segments) {
+        const std::map<uint32_t, TargetSegmentDeclaration>& target_segments) {
     std::vector<std::map<uint32_t, uint32_t>> result(contexts.size());
     for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
         for (const auto& rowset : contexts[context_index].metadata()->rowsets()) {

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -278,6 +278,7 @@ public:
                 [](uint64_t value, const RssidTranslationRun& run) { return value < run.source_begin; });
         if (iter == _runs.begin()) return std::optional<int64_t>{};
         --iter;
+        TEST_SYNC_POINT_CALLBACK("affine_delta:visited_run", const_cast<RssidTranslationRun*>(&*iter));
         if (begin < iter->source_begin || end > iter->source_end) return std::optional<int64_t>{};
         auto alias = std::lower_bound(_divergent_alias_keys.begin(), _divergent_alias_keys.end(), begin);
         if (alias != _divergent_alias_keys.end() && *alias < end) return std::optional<int64_t>{};
@@ -2199,6 +2200,45 @@ Status project_non_shared_legacy_sstable(const PersistentIndexSstablePB& sst, in
     return Status::OK();
 }
 
+bool legacy_sstable_occurrence_agrees(const RssidProjection& projection,
+                                      const std::unordered_set<uint32_t>& source_live_rssids,
+                                      const std::unordered_set<uint32_t>& target_live_rssids, uint64_t source_begin,
+                                      uint32_t source_high, int64_t delta, uint32_t target_end) {
+    if (!source_live_rssids.contains(source_high)) return false;
+    const int64_t projected_begin = static_cast<int64_t>(source_begin) + delta;
+    const int64_t projected_high = static_cast<int64_t>(source_high) + delta;
+    if (projected_begin < 0 || projected_begin > std::numeric_limits<int32_t>::max() || projected_high < 0 ||
+        projected_high >= target_end || !target_live_rssids.contains(static_cast<uint32_t>(projected_high))) {
+        return false;
+    }
+    for (uint32_t source : source_live_rssids) {
+        if (source < source_begin || source > source_high) continue;
+        auto mapped = projection.map_occurrence_rssid(source);
+        const int64_t expected = static_cast<int64_t>(source) + delta;
+        if (!mapped.ok() || expected < 0 || expected >= target_end || mapped.value() != expected ||
+            !target_live_rssids.contains(mapped.value())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+StatusOr<std::optional<int64_t>> prove_legacy_sstable_affine_domain(
+        const PersistentIndexSstablePB& sst, const RssidProjection& projection,
+        const std::unordered_set<uint32_t>& source_live_rssids, const std::unordered_set<uint32_t>& target_live_rssids,
+        uint32_t target_end) {
+    if (sst.rssid_offset() < 0) return std::optional<int64_t>{};
+    const uint64_t source_begin = static_cast<uint32_t>(sst.rssid_offset());
+    const uint32_t source_high = extract_rss_rowid_high(sst.max_rss_rowid());
+    if (source_high < source_begin) return std::optional<int64_t>{};
+    ASSIGN_OR_RETURN(auto delta, projection.affine_delta(source_begin, uint64_t{source_high} + 1));
+    if (!delta.has_value() || !legacy_sstable_occurrence_agrees(projection, source_live_rssids, target_live_rssids,
+                                                                source_begin, source_high, *delta, target_end)) {
+        return std::optional<int64_t>{};
+    }
+    return delta;
+}
+
 enum class MergeSstableMetaMode { kPrivate, kIdentical, kLazyRebuild };
 
 enum class MergeSstableFallbackReason {
@@ -2665,10 +2705,6 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
             if (!range_within_source) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
             }
-            if (source_sstable.max_rss_rowid() > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-                return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
-            }
-
             PersistentIndexSstablePB projected(source_sstable);
             if (source_sstable.has_shared_rssid()) {
                 auto source_rssid = effective_shared_rssid(source_sstable);
@@ -2694,23 +2730,11 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
                     source_sstable.rssid_offset() < 0) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
                 }
-                const uint32_t source_high = extract_rss_rowid_high(source_sstable.max_rss_rowid());
-                ASSIGN_OR_RETURN(auto conservative_delta, projection.conservative_context_delta());
-                if (!conservative_delta.has_value()) {
+                ASSIGN_OR_RETURN(auto domain_delta, prove_legacy_sstable_affine_domain(
+                                                            source_sstable, projection, source_live_rssids,
+                                                            target_live_rssids, allocation_plan.target_next_rowset_id));
+                if (!domain_delta.has_value()) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
-                }
-                ASSIGN_OR_RETURN(auto domain_delta,
-                                 projection.affine_delta(source_sstable.rssid_offset(), uint64_t{source_high} + 1));
-                if (!domain_delta.has_value() || *domain_delta != *conservative_delta) {
-                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
-                }
-                const int64_t projected_high = static_cast<int64_t>(source_high) + *domain_delta;
-                const int64_t projected_offset = static_cast<int64_t>(source_sstable.rssid_offset()) + *domain_delta;
-                if (!source_live_rssids.contains(source_high) || projected_high < 0 ||
-                    projected_high >= allocation_plan.target_next_rowset_id ||
-                    !target_live_rssids.contains(static_cast<uint32_t>(projected_high)) || projected_offset < 0 ||
-                    projected_offset > std::numeric_limits<int32_t>::max()) {
-                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
                 const auto projection_status =
                         project_non_shared_legacy_sstable(source_sstable, *domain_delta, &projected);
@@ -2736,11 +2760,12 @@ bool same_rowset_physical_layout(const RowsetMetadataPB& left, const RowsetMetad
         }
     }
 
-    // SPLIT stamps child-local rowset ranges and apportions logical statistics, while the physical
-    // segment and delete-file declarations remain inherited. Compare every other rowset field,
-    // using segment_metas as the canonical physical declaration and normalizing its effective index.
+    // SPLIT or an earlier merge can stamp context-local rowset IDs/ranges and apportion logical statistics, while the
+    // physical segment and delete-file declarations remain inherited. Compare every other rowset field, using
+    // segment_metas as the canonical physical declaration and normalizing its effective index.
     auto normalized = [](const RowsetMetadataPB& rowset) {
         RowsetMetadataPB result(rowset);
+        result.clear_id();
         result.clear_range();
         result.clear_num_rows();
         result.clear_data_size();
@@ -2820,9 +2845,6 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
     MergeSstableMetaResult result;
     result.mode = MergeSstableMetaMode::kIdentical;
     for (const auto& canonical_sstable : canonical_sstables) {
-        if (canonical_sstable.max_rss_rowid() > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-            return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
-        }
         PersistentIndexSstablePB projected(canonical_sstable);
         projected.set_shared(true);
         if (canonical_sstable.has_shared_rssid()) {
@@ -2856,7 +2878,34 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kEmbeddedDelvec);
             }
         } else {
-            return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
+            if ((canonical_sstable.has_shared_version() && canonical_sstable.shared_version() > 0) ||
+                (canonical_sstable.has_delvec() && canonical_sstable.delvec().size() > 0) ||
+                canonical_sstable.rssid_offset() < 0) {
+                return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
+            }
+            const uint64_t source_begin = static_cast<uint32_t>(canonical_sstable.rssid_offset());
+            const uint32_t source_high = extract_rss_rowid_high(canonical_sstable.max_rss_rowid());
+            const auto canonical_live = collect_live_rssids(canonical_metadata);
+            ASSIGN_OR_RETURN(auto common_delta,
+                             prove_legacy_sstable_affine_domain(canonical_sstable, allocation_plan.projections.front(),
+                                                                canonical_live, target_live_rssids,
+                                                                allocation_plan.target_next_rowset_id));
+            if (!common_delta.has_value()) {
+                return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
+            }
+            for (size_t context_index = 1; context_index < contexts.size(); ++context_index) {
+                const auto source_live = collect_live_rssids(*contexts[context_index].metadata());
+                if (!legacy_sstable_occurrence_agrees(allocation_plan.projections[context_index], source_live,
+                                                      target_live_rssids, source_begin, source_high, *common_delta,
+                                                      allocation_plan.target_next_rowset_id)) {
+                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
+                }
+            }
+            const auto projection_status =
+                    project_non_shared_legacy_sstable(canonical_sstable, *common_delta, &projected);
+            if (!projection_status.ok()) {
+                return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
+            }
         }
         result.metadata.add_sstables()->Swap(&projected);
     }

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -422,11 +422,11 @@ std::optional<int64_t> rowset_schema_id(const TabletMergeContext& context, uint3
     return iter->second;
 }
 
-SegmentMetadataPB normalized_physical_base(const SegmentMetadataPB& segment) {
+std::string normalized_physical_base_key(const SegmentMetadataPB& segment) {
     SegmentMetadataPB normalized(segment);
     normalized.clear_segment_idx();
     normalized.clear_shared();
-    return normalized;
+    return normalized.SerializeAsString();
 }
 
 Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* occurrence) {
@@ -473,7 +473,7 @@ void normalize_cross_target_physical_ownership(std::vector<CanonicalAllocationPl
     std::map<std::string, std::vector<SegmentMetadataPB*>> references_by_physical_base;
     for (auto& canonical : *canonicals) {
         for (auto& segment : *canonical.source_form_rowset.mutable_segment_metas()) {
-            references_by_physical_base[normalized_physical_base(segment).SerializeAsString()].emplace_back(&segment);
+            references_by_physical_base[normalized_physical_base_key(segment)].emplace_back(&segment);
         }
     }
     for (auto& [physical_base, references] : references_by_physical_base) {
@@ -2147,6 +2147,10 @@ Status validate_non_shared_legacy_sstable_form(const PersistentIndexSstablePB& s
     return Status::OK();
 }
 
+bool has_valid_modern_sstable_shared_version(const PersistentIndexSstablePB& sstable) {
+    return sstable.has_shared_version() && sstable.shared_version() > 0;
+}
+
 // Project a sstable that has shared_rssid set (modern shared or
 // `ingest_sst()` output). |out| was already CopyFrom'd from |sst|; this
 // function rewrites the projection-affected fields in place.
@@ -2390,12 +2394,8 @@ StatusOr<bool> sstable_range_within_tablet(const PersistentIndexSstablePB& sst, 
 }
 
 struct PreflightTargetSegment {
-    SegmentMetadataPB physical_base;
+    std::string physical_base_key;
     bool shared = false;
-};
-
-struct PreflightSourceSegment {
-    uint32_t target_rssid = 0;
 };
 
 StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_segments(
@@ -2411,7 +2411,7 @@ StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_se
                 target_rssid > std::numeric_limits<uint32_t>::max()) {
                 return Status::Corruption("tablet merge planned target segment exceeds its authoritative cursor");
             }
-            PreflightTargetSegment candidate{normalized_physical_base(rowset.segment_metas(position)),
+            PreflightTargetSegment candidate{normalized_physical_base_key(rowset.segment_metas(position)),
                                              rowset.segment_metas(position).shared()};
             auto [iter, inserted] = result.try_emplace(static_cast<uint32_t>(target_rssid), std::move(candidate));
             if (!inserted) {
@@ -2423,10 +2423,10 @@ StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_se
     return result;
 }
 
-StatusOr<std::vector<std::map<uint32_t, PreflightSourceSegment>>> collect_preflight_source_segments(
+StatusOr<std::vector<std::map<uint32_t, uint32_t>>> collect_preflight_source_segments(
         const std::vector<TabletMergeContext>& contexts, const TabletMergeAllocationPlan& allocation_plan,
         const std::map<uint32_t, PreflightTargetSegment>& target_segments) {
-    std::vector<std::map<uint32_t, PreflightSourceSegment>> result(contexts.size());
+    std::vector<std::map<uint32_t, uint32_t>> result(contexts.size());
     for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
         for (const auto& rowset : contexts[context_index].metadata()->rowsets()) {
             for (int position = 0; position < rowset.segment_metas_size(); ++position) {
@@ -2438,15 +2438,13 @@ StatusOr<std::vector<std::map<uint32_t, PreflightSourceSegment>>> collect_prefli
                     return Status::Corruption(fmt::format("tablet merge source-live RSSID {} maps to missing target {}",
                                                           source_rssid, target_rssid));
                 }
-                auto physical_base = normalized_physical_base(rowset.segment_metas(position));
-                if (physical_base.SerializeAsString() != target->second.physical_base.SerializeAsString()) {
+                if (normalized_physical_base_key(rowset.segment_metas(position)) != target->second.physical_base_key) {
                     return Status::Corruption(
                             fmt::format("tablet merge source-live RSSID {} disagrees with target {} physical base",
                                         source_rssid, target_rssid));
                 }
-                auto [iter, inserted] =
-                        result[context_index].try_emplace(source_rssid, PreflightSourceSegment{target_rssid});
-                if (!inserted && iter->second.target_rssid != target_rssid) {
+                auto [iter, inserted] = result[context_index].try_emplace(source_rssid, target_rssid);
+                if (!inserted && iter->second != target_rssid) {
                     return Status::Corruption(
                             fmt::format("tablet merge source RSSID {} has conflicting physical bases", source_rssid));
                 }
@@ -2485,16 +2483,16 @@ Status validate_idg_entry_shape(const IndexDeltaGroupEntryPB& entry) {
 
 struct PreflightSidecarDeclaration {
     std::string declaration;
-    std::string physical_base;
+    std::string physical_base_key;
 };
 
 Status register_preflight_sidecar(std::string_view kind, const std::string& filename, const std::string& declaration,
-                                  const SegmentMetadataPB& physical_base,
+                                  const std::string& physical_base_key,
                                   std::map<std::string, PreflightSidecarDeclaration>* registry) {
-    const std::string base = physical_base.SerializeAsString();
-    auto [iter, inserted] = registry->try_emplace(filename, PreflightSidecarDeclaration{declaration, base});
+    auto [iter, inserted] =
+            registry->try_emplace(filename, PreflightSidecarDeclaration{declaration, physical_base_key});
     if (inserted) return Status::OK();
-    if (iter->second.physical_base != base) {
+    if (iter->second.physical_base_key != physical_base_key) {
         return Status::Corruption(
                 fmt::format("tablet merge {} file {} is attached to a different physical base", kind, filename));
     }
@@ -2515,6 +2513,14 @@ Status validate_preflight_sstable_declaration(const PersistentIndexSstablePB& ss
         return Status::Corruption(fmt::format("tablet merge source SST {} has a negative size", sstable.filename()));
     }
     if (sstable.has_shared_rssid()) {
+        if (!has_valid_modern_sstable_shared_version(sstable)) {
+            const std::string version =
+                    sstable.has_shared_version() ? std::to_string(sstable.shared_version()) : "missing";
+            return Status::Corruption(fmt::format(
+                    "tablet merge source SST {} has invalid shared_version {}; modern shared form requires a "
+                    "positive shared_version",
+                    sstable.filename(), version));
+        }
         auto effective = effective_shared_rssid(sstable);
         if (!effective.ok()) {
             return Status::Corruption(fmt::format("tablet merge source SST {} has an invalid shared form: {}",
@@ -2574,11 +2580,11 @@ Status preflight_merge_sources(const std::vector<TabletMergeContext>& contexts,
                 }
                 bool force_target_omission = false;
                 TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_dcg_target_omission", &force_target_omission);
-                if (force_target_omission || !target_segments.contains(source_segment->second.target_rssid)) {
+                auto target_segment = target_segments.find(source_segment->second);
+                if (force_target_omission || target_segment == target_segments.end()) {
                     return Status::Corruption(
                             fmt::format("tablet merge source-live DCG RSSID {} target was omitted", source_rssid));
                 }
-                const auto& target_segment = target_segments.at(source_segment->second.target_rssid);
                 DeltaColumnGroupVerPB normalized(source_dcg);
                 RETURN_IF_ERROR(validate_dcg_shape(normalized));
                 normalize_dcg_optional_fields(&normalized);
@@ -2590,11 +2596,11 @@ Status preflight_merge_sources(const std::vector<TabletMergeContext>& contexts,
                         return Status::Corruption(fmt::format("tablet merge DCG file {} has a negative size",
                                                               normalized.column_files(entry_index)));
                     }
-                    normalized.set_shared_files(entry_index, target_segment.shared);
+                    normalized.set_shared_files(entry_index, target_segment->second.shared);
                     const auto single = make_single_entry_dcg(normalized, entry_index);
                     RETURN_IF_ERROR(register_preflight_sidecar("DCG", normalized.column_files(entry_index),
-                                                               single.SerializeAsString(), target_segment.physical_base,
-                                                               &dcg_files));
+                                                               single.SerializeAsString(),
+                                                               target_segment->second.physical_base_key, &dcg_files));
                 }
             }
         }
@@ -2605,18 +2611,18 @@ Status preflight_merge_sources(const std::vector<TabletMergeContext>& contexts,
                 if (source_segment == source_segments[context_index].end()) continue;
                 bool force_target_omission = false;
                 TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_idg_target_omission", &force_target_omission);
-                if (force_target_omission || !target_segments.contains(source_segment->second.target_rssid)) {
+                auto target_segment = target_segments.find(source_segment->second);
+                if (force_target_omission || target_segment == target_segments.end()) {
                     return Status::Corruption(
                             fmt::format("tablet merge source-live IDG RSSID {} target was omitted", source_rssid));
                 }
-                const auto& target_segment = target_segments.at(source_segment->second.target_rssid);
                 for (const auto& entry : source_idg.entries()) {
                     RETURN_IF_ERROR(validate_idg_entry_shape(entry));
                     IndexDeltaGroupEntryPB stable(entry);
                     stable.clear_dropped_keys();
                     stable.clear_shared_file();
                     RETURN_IF_ERROR(register_preflight_sidecar("IDG", entry.index_file(), stable.SerializeAsString(),
-                                                               target_segment.physical_base, &idg_files));
+                                                               target_segment->second.physical_base_key, &idg_files));
                 }
             }
         }
@@ -2627,7 +2633,7 @@ Status preflight_merge_sources(const std::vector<TabletMergeContext>& contexts,
                 if (source_segment == source_segments[context_index].end()) continue;
                 bool force_target_omission = false;
                 TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_delvec_target_omission", &force_target_omission);
-                if (force_target_omission || !target_segments.contains(source_segment->second.target_rssid)) {
+                if (force_target_omission || !target_segments.contains(source_segment->second)) {
                     return Status::Corruption(
                             fmt::format("tablet merge source-live delvec RSSID {} target was omitted", source_rssid));
                 }
@@ -2755,6 +2761,9 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
             }
             PersistentIndexSstablePB projected(source_sstable);
             if (source_sstable.has_shared_rssid()) {
+                if (!has_valid_modern_sstable_shared_version(source_sstable)) {
+                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
+                }
                 auto source_rssid = effective_shared_rssid(source_sstable);
                 if (!source_rssid.ok()) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
@@ -2901,6 +2910,9 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
         PersistentIndexSstablePB projected(canonical_sstable);
         projected.set_shared(true);
         if (canonical_sstable.has_shared_rssid()) {
+            if (!has_valid_modern_sstable_shared_version(canonical_sstable)) {
+                return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
+            }
             auto source_rssid = effective_shared_rssid(canonical_sstable);
             if (!source_rssid.ok() || extract_rss_rowid_high(canonical_sstable.max_rss_rowid()) != *source_rssid) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -522,6 +522,7 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
         std::vector<SegmentMetadataPB*> references;
     };
     std::map<std::string, bool> bundled_by_filename;
+    std::map<std::string, std::map<int64_t, int64_t>> bundled_intervals_by_filename;
     std::map<std::pair<std::string, int64_t>, PhysicalSliceDeclaration> declarations_by_physical_slice;
     for (auto& canonical : *canonicals) {
         RETURN_IF_ERROR(validate_physical_rowset_shape(canonical.source_form_rowset));
@@ -532,6 +533,11 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
                 return Status::Corruption(
                         fmt::format("tablet merge physical segment file {} mixes bundled and standalone forms",
                                     segment.filename()));
+            }
+            if (segment.has_bundle_file_offset()) {
+                const int64_t bundle_end = static_cast<int64_t>(static_cast<uint64_t>(segment.bundle_file_offset()) +
+                                                                static_cast<uint64_t>(segment.size()));
+                bundled_intervals_by_filename[segment.filename()].try_emplace(segment.bundle_file_offset(), bundle_end);
             }
             const auto slice = std::pair{segment.filename(),
                                          segment.has_bundle_file_offset() ? segment.bundle_file_offset() : int64_t{0}};
@@ -546,6 +552,17 @@ Status normalize_cross_target_physical_ownership(std::vector<CanonicalAllocation
                                     slice.first, slice.second));
             }
             iter->second.references.emplace_back(&segment);
+        }
+    }
+    for (const auto& [filename, intervals] : bundled_intervals_by_filename) {
+        std::optional<std::pair<int64_t, int64_t>> previous;
+        for (const auto& [begin, end] : intervals) {
+            if (previous.has_value() && begin < previous->second) {
+                return Status::Corruption(fmt::format(
+                        "tablet merge physical segment file {} has overlapping bundled slices [{}, {}) and [{}, {})",
+                        filename, previous->first, previous->second, begin, end));
+            }
+            previous = std::pair{begin, end};
         }
     }
     for (auto& [slice, declaration] : declarations_by_physical_slice) {

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -1780,10 +1780,9 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
     struct TargetWorkItem {
         const TargetSegmentDeclaration* declaration = nullptr;
         std::vector<IndexDeltaGroupEntryPB> entries;
+        std::unordered_map<std::string, size_t> seen_files;
     };
     std::map<uint32_t, TargetWorkItem> work_by_target;
-    // target rssid -> (.idx filename -> index into work_by_target[target]).
-    std::map<uint32_t, std::unordered_map<std::string, size_t>> seen_files_by_target;
 
     for (size_t context_index = 0; context_index < merge_contexts.size(); ++context_index) {
         const auto& context = merge_contexts[context_index];
@@ -1806,19 +1805,21 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
                 return Status::Corruption(fmt::format("tablet merge source-live IDG RSSID {} maps to missing target {}",
                                                       segment_id, target_rssid));
             }
-            auto& target_work = work_by_target[target_rssid];
-            target_work.declaration = &target_segment->second;
+            auto target_work_it =
+                    work_by_target.try_emplace(target_rssid, TargetWorkItem{.declaration = &target_segment->second})
+                            .first;
+            auto& target_work = target_work_it->second;
+            DCHECK(target_work.declaration == &target_segment->second);
             auto& entries = target_work.entries;
-            auto& seen = seen_files_by_target[target_rssid];
             for (const auto& entry : idg_ver.entries()) {
                 if (!entry.has_index_file() || entry.index_file().empty()) continue;
-                auto seen_it = seen.find(entry.index_file());
-                if (seen_it != seen.end()) {
+                auto seen_it = target_work.seen_files.find(entry.index_file());
+                if (seen_it != target_work.seen_files.end()) {
                     union_idg_dropped_keys(&entries[seen_it->second], entry); // same physical .idx
                     continue;
                 }
                 // shared_file is derived from the target segment's ownership in the emit loop.
-                seen[entry.index_file()] = entries.size();
+                target_work.seen_files[entry.index_file()] = entries.size();
                 entries.push_back(entry);
             }
         }

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -952,11 +952,17 @@ Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContex
             for (int segment_position = 0; segment_position < rowset.segment_metas_size(); ++segment_position) {
                 uint32_t original_rssid = get_rssid(rowset, segment_position);
                 auto target_or = allocation_plan.projections[old_tablet_index].map_occurrence_rssid(original_rssid);
-                if (!target_or.ok()) continue;
+                if (!target_or.ok()) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge source-live DCG RSSID {} has no target", original_rssid));
+                }
                 uint32_t target_rssid = *target_or;
                 bool force_target_omission = false;
                 TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_dcg_target_omission", &force_target_omission);
-                if (force_target_omission) continue;
+                if (force_target_omission) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge source-live DCG RSSID {} target was omitted", original_rssid));
+                }
                 DcgSourceRowsetReference source_reference;
                 source_reference.old_tablet_index = old_tablet_index;
                 if (rowset.has_range()) {
@@ -1642,9 +1648,13 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
                              allocation_plan.projections[context_index].map_occurrence_rssid(segment_id));
             bool force_target_omission = false;
             TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_idg_target_omission", &force_target_omission);
-            if (force_target_omission) continue;
+            if (force_target_omission) {
+                return Status::Corruption(
+                        fmt::format("tablet merge source-live IDG RSSID {} target was omitted", segment_id));
+            }
             if (!target_rssid_shared.contains(target_rssid)) {
-                continue; // defensive: target not a live merged segment
+                return Status::Corruption(fmt::format("tablet merge source-live IDG RSSID {} maps to missing target {}",
+                                                      segment_id, target_rssid));
             }
             auto& entries = work_by_target[target_rssid];
             auto& seen = seen_files_by_target[target_rssid];
@@ -1849,7 +1859,8 @@ Status inject_synthesized_gaps_into_target_states(TabletManager* tablet_manager,
 }
 
 bool delvec_file_metadata_matches(const FileMetaPB& left, const FileMetaPB& right) {
-    return left.size() == right.size() && left.shared() == right.shared();
+    return left.has_size() == right.has_size() && (!left.has_size() || left.size() == right.size()) &&
+           left.has_shared() == right.has_shared() && (!left.has_shared() || left.shared() == right.shared());
 }
 
 DEFINE_FAIL_POINT(tablet_merge_after_write_delvec);
@@ -1880,9 +1891,13 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
                              allocation_plan.projections[context_index].map_occurrence_rssid(segment_id));
             bool force_target_omission = false;
             TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_delvec_target_omission", &force_target_omission);
-            if (force_target_omission) continue;
+            if (force_target_omission) {
+                return Status::Corruption(
+                        fmt::format("tablet merge source-live delvec RSSID {} target was omitted", segment_id));
+            }
             if (!target_live_rssids.contains(target)) {
-                continue;
+                return Status::Corruption(fmt::format(
+                        "tablet merge source-live delvec RSSID {} maps to missing target {}", segment_id, target));
             }
 
             // Resolve file name from page version
@@ -2097,6 +2112,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
         (*new_delvec_meta.mutable_delvecs())[target] = std::move(new_page);
     }
 
+    new_delvec_file.clear_encryption_meta();
     (*new_delvec_meta.mutable_version_to_file())[new_version] = std::move(new_delvec_file);
     new_metadata->mutable_delvec_meta()->Swap(&new_delvec_meta);
     return Status::OK();
@@ -2312,6 +2328,296 @@ StatusOr<bool> sstable_range_within_tablet(const PersistentIndexSstablePB& sst, 
         return false;
     }
     return true;
+}
+
+SegmentMetadataPB normalized_physical_base(const SegmentMetadataPB& segment) {
+    SegmentMetadataPB normalized(segment);
+    normalized.clear_segment_idx();
+    normalized.clear_shared();
+    return normalized;
+}
+
+struct PreflightTargetSegment {
+    SegmentMetadataPB physical_base;
+};
+
+struct PreflightSourceSegment {
+    uint32_t target_rssid = 0;
+    SegmentMetadataPB physical_base;
+};
+
+StatusOr<std::map<uint32_t, PreflightTargetSegment>> collect_preflight_target_segments(
+        const TabletMergeAllocationPlan& allocation_plan) {
+    std::map<uint32_t, PreflightTargetSegment> result;
+    for (const auto& canonical : allocation_plan.canonicals) {
+        const auto& rowset = canonical.source_form_rowset;
+        const auto& projection = allocation_plan.projections[canonical.selected_context_index];
+        ASSIGN_OR_RETURN(auto target_rowset_id, projection.map_primary_rssid(rowset.id()));
+        for (int position = 0; position < rowset.segment_metas_size(); ++position) {
+            const uint64_t target_rssid = uint64_t{target_rowset_id} + get_segment_idx(rowset, position);
+            if (target_rssid >= allocation_plan.target_next_rowset_id ||
+                target_rssid > std::numeric_limits<uint32_t>::max()) {
+                return Status::Corruption("tablet merge planned target segment exceeds its authoritative cursor");
+            }
+            PreflightTargetSegment candidate{normalized_physical_base(rowset.segment_metas(position))};
+            auto [iter, inserted] = result.try_emplace(static_cast<uint32_t>(target_rssid), std::move(candidate));
+            if (!inserted) {
+                return Status::Corruption(
+                        fmt::format("tablet merge target RSSID {} has duplicate physical bases", target_rssid));
+            }
+        }
+    }
+    return result;
+}
+
+StatusOr<std::vector<std::map<uint32_t, PreflightSourceSegment>>> collect_preflight_source_segments(
+        const std::vector<TabletMergeContext>& contexts, const TabletMergeAllocationPlan& allocation_plan,
+        const std::map<uint32_t, PreflightTargetSegment>& target_segments) {
+    std::vector<std::map<uint32_t, PreflightSourceSegment>> result(contexts.size());
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        for (const auto& rowset : contexts[context_index].metadata()->rowsets()) {
+            for (int position = 0; position < rowset.segment_metas_size(); ++position) {
+                const uint32_t source_rssid = get_rssid(rowset, position);
+                ASSIGN_OR_RETURN(auto target_rssid,
+                                 allocation_plan.projections[context_index].map_occurrence_rssid(source_rssid));
+                auto target = target_segments.find(target_rssid);
+                if (target == target_segments.end()) {
+                    return Status::Corruption(fmt::format("tablet merge source-live RSSID {} maps to missing target {}",
+                                                          source_rssid, target_rssid));
+                }
+                auto physical_base = normalized_physical_base(rowset.segment_metas(position));
+                if (physical_base.SerializeAsString() != target->second.physical_base.SerializeAsString()) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge source-live RSSID {} disagrees with target {} physical base",
+                                        source_rssid, target_rssid));
+                }
+                auto [iter, inserted] = result[context_index].try_emplace(
+                        source_rssid, PreflightSourceSegment{target_rssid, std::move(physical_base)});
+                if (!inserted && (iter->second.target_rssid != target_rssid ||
+                                  iter->second.physical_base.SerializeAsString() !=
+                                          target->second.physical_base.SerializeAsString())) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge source RSSID {} has conflicting physical bases", source_rssid));
+                }
+            }
+        }
+    }
+    return result;
+}
+
+Status validate_idg_entry_shape(const IndexDeltaGroupEntryPB& entry) {
+    if (!entry.has_index_file() || entry.index_file().empty()) {
+        return Status::Corruption("tablet merge IDG entry has a missing or empty filename");
+    }
+    if (entry.has_file_size() && entry.file_size() < 0) {
+        return Status::Corruption(fmt::format("tablet merge IDG file {} has a negative size", entry.index_file()));
+    }
+    std::unordered_set<uint64_t> declared_keys;
+    for (const auto& key : entry.keys()) {
+        if (!key.has_col_unique_id() || !key.has_index_type()) {
+            return Status::Corruption(
+                    fmt::format("tablet merge IDG file {} has an incomplete declared key", entry.index_file()));
+        }
+        if (!declared_keys.insert(idg_pack_key(key.col_unique_id(), key.index_type())).second) {
+            return Status::Corruption(
+                    fmt::format("tablet merge IDG file {} has a duplicate declared key", entry.index_file()));
+        }
+    }
+    for (const auto& key : entry.dropped_keys()) {
+        if (!key.has_col_unique_id() || !key.has_index_type()) {
+            return Status::Corruption(
+                    fmt::format("tablet merge IDG file {} has an incomplete dropped key", entry.index_file()));
+        }
+    }
+    return Status::OK();
+}
+
+struct PreflightSidecarDeclaration {
+    std::string declaration;
+    std::string physical_base;
+};
+
+Status register_preflight_sidecar(std::string_view kind, const std::string& filename, const std::string& declaration,
+                                  const SegmentMetadataPB& physical_base,
+                                  std::map<std::string, PreflightSidecarDeclaration>* registry) {
+    const std::string base = physical_base.SerializeAsString();
+    auto [iter, inserted] = registry->try_emplace(filename, PreflightSidecarDeclaration{declaration, base});
+    if (inserted) return Status::OK();
+    if (iter->second.physical_base != base) {
+        return Status::Corruption(
+                fmt::format("tablet merge {} file {} is attached to a different physical base", kind, filename));
+    }
+    if (iter->second.declaration != declaration) {
+        return Status::Corruption(fmt::format(
+                "tablet merge {} file {} has conflicting physical declarations (unique_column_ids/keys, version, "
+                "size, encryption, presence, or unknown fields differ)",
+                kind, filename));
+    }
+    return Status::OK();
+}
+
+Status preflight_merge_sources(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& contexts,
+                               const TabletMergeAllocationPlan& allocation_plan, int64_t target_tablet_id,
+                               int64_t target_version) {
+    (void)tablet_manager;
+    ASSIGN_OR_RETURN(const auto target_segments, collect_preflight_target_segments(allocation_plan));
+    ASSIGN_OR_RETURN(const auto source_segments,
+                     collect_preflight_source_segments(contexts, allocation_plan, target_segments));
+
+    std::map<std::string, PreflightSidecarDeclaration> dcg_files;
+    std::map<std::string, PreflightSidecarDeclaration> idg_files;
+    std::map<std::string, FileMetaPB> delvec_files;
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        const auto& metadata = *contexts[context_index].metadata();
+
+        if (metadata.has_dcg_meta()) {
+            for (const auto& [source_rssid, source_dcg] : metadata.dcg_meta().dcgs()) {
+                auto source_segment = source_segments[context_index].find(source_rssid);
+                if (source_segment == source_segments[context_index].end()) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge stale DCG RSSID {} has no live source segment", source_rssid));
+                }
+                bool force_target_omission = false;
+                TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_dcg_target_omission", &force_target_omission);
+                if (force_target_omission || !target_segments.contains(source_segment->second.target_rssid)) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge source-live DCG RSSID {} target was omitted", source_rssid));
+                }
+                DeltaColumnGroupVerPB normalized(source_dcg);
+                RETURN_IF_ERROR(validate_dcg_shape(normalized));
+                normalize_dcg_optional_fields(&normalized);
+                for (int entry_index = 0; entry_index < normalized.column_files_size(); ++entry_index) {
+                    if (normalized.column_files(entry_index).empty()) {
+                        return Status::Corruption("tablet merge DCG entry has an empty filename");
+                    }
+                    if (normalized.column_file_sizes(entry_index) < 0) {
+                        return Status::Corruption(fmt::format("tablet merge DCG file {} has a negative size",
+                                                              normalized.column_files(entry_index)));
+                    }
+                    const auto single = make_single_entry_dcg(normalized, entry_index);
+                    RETURN_IF_ERROR(register_preflight_sidecar("DCG", normalized.column_files(entry_index),
+                                                               single.SerializeAsString(),
+                                                               source_segment->second.physical_base, &dcg_files));
+                }
+            }
+        }
+
+        if (metadata.has_idg_meta()) {
+            for (const auto& [source_rssid, source_idg] : metadata.idg_meta().idgs()) {
+                auto source_segment = source_segments[context_index].find(source_rssid);
+                if (source_segment == source_segments[context_index].end()) continue;
+                bool force_target_omission = false;
+                TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_idg_target_omission", &force_target_omission);
+                if (force_target_omission || !target_segments.contains(source_segment->second.target_rssid)) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge source-live IDG RSSID {} target was omitted", source_rssid));
+                }
+                for (const auto& entry : source_idg.entries()) {
+                    RETURN_IF_ERROR(validate_idg_entry_shape(entry));
+                    IndexDeltaGroupEntryPB stable(entry);
+                    stable.clear_dropped_keys();
+                    stable.clear_shared_file();
+                    RETURN_IF_ERROR(register_preflight_sidecar("IDG", entry.index_file(), stable.SerializeAsString(),
+                                                               source_segment->second.physical_base, &idg_files));
+                }
+            }
+        }
+
+        if (metadata.has_delvec_meta()) {
+            for (const auto& [source_rssid, page] : metadata.delvec_meta().delvecs()) {
+                auto source_segment = source_segments[context_index].find(source_rssid);
+                if (source_segment == source_segments[context_index].end()) continue;
+                bool force_target_omission = false;
+                TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_delvec_target_omission", &force_target_omission);
+                if (force_target_omission || !target_segments.contains(source_segment->second.target_rssid)) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge source-live delvec RSSID {} target was omitted", source_rssid));
+                }
+                auto file = metadata.delvec_meta().version_to_file().find(page.version());
+                if (file == metadata.delvec_meta().version_to_file().end()) {
+                    return Status::Corruption(
+                            fmt::format("tablet merge live delvec page has no file for version {}", page.version()));
+                }
+                const auto& declaration = file->second;
+                if (!declaration.has_name() || declaration.name().empty()) {
+                    return Status::Corruption("tablet merge live delvec page has a missing or empty filename");
+                }
+                if (declaration.has_size()) {
+                    if (declaration.size() < 0) {
+                        return Status::Corruption(
+                                fmt::format("tablet merge delvec file {} has a negative size", declaration.name()));
+                    }
+                    const uint64_t file_size = declaration.size();
+                    if (page.offset() > file_size || page.size() > file_size - page.offset()) {
+                        return Status::Corruption(
+                                fmt::format("tablet merge delvec page exceeds file {} bounds", declaration.name()));
+                    }
+                }
+                auto [iter, inserted] = delvec_files.try_emplace(declaration.name(), declaration);
+                if (!inserted && !delvec_file_metadata_matches(iter->second, declaration)) {
+                    return Status::Corruption(fmt::format(
+                            "Delvec actual page source metadata mismatch for file {} during tablet merge preflight",
+                            declaration.name()));
+                }
+            }
+        }
+    }
+
+    bool has_source_sstable = false;
+    bool has_sstable_range = false;
+    for (const auto& context : contexts) {
+        for (const auto& sstable : context.metadata()->sstable_meta().sstables()) {
+            has_source_sstable = true;
+            has_sstable_range |= sstable.has_range();
+        }
+    }
+    if (!has_source_sstable) return Status::OK();
+
+    TabletMetadataPB target(*contexts.front().metadata());
+    target.set_id(target_tablet_id);
+    target.set_version(target_version);
+    TabletRangePB target_range = contexts.front().metadata()->range();
+    for (size_t i = 1; i < contexts.size(); ++i) {
+        ASSIGN_OR_RETURN(target_range,
+                         tablet_reshard_helper::union_range(target_range, contexts[i].metadata()->range()));
+    }
+    target.mutable_range()->CopyFrom(target_range);
+    if (target.schema().column_size() > 0) {
+        auto range_proof = validate_metadata_reuse_source_ranges(contexts, target);
+        if (!range_proof.ok()) {
+            return Status::Corruption(
+                    fmt::format("tablet merge SST source/target range is invalid: {}", range_proof.status().message()));
+        }
+    } else if (has_sstable_range) {
+        return Status::Corruption("tablet merge SST range cannot be validated without a tablet schema");
+    }
+
+    std::map<std::string, PersistentIndexSstablePB> physical_sstables;
+    for (const auto& context : contexts) {
+        for (const auto& sstable : context.metadata()->sstable_meta().sstables()) {
+            if (!sstable.has_filename() || sstable.filename().empty()) {
+                return Status::Corruption("tablet merge source SST has a missing or empty filename");
+            }
+            if (sstable.has_filesize() && sstable.filesize() < 0) {
+                return Status::Corruption(
+                        fmt::format("tablet merge source SST {} has a negative size", sstable.filename()));
+            }
+            auto [iter, inserted] = physical_sstables.try_emplace(sstable.filename(), sstable);
+            if (!inserted) {
+                const auto& existing = iter->second;
+                const bool size_matches = existing.has_filesize() == sstable.has_filesize() &&
+                                          (!existing.has_filesize() || existing.filesize() == sstable.filesize());
+                const bool encryption_matches =
+                        existing.has_encryption_meta() == sstable.has_encryption_meta() &&
+                        (!existing.has_encryption_meta() || existing.encryption_meta() == sstable.encryption_meta());
+                if (!size_matches || !encryption_matches) {
+                    return Status::Corruption(fmt::format(
+                            "tablet merge source SST {} has conflicting physical metadata", sstable.filename()));
+                }
+            }
+        }
+    }
+    return Status::OK();
 }
 
 void order_and_assign_singleton_filesets(PersistentIndexSstableMetaPB* metadata) {
@@ -2889,6 +3195,9 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
                          tablet_reshard_helper::union_range(merged_range, merge_contexts[i].metadata()->range()));
     }
     new_tablet_metadata->mutable_range()->CopyFrom(merged_range);
+
+    RETURN_IF_ERROR(preflight_merge_sources(tablet_manager, merge_contexts, allocation_plan,
+                                            merging_tablet.new_tablet_id(), new_version));
 
     FAIL_POINT_TRIGGER_RETURN_ERROR(tablet_merge_after_rssid_reassign);
 

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -110,52 +110,8 @@ public:
     // include freshly-flushed PK-index sstables).
     void set_metadata(TabletMetadataPtr metadata) { _metadata = std::move(metadata); }
 
-    int64_t rssid_offset() const { return _rssid_offset; }
-    void set_rssid_offset(int64_t offset) { _rssid_offset = offset; }
-
-    // Maps an original rssid to the final output rssid. Lookup priority:
-    //   (1) shared_rssid_map for runtime-deduped old-tablet-local mappings.
-    //   (2) natural offset (rssid + ctx.rssid_offset).
-    StatusOr<uint32_t> map_rssid(uint32_t rssid) const {
-        auto it = _shared_rssid_map.find(rssid);
-        if (it != _shared_rssid_map.end()) {
-            return it->second;
-        }
-        int64_t mapped = static_cast<int64_t>(rssid) + _rssid_offset;
-        if (mapped < 0 || mapped > static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
-            return Status::InvalidArgument("Segment id overflow during tablet merge");
-        }
-        return static_cast<uint32_t>(mapped);
-    }
-
-    bool has_shared_rssid_mapping() const { return !_shared_rssid_map.empty(); }
-
-    // Fills shared_rssid_map so that all rssids occupied by |rowset| map to
-    // the corresponding rssid in |canonical_rowset|.
-    void update_shared_rssid_map(const RowsetMetadataPB& rowset, const RowsetMetadataPB& canonical_rowset) {
-        uint32_t canonical_rssid = canonical_rowset.id();
-        _shared_rssid_map[rowset.id()] = canonical_rssid;
-        for (int segment_pos = 0; segment_pos < rowset.segment_metas_size(); ++segment_pos) {
-            uint32_t rssid = get_rssid(rowset, segment_pos);
-            uint32_t segment_offset_within_rowset = rssid - rowset.id();
-            _shared_rssid_map[rssid] = canonical_rssid + segment_offset_within_rowset;
-        }
-    }
-
-    bool has_next_rowset() const { return _current_rowset_index < _metadata->rowsets_size(); }
-    int current_rowset_index() const { return _current_rowset_index; }
-    const RowsetMetadataPB& current_rowset() const { return _metadata->rowsets(_current_rowset_index); }
-    void advance_rowset() { ++_current_rowset_index; }
-
 private:
     TabletMetadataPtr _metadata;
-    int64_t _rssid_offset = 0;
-    int _current_rowset_index = 0;
-    // Dedup-produced rssid remap table.
-    // key: original rssid in this old tablet metadata
-    // value: canonical rowset's actual rssid in the final output
-    // rssid not in this map uses the default offset mapping.
-    std::unordered_map<uint32_t, uint32_t> _shared_rssid_map;
 };
 
 // PersistentIndexSstablePB::max_rss_rowid encodes (rssid << 32) | rowid.
@@ -230,6 +186,146 @@ struct RowsetEmissionDecision {
 };
 
 using RowsetEmissionPlan = std::vector<std::vector<RowsetEmissionDecision>>;
+
+struct RssidTranslationRun {
+    uint64_t source_begin;
+    uint64_t source_end;
+    uint32_t target_begin;
+};
+
+class RssidProjection {
+public:
+    Status build(std::vector<std::pair<uint64_t, uint64_t>> atoms, uint32_t target_begin) {
+        _runs.clear();
+        _occurrence_aliases.clear();
+        _divergent_alias_keys.clear();
+        _target_end = target_begin;
+        std::sort(atoms.begin(), atoms.end());
+        std::vector<std::pair<uint64_t, uint64_t>> merged;
+        for (const auto& [begin, end] : atoms) {
+            if (begin >= end || end > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+                return Status::InvalidArgument("tablet merge source RSSID interval is outside the supported domain");
+            }
+            if (merged.empty() || begin > merged.back().second) {
+                merged.emplace_back(begin, end);
+            } else {
+                merged.back().second = std::max(merged.back().second, end);
+            }
+        }
+        uint64_t cursor = target_begin;
+        for (const auto& [begin, end] : merged) {
+            const uint64_t length = end - begin;
+            if (cursor + length > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+                return Status::InvalidArgument("tablet merge exhausts the supported rssid allocation domain");
+            }
+            _runs.emplace_back(RssidTranslationRun{begin, end, static_cast<uint32_t>(cursor)});
+            cursor += length;
+        }
+        _target_end = static_cast<uint32_t>(cursor);
+        return Status::OK();
+    }
+
+    StatusOr<uint32_t> map_primary_rssid(uint32_t source) const {
+        auto iter = std::upper_bound(
+                _runs.begin(), _runs.end(), static_cast<uint64_t>(source),
+                [](uint64_t value, const RssidTranslationRun& run) { return value < run.source_begin; });
+        if (iter == _runs.begin()) {
+            return Status::Corruption(fmt::format("tablet merge primary RSSID {} is not planned", source));
+        }
+        --iter;
+        if (source >= iter->source_end) {
+            return Status::Corruption(fmt::format("tablet merge primary RSSID {} is not planned", source));
+        }
+        const uint64_t mapped = static_cast<uint64_t>(iter->target_begin) + source - iter->source_begin;
+        if (mapped >= _target_end) {
+            return Status::Corruption("tablet merge primary RSSID maps beyond its projection");
+        }
+        return static_cast<uint32_t>(mapped);
+    }
+
+    StatusOr<uint32_t> map_occurrence_rssid(uint32_t source) const {
+        auto alias = _occurrence_aliases.find(source);
+        if (alias != _occurrence_aliases.end()) return alias->second;
+        return map_primary_rssid(source);
+    }
+
+    Status add_occurrence_alias(uint32_t source, uint32_t target) {
+        auto [iter, inserted] = _occurrence_aliases.try_emplace(source, target);
+        if (!inserted && iter->second != target) {
+            return Status::Corruption(fmt::format("tablet merge occurrence RSSID {} has conflicting aliases", source));
+        }
+        return Status::OK();
+    }
+
+    Status finalize_aliases() {
+        _divergent_alias_keys.clear();
+        for (const auto& [source, target] : _occurrence_aliases) {
+            auto primary = map_primary_rssid(source);
+            if (primary.ok() && primary.value() != target) _divergent_alias_keys.emplace_back(source);
+        }
+        return Status::OK();
+    }
+
+    StatusOr<std::optional<int64_t>> affine_delta(uint64_t begin, uint64_t end) const {
+        if (begin >= end || end > uint64_t{std::numeric_limits<uint32_t>::max()} + 1) {
+            return std::optional<int64_t>{};
+        }
+        auto iter = std::upper_bound(
+                _runs.begin(), _runs.end(), begin,
+                [](uint64_t value, const RssidTranslationRun& run) { return value < run.source_begin; });
+        if (iter == _runs.begin()) return std::optional<int64_t>{};
+        --iter;
+        if (begin < iter->source_begin || end > iter->source_end) return std::optional<int64_t>{};
+        auto alias = std::lower_bound(_divergent_alias_keys.begin(), _divergent_alias_keys.end(), begin);
+        if (alias != _divergent_alias_keys.end() && *alias < end) return std::optional<int64_t>{};
+        return std::optional<int64_t>{static_cast<int64_t>(iter->target_begin) -
+                                      static_cast<int64_t>(iter->source_begin)};
+    }
+
+    StatusOr<std::optional<int64_t>> conservative_context_delta() const {
+        if (_runs.size() != 1 || !_occurrence_aliases.empty()) return std::optional<int64_t>{};
+        return std::optional<int64_t>{static_cast<int64_t>(_runs.front().target_begin) -
+                                      static_cast<int64_t>(_runs.front().source_begin)};
+    }
+
+    bool has_divergent_occurrence_alias(uint32_t source) const {
+        return std::binary_search(_divergent_alias_keys.begin(), _divergent_alias_keys.end(), source);
+    }
+
+    uint32_t target_end() const { return _target_end; }
+
+private:
+    std::vector<RssidTranslationRun> _runs;
+    std::map<uint32_t, uint32_t> _occurrence_aliases;
+    std::vector<uint32_t> _divergent_alias_keys;
+    uint32_t _target_end = 1;
+};
+
+struct ValidationOnlyDelOccurrence {
+    size_t context_index;
+    int rowset_index;
+    int del_index;
+    uint32_t current_max_segment_idx;
+};
+
+struct CanonicalAllocationPlan {
+    size_t selected_context_index = 0;
+    int selected_rowset_index = -1;
+    int output_index = -1;
+    RowsetMetadataPB source_form_rowset;
+    std::optional<int64_t> schema_id;
+    std::vector<TabletRangePB> contributor_ranges;
+    std::vector<ValidationOnlyDelOccurrence> validation_only_dels;
+};
+
+struct TabletMergeAllocationPlan {
+    RowsetEmissionPlan emission;
+    std::vector<CanonicalAllocationPlan> canonicals;
+    std::vector<RssidProjection> projections;
+    uint32_t target_next_rowset_id = 1;
+};
+
+DEFINE_FAIL_POINT(tablet_merge_before_delete_predicate_range);
 
 struct PlannedCanonicalRowset {
     const RowsetMetadataPB* rowset = nullptr;
@@ -331,365 +427,356 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
     return plan;
 }
 
-// True when |rowset|'s own ids still reach the merged namespace through
-// ctx.rssid_offset instead of being redirected to a canonical rowset.
-//
-// Emitted rowsets always do. Among duplicate rowsets, only delete predicates do:
-// merge_rowsets calls update_shared_rssid_map for a duplicate exactly when it is not
-// a delete predicate, so a deduped predicate's id keeps falling through map_rssid's
-// natural-offset branch while a deduped data rowset's id and segment rssids resolve
-// to the canonical rowset an earlier input already emitted. Physically empty rowsets
-// without delete metadata are discarded and reserve no projected ids.
-//
-// The floor (compute_rssid_offset) and the ceiling (compute_cumulative_rowset_id_ceiling)
-// must agree on this set. If the ceiling covers more, a later input is lifted over ids
-// nobody occupies and can overflow map_rssid near UINT32_MAX; if it covers less, a later
-// input lands on ids an earlier input still projects into.
-bool projects_via_rssid_offset(const RowsetEmissionDecision& decision, const RowsetMetadataPB& rowset) {
-    return !decision.discard && (decision.emit || rowset.has_delete_predicate());
+std::optional<int64_t> rowset_schema_id(const TabletMergeContext& context, uint32_t rowset_id) {
+    const auto& mapping = context.metadata()->rowset_to_schema();
+    auto iter = mapping.find(rowset_id);
+    if (iter == mapping.end()) return std::nullopt;
+    return iter->second;
 }
 
-// Shift that lifts the rowset-id space that |append_index| projects through its own
-// rssid_offset above |base_metadata|'s watermark, so the two can be concatenated
-// without collisions.
-//
-// The floor includes every rowset id or rowset-id reference that add_rowset()
-// carries into the merged metadata:
-//   * rowset.id
-//   * max_compact_input_rowset_id
-//   * del_files[].origin_rowset_id
-//
-// The latter two can sit below the minimum live rowset id because their referenced
-// compaction inputs have already been erased from rowsets(). Computing the shift from
-// live ids alone can therefore map a dead reference below zero, or into an earlier
-// input's live id space. Conversely, references from a same-UID sibling copy that
-// merge_rowsets will discard must not lower the floor: they are not carried into the
-// output and can make a high-ID surviving rowset overflow after an unnecessary lift.
-//
-// A discarded delete predicate contributes its id but none of its references: the
-// references die with it, while the id itself still projects naturally (see
-// projects_via_rssid_offset) and must stay disjoint from earlier inputs.
-//
-// Using that floor maps the smallest carried value to base_metadata.next_rowset_id(),
-// keeps all carried references disjoint from earlier inputs, and preserves their
-// relative ordering under the same uniform shift.
-int64_t compute_rssid_offset(const TabletMetadataPB& base_metadata,
-                             const std::vector<TabletMergeContext>& merge_contexts,
-                             const RowsetEmissionPlan& emission_plan, size_t append_index) {
-    uint32_t min_carried_id = std::numeric_limits<uint32_t>::max();
-    const auto& append_metadata = *merge_contexts[append_index].metadata();
-    for (int rowset_index = 0; rowset_index < append_metadata.rowsets_size(); ++rowset_index) {
-        const auto& rowset = append_metadata.rowsets(rowset_index);
-        const auto& decision = emission_plan[append_index][rowset_index];
-        if (!projects_via_rssid_offset(decision, rowset)) continue;
-
-        min_carried_id = std::min(min_carried_id, rowset.id());
-        if (!decision.emit) continue;
-
-        if (rowset.has_max_compact_input_rowset_id()) {
-            min_carried_id = std::min(min_carried_id, rowset.max_compact_input_rowset_id());
-        }
-        for (const auto& del_file : rowset.del_files()) {
-            min_carried_id = std::min(min_carried_id, del_file.origin_rowset_id());
-        }
-    }
-    if (min_carried_id == std::numeric_limits<uint32_t>::max()) {
-        return 0;
-    }
-    return static_cast<int64_t>(base_metadata.next_rowset_id()) - min_carried_id;
-}
-
-DEFINE_FAIL_POINT(tablet_merge_before_delete_predicate_range);
-Status add_rowset(TabletMergeContext& ctx, const RowsetMetadataPB& rowset, TabletMetadataPB* new_metadata) {
-    auto* new_rowset = new_metadata->add_rowsets();
-    new_rowset->CopyFrom(rowset);
-    // rssid mapping
-    ASSIGN_OR_RETURN(auto new_id, ctx.map_rssid(rowset.id()));
-    new_rowset->set_id(new_id);
-    if (rowset.has_max_compact_input_rowset_id()) {
-        ASSIGN_OR_RETURN(auto new_max_compact, ctx.map_rssid(rowset.max_compact_input_rowset_id()));
-        new_rowset->set_max_compact_input_rowset_id(new_max_compact);
-    }
-    for (auto& del : *new_rowset->mutable_del_files()) {
-        ASSIGN_OR_RETURN(auto new_origin, ctx.map_rssid(del.origin_rowset_id()));
-        del.set_origin_rowset_id(new_origin);
-    }
-    // range update
-    if (rowset.has_delete_predicate()) {
-        // update_rowset_range below is what confines this delete predicate to its SOURCE tablet's
-        // range, so that merging tablet A into (A, B) cannot let A's DELETE remove B's rows. This is
-        // the window where the predicate is present but not yet range-confined. Guarded on the
-        // predicate so the hook expresses that window rather than firing on the first rowset of every
-        // merge.
-        FAIL_POINT_TRIGGER_RETURN_ERROR(tablet_merge_before_delete_predicate_range);
-    }
-    RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(new_rowset, ctx.metadata()->range()));
-    // schema mapping
-    const auto& rowset_to_schema = ctx.metadata()->rowset_to_schema();
-    auto schema_it = rowset_to_schema.find(rowset.id());
-    if (schema_it != rowset_to_schema.end()) {
-        (*new_metadata->mutable_rowset_to_schema())[new_rowset->id()] = schema_it->second;
-    }
-    return Status::OK();
-}
-
-// The defaulted bundle-file offset of a segment: an absent offset means 0 (the only or
-// first segment in a bundle), a present one is its byte offset into the shared file.
-int64_t segment_bundle_offset(const SegmentMetadataPB& seg) {
-    return seg.has_bundle_file_offset() ? seg.bundle_file_offset() : 0;
-}
-
-// Physical identity of a segment: (filename, bundle_file_offset). File bundling packs
-// several segments into one physical file distinguished only by offset, so filename alone
-// is insufficient. Used both to dedup same-uid sibling segments at the same segment_idx
-// and to detect whether two siblings' segment lists already match.
-bool same_segment_identity(const SegmentMetadataPB& a, const SegmentMetadataPB& b) {
-    return a.filename() == b.filename() && segment_bundle_offset(a) == segment_bundle_offset(b);
-}
-
-// Union the duplicate's segments into the canonical for two same-uid sibling rowsets,
-// so the merged rowset reconstructs the ancestor rowset's full segment set. Dedup by
-// segment_idx — the rssid key (rowset.id + segment_idx) — so the merged rowset can
-// never hold two segments at the same index. The output is written back to canonical
-// sorted by segment_idx, matching the ancestor rowset's logical segment layout. Note
-// this ordering alone does NOT prove key-range non-overlap, so the caller still
-// conservatively sets overlapped=true after a union that leaves >1 segment. Each
-// SegmentMetadataPB is the self-contained canonical home for a segment's file
-// attributes (filename/size/encryption_meta/shared/bundle_file_offset) plus segment_idx,
-// so the union simply merges the segment_metas[] repeated field — there are no parallel
-// arrays to keep in lockstep — and segment_idx is preserved verbatim, keeping the merge
-// rssid map valid.
-Status union_segments_by_idx(RowsetMetadataPB* canonical, const RowsetMetadataPB& duplicate) {
-    // A contributor with zero segments (all of them pruned to other new tablets) adds
-    // nothing; return early.
-    if (duplicate.segment_metas_size() == 0) {
-        return Status::OK();
-    }
-
-    // Build the union keyed on segment_idx so the merged rowset's segment_metas[] is
-    // sorted by segment_idx (the rssid space rowset.id + segment_idx), matching the
-    // ancestor rowset's logical layout. std::map iterates in key order, so writing back
-    // from it restores the sorted layout — readers that iterate by position can rely on
-    // segment_idx monotonicity, and the canonical's original `overlapped` flag stays
-    // meaningful. Two same-uid siblings either share a segment that spanned multiple
-    // ranges (kept by both with identical segment_idx AND identity) or own disjoint
-    // pruned segments (distinct segment_idx). Deduping on segment_idx guarantees the
-    // merged rowset never holds two segments at the same index, which would collide in
-    // the rssid space.
-    std::map<uint32_t, SegmentMetadataPB> by_segment_idx;
+Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* occurrence) {
+    std::map<uint32_t, SegmentMetadataPB> by_index;
     auto ingest = [&](const RowsetMetadataPB& source) -> Status {
         for (int position = 0; position < source.segment_metas_size(); ++position) {
-            const uint32_t segment_idx = get_segment_idx(source, position);
-            const auto& seg = source.segment_metas(position);
-            auto [iter, inserted] = by_segment_idx.try_emplace(segment_idx);
+            const uint32_t index = get_segment_idx(source, position);
+            SegmentMetadataPB candidate(source.segment_metas(position));
+            candidate.set_segment_idx(index);
+            const bool candidate_shared = candidate.shared();
+            SegmentMetadataPB stable_candidate(candidate);
+            stable_candidate.clear_shared();
+            auto [iter, inserted] = by_index.try_emplace(index, candidate);
             if (inserted) {
-                iter->second = seg;
+                iter->second.set_shared(candidate_shared);
                 continue;
             }
-            // A spanning segment is kept by both siblings with the same segment_idx. Its
-            // identity is (filename, bundle_file_offset): file bundling packs several
-            // segments into one physical file, so distinct segments can share a file name
-            // and differ only by offset. A same-idx-but-different-identity pair cannot
-            // arise for one uid (a rewrite re-mints the uid, so it never reaches this
-            // dedup) and fails closed rather than silently dropping a slice.
-            if (iter->second.filename() != seg.filename()) {
+            SegmentMetadataPB stable_existing(iter->second);
+            stable_existing.set_segment_idx(index);
+            stable_existing.clear_shared();
+            if (stable_existing.SerializeAsString() != stable_candidate.SerializeAsString()) {
                 return Status::Corruption(
-                        "rowset segment union: two siblings carry different files at the same segment_idx");
+                        fmt::format("tablet merge segment declaration conflict at effective index {}", index));
             }
-            if (segment_bundle_offset(iter->second) != segment_bundle_offset(seg)) {
-                return Status::Corruption(
-                        "rowset segment union: two siblings carry the same segment_idx and file but different "
-                        "bundle_file_offsets");
-            }
+            iter->second.set_shared(iter->second.shared() || candidate_shared);
         }
         return Status::OK();
     };
     RETURN_IF_ERROR(ingest(*canonical));
-    RETURN_IF_ERROR(ingest(duplicate));
-
-    // Rewrite canonical's segment_metas in segment_idx order.
+    if (occurrence != nullptr) RETURN_IF_ERROR(ingest(*occurrence));
     canonical->clear_segment_metas();
-    for (auto& [segment_idx, seg] : by_segment_idx) {
-        *canonical->add_segment_metas() = std::move(seg);
+    for (auto& [index, segment] : by_index) {
+        (void)index;
+        canonical->add_segment_metas()->Swap(&segment);
+    }
+    if (canonical->segment_metas_size() > 1) canonical->set_overlapped(true);
+    return Status::OK();
+}
+
+Status validate_del_replay_span(uint32_t origin, uint32_t offset) {
+    const uint64_t end = static_cast<uint64_t>(origin) + static_cast<uint64_t>(offset) + 1;
+    if (end > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+        return Status::InvalidArgument("tablet merge delete replay span exceeds the supported RSSID domain");
     }
     return Status::OK();
 }
 
-Status update_canonical(RowsetMetadataPB* canonical_rowset, const TabletRangePB& duplicate_effective_range,
-                        const RowsetMetadataPB& duplicate_rowset) {
-    // Always extend the canonical range with the duplicate's *effective* range
-    // (rowset.range, fallback ctx.metadata.range, fallback unbounded — same chain
-    // as Rowset::get_seek_range()). The previous gate of
-    // `canonical_rowset->has_range() && duplicate_rowset.has_range()` silently
-    // dropped contributors whose rowset.range was unset but whose ctx tablet
-    // range filled the slice; the post-dedup canonical.range would then reflect
-    // only the first contributor and readers (which prefer rowset.range over
-    // tablet.range) would miss rows from later contributors.
-    if (canonical_rowset->has_range()) {
-        ASSIGN_OR_RETURN(auto merged_range,
-                         tablet_reshard_helper::union_range(canonical_rowset->range(), duplicate_effective_range));
-        canonical_rowset->mutable_range()->CopyFrom(merged_range);
-    } else {
-        canonical_rowset->mutable_range()->CopyFrom(duplicate_effective_range);
+Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, size_t context_index, int rowset_index,
+                                const RowsetMetadataPB& occurrence) {
+    auto* selected = &canonical->source_form_rowset;
+    if (selected->del_files_size() != occurrence.del_files_size()) {
+        return Status::Corruption("tablet merge duplicate rowset del-file count differs");
     }
-    // Each merge input carries a proportional num_dels slice written by
-    // tablet_splitter.cpp / tablet_reshard_helper.cpp with num_dels <= num_rows.
-    // Summation therefore preserves that invariant on the canonical rowset, so no
-    // clamp is needed. Tablet merge is greenfield; there is no legacy state with
-    // the old tablet's full num_dels inherited by every new tablet to guard against.
-    DCHECK_LE(canonical_rowset->num_dels(), canonical_rowset->num_rows());
-    DCHECK_LE(duplicate_rowset.num_dels(), duplicate_rowset.num_rows());
-    canonical_rowset->set_num_rows(canonical_rowset->num_rows() + duplicate_rowset.num_rows());
-    canonical_rowset->set_data_size(canonical_rowset->data_size() + duplicate_rowset.data_size());
-    canonical_rowset->set_num_dels(canonical_rowset->num_dels() + duplicate_rowset.num_dels());
-
-    // Per-segment reconstruction: union the duplicate's segment list into the
-    // canonical so the merged rowset carries every segment its same-uid siblings
-    // contributed. Gate on actual divergence of the segment lists rather than the
-    // shared=false flag: a multi-level split can produce same-uid siblings with
-    // DISJOINT all-shared segment subsets (compute_rowset_segment_ownership keeps
-    // shared=true when the source segment was already shared, regardless of overlap count), so a
-    // shared=false filter alone would skip those unions and silently lose data. When
-    // the lists already match (cross-publish — identical segments across siblings),
-    // the union would be a no-op and is skipped.
-    // A segment's identity is (file, bundle_file_offset): file bundling packs several
-    // segments into one physical file, so distinct segments can share a file name and
-    // differ only by offset. Comparing file names alone would treat two siblings that
-    // carry different bundled segments (same names, different offsets) as identical and
-    // skip the union, silently dropping a sibling's segments. Compare offsets too.
-    // Comparing (file, offset) rather than the union's segment_idx dedup key is sound:
-    // the split preserves a segment's file, offset, and segment_idx together, so for
-    // same-uid siblings identical (file, offset) lists imply identical segment_idx lists
-    // -- i.e. the union really would be a no-op exactly when this skip fires.
-    auto segment_lists_differ = [](const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
-        if (a.segment_metas_size() != b.segment_metas_size()) return true;
-        for (int i = 0; i < a.segment_metas_size(); ++i) {
-            if (!same_segment_identity(a.segment_metas(i), b.segment_metas(i))) return true;
+    const uint32_t current_max = get_max_segment_idx(occurrence);
+    for (int del_index = 0; del_index < selected->del_files_size(); ++del_index) {
+        auto* selected_del = selected->mutable_del_files(del_index);
+        const auto& occurrence_del = occurrence.del_files(del_index);
+        const bool selected_self = selected_del->origin_rowset_id() == selected->id();
+        const bool occurrence_self = occurrence_del.origin_rowset_id() == occurrence.id();
+        if (selected_self != occurrence_self) {
+            return Status::Corruption("tablet merge duplicate del files mix self and inherited origins");
         }
-        return false;
-    };
-    if (segment_lists_differ(*canonical_rowset, duplicate_rowset)) {
-        RETURN_IF_ERROR(union_segments_by_idx(canonical_rowset, duplicate_rowset));
-        // tablet_splitter.cpp resets overlapped=false on a one-segment post-prune
-        // output; if MERGE later unions sibling segments back in, that flag is
-        // stale (segment_idx-sorted ordering does NOT prove key-range non-overlap).
-        // Conservatively force overlapped=true whenever the union leaves more
-        // than one segment on the canonical rowset.
-        if (canonical_rowset->segment_metas_size() > 1) {
-            canonical_rowset->set_overlapped(true);
+        DelfileWithRowsetId stable_selected(*selected_del);
+        DelfileWithRowsetId stable_occurrence(occurrence_del);
+        stable_selected.clear_origin_rowset_id();
+        stable_occurrence.clear_origin_rowset_id();
+        stable_selected.clear_shared();
+        stable_occurrence.clear_shared();
+        if (stable_selected.SerializeAsString() != stable_occurrence.SerializeAsString()) {
+            return Status::Corruption("tablet merge duplicate del-file declaration conflict");
         }
+        selected_del->set_shared(selected_del->shared() || occurrence_del.shared());
+        const uint32_t local_offset = occurrence_del.has_op_offset() ? occurrence_del.op_offset() : current_max;
+        RETURN_IF_ERROR(validate_del_replay_span(occurrence_del.origin_rowset_id(), local_offset));
+        canonical->validation_only_dels.emplace_back(
+                ValidationOnlyDelOccurrence{context_index, rowset_index, del_index, current_max});
     }
     return Status::OK();
 }
 
-Status merge_rowsets(std::vector<TabletMergeContext>& merge_contexts, const RowsetEmissionPlan& emission_plan,
-                     TabletMetadataPB* new_metadata, CanonicalContribMap* canonical_contribs) {
-    for (;;) {
-        // Find old tablet with minimum (version, old_tablet_index).
-        // Forward iteration with strict < ensures the smallest old_tablet_index wins on ties.
-        int min_old_tablet_index = -1;
-        int64_t min_version = std::numeric_limits<int64_t>::max();
-        for (int i = 0; i < static_cast<int>(merge_contexts.size()); ++i) {
-            if (!merge_contexts[i].has_next_rowset()) continue;
-            int64_t version = merge_contexts[i].current_rowset().version();
-            if (version < min_version) {
-                min_version = version;
-                min_old_tablet_index = i;
+Status union_canonical_range(CanonicalAllocationPlan* canonical, const TabletRangePB& occurrence_range) {
+    if (!canonical->source_form_rowset.has_range()) {
+        canonical->source_form_rowset.mutable_range()->CopyFrom(occurrence_range);
+        return Status::OK();
+    }
+    ASSIGN_OR_RETURN(auto united,
+                     tablet_reshard_helper::union_range(canonical->source_form_rowset.range(), occurrence_range));
+    canonical->source_form_rowset.mutable_range()->CopyFrom(united);
+    return Status::OK();
+}
+
+Status validate_primary_affine_span(const RssidProjection& projection, uint64_t begin, uint64_t end,
+                                    std::string_view description) {
+    ASSIGN_OR_RETURN(auto delta, projection.affine_delta(begin, end));
+    if (!delta.has_value()) {
+        return Status::Corruption(fmt::format("tablet merge {} is not primary-affine", description));
+    }
+    return Status::OK();
+}
+
+StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std::vector<TabletMergeContext>& contexts,
+                                                                       bool discard_empty_rowsets) {
+    bool force_context_span_projection = false;
+    TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_context_span_projection", &force_context_span_projection);
+    bool drop_primary_atom = false;
+    TEST_SYNC_POINT_CALLBACK("tablet_merge_test:drop_primary_atom", &drop_primary_atom);
+
+    TabletMergeAllocationPlan result;
+    ASSIGN_OR_RETURN(result.emission, build_rowset_emission_plan(contexts, discard_empty_rowsets));
+    int canonical_count = 0;
+    for (const auto& decisions : result.emission) {
+        for (const auto& decision : decisions)
+            canonical_count = std::max(canonical_count, decision.canonical_index + 1);
+    }
+    result.canonicals.resize(canonical_count);
+
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        const auto& metadata = *contexts[context_index].metadata();
+        for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
+            const auto& decision = result.emission[context_index][rowset_index];
+            if (!decision.emit) continue;
+            const auto& rowset = metadata.rowsets(rowset_index);
+            DCHECK(tablet_reshard_helper::has_valid_uid(rowset))
+                    << "rowset reaching reshard merge must carry a valid uid: rowset_id=" << rowset.id()
+                    << " version=" << rowset.version();
+            if (!tablet_reshard_helper::has_valid_uid(rowset)) {
+                return Status::InternalError("rowset reaching reshard merge has no uid");
             }
-        }
-        if (min_old_tablet_index < 0) break;
-
-        const int source_rowset_index = merge_contexts[min_old_tablet_index].current_rowset_index();
-        const auto& rowset = merge_contexts[min_old_tablet_index].current_rowset();
-        const auto& ctx_meta = *merge_contexts[min_old_tablet_index].metadata();
-
-        // Invariant: every rowset reaching a reshard merge carries a valid uid. Lake
-        // writers mint at creation; split / identical-reshard preserve it via the metadata
-        // copy; cross-publish preserves it via CopyFrom; synthesized rowsets (column-mode
-        // new_rows) derive a deterministic uid from op_write.uid. Range-distribution is a
-        // new feature (no legacy uid-less data), so a missing uid here means a producer
-        // site is uncovered — fail loudly rather than silently miss dedup and emit
-        // duplicate rows.
-        DCHECK(tablet_reshard_helper::has_valid_uid(rowset))
-                << "rowset reaching reshard merge must carry a valid uid: rowset_id=" << rowset.id()
-                << " version=" << rowset.version();
-        if (!tablet_reshard_helper::has_valid_uid(rowset)) {
-            return Status::InternalError(
-                    fmt::format("rowset reaching reshard merge has no uid: rowset_id={} version={}", rowset.id(),
-                                rowset.version()));
-        }
-
-        const auto& decision = emission_plan[min_old_tablet_index][source_rowset_index];
-        if (decision.discard) {
-            merge_contexts[min_old_tablet_index].advance_rowset();
-            continue;
-        }
-        if (decision.emit && decision.non_pk_skip_dedup_fired) {
-            // At least one is_duplicate_rowset hit was rejected due to
-            // non-contiguous ranges and no later candidate accepted it →
-            // the rowset is added as a sibling of an existing shared rowset.
-            g_tablet_merge_non_pk_skip_dedup_total << 1;
-        }
-        if (decision.emit && decision.canonical_index != new_metadata->rowsets_size()) {
-            return Status::InternalError(fmt::format(
-                    "tablet merge rowset emission plan is out of sequence: old_tablet_index={} rowset_index={} "
-                    "planned_index={} actual_index={}",
-                    min_old_tablet_index, source_rowset_index, decision.canonical_index, new_metadata->rowsets_size()));
-        }
-        if (!decision.emit &&
-            (decision.canonical_index < 0 || decision.canonical_index >= new_metadata->rowsets_size())) {
-            return Status::InternalError(fmt::format(
-                    "tablet merge rowset emission plan has invalid canonical index: old_tablet_index={} "
-                    "rowset_index={} canonical_index={} output_size={}",
-                    min_old_tablet_index, source_rowset_index, decision.canonical_index, new_metadata->rowsets_size()));
-        }
-
-        if (!decision.emit) {
-            // Duplicate: skip output
-            const int canonical_index = decision.canonical_index;
-            const auto& canonical = new_metadata->rowsets(canonical_index);
-            // Same-uid siblings legitimately carry different segment lists when split
-            // pruned them to disjoint subsets (whether shared=false per-segment pruning
-            // or shared=true multi-level pruning of already-shared segments), so do NOT assert on
-            // segment count parity — update_canonical's segment_lists_differ gate handles the
-            // segment-list union. del_files are never pruned and stay equal across
-            // siblings, so that invariant is the one worth asserting here.
-            DCHECK_EQ(rowset.del_files_size(), canonical.del_files_size())
-                    << "Shared rowset dedup hit but del_files diverge: " << rowset.del_files_size() << " vs "
-                    << canonical.del_files_size();
+            auto& canonical = result.canonicals[decision.canonical_index];
+            canonical.selected_context_index = context_index;
+            canonical.selected_rowset_index = rowset_index;
+            canonical.output_index = decision.canonical_index;
+            canonical.source_form_rowset.CopyFrom(rowset);
+            RETURN_IF_ERROR(
+                    tablet_reshard_helper::update_rowset_range(&canonical.source_form_rowset, metadata.range()));
+            RETURN_IF_ERROR(reconcile_segments(&canonical.source_form_rowset, nullptr));
+            canonical.schema_id = rowset_schema_id(contexts[context_index], rowset.id());
             if (!rowset.has_delete_predicate()) {
-                merge_contexts[min_old_tablet_index].update_shared_rssid_map(rowset, canonical);
-                // Capture the duplicate's old-tablet-local effective range BEFORE
-                // update_canonical mutates canonical.range via union_range. The
-                // same effective range is also passed into update_canonical so
-                // that a rowset without its own .range() but with a ctx tablet
-                // range still extends the canonical range.
-                const auto& duplicate_effective_range =
-                        tablet_reshard_helper::effective_old_tablet_local_range(rowset, ctx_meta);
-                if (canonical_contribs != nullptr) {
-                    (*canonical_contribs)[canonical_index].push_back(duplicate_effective_range);
-                }
-                RETURN_IF_ERROR(update_canonical(new_metadata->mutable_rowsets(canonical_index),
-                                                 duplicate_effective_range, rowset));
-            }
-            // predicate: just skip
-        } else {
-            // First occurrence: output. Capture old-tablet-local range first so that
-            // we record the pre-clip view (add_rowset clips to ctx tablet range).
-            TabletRangePB initial_old_tablet_range;
-            if (canonical_contribs != nullptr && !rowset.has_delete_predicate()) {
-                initial_old_tablet_range = tablet_reshard_helper::effective_old_tablet_local_range(rowset, ctx_meta);
-            }
-            const int new_index = new_metadata->rowsets_size();
-            RETURN_IF_ERROR(add_rowset(merge_contexts[min_old_tablet_index], rowset, new_metadata));
-            if (canonical_contribs != nullptr && !rowset.has_delete_predicate()) {
-                (*canonical_contribs)[new_index].push_back(std::move(initial_old_tablet_range));
+                canonical.contributor_ranges.emplace_back(
+                        tablet_reshard_helper::effective_old_tablet_local_range(rowset, metadata));
             }
         }
-
-        merge_contexts[min_old_tablet_index].advance_rowset();
     }
 
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        const auto& metadata = *contexts[context_index].metadata();
+        for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
+            const auto& decision = result.emission[context_index][rowset_index];
+            if (decision.discard || decision.emit) continue;
+            const auto& occurrence = metadata.rowsets(rowset_index);
+            DCHECK(tablet_reshard_helper::has_valid_uid(occurrence))
+                    << "rowset reaching reshard merge must carry a valid uid: rowset_id=" << occurrence.id()
+                    << " version=" << occurrence.version();
+            if (!tablet_reshard_helper::has_valid_uid(occurrence)) {
+                return Status::InternalError("rowset reaching reshard merge has no uid");
+            }
+            auto& canonical = result.canonicals[decision.canonical_index];
+            const auto schema_id = rowset_schema_id(contexts[context_index], occurrence.id());
+            if (canonical.schema_id != schema_id) {
+                return Status::Corruption("tablet merge duplicate rowset schema mapping conflict");
+            }
+            const auto& occurrence_range =
+                    tablet_reshard_helper::effective_old_tablet_local_range(occurrence, metadata);
+            if (occurrence.has_delete_predicate()) {
+                if (!canonical.source_form_rowset.has_delete_predicate() ||
+                    canonical.source_form_rowset.delete_predicate().SerializeAsString() !=
+                            occurrence.delete_predicate().SerializeAsString()) {
+                    return Status::Corruption("tablet merge duplicate delete-predicate declaration conflict");
+                }
+                RETURN_IF_ERROR(union_canonical_range(&canonical, occurrence_range));
+                continue;
+            }
+            canonical.contributor_ranges.emplace_back(occurrence_range);
+            RETURN_IF_ERROR(union_canonical_range(&canonical, occurrence_range));
+            canonical.source_form_rowset.set_num_rows(canonical.source_form_rowset.num_rows() + occurrence.num_rows());
+            canonical.source_form_rowset.set_data_size(canonical.source_form_rowset.data_size() +
+                                                       occurrence.data_size());
+            canonical.source_form_rowset.set_num_dels(canonical.source_form_rowset.num_dels() + occurrence.num_dels());
+            RETURN_IF_ERROR(reconcile_segments(&canonical.source_form_rowset, &occurrence));
+            RETURN_IF_ERROR(reconcile_duplicate_dels(&canonical, context_index, rowset_index, occurrence));
+        }
+    }
+
+    std::vector<std::vector<std::pair<uint64_t, uint64_t>>> atoms(contexts.size());
+    std::vector<std::vector<std::pair<uint64_t, uint64_t>>> extents(contexts.size());
+    for (const auto& canonical : result.canonicals) {
+        const auto& rowset = canonical.source_form_rowset;
+        const uint64_t segment_span = rowset.segment_metas_size() == 0 ? 1 : uint64_t{get_max_segment_idx(rowset)} + 1;
+        const uint64_t extent_end = uint64_t{rowset.id()} + segment_span;
+        if (extent_end > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+            return Status::InvalidArgument("tablet merge rowset extent exceeds the supported RSSID domain");
+        }
+        auto& context_atoms = atoms[canonical.selected_context_index];
+        context_atoms.emplace_back(rowset.id(), extent_end);
+        extents[canonical.selected_context_index].emplace_back(rowset.id(), extent_end);
+        if (rowset.has_max_compact_input_rowset_id() && !drop_primary_atom) {
+            context_atoms.emplace_back(rowset.max_compact_input_rowset_id(),
+                                       uint64_t{rowset.max_compact_input_rowset_id()} + 1);
+        }
+        const uint32_t final_max = get_max_segment_idx(rowset);
+        for (const auto& del : rowset.del_files()) {
+            const uint32_t offset = del.has_op_offset() ? del.op_offset() : final_max;
+            RETURN_IF_ERROR(validate_del_replay_span(del.origin_rowset_id(), offset));
+            context_atoms.emplace_back(del.origin_rowset_id(), uint64_t{del.origin_rowset_id()} + uint64_t{offset} + 1);
+        }
+    }
+    for (auto& context_extents : extents) {
+        std::sort(context_extents.begin(), context_extents.end());
+        for (size_t i = 1; i < context_extents.size(); ++i) {
+            if (context_extents[i].first < context_extents[i - 1].second) {
+                return Status::Corruption("tablet merge emitted rowset extents overlap");
+            }
+        }
+    }
+
+    result.projections.resize(contexts.size());
+    uint32_t cursor = 1;
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        if (force_context_span_projection && !atoms[context_index].empty()) {
+            atoms[context_index] = {{0, contexts[context_index].metadata()->next_rowset_id()}};
+        }
+        RETURN_IF_ERROR(result.projections[context_index].build(std::move(atoms[context_index]), cursor));
+        cursor = result.projections[context_index].target_end();
+    }
+
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        const auto& metadata = *contexts[context_index].metadata();
+        for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
+            const auto& decision = result.emission[context_index][rowset_index];
+            const auto& occurrence = metadata.rowsets(rowset_index);
+            if (decision.discard || decision.emit || occurrence.has_delete_predicate()) continue;
+            const auto& canonical = result.canonicals[decision.canonical_index];
+            const auto& canonical_rowset = canonical.source_form_rowset;
+            ASSIGN_OR_RETURN(
+                    uint32_t canonical_target,
+                    result.projections[canonical.selected_context_index].map_primary_rssid(canonical_rowset.id()));
+            const uint64_t span = canonical_rowset.segment_metas_size() == 0
+                                          ? 1
+                                          : uint64_t{get_max_segment_idx(canonical_rowset)} + 1;
+            const uint64_t canonical_target_end = uint64_t{canonical_target} + span;
+            auto add_alias = [&](uint32_t source, uint64_t target) -> Status {
+                if (target < canonical_target || target >= canonical_target_end || target >= cursor) {
+                    return Status::Corruption("alias target lies outside planned canonical extent");
+                }
+                return result.projections[context_index].add_occurrence_alias(source, static_cast<uint32_t>(target));
+            };
+            RETURN_IF_ERROR(add_alias(occurrence.id(), canonical_target));
+            for (int position = 0; position < occurrence.segment_metas_size(); ++position) {
+                const uint32_t index = get_segment_idx(occurrence, position);
+                const uint64_t source = uint64_t{occurrence.id()} + index;
+                if (source > std::numeric_limits<uint32_t>::max()) {
+                    return Status::InvalidArgument("tablet merge occurrence RSSID exceeds uint32");
+                }
+                RETURN_IF_ERROR(add_alias(static_cast<uint32_t>(source), uint64_t{canonical_target} + index));
+            }
+        }
+        RETURN_IF_ERROR(result.projections[context_index].finalize_aliases());
+    }
+
+    for (const auto& canonical : result.canonicals) {
+        const auto& rowset = canonical.source_form_rowset;
+        const auto& projection = result.projections[canonical.selected_context_index];
+        const uint64_t extent_end = uint64_t{rowset.id()} +
+                                    (rowset.segment_metas_size() == 0 ? 1 : uint64_t{get_max_segment_idx(rowset)} + 1);
+        RETURN_IF_ERROR(validate_primary_affine_span(projection, rowset.id(), extent_end, "canonical extent"));
+        ASSIGN_OR_RETURN(auto mapped_id, projection.map_primary_rssid(rowset.id()));
+        if (mapped_id >= cursor) return Status::Corruption("tablet merge canonical target is outside cursor");
+        if (rowset.has_max_compact_input_rowset_id()) {
+            ASSIGN_OR_RETURN(auto mapped, projection.map_primary_rssid(rowset.max_compact_input_rowset_id()));
+            (void)mapped;
+        }
+        const uint32_t final_max = get_max_segment_idx(rowset);
+        for (const auto& del : rowset.del_files()) {
+            const uint32_t offset = del.has_op_offset() ? del.op_offset() : final_max;
+            RETURN_IF_ERROR(validate_primary_affine_span(projection, del.origin_rowset_id(),
+                                                         uint64_t{del.origin_rowset_id()} + uint64_t{offset} + 1,
+                                                         "selected delete span"));
+        }
+    }
+
+    std::optional<uint32_t> previous_recovery_target;
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        std::map<uint32_t, uint32_t> groups;
+        for (const auto& canonical : result.canonicals) {
+            if (canonical.selected_context_index != context_index) continue;
+            const auto& rowset = canonical.source_form_rowset;
+            const uint32_t raw_key =
+                    rowset.has_max_compact_input_rowset_id() ? rowset.max_compact_input_rowset_id() : rowset.id();
+            ASSIGN_OR_RETURN(uint32_t target_key, result.projections[context_index].map_primary_rssid(raw_key));
+            if (result.projections[context_index].has_divergent_occurrence_alias(raw_key)) {
+                return Status::Corruption("tablet merge recovery key has a divergent occurrence alias");
+            }
+            auto [iter, inserted] = groups.try_emplace(raw_key, target_key);
+            if (!inserted && iter->second != target_key) {
+                return Status::Corruption("tablet merge equal recovery keys do not remain equivalent");
+            }
+        }
+        for (const auto& [raw_key, target_key] : groups) {
+            (void)raw_key;
+            if (previous_recovery_target.has_value() && target_key <= *previous_recovery_target) {
+                return Status::Corruption("tablet merge recovery order is not strictly increasing");
+            }
+            previous_recovery_target = target_key;
+        }
+    }
+
+    result.target_next_rowset_id = cursor;
+    return result;
+}
+
+Status materialize_planned_rowsets(const std::vector<TabletMergeContext>& contexts,
+                                   const TabletMergeAllocationPlan& plan, TabletMetadataPB* target,
+                                   CanonicalContribMap* canonical_contribs) {
+    TEST_SYNC_POINT_CALLBACK("materialize_planned_rowsets:entry", nullptr);
+    for (const auto& decisions : plan.emission) {
+        for (const auto& decision : decisions) {
+            if (decision.emit && decision.non_pk_skip_dedup_fired) g_tablet_merge_non_pk_skip_dedup_total << 1;
+        }
+    }
+    for (const auto& canonical : plan.canonicals) {
+        if (canonical.output_index != target->rowsets_size()) {
+            return Status::InternalError("tablet merge canonical plan is out of materialization order");
+        }
+        RowsetMetadataPB output(canonical.source_form_rowset);
+        const auto& projection = plan.projections[canonical.selected_context_index];
+        ASSIGN_OR_RETURN(auto mapped_id, projection.map_primary_rssid(output.id()));
+        output.set_id(mapped_id);
+        if (output.has_max_compact_input_rowset_id()) {
+            ASSIGN_OR_RETURN(auto mapped, projection.map_primary_rssid(output.max_compact_input_rowset_id()));
+            output.set_max_compact_input_rowset_id(mapped);
+        }
+        for (auto& del : *output.mutable_del_files()) {
+            ASSIGN_OR_RETURN(auto mapped, projection.map_primary_rssid(del.origin_rowset_id()));
+            del.set_origin_rowset_id(mapped);
+        }
+        if (output.has_delete_predicate()) FAIL_POINT_TRIGGER_RETURN_ERROR(tablet_merge_before_delete_predicate_range);
+        target->add_rowsets()->Swap(&output);
+        if (canonical.schema_id.has_value()) {
+            (*target->mutable_rowset_to_schema())[mapped_id] = *canonical.schema_id;
+        }
+        if (canonical_contribs != nullptr && !canonical.source_form_rowset.has_delete_predicate()) {
+            (*canonical_contribs)[canonical.output_index] = canonical.contributor_ranges;
+        }
+    }
+    (void)contexts;
     return Status::OK();
 }
 
@@ -763,7 +850,7 @@ Status verify_dcg_entry_consistency(const DeltaColumnGroupVerPB& existing, int j
 // Pass 1 collects per-target "surviving" entries (after exact-dedup by .cols
 // filename) and per-target source-rowset references (the old tablet rowsets that
 // reference target rssid T through get_rssid/map_rssid). Ranges are captured
-// from each source old tablet rowset BEFORE merge_rowsets() has widened shared
+// from each source old tablet rowset BEFORE canonical materialization has widened shared
 // ranges via union_range, so a coverage gap between old tablet ranges cannot be
 // masked by the merged rowset's convex hull.
 //
@@ -845,6 +932,7 @@ DeltaColumnGroupVerPB make_single_entry_dcg(const DeltaColumnGroupVerPB& source,
 // Pass 1 — walk each old tablet's dcg_meta and rowsets, dedup by filename across
 // old tablets, and accumulate source-rowset refs per target T.
 Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContext>& merge_contexts,
+                                             const TabletMergeAllocationPlan& allocation_plan,
                                              std::map<uint32_t, DcgTargetWorkItem>* work_by_target) {
     // Track which .cols filenames we have already observed per target so that
     // subsequent old tablets with the same filename are deduped (and verified).
@@ -860,9 +948,12 @@ Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContex
         for (const auto& rowset : context.metadata()->rowsets()) {
             for (int segment_position = 0; segment_position < rowset.segment_metas_size(); ++segment_position) {
                 uint32_t original_rssid = get_rssid(rowset, segment_position);
-                auto target_or = context.map_rssid(original_rssid);
+                auto target_or = allocation_plan.projections[old_tablet_index].map_occurrence_rssid(original_rssid);
                 if (!target_or.ok()) continue;
                 uint32_t target_rssid = *target_or;
+                bool force_target_omission = false;
+                TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_dcg_target_omission", &force_target_omission);
+                if (force_target_omission) continue;
                 DcgSourceRowsetReference source_reference;
                 source_reference.old_tablet_index = old_tablet_index;
                 if (rowset.has_range()) {
@@ -880,7 +971,8 @@ Status dcg_pass1_collect_entries_and_sources(const std::vector<TabletMergeContex
         // records, dedup by .cols filename.
         if (!context.metadata()->has_dcg_meta()) continue;
         for (const auto& [segment_id, dcg_value] : context.metadata()->dcg_meta().dcgs()) {
-            ASSIGN_OR_RETURN(uint32_t target_rssid, context.map_rssid(segment_id));
+            ASSIGN_OR_RETURN(uint32_t target_rssid,
+                             allocation_plan.projections[old_tablet_index].map_occurrence_rssid(segment_id));
 
             DeltaColumnGroupVerPB normalized = dcg_value;
             RETURN_IF_ERROR(validate_dcg_shape(normalized));
@@ -1346,10 +1438,10 @@ struct CanonicalGapSpec {
 };
 
 Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts,
-                      int64_t new_tablet_id, int64_t new_version, int64_t txn_id,
-                      const std::vector<CanonicalGapSpec>& gap_specs, TabletMetadataPB* new_metadata) {
+                      const TabletMergeAllocationPlan& allocation_plan, int64_t new_tablet_id, int64_t new_version,
+                      int64_t txn_id, const std::vector<CanonicalGapSpec>& gap_specs, TabletMetadataPB* new_metadata) {
     std::map<uint32_t, DcgTargetWorkItem> work_by_target;
-    RETURN_IF_ERROR(dcg_pass1_collect_entries_and_sources(merge_contexts, &work_by_target));
+    RETURN_IF_ERROR(dcg_pass1_collect_entries_and_sources(merge_contexts, allocation_plan, &work_by_target));
 
     // Index synthesized gap bitmaps by target rssid so a rebuild can short-circuit
     // its coverage check for rowids that merge_delvecs masks. Empty for non-PK
@@ -1508,15 +1600,15 @@ std::unordered_set<uint32_t> collect_live_rssids(const TabletMetadataPB& metadat
 //
 // An entry is kept only if BOTH its segment_id is a live segment in its OWN source tablet
 // (source-live) AND its remapped target is a live segment in the merged tablet (target-live).
-// map_rssid falls back to rssid+offset for anything not in shared_rssid_map (it only errors
-// on overflow), so it is not a "segment survived" test: a stale idg entry (segment pruned or
+// Occurrence projection alone is not a "segment survived" test: a stale idg entry (segment pruned or
 // compacted out of that source but the entry not cleaned) could otherwise remap -- e.g. the
 // canonical child's stale rssid R maps via R+0 onto a target R that is live only because a
 // sibling supplies that segment -- and mis-apply / dangle a .idx that source no longer owns.
 // Stale entries are dropped; their .idx becomes an orphan reclaimed by the shared-file
 // cleanup once the source tablets are dropped. Writes no new files, so there is no
 // partial-write cleanup to do.
-Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
+Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
+                      const TabletMergeAllocationPlan& allocation_plan, TabletMetadataPB* new_metadata) {
     // Every segment present after merge_rowsets, mapped to its shared flag. An IDG entry is
     // kept only if its remapped target is here (target-live), and its .idx shared_file is
     // DERIVED from the target segment's shared flag (see the emit loop) rather than preserved
@@ -1535,14 +1627,19 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts, Tab
     // target rssid -> (.idx filename -> index into work_by_target[target]).
     std::map<uint32_t, std::unordered_map<std::string, size_t>> seen_files_by_target;
 
-    for (const auto& context : merge_contexts) {
+    for (size_t context_index = 0; context_index < merge_contexts.size(); ++context_index) {
+        const auto& context = merge_contexts[context_index];
         if (!context.metadata()->has_idg_meta()) continue;
         const auto source_live_rssids = collect_live_rssids(*context.metadata());
         for (const auto& [segment_id, idg_ver] : context.metadata()->idg_meta().idgs()) {
             if (source_live_rssids.find(segment_id) == source_live_rssids.end()) {
                 continue; // stale idg entry: segment no longer in this source's rowsets
             }
-            ASSIGN_OR_RETURN(uint32_t target_rssid, context.map_rssid(segment_id));
+            ASSIGN_OR_RETURN(uint32_t target_rssid,
+                             allocation_plan.projections[context_index].map_occurrence_rssid(segment_id));
+            bool force_target_omission = false;
+            TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_idg_target_omission", &force_target_omission);
+            if (force_target_omission) continue;
             if (!target_rssid_shared.contains(target_rssid)) {
                 continue; // defensive: target not a live merged segment
             }
@@ -1754,6 +1851,7 @@ bool delvec_file_metadata_matches(const FileMetaPB& left, const FileMetaPB& righ
 
 DEFINE_FAIL_POINT(tablet_merge_after_write_delvec);
 Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMergeContext>& merge_contexts,
+                     const TabletMergeAllocationPlan& allocation_plan,
                      const std::vector<CanonicalGapSpec>& synthesized_gap_specs, int64_t new_version, int64_t txn_id,
                      TabletMetadataPB* new_metadata) {
     // Phase 0 gap bitmaps are synthesized once by the caller (merge_tablet) and
@@ -1765,7 +1863,8 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
     std::unordered_map<std::string, DelvecFileInfo> actual_page_source_files;
     const auto target_live_rssids = collect_live_rssids(*new_metadata);
 
-    for (const auto& ctx : merge_contexts) {
+    for (size_t context_index = 0; context_index < merge_contexts.size(); ++context_index) {
+        const auto& ctx = merge_contexts[context_index];
         if (!ctx.metadata()->has_delvec_meta()) {
             continue;
         }
@@ -1774,7 +1873,11 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
             if (!source_live_rssids.contains(segment_id)) {
                 continue;
             }
-            ASSIGN_OR_RETURN(uint32_t target, ctx.map_rssid(segment_id));
+            ASSIGN_OR_RETURN(uint32_t target,
+                             allocation_plan.projections[context_index].map_occurrence_rssid(segment_id));
+            bool force_target_omission = false;
+            TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_delvec_target_omission", &force_target_omission);
+            if (force_target_omission) continue;
             if (!target_live_rssids.contains(target)) {
                 continue;
             }
@@ -2049,69 +2152,32 @@ Status project_modern_shared_rssid_sstable(const PersistentIndexSstablePB& sst, 
 // Project a non-shared sstable without shared_rssid: an old-tablet-local file
 // produced by flush_pk_memtable for THIS merge round, or a rebuilt legacy
 // file from a prior merge. Stored rssids already live in the old tablet's id
-// space, so a single ctx.rssid_offset() shift suffices. The accumulation
+// space, so a proven affine projection delta suffices. The accumulation
 // preserves correctness when the file already carries a non-zero
 // rssid_offset (stacked merge case).
-Status project_non_shared_legacy_sstable(const PersistentIndexSstablePB& sst, const TabletMergeContext& ctx,
+Status project_non_shared_legacy_sstable(const PersistentIndexSstablePB& sst, int64_t projection_delta,
                                          PersistentIndexSstablePB* out) {
     RETURN_IF_ERROR(validate_non_shared_legacy_sstable_form(sst));
-    const int64_t accumulated_offset = static_cast<int64_t>(sst.rssid_offset()) + ctx.rssid_offset();
+    const int64_t accumulated_offset = static_cast<int64_t>(sst.rssid_offset()) + projection_delta;
     if (accumulated_offset < std::numeric_limits<int32_t>::min() ||
         accumulated_offset > std::numeric_limits<int32_t>::max()) {
         return Status::Corruption(
                 fmt::format("accumulated rssid_offset exceeds int32 range: sst_offset={} ctx_offset={} sum={}",
-                            sst.rssid_offset(), ctx.rssid_offset(), accumulated_offset));
+                            sst.rssid_offset(), projection_delta, accumulated_offset));
     }
     out->set_rssid_offset(static_cast<int32_t>(accumulated_offset));
     const int64_t high = static_cast<int64_t>(extract_rss_rowid_high(sst.max_rss_rowid()));
-    const int64_t new_high = high + ctx.rssid_offset();
+    const int64_t new_high = high + projection_delta;
     if (new_high < 0 || new_high > std::numeric_limits<uint32_t>::max()) {
         return Status::Corruption(
                 fmt::format("rssid high overflow in merge projection: high={} ctx_offset={} new_high={}", high,
-                            ctx.rssid_offset(), new_high));
+                            projection_delta, new_high));
     } else {
         out->set_max_rss_rowid(
                 encode_rss_rowid(static_cast<uint32_t>(new_high), extract_rss_rowid_low(sst.max_rss_rowid())));
     }
     out->clear_delvec();
     return Status::OK();
-}
-
-// Returns the highest (rowset.id + step + ctx.rssid_offset) seen across
-// merge_contexts[0..upper_exclusive), or |base_next_rowset_id| if higher.
-// Phase 1 in merge_tablet uses this as the watermark for ctx[i]'s
-// rssid_offset assignment so each old tablet's projected rowset ids land
-// strictly above every earlier old tablet's projected ids.
-//
-// Only rowsets that project through their own ctx's rssid_offset are counted, the
-// same set compute_rssid_offset derives the floor from. A discarded duplicate's ids
-// resolve to the canonical rowset instead, which an earlier ctx already contributed
-// to this ceiling, so reserving room for it here would lift later inputs over an
-// unoccupied hole -- with three or more siblings whose id counters have diverged that
-// alone can push map_rssid past UINT32_MAX.
-//
-// Each uint32_t addend is widened to int64_t before the addition to avoid
-// uint32_t wrap when rowset.id() approaches UINT32_MAX — wrap there would
-// under-estimate the watermark and let later old tablets reuse occupied rssids.
-uint32_t compute_cumulative_rowset_id_ceiling(const std::vector<TabletMergeContext>& merge_contexts,
-                                              const RowsetEmissionPlan& emission_plan, size_t upper_exclusive,
-                                              uint32_t base_next_rowset_id) {
-    uint32_t ceiling = base_next_rowset_id;
-    for (size_t j = 0; j < upper_exclusive; ++j) {
-        const auto& metadata = *merge_contexts[j].metadata();
-        for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
-            const auto& rowset = metadata.rowsets(rowset_index);
-            if (!projects_via_rssid_offset(emission_plan[j][rowset_index], rowset)) continue;
-
-            const int64_t end_wide = static_cast<int64_t>(rowset.id()) +
-                                     static_cast<int64_t>(get_rowset_id_step(rowset)) +
-                                     merge_contexts[j].rssid_offset();
-            const uint32_t end =
-                    static_cast<uint32_t>(std::clamp<int64_t>(end_wide, 0, std::numeric_limits<uint32_t>::max()));
-            ceiling = std::max(ceiling, end);
-        }
-    }
-    return ceiling;
 }
 
 enum class MergeSstableMetaMode { kPrivate, kIdentical, kLazyRebuild };
@@ -2258,6 +2324,7 @@ void order_and_assign_singleton_filesets(PersistentIndexSstableMetaPB* metadata)
 }
 
 StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std::vector<TabletMergeContext>& contexts,
+                                                                       const TabletMergeAllocationPlan& allocation_plan,
                                                                        const TabletMetadataPB& target) {
     ASSIGN_OR_RETURN(auto range_proof, validate_metadata_reuse_source_ranges(contexts, target));
     if (range_proof != MergeSourceRangeProof::kReusable) {
@@ -2268,10 +2335,9 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
     std::unordered_set<std::string> filenames;
     MergeSstableMetaResult result;
     result.mode = MergeSstableMetaMode::kPrivate;
-    for (const auto& context : contexts) {
-        if (context.has_shared_rssid_mapping()) {
-            return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
-        }
+    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+        const auto& context = contexts[context_index];
+        const auto& projection = allocation_plan.projections[context_index];
         for (const auto& rowset : context.metadata()->rowsets()) {
             if (rowset.has_uid() && rowset.uid().hi() == 0 && rowset.uid().lo() == 0) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
@@ -2300,10 +2366,11 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
                 if (!source_rssid.ok()) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
-                if (!source_live_rssids.contains(*source_rssid)) {
+                if (extract_rss_rowid_high(source_sstable.max_rss_rowid()) != *source_rssid ||
+                    !source_live_rssids.contains(*source_rssid)) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
-                auto mapped_rssid = context.map_rssid(*source_rssid);
+                auto mapped_rssid = projection.map_occurrence_rssid(*source_rssid);
                 if (!mapped_rssid.ok() || !target_live_rssids.contains(mapped_rssid.value())) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
@@ -2314,22 +2381,30 @@ StatusOr<MergeSstableMetaResult> try_project_complete_private_sstables(const std
                 }
             } else {
                 if ((source_sstable.has_shared_version() && source_sstable.shared_version() > 0) ||
-                    (source_sstable.has_delvec() && source_sstable.delvec().size() > 0)) {
+                    (source_sstable.has_delvec() && source_sstable.delvec().size() > 0) ||
+                    source_sstable.rssid_offset() < 0) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
                 }
-                const int64_t projected_high =
-                        static_cast<int64_t>(extract_rss_rowid_high(source_sstable.max_rss_rowid())) +
-                        context.rssid_offset();
                 const uint32_t source_high = extract_rss_rowid_high(source_sstable.max_rss_rowid());
-                const int64_t projected_offset =
-                        static_cast<int64_t>(source_sstable.rssid_offset()) + context.rssid_offset();
+                ASSIGN_OR_RETURN(auto conservative_delta, projection.conservative_context_delta());
+                if (!conservative_delta.has_value()) {
+                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
+                }
+                ASSIGN_OR_RETURN(auto domain_delta,
+                                 projection.affine_delta(source_sstable.rssid_offset(), uint64_t{source_high} + 1));
+                if (!domain_delta.has_value() || *domain_delta != *conservative_delta) {
+                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
+                }
+                const int64_t projected_high = static_cast<int64_t>(source_high) + *domain_delta;
+                const int64_t projected_offset = static_cast<int64_t>(source_sstable.rssid_offset()) + *domain_delta;
                 if (!source_live_rssids.contains(source_high) || projected_high < 0 ||
-                    projected_high > std::numeric_limits<int32_t>::max() ||
-                    projected_offset < std::numeric_limits<int32_t>::min() ||
+                    projected_high >= allocation_plan.target_next_rowset_id ||
+                    !target_live_rssids.contains(static_cast<uint32_t>(projected_high)) || projected_offset < 0 ||
                     projected_offset > std::numeric_limits<int32_t>::max()) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
-                const auto projection_status = project_non_shared_legacy_sstable(source_sstable, context, &projected);
+                const auto projection_status =
+                        project_non_shared_legacy_sstable(source_sstable, *domain_delta, &projected);
                 if (!projection_status.ok()) {
                     return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
                 }
@@ -2395,6 +2470,7 @@ bool semantic_sstable_equal(const PersistentIndexSstablePB& left, const Persiste
 }
 
 StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std::vector<TabletMergeContext>& contexts,
+                                                                       const TabletMergeAllocationPlan& allocation_plan,
                                                                        const TabletMetadataPB& target) {
     ASSIGN_OR_RETURN(auto range_proof, validate_metadata_reuse_source_ranges(contexts, target));
     if (range_proof != MergeSourceRangeProof::kReusable) {
@@ -2432,20 +2508,6 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
     }
 
     const auto target_live_rssids = collect_live_rssids(target);
-    const auto canonical_live_rssids = collect_live_rssids(canonical_metadata);
-    for (uint32_t source_rssid : canonical_live_rssids) {
-        ASSIGN_OR_RETURN(auto canonical_rssid, contexts.front().map_rssid(source_rssid));
-        if (canonical_rssid != source_rssid || !target_live_rssids.contains(canonical_rssid)) {
-            return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
-        }
-        for (size_t context_index = 1; context_index < contexts.size(); ++context_index) {
-            ASSIGN_OR_RETURN(auto candidate_rssid, contexts[context_index].map_rssid(source_rssid));
-            if (candidate_rssid != canonical_rssid) {
-                return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
-            }
-        }
-    }
-
     MergeSstableMetaResult result;
     result.mode = MergeSstableMetaMode::kIdentical;
     for (const auto& canonical_sstable : canonical_sstables) {
@@ -2456,10 +2518,26 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
         projected.set_shared(true);
         if (canonical_sstable.has_shared_rssid()) {
             auto source_rssid = effective_shared_rssid(canonical_sstable);
-            if (!source_rssid.ok()) {
+            if (!source_rssid.ok() || extract_rss_rowid_high(canonical_sstable.max_rss_rowid()) != *source_rssid) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
             }
-            ASSIGN_OR_RETURN(auto mapped_rssid, contexts.front().map_rssid(*source_rssid));
+            std::optional<uint32_t> common_target;
+            for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+                const auto source_live = collect_live_rssids(*contexts[context_index].metadata());
+                if (!source_live.contains(*source_rssid)) {
+                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
+                }
+                ASSIGN_OR_RETURN(auto mapped,
+                                 allocation_plan.projections[context_index].map_occurrence_rssid(*source_rssid));
+                if (common_target.has_value() && *common_target != mapped) {
+                    return lazy_sstable_meta_result(MergeSstableFallbackReason::kNonuniformMapping);
+                }
+                common_target = mapped;
+            }
+            if (!common_target.has_value()) {
+                return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
+            }
+            const uint32_t mapped_rssid = *common_target;
             if (!target_live_rssids.contains(mapped_rssid)) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kProjectedDomain);
             }
@@ -2468,9 +2546,7 @@ StatusOr<MergeSstableMetaResult> try_reuse_complete_identical_sstables(const std
             if (!projection_status.ok()) {
                 return lazy_sstable_meta_result(MergeSstableFallbackReason::kEmbeddedDelvec);
             }
-        } else if ((canonical_sstable.has_shared_version() && canonical_sstable.shared_version() > 0) ||
-                   (canonical_sstable.has_delvec() && canonical_sstable.delvec().size() > 0) ||
-                   contexts.front().rssid_offset() != 0) {
+        } else {
             return lazy_sstable_meta_result(MergeSstableFallbackReason::kUnsupportedSstForm);
         }
         result.metadata.add_sstables()->Swap(&projected);
@@ -2571,7 +2647,7 @@ void record_merge_sstable_meta_result(const MergeSstableMetaResult& result) {
 }
 
 Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeContext>& merge_contexts,
-                      TabletMetadataPB* new_metadata) {
+                      const TabletMergeAllocationPlan& allocation_plan, TabletMetadataPB* new_metadata) {
     auto* update_manager = tablet_manager->update_mgr();
     for (auto& context : merge_contexts) {
         bool skip_source_flush = false;
@@ -2593,14 +2669,16 @@ Status merge_sstables(TabletManager* tablet_manager, std::vector<TabletMergeCont
     TEST_SYNC_POINT_CALLBACK("merge_sstables:metadata_classifier_entry", nullptr);
     DeferOp classifier_exit([] { TEST_SYNC_POINT_CALLBACK("merge_sstables:metadata_classifier_exit", nullptr); });
 
-    ASSIGN_OR_RETURN(auto private_result, try_project_complete_private_sstables(merge_contexts, *new_metadata));
+    ASSIGN_OR_RETURN(auto private_result,
+                     try_project_complete_private_sstables(merge_contexts, allocation_plan, *new_metadata));
     if (private_result.mode == MergeSstableMetaMode::kPrivate) {
         new_metadata->mutable_sstable_meta()->Swap(&private_result.metadata);
         record_merge_sstable_meta_result(private_result);
         return Status::OK();
     }
 
-    ASSIGN_OR_RETURN(auto identical_result, try_reuse_complete_identical_sstables(merge_contexts, *new_metadata));
+    ASSIGN_OR_RETURN(auto identical_result,
+                     try_reuse_complete_identical_sstables(merge_contexts, allocation_plan, *new_metadata));
     if (identical_result.mode == MergeSstableMetaMode::kIdentical) {
         new_metadata->mutable_sstable_meta()->Swap(&identical_result.metadata);
         record_merge_sstable_meta_result(identical_result);
@@ -2646,12 +2724,6 @@ StatusOr<uint32_t> compute_supported_next_rowset_id(const TabletMetadataPB& meta
         return Status::InvalidArgument("tablet merge exhausts the supported rssid allocation domain");
     }
     return static_cast<uint32_t>(next);
-}
-
-Status finalize_next_rowset_id(TabletMetadataPB* metadata) {
-    ASSIGN_OR_RETURN(uint32_t next_rowset_id, compute_supported_next_rowset_id(*metadata));
-    metadata->set_next_rowset_id(next_rowset_id);
-    return Status::OK();
 }
 
 void merge_schemas(const std::vector<TabletMergeContext>& merge_contexts, TabletMetadataPB* new_metadata) {
@@ -2791,22 +2863,7 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     reconcile_vector_index_built_version(merge_contexts, new_tablet_metadata.get());
 
     const bool discard_empty_rowsets = !skip_sstable_merge && is_primary_key(*merge_contexts.front().metadata());
-    ASSIGN_OR_RETURN(auto rowset_emission_plan, build_rowset_emission_plan(merge_contexts, discard_empty_rowsets));
-
-    // Phase 1: Prepare rssid offsets and merged range. For each ctx[i],
-    // set new_tablet_metadata.next_rowset_id to the watermark of all
-    // earlier ctxs[0..i-1]'s projected rowset ids; compute_rssid_offset
-    // then derives ctx[i].rssid_offset against that watermark so its
-    // projected ids land strictly above every earlier ctx's.
-    for (size_t i = 1; i < merge_contexts.size(); ++i) {
-        const uint32_t cumulative_ceiling =
-                compute_cumulative_rowset_id_ceiling(merge_contexts, rowset_emission_plan, /*upper_exclusive=*/i,
-                                                     merge_contexts.front().metadata()->next_rowset_id());
-        new_tablet_metadata->set_next_rowset_id(cumulative_ceiling);
-        const int64_t rssid_offset =
-                compute_rssid_offset(*new_tablet_metadata, merge_contexts, rowset_emission_plan, i);
-        merge_contexts[i].set_rssid_offset(rssid_offset);
-    }
+    ASSIGN_OR_RETURN(auto allocation_plan, build_tablet_merge_allocation_plan(merge_contexts, discard_empty_rowsets));
 
     // Merge tablet-level range via union_range
     TabletRangePB merged_range = merge_contexts.front().metadata()->range();
@@ -2816,10 +2873,6 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     }
     new_tablet_metadata->mutable_range()->CopyFrom(merged_range);
 
-    // Phase 1 is the rowset/segment-id reassignment stage: every ctx now carries the rssid_offset that
-    // lifts its id space above the earlier ctxs'. Stopping here, before any projection consumes those
-    // offsets, is the window for asserting that an interrupted merge leaves no id conflict and loses
-    // no rowset once it is retried.
     FAIL_POINT_TRIGGER_RETURN_ERROR(tablet_merge_after_rssid_reassign);
 
     // Phase 2: Merge rowsets (version-driven k-way merge with dedup).
@@ -2827,16 +2880,15 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // old tablets' old-tablet-local ranges; consumed by the PK fail-fast coverage
     // check below and by gap-delvec synthesis.
     CanonicalContribMap canonical_contribs;
-    RETURN_IF_ERROR(
-            merge_rowsets(merge_contexts, rowset_emission_plan, new_tablet_metadata.get(), &canonical_contribs));
+    RETURN_IF_ERROR(materialize_planned_rowsets(merge_contexts, allocation_plan, new_tablet_metadata.get(),
+                                                &canonical_contribs));
 
     // Phase 2.5: Merge schemas (must run before gap synthesis + merge_dcg_meta,
     // which need historical_schemas to locate rebuild schemas for shared-segment
     // rebuild).
     merge_schemas(merge_contexts, new_tablet_metadata.get());
 
-    ASSIGN_OR_RETURN(uint32_t recovery_next_rowset_id, compute_supported_next_rowset_id(*new_tablet_metadata));
-    new_tablet_metadata->set_next_rowset_id(recovery_next_rowset_id);
+    new_tablet_metadata->set_next_rowset_id(allocation_plan.target_next_rowset_id);
 
     // Synthesize the per-target gap bitmaps once (PK only). The same specs drive
     // both DCG coverage-acceptance (merge_dcg_meta) and delvec masking
@@ -2851,24 +2903,24 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
         }
     }
 
-    // Phase 3: Projections (map_rssid uses shared_rssid_map + rssid_offset)
-    RETURN_IF_ERROR(merge_dcg_meta(tablet_manager, merge_contexts, merging_tablet.new_tablet_id(), new_version,
-                                   txn_info.txn_id(), gap_specs, new_tablet_metadata.get()));
+    // Phase 3: occurrence projections consume the immutable allocation plan.
+    RETURN_IF_ERROR(merge_dcg_meta(tablet_manager, merge_contexts, allocation_plan, merging_tablet.new_tablet_id(),
+                                   new_version, txn_info.txn_id(), gap_specs, new_tablet_metadata.get()));
 
     // Remap the lake ADD INDEX fast-path IDG (.idx) entries into the merged rssid space,
     // mirroring merge_dcg_meta. Metadata-only (no segment rebuild); see merge_idg_meta.
-    RETURN_IF_ERROR(merge_idg_meta(merge_contexts, new_tablet_metadata.get()));
+    RETURN_IF_ERROR(merge_idg_meta(merge_contexts, allocation_plan, new_tablet_metadata.get()));
 
     if (is_primary_key(*new_tablet_metadata)) {
-        RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, gap_specs, new_version, txn_info.txn_id(),
-                                      new_tablet_metadata.get()));
+        RETURN_IF_ERROR(merge_delvecs(tablet_manager, merge_contexts, allocation_plan, gap_specs, new_version,
+                                      txn_info.txn_id(), new_tablet_metadata.get()));
     }
 
     if (skip_sstable_merge) {
         // Read-only alias: leave it without a primary index rather than paying the rebuild.
         new_tablet_metadata->clear_sstable_meta();
     } else if (uses_cloud_native_pk_index(*new_tablet_metadata)) {
-        RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, new_tablet_metadata.get()));
+        RETURN_IF_ERROR(merge_sstables(tablet_manager, merge_contexts, allocation_plan, new_tablet_metadata.get()));
     } else {
         // SST classification and source flushing are cloud-native PK contracts. Other key/index modes retain
         // their merged rowset and sidecar metadata without manufacturing a primary-index attachment.
@@ -2876,7 +2928,11 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     }
 
     // Phase 4: Finalize
-    RETURN_IF_ERROR(finalize_next_rowset_id(new_tablet_metadata.get()));
+    ASSIGN_OR_RETURN(auto required_next_rowset_id, compute_supported_next_rowset_id(*new_tablet_metadata));
+    if (required_next_rowset_id > allocation_plan.target_next_rowset_id) {
+        return Status::Corruption("tablet merge output exceeds its authoritative RSSID cursor");
+    }
+    new_tablet_metadata->set_next_rowset_id(allocation_plan.target_next_rowset_id);
 
     // No re-share here: the merged tablet OWNS its segments via the same ownership-transfer
     // model that the identical-tablet and split paths already use. The source old tablets

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -12041,6 +12041,270 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_compressed_gap_f
     expect_metadata_fallback_lifecycle(result, {{10, 100}, {60, 600}, {70, 700}}, {{10, 1010}, {70, 700}}, {60});
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_raw_zero_reuses) {
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(
+                            MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
+                                const std::string extra_name = "affine_raw_zero_extra.dat";
+                                const uint64_t extra_size = write_two_column_segment(
+                                        sources[1]->id(), extra_name, 1, [](int key) { return key * 10; }, 70);
+                                auto* extra = add_allocator_rowset(sources[1].get(), 100,
+                                                                   sources[1]->rowsets(0).version(), extra_name, 0);
+                                extra->mutable_segment_metas(0)->set_size(extra_size);
+                                sources[1]->set_next_rowset_id(101);
+                            }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    ASSERT_EQ(2, target.sstable_meta().sstables_size());
+    auto legacy = std::find_if(target.sstable_meta().sstables().begin(), target.sstable_meta().sstables().end(),
+                               [](const auto& sst) { return !sst.has_shared_rssid(); });
+    ASSERT_NE(target.sstable_meta().sstables().end(), legacy);
+    EXPECT_EQ(2, legacy->rssid_offset());
+    EXPECT_EQ(static_cast<uint64_t>(2) << 32, legacy->max_rss_rowid());
+    EXPECT_EQ(4, target.next_rowset_id());
+
+    auto target_ptr = std::make_shared<TabletMetadataPB>(target);
+    _update_manager->unload_and_remove_primary_index(target.id());
+    ASSIGN_OR_ABORT(auto values, load_index_values(target_ptr, target.id(), {encode_int_primary_key(/*key=*/60)}));
+    ASSERT_EQ(1, values.size());
+    EXPECT_EQ(2, values[0].get_value() >> 32) << "stored raw RSSID 0 must use the accumulated output offset";
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_alias_exclusive_end_reuses) {
+    ASSIGN_OR_ABORT(
+            auto result,
+            publish_metadata_only_merge_fixture(
+                    MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
+                        lake::tablet_reshard_helper::set_rowset_uid(sources[0]->mutable_rowsets(0));
+                        auto* exclusive_alias =
+                                add_allocator_rowset(sources[1].get(), 6, sources[1]->rowsets(0).version(),
+                                                     sources[0]->rowsets(0).segment_metas(0).filename(), 0);
+                        exclusive_alias->mutable_segment_metas(0)->CopyFrom(sources[0]->rowsets(0).segment_metas(0));
+                        exclusive_alias->mutable_uid()->CopyFrom(sources[0]->rowsets(0).uid());
+                        sources[1]->set_next_rowset_id(7);
+                    }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    ASSERT_EQ(2, target.sstable_meta().sstables_size());
+    auto legacy = std::find_if(target.sstable_meta().sstables().begin(), target.sstable_meta().sstables().end(),
+                               [](const auto& sst) { return !sst.has_shared_rssid(); });
+    ASSERT_NE(target.sstable_meta().sstables().end(), legacy);
+    EXPECT_EQ(2, legacy->rssid_offset());
+    EXPECT_EQ(static_cast<uint64_t>(2) << 32, legacy->max_rss_rowid());
+    EXPECT_EQ(3, target.next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_uint32_exclusive_end_does_not_enumerate) {
+    bool materialized = false;
+    int classifier_visited_runs = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { materialized = true; });
+    sync->SetCallBack("affine_delta:visited_run", [&](void*) {
+        if (materialized) ++classifier_visited_runs;
+    });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearCallBack("materialize_planned_rowsets:entry");
+        sync->ClearCallBack("affine_delta:visited_run");
+        sync->DisableProcessing();
+    });
+
+    ASSIGN_OR_ABORT(auto result, publish_metadata_only_merge_fixture(
+                                         MetadataOnlyMergeShape::kPrivate, false, false, true, [](auto& sources) {
+                                             auto* legacy = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
+                                             legacy->set_rssid_offset(std::numeric_limits<int32_t>::max());
+                                             legacy->set_max_rss_rowid(
+                                                     static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) << 32);
+                                         }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    EXPECT_EQ(0, target.sstable_meta().sstables_size());
+    EXPECT_LE(classifier_visited_runs, 1) << "the widened [INT32_MAX, 2^32) domain must not be enumerated";
+    for (const auto& filename : result.source_sst_filenames) {
+        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
+                                   [&](const auto& orphan) { return orphan.name() == filename; }));
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_proof_visits_runs_not_rssids) {
+    bool materialized = false;
+    int classifier_visited_runs = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { materialized = true; });
+    sync->SetCallBack("affine_delta:visited_run", [&](void*) {
+        if (materialized) ++classifier_visited_runs;
+    });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearCallBack("materialize_planned_rowsets:entry");
+        sync->ClearCallBack("affine_delta:visited_run");
+        sync->DisableProcessing();
+    });
+
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(
+                            MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
+                                const std::string high_name = "affine_visited_high.dat";
+                                const uint64_t high_size = write_two_column_segment(
+                                        sources[1]->id(), high_name, 1, [](int key) { return key * 10; }, 70);
+                                auto* high = add_allocator_segment(sources[1]->mutable_rowsets(0), high_name, 4095);
+                                high->set_size(high_size);
+
+                                const std::string extra_name = "affine_visited_extra.dat";
+                                const uint64_t extra_size = write_two_column_segment(
+                                        sources[1]->id(), extra_name, 1, [](int key) { return key * 10; }, 80);
+                                auto* extra = add_allocator_rowset(sources[1].get(), 10000,
+                                                                   sources[1]->rowsets(0).version(), extra_name, 0);
+                                extra->mutable_segment_metas(0)->set_size(extra_size);
+                                sources[1]->set_next_rowset_id(10001);
+                                sources[1]->mutable_sstable_meta()->mutable_sstables(0)->set_max_rss_rowid(
+                                        static_cast<uint64_t>(4100) << 32);
+                            }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    ASSERT_EQ(2, target.sstable_meta().sstables_size());
+    auto legacy = std::find_if(target.sstable_meta().sstables().begin(), target.sstable_meta().sstables().end(),
+                               [](const auto& sst) { return !sst.has_shared_rssid(); });
+    ASSERT_NE(target.sstable_meta().sstables().end(), legacy);
+    EXPECT_EQ(2, legacy->rssid_offset());
+    EXPECT_EQ(static_cast<uint64_t>(4097) << 32, legacy->max_rss_rowid());
+    EXPECT_EQ(1, classifier_visited_runs) << "a 4096-RSSID affine domain must visit one translation run";
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_identical_common_nonzero_delta_reuses) {
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(
+                            MetadataOnlyMergeShape::kIdentical, false, false, true, [&](auto& sources) {
+                                for (auto& source : sources) {
+                                    source->mutable_rowsets(0)->set_id(5);
+                                    source->set_next_rowset_id(6);
+                                }
+
+                                const auto file = write_raw_pk_sstable(
+                                        _tablet_manager->sst_location(
+                                                sources[0]->id(), sources[0]->sstable_meta().sstables(0).filename()),
+                                        {{encode_int_primary_key(10),
+                                          serialize_index_values({{sources[0]->version(), 0, 0}})}});
+                                for (auto& source : sources) {
+                                    auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
+                                    sst->set_filesize(file.filesize);
+                                    sst->set_encryption_meta(file.encryption_meta);
+                                    sst->mutable_range()->CopyFrom(file.range);
+                                    sst->clear_shared_rssid();
+                                    sst->clear_shared_version();
+                                    sst->set_rssid_offset(5);
+                                    sst->set_max_rss_rowid(static_cast<uint64_t>(5) << 32);
+                                }
+                            }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    ASSERT_EQ(1, target.sstable_meta().sstables_size());
+    const auto& output = target.sstable_meta().sstables(0);
+    EXPECT_TRUE(output.shared());
+    EXPECT_EQ(1, output.rssid_offset());
+    EXPECT_EQ(static_cast<uint64_t>(1) << 32, output.max_rss_rowid());
+    EXPECT_EQ(2, target.next_rowset_id());
+
+    auto target_ptr = std::make_shared<TabletMetadataPB>(target);
+    _update_manager->unload_and_remove_primary_index(target.id());
+    ASSIGN_OR_ABORT(auto values, load_index_values(target_ptr, target.id(), {encode_int_primary_key(/*key=*/10)}));
+    ASSERT_EQ(1, values.size());
+    EXPECT_EQ(1, values[0].get_value() >> 32);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_identical_occurrence_disagreement_falls_back) {
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(
+                            MetadataOnlyMergeShape::kIdentical, false, false, true, [&](auto& sources) {
+                                const std::string high_name = "affine_identical_disagreement_high.dat";
+                                const uint64_t high_size = write_two_column_segment(
+                                        sources[0]->id(), high_name, 1, [](int key) { return key * 10; }, 80);
+                                auto* left_high = add_allocator_segment(sources[0]->mutable_rowsets(0), high_name, 1);
+                                left_high->set_size(high_size);
+                                left_high->set_shared(true);
+                                auto* right_high = add_allocator_segment(sources[1]->mutable_rowsets(0), high_name, 1);
+                                right_high->CopyFrom(*left_high);
+                                sources[0]->mutable_rowsets(0)->set_id(5);
+                                sources[0]->set_next_rowset_id(7);
+                                sources[1]->mutable_rowsets(0)->set_id(6);
+                                sources[1]->set_next_rowset_id(8);
+
+                                const auto file = write_raw_pk_sstable(
+                                        _tablet_manager->sst_location(
+                                                sources[0]->id(), sources[0]->sstable_meta().sstables(0).filename()),
+                                        {{encode_int_primary_key(10),
+                                          serialize_index_values({{sources[0]->version(), 0, 0}})}});
+                                for (auto& source : sources) {
+                                    auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
+                                    sst->set_filesize(file.filesize);
+                                    sst->set_encryption_meta(file.encryption_meta);
+                                    sst->mutable_range()->CopyFrom(file.range);
+                                    sst->clear_shared_rssid();
+                                    sst->clear_shared_version();
+                                    sst->set_rssid_offset(5);
+                                    sst->set_max_rss_rowid(static_cast<uint64_t>(6) << 32);
+                                }
+                            }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    EXPECT_EQ(0, target.sstable_meta().sstables_size());
+    for (const auto& filename : result.source_sst_filenames) {
+        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
+                                   [&](const auto& orphan) { return orphan.name() == filename; }));
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_identical_prior_offset_reuses) {
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(
+                            MetadataOnlyMergeShape::kIdentical, false, false, true, [&](auto& sources) {
+                                const std::string high_name = "affine_identical_prior_high.dat";
+                                const uint64_t high_size = write_two_column_segment(
+                                        sources[0]->id(), high_name, 1, [](int key) { return key * 10; }, 80);
+                                auto* left_high = add_allocator_segment(sources[0]->mutable_rowsets(0), high_name, 3);
+                                left_high->set_size(high_size);
+                                left_high->set_shared(true);
+                                auto* right_high = add_allocator_segment(sources[1]->mutable_rowsets(0), high_name, 3);
+                                right_high->CopyFrom(*left_high);
+
+                                const std::string live_name = "affine_identical_prior_live.dat";
+                                const uint64_t live_size = write_two_column_segment(
+                                        sources[0]->id(), live_name, 1, [](int key) { return key * 10; }, 90);
+                                auto* left_live = add_allocator_rowset(sources[0].get(), 5,
+                                                                       sources[0]->rowsets(0).version(), live_name, 0);
+                                left_live->mutable_segment_metas(0)->set_size(live_size);
+                                left_live->mutable_segment_metas(0)->set_shared(true);
+                                auto* right_live = add_allocator_rowset(sources[1].get(), 5,
+                                                                        sources[1]->rowsets(0).version(), live_name, 0);
+                                right_live->mutable_segment_metas(0)->CopyFrom(left_live->segment_metas(0));
+                                right_live->mutable_uid()->CopyFrom(left_live->uid());
+                                for (auto& source : sources) {
+                                    source->set_next_rowset_id(6);
+                                }
+                                const auto file = write_raw_pk_sstable(
+                                        _tablet_manager->sst_location(
+                                                sources[0]->id(), sources[0]->sstable_meta().sstables(0).filename()),
+                                        {{encode_int_primary_key(10),
+                                          serialize_index_values({{sources[0]->version(), 0, 0}})}});
+                                for (auto& source : sources) {
+                                    auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
+                                    sst->set_filesize(file.filesize);
+                                    sst->set_encryption_meta(file.encryption_meta);
+                                    sst->mutable_range()->CopyFrom(file.range);
+                                    sst->clear_shared_rssid();
+                                    sst->clear_shared_version();
+                                    sst->set_rssid_offset(5);
+                                    sst->set_max_rss_rowid(static_cast<uint64_t>(5) << 32);
+                                }
+                            }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    ASSERT_EQ(1, target.sstable_meta().sstables_size());
+    const auto& output = target.sstable_meta().sstables(0);
+    EXPECT_TRUE(output.shared());
+    EXPECT_EQ(5, output.rssid_offset());
+    EXPECT_EQ(static_cast<uint64_t>(5) << 32, output.max_rss_rowid());
+
+    auto target_ptr = std::make_shared<TabletMetadataPB>(target);
+    _update_manager->unload_and_remove_primary_index(target.id());
+    ASSIGN_OR_ABORT(auto values, load_index_values(target_ptr, target.id(), {encode_int_primary_key(/*key=*/10)}));
+    ASSERT_EQ(1, values.size());
+    EXPECT_EQ(5, values[0].get_value() >> 32);
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_alias_interior_rejected_before_materialize) {
     int materialize_count = 0;
     auto* sync = SyncPoint::GetInstance();

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -180,6 +180,25 @@ protected:
         ASSERT_OK(writer->close());
     }
 
+    std::string write_encrypted_binary_del_file(int64_t tablet_id, const std::string& name,
+                                                const std::vector<std::string>& keys) {
+        auto column = BinaryColumn::create();
+        for (const auto& key : keys) column->append(Slice(key));
+        const int64_t max_size = serde::ColumnArraySerde::max_serialized_size(*column);
+        std::vector<uint8_t> buffer(max_size);
+        ASSIGN_OR_ABORT(auto* end, serde::ColumnArraySerde::serialize(*column, buffer.data()));
+        ensure_kek_in_key_cache();
+        ASSIGN_OR_ABORT(auto encryption_pair, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+        WritableFileOptions options;
+        options.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+        options.encryption_info = encryption_pair.info;
+        ASSIGN_OR_ABORT(auto writer, FileSystem::Default()->new_writable_file(
+                                             options, _tablet_manager->del_location(tablet_id, name)));
+        CHECK_OK(writer->append(Slice(reinterpret_cast<const char*>(buffer.data()), end - buffer.data())));
+        CHECK_OK(writer->close());
+        return encryption_pair.encryption_meta;
+    }
+
     void set_primary_key_schema(TabletMetadataPB* metadata, int64_t schema_id) {
         auto* schema = metadata->mutable_schema();
         schema->set_keys_type(PRIMARY_KEYS);
@@ -1440,6 +1459,41 @@ protected:
         for (size_t i = expected_rows.size(); i < values.size(); ++i) {
             EXPECT_EQ(IndexValue(NullIndexValue), values[i]) << deleted_keys[i - expected_rows.size()];
         }
+    }
+
+    void expect_metadata_fallback_lifecycle(const MetadataOnlyMergeResult& result,
+                                            const std::vector<std::pair<int32_t, int32_t>>& initial_rows,
+                                            const std::vector<std::pair<int32_t, int32_t>>& rows_after_dml,
+                                            const std::vector<int32_t>& deleted_keys) {
+        const bool old_parallel_compaction = config::enable_pk_index_parallel_compaction;
+        config::enable_pk_index_parallel_compaction = false;
+        DeferOp restore_parallel([&] { config::enable_pk_index_parallel_compaction = old_parallel_compaction; });
+
+        auto target = std::make_shared<TabletMetadataPB>(result.published.at(result.target_tablet_id));
+        ASSERT_EQ(0, target->sstable_meta().sstables_size()) << "fallback must enter native index rebuild";
+        _update_manager->unload_and_remove_primary_index(result.target_tablet_id);
+        expect_lifecycle_oracle(target, initial_rows, {});
+
+        _update_manager->unload_and_remove_primary_index(result.target_tablet_id);
+        ASSIGN_OR_ABORT(auto after_dml, publish_followup_upsert_delete(result.target_tablet_id, result.target_version,
+                                                                       /*upsert_key=*/10, /*upsert_value=*/1010,
+                                                                       /*delete_key=*/60));
+        expect_lifecycle_oracle(after_dml, rows_after_dml, deleted_keys);
+
+        _update_manager->unload_and_remove_primary_index(result.target_tablet_id);
+        ASSIGN_OR_ABORT(auto reopened_after_dml,
+                        _tablet_manager->get_tablet_metadata(result.target_tablet_id, after_dml->version()));
+        expect_lifecycle_oracle(reopened_after_dml, rows_after_dml, deleted_keys);
+
+        ASSIGN_OR_ABORT(auto compacted,
+                        compact_tablet(result.target_tablet_id, reopened_after_dml->version(), /*force_base=*/true));
+        EXPECT_EQ(reopened_after_dml->version() + 1, compacted->version());
+        expect_lifecycle_oracle(compacted, rows_after_dml, deleted_keys);
+
+        _update_manager->unload_and_remove_primary_index(result.target_tablet_id);
+        ASSIGN_OR_ABORT(auto reopened_compacted,
+                        _tablet_manager->get_tablet_metadata(result.target_tablet_id, compacted->version()));
+        expect_lifecycle_oracle(reopened_compacted, rows_after_dml, deleted_keys);
     }
 
     void assert_published_sstables_reopen(const TabletMetadataPtr& metadata) {
@@ -10209,12 +10263,9 @@ TEST_F(LakeTabletReshardTest, test_collect_compaction_output_files_skips_passthr
                 ::testing::Not(::testing::Contains(_tablet_manager->sst_location(tablet_id, "parallel_reused.sst"))));
 }
 
-// LakePersistentIndex::commit() interprets max_rss_rowid through signed int64
-// monotonic ordering, while other merge paths use unsigned RSSID arithmetic.
-// An encoded watermark with bit 63 set therefore has incompatible ordering
-// semantics and is outside the supported merge allocation domain. Merges must
-// fail closed instead of attempting to sort such a cross-sign input.
-TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_sstable_merge_rejects_sign_bit_source_watermark) {
+// Read-only aliasing discards the source SST cohort, so its uint32 RSSID high
+// half does not constrain the signed packed target cursor.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_sstable_merge_accepts_sign_bit_source_watermark) {
     const int64_t source_tablet = next_id();
     const int64_t merged_tablet = next_id();
     auto source = std::make_shared<TabletMetadataPB>();
@@ -10241,7 +10292,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_sstable_merge_rejects_sig
     auto merged = lake::merge_tablet(_tablet_manager.get(), sources, merging_info, /*new_version=*/2, txn_info,
                                      /*skip_sstable_merge=*/true);
 
-    EXPECT_TRUE(merged.status().is_invalid_argument()) << merged.status();
+    ASSERT_OK(merged.status());
+    ASSERT_EQ(1, merged.value()->rowsets_size());
+    EXPECT_EQ(1, merged.value()->rowsets(0).id());
+    EXPECT_EQ(2, merged.value()->next_rowset_id());
+    EXPECT_EQ(0, merged.value()->sstable_meta().sstables_size());
     EXPECT_EQ(source_before, source->SerializeAsString());
 }
 
@@ -10384,7 +10439,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_rowset_zero_before_any
     run_case(/*rowset_id=*/0, /*primary_key=*/false, /*skip_sstable_merge=*/false, /*expect_rejection=*/false);
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_exhausted_live_rowset_domain_without_sst) {
+TEST_F(LakeTabletReshardTest, test_tablet_merging_packs_upper_half_live_rowset_without_sst) {
     const int64_t base_version = 1;
     const int64_t source_tablet = next_id();
     const int64_t merged_tablet = next_id();
@@ -10416,9 +10471,13 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_exhausted_live_rowset_
     auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version,
                                                   base_version + 1, txn_info, false, tablet_metadatas, tablet_ranges);
 
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    ASSERT_OK(status);
     EXPECT_EQ(source_before, source->SerializeAsString());
-    EXPECT_EQ(tablet_metadatas.end(), tablet_metadatas.find(merged_tablet));
+    auto target = tablet_metadatas.find(merged_tablet);
+    ASSERT_NE(tablet_metadatas.end(), target);
+    ASSERT_EQ(1, target->second->rowsets_size());
+    EXPECT_EQ(1, target->second->rowsets(0).id());
+    EXPECT_EQ(2, target->second->next_rowset_id());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_near_rssid_boundary_remains_writable) {
@@ -10843,6 +10902,22 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_compresses
     EXPECT_EQ(3, merged->next_rowset_id());
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_accepts_upper_half_source_domain) {
+    constexpr uint32_t kSourceRowset = std::numeric_limits<uint32_t>::max() - 10;
+    auto source = make_allocator_source(next_id(), std::numeric_limits<uint32_t>::max());
+    auto* rowset = add_allocator_rowset(source.get(), kSourceRowset, 1, "upper_half_0.dat", 0);
+    add_allocator_segment(rowset, "upper_half_10.dat", 10);
+
+    auto merged_or = publish_allocator_merge({source});
+    ASSERT_OK(merged_or.status());
+    auto merged = std::move(merged_or).value();
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(1, merged->rowsets(0).id());
+    ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
+    EXPECT_EQ(11, merged->rowsets(0).id() + lake::get_segment_idx(merged->rowsets(0), 1));
+    EXPECT_EQ(12, merged->next_rowset_id());
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_reserves_duplicate_high_segment_idx) {
     auto selected_source = make_allocator_source(next_id(), 11);
     auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "duplicate_low.dat", 0);
@@ -10974,19 +11049,48 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_validation_only_delete_uses_lo
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped_delete_origins) {
-    auto selected_source = make_allocator_source(next_id(), 42);
+    const bool old_parallel_compaction = config::enable_pk_index_parallel_compaction;
+    config::enable_pk_index_parallel_compaction = false;
+    DeferOp restore_parallel([&] { config::enable_pk_index_parallel_compaction = old_parallel_compaction; });
+    const int64_t selected_id = next_id();
+    const int64_t duplicate_id = next_id();
+    prepare_tablet_dirs(selected_id);
+    prepare_tablet_dirs(duplicate_id);
+    auto selected_source = make_allocator_source(selected_id, 42);
+    auto duplicate_source = make_allocator_source(duplicate_id, 402);
+    for (auto* source : {selected_source.get(), duplicate_source.get()}) {
+        set_two_column_pk_schema(source, 4001);
+        source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+        source->set_enable_persistent_index(true);
+        source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+    }
+    selected_source->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    selected_source->mutable_range()->set_lower_bound_included(true);
+    selected_source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(50));
+    selected_source->mutable_range()->set_upper_bound_included(false);
+    duplicate_source->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(50));
+    duplicate_source->mutable_range()->set_lower_bound_included(true);
+    duplicate_source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+    duplicate_source->mutable_range()->set_upper_bound_included(false);
+    const uint64_t selected_size = write_two_column_segment(selected_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
+    write_two_column_segment(duplicate_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
     auto* selected = add_allocator_rowset(selected_source.get(), 41, 1, "rejoin.dat", 0);
+    selected->mutable_segment_metas(0)->set_size(selected_size);
+    selected->mutable_segment_metas(0)->set_shared(true);
     auto* selected_del = selected->add_del_files();
     selected_del->set_name("rejoin.del");
     selected_del->set_origin_rowset_id(40);
-    selected_del->set_encryption_meta("rejoin encrypted metadata");
-    auto duplicate_source = make_allocator_source(next_id(), 402);
+    selected_del->set_encryption_meta(write_encrypted_binary_del_file(selected_id, selected_del->name(), {}));
+    selected_del->set_shared(true);
     auto* duplicate = add_allocator_rowset(duplicate_source.get(), 401, 1, "rejoin.dat", 0);
+    duplicate->mutable_segment_metas(0)->set_size(selected_size);
+    duplicate->mutable_segment_metas(0)->set_shared(true);
     duplicate->mutable_uid()->CopyFrom(selected->uid());
     auto* duplicate_del = duplicate->add_del_files();
     duplicate_del->set_name(selected_del->name());
     duplicate_del->set_origin_rowset_id(400);
     duplicate_del->set_encryption_meta(selected_del->encryption_meta());
+    duplicate_del->set_shared(true);
 
     auto merged_or = publish_allocator_merge({selected_source, duplicate_source});
     ASSERT_OK(merged_or.status());
@@ -10996,6 +11100,21 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped
     ASSERT_EQ(1, merged->rowsets(0).del_files_size());
     EXPECT_EQ(1, merged->rowsets(0).del_files(0).origin_rowset_id());
     EXPECT_EQ(3, merged->next_rowset_id());
+    ASSERT_EQ(0, merged->sstable_meta().sstables_size());
+    _update_manager->unload_and_remove_primary_index(merged->id());
+    expect_lifecycle_oracle(merged, {{10, 100}}, {});
+
+    _update_manager->unload_and_remove_primary_index(merged->id());
+    ASSIGN_OR_ABORT(auto after_dml, publish_followup_upsert_delete(merged->id(), merged->version(), 10, 1010, 60));
+    expect_lifecycle_oracle(after_dml, {{10, 1010}}, {60});
+    _update_manager->unload_and_remove_primary_index(merged->id());
+    ASSIGN_OR_ABORT(auto reopened_after_dml, _tablet_manager->get_tablet_metadata(merged->id(), after_dml->version()));
+    expect_lifecycle_oracle(reopened_after_dml, {{10, 1010}}, {60});
+    ASSIGN_OR_ABORT(auto compacted, compact_tablet(merged->id(), reopened_after_dml->version(), /*force_base=*/true));
+    expect_lifecycle_oracle(compacted, {{10, 1010}}, {60});
+    _update_manager->unload_and_remove_primary_index(merged->id());
+    ASSIGN_OR_ABORT(auto reopened_compacted, _tablet_manager->get_tablet_metadata(merged->id(), compacted->version()));
+    expect_lifecycle_oracle(reopened_compacted, {{10, 1010}}, {60});
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_mixed_self_inherited_del_class) {
@@ -11211,10 +11330,22 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_rowset_schema_mapping_
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_equal_recovery_key_equivalence_on_cold_load) {
-    auto source = make_allocator_source(next_id(), 805);
+    const int64_t source_id = next_id();
+    prepare_tablet_dirs(source_id);
+    auto source = make_allocator_source(source_id, 805);
+    set_two_column_pk_schema(source.get(), 4001);
+    source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    source->set_enable_persistent_index(true);
+    source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+    const uint64_t first_size =
+            write_two_column_segment(source_id, "recovery_equal_a.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size =
+            write_two_column_segment(source_id, "recovery_equal_b.dat", 1, [](int) { return 200; }, 20);
     auto* first = add_allocator_rowset(source.get(), 798, 1, "recovery_equal_a.dat", 0);
+    first->mutable_segment_metas(0)->set_size(first_size);
     first->set_max_compact_input_rowset_id(797);
     auto* second = add_allocator_rowset(source.get(), 803, 2, "recovery_equal_b.dat", 0);
+    second->mutable_segment_metas(0)->set_size(second_size);
     second->set_max_compact_input_rowset_id(797);
 
     ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({source}));
@@ -11222,6 +11353,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_equal_recovery_key_e
     ASSERT_TRUE(merged->rowsets(0).has_max_compact_input_rowset_id());
     ASSERT_TRUE(merged->rowsets(1).has_max_compact_input_rowset_id());
     EXPECT_EQ(merged->rowsets(0).max_compact_input_rowset_id(), merged->rowsets(1).max_compact_input_rowset_id());
+    ASSIGN_OR_ABORT(auto rows, read_two_column_rows(merged));
+    EXPECT_EQ((std::vector<std::pair<int32_t, int32_t>>{{10, 100}, {20, 200}}), rows);
+    _update_manager->unload_and_remove_primary_index(merged->id());
+    const std::vector<std::string> keys = {encode_int_primary_key(10), encode_int_primary_key(20)};
+    ASSIGN_OR_ABORT(auto values, load_index_values(merged, merged->id(), keys));
+    ASSERT_EQ(2, values.size());
+    EXPECT_EQ(2, values[0].get_value() >> 32);
+    EXPECT_EQ(3, values[1].get_value() >> 32);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_alias_reversed_recovery_order_before_io) {
@@ -11247,15 +11386,39 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_alias_reversed_recover
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_strict_recovery_order_on_cold_load) {
-    auto first = make_allocator_source(next_id(), 3);
-    add_allocator_rowset(first.get(), 2, 1, "recovery_strict_2.dat", 0);
-    auto second = make_allocator_source(next_id(), 21);
-    add_allocator_rowset(second.get(), 20, 2, "recovery_strict_20.dat", 0);
+    const int64_t first_id = next_id();
+    const int64_t second_id = next_id();
+    prepare_tablet_dirs(first_id);
+    prepare_tablet_dirs(second_id);
+    auto first = make_allocator_source(first_id, 3);
+    auto second = make_allocator_source(second_id, 21);
+    for (auto* source : {first.get(), second.get()}) {
+        set_two_column_pk_schema(source, 4001);
+        source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+        source->set_enable_persistent_index(true);
+        source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+    }
+    const uint64_t first_size =
+            write_two_column_segment(first_id, "recovery_strict_2.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size =
+            write_two_column_segment(second_id, "recovery_strict_20.dat", 1, [](int) { return 600; }, 60);
+    auto* first_rowset = add_allocator_rowset(first.get(), 2, 1, "recovery_strict_2.dat", 0);
+    first_rowset->mutable_segment_metas(0)->set_size(first_size);
+    auto* second_rowset = add_allocator_rowset(second.get(), 20, 2, "recovery_strict_20.dat", 0);
+    second_rowset->mutable_segment_metas(0)->set_size(second_size);
 
     ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second}));
     ASSERT_EQ(2, merged->rowsets_size());
     EXPECT_EQ((std::vector<uint32_t>{1, 2}), allocator_rowset_ids(*merged));
     EXPECT_EQ(3, merged->next_rowset_id());
+    ASSIGN_OR_ABORT(auto rows, read_two_column_rows(merged));
+    EXPECT_EQ((std::vector<std::pair<int32_t, int32_t>>{{10, 100}, {60, 600}}), rows);
+    _update_manager->unload_and_remove_primary_index(merged->id());
+    const std::vector<std::string> keys = {encode_int_primary_key(10), encode_int_primary_key(60)};
+    ASSIGN_OR_ABORT(auto values, load_index_values(merged, merged->id(), keys));
+    ASSERT_EQ(2, values.size());
+    EXPECT_EQ(1, values[0].get_value() >> 32);
+    EXPECT_EQ(2, values[1].get_value() >> 32);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_modern_source_stale_falls_back) {
@@ -11328,26 +11491,31 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_negative_offset_
         EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
                                    [&](const auto& orphan) { return orphan.name() == filename; }));
     }
+    expect_metadata_fallback_lifecycle(result, {{10, 100}, {60, 600}}, {{10, 1010}}, {60});
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_compressed_gap_falls_back) {
-    ASSIGN_OR_ABORT(auto result, publish_metadata_only_merge_fixture(
-                                         MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
-                                             auto* extra = add_allocator_rowset(sources[1].get(), 100,
-                                                                                sources[1]->rowsets(0).version(),
-                                                                                "legacy_gap_100.dat", 0);
-                                             extra->mutable_segment_metas(0)->set_size(1);
-                                             sources[1]->set_next_rowset_id(101);
-                                             auto* legacy = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
-                                             legacy->set_rssid_offset(5);
-                                             legacy->set_max_rss_rowid(static_cast<uint64_t>(100) << 32);
-                                         }));
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(
+                            MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
+                                const uint64_t extra_size = write_two_column_segment(
+                                        sources[1]->id(), "legacy_gap_100.dat", 1, [](int) { return 700; }, 70);
+                                auto* extra =
+                                        add_allocator_rowset(sources[1].get(), 100, sources[1]->rowsets(0).version(),
+                                                             "legacy_gap_100.dat", 0);
+                                extra->mutable_segment_metas(0)->set_size(extra_size);
+                                sources[1]->set_next_rowset_id(101);
+                                auto* legacy = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
+                                legacy->set_rssid_offset(5);
+                                legacy->set_max_rss_rowid(static_cast<uint64_t>(100) << 32);
+                            }));
     const auto& target = result.published.at(result.target_tablet_id);
     EXPECT_EQ(0, target.sstable_meta().sstables_size());
     for (const auto& filename : result.source_sst_filenames) {
         EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
                                    [&](const auto& orphan) { return orphan.name() == filename; }));
     }
+    expect_metadata_fallback_lifecycle(result, {{10, 100}, {60, 600}, {70, 700}}, {{10, 1010}, {70, 700}}, {60});
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_alias_interior_rejected_before_materialize) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -10194,14 +10194,18 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
 
     TabletMetadataPB compacted(*reopened);
     compacted.set_version(reopened->version() + 1);
-    compacted.set_prev_garbage_version(reopened->version());
+    RowsetMetadataPB retired;
     RowsetMetadataPB retained;
     for (const auto& rowset : compacted.rowsets()) {
+        if (rowset.id() == 1) retired.CopyFrom(rowset);
         if (rowset.id() == 2) retained.CopyFrom(rowset);
     }
+    ASSERT_TRUE(retired.has_id());
     ASSERT_TRUE(retained.has_id());
     compacted.clear_rowsets();
     compacted.add_rowsets()->CopyFrom(retained);
+    compacted.clear_compaction_inputs();
+    compacted.add_compaction_inputs()->CopyFrom(retired);
     const std::string compacted_name = "cross_target_compacted.dat";
     const uint64_t compacted_size = write_two_column_segment(target_id, compacted_name, 1, [](int) { return 1000; });
     auto* output = compacted.add_rowsets();
@@ -10224,12 +10228,29 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     compacted.mutable_idg_meta()->mutable_idgs()->erase(1);
     compacted.mutable_delvec_meta()->mutable_delvecs()->erase(1);
     compacted.clear_orphan_files();
+    auto add_orphan = [&](const std::string& name, int64_t size, bool shared, int64_t version) {
+        auto* orphan = compacted.add_orphan_files();
+        orphan->set_name(name);
+        orphan->set_size(size);
+        orphan->set_shared(shared);
+        orphan->set_version(version);
+    };
+    add_orphan(cols_name, cols_size, /*shared=*/true, /*version=*/1);
+    add_orphan(idx_name, idx_file.filesize, /*shared=*/true, /*version=*/1);
+    const std::string private_control_name = "cross_target_private_control.idx";
+    const auto private_control = write_sidecar_payload(
+            _tablet_manager->segment_location(target_id, private_control_name), "private-vacuum-control",
+            /*encrypted=*/false);
+    add_orphan(private_control_name, private_control.filesize, /*shared=*/false, compacted.version());
+    ASSERT_EQ(1, compacted.compaction_inputs_size());
+    ASSERT_EQ(3, compacted.orphan_files_size());
     ASSERT_OK(put_tablet_metadata(compacted));
 
     _tablet_manager->prune_metacache();
     ASSIGN_OR_ABORT(auto cold_compacted, _tablet_manager->get_tablet_metadata(target_id, compacted.version()));
     ASSIGN_OR_ABORT(auto compacted_rows, read_two_column_rows(cold_compacted));
     EXPECT_EQ((std::vector<std::pair<int32_t, int32_t>>{{0, 1000}, {1, 2000}}), compacted_rows);
+    EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, private_control_name)));
 
     VacuumRequest request;
     VacuumResponse response;
@@ -10249,6 +10270,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, base_name)));
     EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, cols_name)));
     EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, idx_name)));
+    EXPECT_TRUE(FileSystem::Default()
+                        ->path_exists(_tablet_manager->segment_location(target_id, private_control_name))
+                        .is_not_found());
 
     _tablet_manager->prune_metacache();
     ASSIGN_OR_ABORT(auto reopened_after_vacuum, _tablet_manager->get_tablet_metadata(target_id, compacted.version()));
@@ -10382,6 +10406,29 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_sst_invalid_
         MergePhaseCounts counts;
         auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
         EXPECT_TRUE(status.message().contains("SST")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_modern_sst_invalid_shared_version_before_io) {
+    struct InvalidSharedVersion {
+        const char* name;
+        std::function<void(PersistentIndexSstablePB*)> apply;
+    };
+    const std::vector<InvalidSharedVersion> invalid_versions = {
+            {"missing", [](PersistentIndexSstablePB* sst) { sst->clear_shared_version(); }},
+            {"zero", [](PersistentIndexSstablePB* sst) { sst->set_shared_version(0); }},
+            {"negative", [](PersistentIndexSstablePB* sst) { sst->set_shared_version(-1); }},
+    };
+
+    for (const auto& invalid : invalid_versions) {
+        SCOPED_TRACE(invalid.name);
+        auto sources = make_preflight_sst_sources(fmt::format("sst_invalid_shared_version_{}", next_id()));
+        for (auto& source : sources) invalid.apply(source->mutable_sstable_meta()->mutable_sstables(0));
+        std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("SST")) << status;
+        EXPECT_TRUE(status.message().contains("shared_version")) << status;
     }
 }
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -340,6 +340,73 @@ protected:
         return tablet_metadatas.at(merged_tablet);
     }
 
+    std::shared_ptr<TabletMetadataPB> make_allocator_source(int64_t tablet_id, uint32_t next_rowset_id = 1) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(1);
+        metadata->set_next_rowset_id(next_rowset_id);
+        set_primary_key_schema(metadata.get(), 1001);
+        return metadata;
+    }
+
+    RowsetMetadataPB* add_allocator_rowset(TabletMetadataPB* metadata, uint32_t rowset_id, int64_t version,
+                                           const std::string& segment_name, uint32_t segment_idx = 0,
+                                           bool explicit_segment_idx = true) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(rowset_id);
+        rowset->set_version(version);
+        rowset->set_num_rows(1);
+        rowset->set_data_size(1);
+        rowset->set_overlapped(false);
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(segment_name);
+        segment->set_size(1);
+        segment->set_num_rows(1);
+        if (explicit_segment_idx) segment->set_segment_idx(segment_idx);
+        lake::tablet_reshard_helper::set_rowset_uid(rowset);
+        return rowset;
+    }
+
+    SegmentMetadataPB* add_allocator_segment(RowsetMetadataPB* rowset, const std::string& segment_name,
+                                             uint32_t segment_idx, bool explicit_segment_idx = true) {
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(segment_name);
+        segment->set_size(1);
+        segment->set_num_rows(1);
+        if (explicit_segment_idx) segment->set_segment_idx(segment_idx);
+        rowset->set_num_rows(rowset->num_rows() + 1);
+        rowset->set_data_size(rowset->data_size() + 1);
+        return segment;
+    }
+
+    StatusOr<TabletMetadataPtr> publish_allocator_merge(
+            const std::vector<std::shared_ptr<TabletMetadataPB>>& mutable_sources,
+            const std::function<void()>& before_merge = {}, int64_t* attempted_target_id = nullptr) {
+        if (mutable_sources.empty()) return Status::InvalidArgument("allocator merge fixture has no source");
+        const int64_t target_id = next_id();
+        if (attempted_target_id != nullptr) *attempted_target_id = target_id;
+        prepare_tablet_dirs(target_id);
+        std::vector<TabletMetadataPtr> sources;
+        sources.reserve(mutable_sources.size());
+        for (const auto& source : mutable_sources) {
+            prepare_tablet_dirs(source->id());
+            sources.emplace_back(source);
+        }
+        std::unordered_map<int64_t, TabletMetadataPtr> published;
+        RETURN_IF_ERROR(publish_resharding_merge(sources, target_id, /*base_version=*/1, /*new_version=*/2,
+                                                 /*txn_id=*/next_id(), published, before_merge));
+        auto target = published.find(target_id);
+        if (target == published.end()) return Status::InternalError("allocator merge target was not published");
+        return target->second;
+    }
+
+    static std::vector<uint32_t> allocator_rowset_ids(const TabletMetadataPB& metadata) {
+        std::vector<uint32_t> result;
+        result.reserve(metadata.rowsets_size());
+        for (const auto& rowset : metadata.rowsets()) result.emplace_back(rowset.id());
+        return result;
+    }
+
     struct MetadataOnlyMergeResult {
         int64_t target_tablet_id = 0;
         int64_t target_version = 0;
@@ -383,8 +450,8 @@ protected:
         const bool identical = shape == MetadataOnlyMergeShape::kIdentical;
         const std::string segment_a = "metadata_only_a.dat";
         const std::string segment_b = identical ? segment_a : "metadata_only_b.dat";
-        const uint64_t segment_a_size = write_two_column_segment(
-                source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
+        const uint64_t segment_a_size =
+                write_two_column_segment(source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
         uint64_t segment_b_size = segment_a_size;
         if (!identical) {
             segment_b_size = write_two_column_segment(
@@ -1426,8 +1493,8 @@ protected:
         prepare_tablet_dirs(target_tablet_id);
         const uint64_t old_size = write_two_column_segment(child_a, old_segment, 1, [](int) { return 100; });
         const uint64_t tail_size = write_two_column_segment(child_a, tail_segment, 1, [](int) { return 200; });
-        const uint64_t sibling_size = write_two_column_segment(
-                child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
+        const uint64_t sibling_size =
+                write_two_column_segment(child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
         const uint32_t tombstone = std::numeric_limits<uint32_t>::max();
         const uint64_t tombstone_size =
                 write_versioned_pk_sstable(_tablet_manager->sst_location(child_a, tombstone_filename),
@@ -1996,8 +2063,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_projected_target_domai
         conflicting_dcg.add_shared_files(false);
     };
 
-    // The source contexts are each individually valid. Their ordered merge maps
-    // the second context into (INT32_MAX, UINT32_MAX], which must be rejected
+    // Dense allocation removes the old projected-overflow path. The synthetic
+    // DCG key is not in the authoritative closure and must instead fail closed
     // before DCG/delvec/source-index output is attempted.
     auto result = publish_metadata_only_merge_fixture(
             MetadataOnlyMergeShape::kPrivate, /*enable_tde=*/false,
@@ -2008,7 +2075,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_projected_target_domai
                 ASSIGN_OR_ABORT(target_metadata_root_before,
                                 directory_inventory(_location_provider->metadata_root_location(target)));
             });
-    EXPECT_TRUE(result.status().is_invalid_argument()) << result.status();
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
     EXPECT_EQ(0, dcg_rebuild_count);
     EXPECT_EQ(0, delvec_writer_count);
     EXPECT_EQ(0, source_flush_count);
@@ -2683,7 +2750,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_allocation_covers_pr
                                                         /*with_del_file=*/false, /*skip_source_flush=*/true,
                                                         foreign_origin_delete_history));
     const auto& foreign_origin_target = foreign_origin_control.published.at(foreign_origin_control.target_tablet_id);
-    EXPECT_GT(foreign_origin_target.next_rowset_id(), uint64_t{kForeignOriginRowset} + kOpOffset);
+    ASSERT_EQ(1, foreign_origin_target.rowsets_size());
+    ASSERT_EQ(1, foreign_origin_target.rowsets(0).del_files_size());
+    EXPECT_EQ(2, foreign_origin_target.rowsets(0).del_files(0).origin_rowset_id());
+    EXPECT_EQ(10, foreign_origin_target.next_rowset_id());
 
     auto zero_segment_no_del = [](std::vector<std::shared_ptr<TabletMetadataPB>>& sources) {
         sources[0]->mutable_rowsets(0)->clear_segment_metas();
@@ -3460,7 +3530,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_split_identical_layo
         EXPECT_TRUE(sstable.shared());
         output_sstables.insert(sstable.filename());
     }
-    EXPECT_EQ(source_sstables, output_sstables);
+    EXPECT_TRUE(output_sstables.empty()) << "Task 1 conservatively falls back for identical legacy SSTs";
+    for (const auto& filename : source_sstables) {
+        EXPECT_EQ(1, std::count_if(final_metadata->orphan_files().begin(), final_metadata->orphan_files().end(),
+                                   [&](const auto& orphan) { return orphan.name() == filename; }));
+    }
     ASSIGN_OR_ABORT(auto inventory_after_merge, sst_inventory(final_id));
     EXPECT_EQ(inventory_before_merge, inventory_after_merge) << "metadata-only reuse must write no SST";
     expect_lifecycle_oracle(final_metadata, expected, {});
@@ -4648,13 +4722,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_drops_live_source_page_
 
     ASSIGN_OR_ABORT(auto files_before_merge, delvec_inventory(merged_tablet));
     std::unordered_map<int64_t, TabletMetadataPtr> published;
-    ASSERT_OK(publish_resharding_merge({canonical, noncanonical}, merged_tablet, kBaseVersion, kMergeVersion, next_id(),
-                                       published));
-    const auto& merged = published.at(merged_tablet);
-    ASSERT_EQ(1, merged->rowsets_size());
-    EXPECT_EQ(0, merged->rowsets(0).segment_metas_size());
-    EXPECT_EQ(0, merged->delvec_meta().delvecs_size());
-    EXPECT_EQ(0, merged->delvec_meta().version_to_file_size());
+    auto merge_status = publish_resharding_merge({canonical, noncanonical}, merged_tablet, kBaseVersion, kMergeVersion,
+                                                 next_id(), published);
+    EXPECT_TRUE(merge_status.is_corruption()) << merge_status;
+    EXPECT_FALSE(published.contains(merged_tablet));
     ASSIGN_OR_ABORT(auto files_after_merge, delvec_inventory(merged_tablet));
     EXPECT_EQ(files_before_merge, files_after_merge);
 }
@@ -5562,8 +5633,8 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {
     // - Tablet B rowset 1 (id=4, version 1, data, offset=3 from tablet A) -> comes before predicate
     // - Tablet A rowset 2 (id=2, version 10, predicate) -> kept, tablet B's duplicate predicate removed
     // - Tablet A rowset 3 (id=3, version 11, data) -> after predicate
-    // - Tablet B rowset 3 (id=6, version 11, data, offset=3) -> after predicate
-    EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 3, 6}), rowset_ids);
+    // - Tablet B rowset 3 (id=5, version 11, densely packed) -> after predicate
+    EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 3, 5}), rowset_ids);
 }
 
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_different_predicate_versions) {
@@ -5645,10 +5716,10 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_different_predicate_versions) {
     // Version-driven k-way merge order:
     // v1: A(id=1), B(id=4)
     // v10: A predicate(id=2) output, B predicate dedup skip
-    // v11: A(id=3), B(id=6)
-    // v20: B predicate(id=7)
-    // v21: B(id=8)
-    EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 3, 6, 7, 8}), rowset_ids);
+    // v11: A(id=3), B(id=5)
+    // v20: B predicate(id=6)
+    // v21: B(id=7)
+    EXPECT_EQ((std::vector<uint32_t>{1, 4, 2, 3, 5, 6, 7}), rowset_ids);
 }
 
 TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
@@ -5926,8 +5997,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
 
     auto merged = tablet_metadatas.at(new_tablet_id);
     ASSERT_TRUE(merged->has_range());
-    const int64_t offset = static_cast<int64_t>(meta1->next_rowset_id()) - 1;
-    const uint32_t expected_rowset_id = static_cast<uint32_t>(1 + offset);
+    const uint32_t expected_rowset_id = 3;
 
     bool found_rowset = false;
     for (const auto& rowset : merged->rowsets()) {
@@ -5936,9 +6006,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
             ASSERT_TRUE(rowset.has_range());
             EXPECT_EQ(rowset.range().SerializeAsString(), meta2->range().SerializeAsString());
             ASSERT_TRUE(rowset.has_max_compact_input_rowset_id());
-            EXPECT_EQ(static_cast<uint32_t>(3 + offset), rowset.max_compact_input_rowset_id());
+            EXPECT_EQ(4, rowset.max_compact_input_rowset_id());
             ASSERT_EQ(1, rowset.del_files_size());
-            EXPECT_EQ(static_cast<uint32_t>(1 + offset), rowset.del_files(0).origin_rowset_id());
+            EXPECT_EQ(3, rowset.del_files(0).origin_rowset_id());
             break;
         }
     }
@@ -5946,7 +6016,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
 
     bool found_rowset_from_meta1 = false;
     for (const auto& rowset : merged->rowsets()) {
-        if (rowset.id() == 10) {
+        if (rowset.id() == 2) {
             found_rowset_from_meta1 = true;
             ASSERT_TRUE(rowset.has_range());
             EXPECT_EQ(rowset.range().SerializeAsString(), meta1->range().SerializeAsString());
@@ -5977,7 +6047,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
     }
     EXPECT_TRUE(source_sstables.empty());
 
-    const uint32_t expected_segment_id = static_cast<uint32_t>(1 + offset);
+    const uint32_t expected_segment_id = 3;
     auto delvec_it = merged->delvec_meta().delvecs().find(expected_segment_id);
     ASSERT_TRUE(delvec_it != merged->delvec_meta().delvecs().end());
     EXPECT_EQ(new_version, delvec_it->second.version());
@@ -6200,7 +6270,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_version_missing) {
     std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
     auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
                                               txn_info, false, tablet_metadatas, tablet_ranges);
-    EXPECT_TRUE(st.is_invalid_argument());
+    EXPECT_TRUE(st.is_invalid_argument()) << st;
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) {
@@ -6495,7 +6565,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_segment_overflow) {
     std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
     auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
                                               txn_info, false, tablet_metadatas, tablet_ranges);
-    EXPECT_TRUE(st.is_invalid_argument());
+    EXPECT_TRUE(st.is_corruption()) << st;
 }
 
 TEST_F(LakeTabletReshardTest, test_split_cross_publish_sets_rowset_range_in_txn_log) {
@@ -7426,7 +7496,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_num_dels) {
         {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
-            sm->set_size(data_size);
+            sm->set_size(100);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -10382,10 +10452,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_near_rssid_boundary_remains_wr
     ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, merged_version,
                                               merge_txn, false, tablet_metadatas, tablet_ranges));
     auto merged = tablet_metadatas.at(merged_tablet);
-    ASSERT_EQ(std::numeric_limits<int32_t>::max(), merged->next_rowset_id());
+    ASSERT_EQ(2, merged->next_rowset_id());
 
-    const uint64_t write_segment_size = write_two_column_segment(
-            merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
+    const uint64_t write_segment_size =
+            write_two_column_segment(merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
     TxnLogPB write_log;
     write_log.set_tablet_id(merged_tablet);
     write_log.set_txn_id(2);
@@ -10406,9 +10476,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_near_rssid_boundary_remains_wr
             lake::publish_version(_tablet_manager.get(), lake::PublishTabletInfo(merged_tablet), merged_version,
                                   merged_version + 1, std::span<const TxnInfoPB>(&write_txn, 1), false);
     ASSERT_OK(published.status());
-    ASSERT_FALSE(published.value()->sstable_meta().sstables().empty());
-    EXPECT_LE(published.value()->sstable_meta().sstables().rbegin()->max_rss_rowid(),
-              static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+    EXPECT_EQ(3, published.value()->next_rowset_id());
+    if (!published.value()->sstable_meta().sstables().empty()) {
+        EXPECT_LE(published.value()->sstable_meta().sstables().rbegin()->max_rss_rowid(),
+                  static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+    }
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_hot_sibling_id_space_does_not_overflow) {
@@ -10481,32 +10553,32 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_hot_sibling_id_space_does_not_
     // The complete carried floor is origin_rowset_id 766, so the hot tablet receives
     // offset 12 - 766 = -754. Its live rowsets remain above every projected dead
     // reference while the complete projected space starts at the cold tablet's ceiling.
-    ASSERT_TRUE(by_id.count(11)) << "cold sibling's rowset must keep id 11";
-    ASSERT_TRUE(by_id.count(44)) << "hot sibling's rowsets must use the complete carried floor";
-    ASSERT_TRUE(by_id.count(49));
-    ASSERT_TRUE(by_id.count(106));
+    ASSERT_TRUE(by_id.count(2));
+    ASSERT_TRUE(by_id.count(5));
+    ASSERT_TRUE(by_id.count(6));
+    ASSERT_TRUE(by_id.count(8));
 
     // The two dead-reference fields are shifted by the same offset as the live ids.
     // The minimum reference lands exactly at base.next_rowset_id instead of below zero.
-    const auto* compaction_output = by_id[49];
-    EXPECT_EQ(43u, compaction_output->max_compact_input_rowset_id());
+    const auto* compaction_output = by_id[6];
+    EXPECT_EQ(4u, compaction_output->max_compact_input_rowset_id());
     ASSERT_EQ(1, compaction_output->del_files_size());
-    EXPECT_EQ(12u, compaction_output->del_files(0).origin_rowset_id());
+    EXPECT_EQ(3u, compaction_output->del_files(0).origin_rowset_id());
 
     // Every value carried by the hot sibling must stay above the cold sibling's live
     // rowset id. Under the old live-only floor, max_compact_input_rowset_id 797
     // landed exactly on 11 and origin_rowset_id 766 underflowed to -20.
     for (const auto& rowset : merged->rowsets()) {
-        if (rowset.id() == 11) continue; // cold sibling's rowset
-        EXPECT_GT(rowset.id(), 11u);
-        EXPECT_GT(rowset.max_compact_input_rowset_id(), 11u);
+        if (rowset.id() == 2) continue;
+        EXPECT_GT(rowset.id(), 2u);
+        EXPECT_GT(rowset.max_compact_input_rowset_id(), 2u);
         for (const auto& del_file : rowset.del_files()) {
-            EXPECT_GT(del_file.origin_rowset_id(), 11u);
+            EXPECT_GT(del_file.origin_rowset_id(), 2u);
         }
     }
 
     // Future writes must not reuse an occupied id.
-    EXPECT_EQ(107u, merged->next_rowset_id());
+    EXPECT_EQ(9u, merged->next_rowset_id());
 }
 
 // A later input's compacted-away reference can numerically equal an earlier
@@ -10569,17 +10641,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dead_reference_does_not_collid
         by_id[rowset.id()] = &rowset;
     }
 
-    ASSERT_TRUE(by_id.count(766)) << "the earlier input's live rowset keeps id 766";
-    ASSERT_TRUE(by_id.count(800)) << "the later input shifts by 767 - 765 = 2";
-    ASSERT_TRUE(by_id.count(805));
+    ASSERT_TRUE(by_id.count(2));
+    ASSERT_TRUE(by_id.count(6));
+    ASSERT_TRUE(by_id.count(7));
 
-    const auto* later_compaction_output = by_id[805];
+    const auto* later_compaction_output = by_id[7];
     ASSERT_EQ(1, later_compaction_output->del_files_size());
-    EXPECT_EQ(768u, later_compaction_output->del_files(0).origin_rowset_id())
-            << "the later input's dead reference must not alias the earlier live rowset";
-    EXPECT_EQ(767u, later_compaction_output->max_compact_input_rowset_id())
-            << "the later input's compaction watermark must also stay above the earlier live rowset";
-    EXPECT_EQ(806u, merged->next_rowset_id());
+    EXPECT_EQ(4u, later_compaction_output->del_files(0).origin_rowset_id());
+    EXPECT_EQ(3u, later_compaction_output->max_compact_input_rowset_id());
+    EXPECT_EQ(8u, merged->next_rowset_id());
 }
 
 // A same-UID sibling copy is discarded by merge_rowsets, so its historical
@@ -10649,23 +10719,18 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_duplicate_does_not_l
     for (const auto& rowset : merged->rowsets()) {
         by_id[rowset.id()] = &rowset;
     }
-    ASSERT_TRUE(by_id.count(kBaseRowsetId));
-    ASSERT_TRUE(by_id.count(kBaseNextRowsetId))
-            << "the emitted high-ID rowset must map from its own floor, not the discarded copy's reference";
-    EXPECT_EQ(kBaseNextRowsetId + 1, merged->next_rowset_id());
+    ASSERT_TRUE(by_id.count(2));
+    ASSERT_TRUE(by_id.count(3));
+    EXPECT_EQ(4, merged->next_rowset_id());
 }
 
 // Three siblings whose rowset-id counters have diverged, where the middle one
 // carries nothing but a delete predicate that dedups away against the first
 // sibling's predicate at the same version.
 //
-// A discarded predicate is the one discarded rowset whose id still reaches the
-// merged namespace through the natural offset: merge_rowsets records a
-// shared_rssid_map entry for a discarded duplicate only when it is NOT a delete
-// predicate. So the floor must include it -- otherwise the middle sibling has no
-// floor at all, keeps offset 0, and its raw id (here 2.1e9) becomes the watermark
-// the third sibling is lifted above, pushing the third sibling's own high-ID
-// rowset past INT32_MAX even though the emitted namespace has room for it.
+// The discarded predicate contributes no canonical extent or primary atom. Its
+// sparse raw id must therefore consume no target slot and must not raise the
+// cursor seen by the third sibling.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_inflate_later_sibling_ceiling) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -10749,8 +10814,566 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     // ctx[1]'s floor is its discarded predicate id, so it shifts down to the base
     // watermark 3 and reserves exactly that one slot. ctx[2] is then lifted to 4
     // instead of to 2'100'000'001, and its span survives intact.
-    EXPECT_EQ((std::vector<uint32_t>{1, 2, 4, kWideSpanTopId - 1}), rowset_ids);
-    EXPECT_EQ(kWideSpanTopId, merged->next_rowset_id());
+    EXPECT_EQ((std::vector<uint32_t>{1, 2, 3, 4}), rowset_ids);
+    EXPECT_EQ(5, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_packs_sparse_contexts) {
+    auto first = make_allocator_source(next_id(), 102);
+    add_allocator_rowset(first.get(), 100, 1, "sparse_100.dat");
+    add_allocator_rowset(first.get(), 101, 2, "sparse_101.dat");
+    auto second = make_allocator_source(next_id(), 1'000'002);
+    add_allocator_rowset(second.get(), 1'000'000, 3, "sparse_1000000.dat");
+    add_allocator_rowset(second.get(), 1'000'001, 4, "sparse_1000001.dat");
+    auto third = make_allocator_source(next_id(), 1'500'001);
+    add_allocator_rowset(third.get(), 1'500'000, 5, "sparse_1500000.dat");
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second, third}));
+    EXPECT_EQ((std::vector<uint32_t>{1, 2, 3, 4, 5}), allocator_rowset_ids(*merged));
+    EXPECT_EQ(6, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_compresses_context_zero) {
+    auto source = make_allocator_source(next_id(), 106);
+    add_allocator_rowset(source.get(), 100, 1, "context_zero_100.dat");
+    add_allocator_rowset(source.get(), 105, 2, "context_zero_105.dat");
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({source}));
+    EXPECT_EQ((std::vector<uint32_t>{1, 2}), allocator_rowset_ids(*merged));
+    EXPECT_EQ(3, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_reserves_duplicate_high_segment_idx) {
+    auto selected_source = make_allocator_source(next_id(), 11);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "duplicate_low.dat", 0);
+    auto duplicate_source = make_allocator_source(next_id(), 121);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "duplicate_high.dat", 100);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+
+    auto merged_or = publish_allocator_merge({selected_source, duplicate_source});
+    ASSERT_OK(merged_or.status());
+    auto merged = std::move(merged_or).value();
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(1, merged->rowsets(0).id());
+    ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
+    EXPECT_EQ(0, lake::get_segment_idx(merged->rowsets(0), 0));
+    EXPECT_EQ(100, lake::get_segment_idx(merged->rowsets(0), 1));
+    EXPECT_EQ(102, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_rejects_overlapping_final_ownership) {
+    auto source = make_allocator_source(next_id(), 16);
+    auto* wide = add_allocator_rowset(source.get(), 10, 1, "overlap_0.dat", 0);
+    for (uint32_t idx = 1; idx <= 10; ++idx) {
+        add_allocator_segment(wide, fmt::format("overlap_{}.dat", idx), idx);
+    }
+    add_allocator_rowset(source.get(), 15, 2, "overlap_other.dat", 0);
+
+    int materialize_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++materialize_count; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    auto result = publish_allocator_merge({source});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+    EXPECT_EQ(0, materialize_count);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_missing_primary_map_fails_closed) {
+    auto source = make_allocator_source(next_id(), 4);
+    auto* rowset = add_allocator_rowset(source.get(), 3, 1, "missing_primary.dat", 0);
+    rowset->set_max_compact_input_rowset_id(1);
+
+    int drop_atom_count = 0;
+    int materialize_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_merge_test:drop_primary_atom", [&](void* arg) {
+        *static_cast<bool*>(arg) = true;
+        ++drop_atom_count;
+    });
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++materialize_count; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    auto result = publish_allocator_merge({source});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+    EXPECT_EQ(1, drop_atom_count);
+    EXPECT_EQ(0, materialize_count);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_selected_delete_uses_final_canonical_max) {
+    auto selected_source = make_allocator_source(next_id(), 101);
+    auto* selected = add_allocator_rowset(selected_source.get(), 100, 1, "selected_del_low.dat", 0);
+    auto* selected_del = selected->add_del_files();
+    selected_del->set_name("selected_final.del");
+    selected_del->set_origin_rowset_id(80);
+    auto duplicate_source = make_allocator_source(next_id(), 301);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 200, 1, "selected_del_high.dat", 100);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    auto* duplicate_del = duplicate->add_del_files();
+    duplicate_del->set_name(selected_del->name());
+    duplicate_del->set_origin_rowset_id(180);
+
+    auto merged_or = publish_allocator_merge({selected_source, duplicate_source});
+    ASSERT_OK(merged_or.status());
+    auto merged = std::move(merged_or).value();
+    ASSERT_EQ(1, merged->rowsets_size());
+    const auto& output = merged->rowsets(0);
+    EXPECT_EQ(21, output.id());
+    ASSERT_EQ(1, output.del_files_size());
+    EXPECT_EQ(1, output.del_files(0).origin_rowset_id());
+    ASSERT_EQ(2, output.segment_metas_size());
+    EXPECT_EQ(121, output.id() + lake::get_segment_idx(output, 1));
+    EXPECT_GE(output.del_files(0).origin_rowset_id() + 100, output.id());
+    EXPECT_EQ(122, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_validation_only_delete_origin_allocates_no_slots) {
+    auto selected_source = make_allocator_source(next_id(), 111);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "validation_high.dat", 100);
+    auto* selected_del = selected->add_del_files();
+    selected_del->set_name("validation_only.del");
+    selected_del->set_origin_rowset_id(5);
+    auto duplicate_source = make_allocator_source(next_id(), 21);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "validation_low.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    auto* duplicate_del = duplicate->add_del_files();
+    duplicate_del->set_name(selected_del->name());
+    duplicate_del->set_origin_rowset_id(std::numeric_limits<int32_t>::max() - 50);
+
+    auto merged_or = publish_allocator_merge({selected_source, duplicate_source});
+    ASSERT_OK(merged_or.status());
+    auto merged = std::move(merged_or).value();
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(6, merged->rowsets(0).id());
+    EXPECT_EQ(1, merged->rowsets(0).del_files(0).origin_rowset_id());
+    EXPECT_EQ(107, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_validation_only_delete_uses_local_max) {
+    auto selected_source = make_allocator_source(next_id(), 111);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "validation_local_high.dat", 100);
+    auto* selected_del = selected->add_del_files();
+    selected_del->set_name("validation_local.del");
+    selected_del->set_origin_rowset_id(5);
+    auto duplicate_source = make_allocator_source(next_id(), 21);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "validation_local_low.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    auto* duplicate_del = duplicate->add_del_files();
+    duplicate_del->set_name(selected_del->name());
+    duplicate_del->set_origin_rowset_id(std::numeric_limits<int32_t>::max() - 50);
+
+    auto merged = publish_allocator_merge({selected_source, duplicate_source});
+    ASSERT_OK(merged.status());
+    EXPECT_EQ(107, merged.value()->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped_delete_origins) {
+    auto selected_source = make_allocator_source(next_id(), 42);
+    auto* selected = add_allocator_rowset(selected_source.get(), 41, 1, "rejoin.dat", 0);
+    auto* selected_del = selected->add_del_files();
+    selected_del->set_name("rejoin.del");
+    selected_del->set_origin_rowset_id(40);
+    selected_del->set_encryption_meta("rejoin encrypted metadata");
+    auto duplicate_source = make_allocator_source(next_id(), 402);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 401, 1, "rejoin.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    auto* duplicate_del = duplicate->add_del_files();
+    duplicate_del->set_name(selected_del->name());
+    duplicate_del->set_origin_rowset_id(400);
+    duplicate_del->set_encryption_meta(selected_del->encryption_meta());
+
+    auto merged_or = publish_allocator_merge({selected_source, duplicate_source});
+    ASSERT_OK(merged_or.status());
+    auto merged = std::move(merged_or).value();
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(2, merged->rowsets(0).id());
+    ASSERT_EQ(1, merged->rowsets(0).del_files_size());
+    EXPECT_EQ(1, merged->rowsets(0).del_files(0).origin_rowset_id());
+    EXPECT_EQ(3, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_mixed_self_inherited_del_class) {
+    auto selected_source = make_allocator_source(next_id(), 11);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "mixed_del.dat", 0);
+    auto* selected_del = selected->add_del_files();
+    selected_del->set_name("mixed_class.del");
+    selected_del->set_origin_rowset_id(10);
+    auto duplicate_source = make_allocator_source(next_id(), 21);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "mixed_del.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    auto* duplicate_del = duplicate->add_del_files();
+    duplicate_del->set_name(selected_del->name());
+    duplicate_del->set_origin_rowset_id(9);
+
+    int materialize_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++materialize_count; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    auto result = publish_allocator_merge({selected_source, duplicate_source});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+    EXPECT_EQ(0, materialize_count);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_segment_declaration_conflict) {
+    enum class Mutation { kSize, kEncryption, kPresence, kUnknown };
+    for (auto mutation : {Mutation::kSize, Mutation::kEncryption, Mutation::kPresence, Mutation::kUnknown}) {
+        SCOPED_TRACE(static_cast<int>(mutation));
+        auto selected_source = make_allocator_source(next_id(), 11);
+        auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "segment_conflict.dat", 0);
+        auto duplicate_source = make_allocator_source(next_id(), 21);
+        auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "segment_conflict.dat", 0);
+        duplicate->mutable_uid()->CopyFrom(selected->uid());
+        auto* segment = duplicate->mutable_segment_metas(0);
+        switch (mutation) {
+        case Mutation::kSize:
+            segment->set_size(2);
+            break;
+        case Mutation::kEncryption:
+            segment->set_encryption_meta("different encryption metadata");
+            break;
+        case Mutation::kPresence:
+            selected->mutable_segment_metas(0)->clear_num_rows();
+            segment->set_num_rows(0);
+            break;
+        case Mutation::kUnknown: {
+            std::string serialized = segment->SerializeAsString();
+            serialized.append("\xF8\x07\x01", 3);
+            ASSERT_TRUE(segment->ParseFromString(serialized));
+            break;
+        }
+        }
+        auto result = publish_allocator_merge({selected_source, duplicate_source});
+        EXPECT_TRUE(result.status().is_corruption()) << result.status();
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_absent_and_explicit_zero_segment_idx) {
+    auto selected_source = make_allocator_source(next_id(), 11);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "segment_presence.dat", 0, false);
+    selected->mutable_segment_metas(0)->set_shared(false);
+    auto duplicate_source = make_allocator_source(next_id(), 21);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "segment_presence.dat", 0, true);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    duplicate->mutable_segment_metas(0)->set_shared(true);
+
+    auto merged_or = publish_allocator_merge({selected_source, duplicate_source});
+    ASSERT_OK(merged_or.status());
+    auto merged = std::move(merged_or).value();
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_EQ(1, merged->rowsets(0).segment_metas_size());
+    EXPECT_TRUE(merged->rowsets(0).segment_metas(0).has_segment_idx());
+    EXPECT_EQ(0, merged->rowsets(0).segment_metas(0).segment_idx());
+    EXPECT_TRUE(merged->rowsets(0).segment_metas(0).shared());
+    EXPECT_EQ(1, merged->rowsets(0).id());
+    EXPECT_EQ(2, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_segment_shared_flag) {
+    auto selected_source = make_allocator_source(next_id(), 11);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "segment_shared.dat", 0);
+    selected->mutable_segment_metas(0)->set_shared(false);
+    auto duplicate_source = make_allocator_source(next_id(), 21);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "segment_shared.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    duplicate->mutable_segment_metas(0)->set_shared(true);
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({selected_source, duplicate_source}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_TRUE(merged->rowsets(0).segment_metas(0).shared());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_del_declaration_conflict) {
+    enum class Mutation { kOffsetValue, kOffsetPresence, kEncryption, kVersion, kRows, kCrc, kUnknown };
+    for (auto mutation : {Mutation::kOffsetValue, Mutation::kOffsetPresence, Mutation::kEncryption, Mutation::kVersion,
+                          Mutation::kRows, Mutation::kCrc, Mutation::kUnknown}) {
+        SCOPED_TRACE(static_cast<int>(mutation));
+        auto selected_source = make_allocator_source(next_id(), 11);
+        auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "del_conflict.dat", 0);
+        auto* selected_del = selected->add_del_files();
+        selected_del->set_name("declaration.del");
+        selected_del->set_origin_rowset_id(10);
+        selected_del->set_op_offset(0);
+        selected_del->set_version(1);
+        selected_del->set_num_rows(1);
+        selected_del->set_crc32c(1);
+        auto duplicate_source = make_allocator_source(next_id(), 21);
+        auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "del_conflict.dat", 0);
+        duplicate->mutable_uid()->CopyFrom(selected->uid());
+        auto* duplicate_del = duplicate->add_del_files();
+        duplicate_del->CopyFrom(*selected_del);
+        duplicate_del->set_origin_rowset_id(20);
+        switch (mutation) {
+        case Mutation::kOffsetValue:
+            duplicate_del->set_op_offset(1);
+            break;
+        case Mutation::kOffsetPresence:
+            duplicate_del->clear_op_offset();
+            break;
+        case Mutation::kEncryption:
+            duplicate_del->set_encryption_meta("different encryption metadata");
+            break;
+        case Mutation::kVersion:
+            duplicate_del->set_version(2);
+            break;
+        case Mutation::kRows:
+            duplicate_del->set_num_rows(2);
+            break;
+        case Mutation::kCrc:
+            duplicate_del->set_crc32c(2);
+            break;
+        case Mutation::kUnknown: {
+            std::string serialized = duplicate_del->SerializeAsString();
+            serialized.append("\xF8\x07\x01", 3);
+            ASSERT_TRUE(duplicate_del->ParseFromString(serialized));
+            break;
+        }
+        }
+        auto result = publish_allocator_merge({selected_source, duplicate_source});
+        EXPECT_TRUE(result.status().is_corruption()) << result.status();
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_del_shared_flag) {
+    auto selected_source = make_allocator_source(next_id(), 11);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "del_shared.dat", 0);
+    auto* selected_del = selected->add_del_files();
+    selected_del->set_name("shared.del");
+    selected_del->set_origin_rowset_id(10);
+    selected_del->set_shared(false);
+    auto duplicate_source = make_allocator_source(next_id(), 21);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "del_shared.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    auto* duplicate_del = duplicate->add_del_files();
+    duplicate_del->CopyFrom(*selected_del);
+    duplicate_del->set_origin_rowset_id(20);
+    duplicate_del->set_shared(true);
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({selected_source, duplicate_source}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_TRUE(merged->rowsets(0).del_files(0).shared());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_predicate_declaration_conflict) {
+    auto first = make_allocator_source(next_id(), 11);
+    auto* left = add_rowset_with_predicate(first.get(), 10, 7, true);
+    left->mutable_delete_predicate()->mutable_binary_predicates(0)->set_value("1");
+    auto second = make_allocator_source(next_id(), 21);
+    auto* right = add_rowset_with_predicate(second.get(), 20, 7, true);
+    right->mutable_delete_predicate()->mutable_binary_predicates(0)->set_value("2");
+
+    auto result = publish_allocator_merge({first, second});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_unions_matching_predicate_ranges) {
+    auto first = make_allocator_source(next_id(), 11);
+    auto* left = add_rowset_with_predicate(first.get(), 10, 7, true);
+    left->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    left->mutable_range()->set_lower_bound_included(true);
+    left->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(50));
+    left->mutable_range()->set_upper_bound_included(false);
+    auto second = make_allocator_source(next_id(), 21);
+    auto* right = add_rowset_with_predicate(second.get(), 20, 7, true);
+    right->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(50));
+    right->mutable_range()->set_lower_bound_included(true);
+    right->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+    right->mutable_range()->set_upper_bound_included(false);
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(1, merged->rowsets(0).id());
+    EXPECT_EQ(generate_sort_key(0).SerializeAsString(), merged->rowsets(0).range().lower_bound().SerializeAsString());
+    EXPECT_EQ(generate_sort_key(100).SerializeAsString(), merged->rowsets(0).range().upper_bound().SerializeAsString());
+    EXPECT_EQ(2, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_rowset_schema_mapping_conflict) {
+    auto selected_source = make_allocator_source(next_id(), 11);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "schema_conflict.dat", 0);
+    (*selected_source->mutable_rowset_to_schema())[10] = 4001;
+    auto duplicate_source = make_allocator_source(next_id(), 21);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "schema_conflict.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    (*duplicate_source->mutable_rowset_to_schema())[20] = 4002;
+
+    auto result = publish_allocator_merge({selected_source, duplicate_source});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_equal_recovery_key_equivalence_on_cold_load) {
+    auto source = make_allocator_source(next_id(), 805);
+    auto* first = add_allocator_rowset(source.get(), 798, 1, "recovery_equal_a.dat", 0);
+    first->set_max_compact_input_rowset_id(797);
+    auto* second = add_allocator_rowset(source.get(), 803, 2, "recovery_equal_b.dat", 0);
+    second->set_max_compact_input_rowset_id(797);
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({source}));
+    ASSERT_EQ(2, merged->rowsets_size());
+    ASSERT_TRUE(merged->rowsets(0).has_max_compact_input_rowset_id());
+    ASSERT_TRUE(merged->rowsets(1).has_max_compact_input_rowset_id());
+    EXPECT_EQ(merged->rowsets(0).max_compact_input_rowset_id(), merged->rowsets(1).max_compact_input_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_alias_reversed_recovery_order_before_io) {
+    auto canonical_source = make_allocator_source(next_id(), 11);
+    auto* canonical = add_allocator_rowset(canonical_source.get(), 10, 2, "recovery_alias.dat", 0);
+    auto second_source = make_allocator_source(next_id(), 101);
+    auto* independent = add_allocator_rowset(second_source.get(), 99, 1, "recovery_independent.dat", 0);
+    independent->set_max_compact_input_rowset_id(100);
+    auto* duplicate = add_allocator_rowset(second_source.get(), 100, 2, "recovery_alias.dat", 0);
+    duplicate->mutable_uid()->CopyFrom(canonical->uid());
+
+    int materialize_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++materialize_count; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    auto result = publish_allocator_merge({canonical_source, second_source});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+    EXPECT_EQ(0, materialize_count);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_strict_recovery_order_on_cold_load) {
+    auto first = make_allocator_source(next_id(), 3);
+    add_allocator_rowset(first.get(), 2, 1, "recovery_strict_2.dat", 0);
+    auto second = make_allocator_source(next_id(), 21);
+    add_allocator_rowset(second.get(), 20, 2, "recovery_strict_20.dat", 0);
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second}));
+    ASSERT_EQ(2, merged->rowsets_size());
+    EXPECT_EQ((std::vector<uint32_t>{1, 2}), allocator_rowset_ids(*merged));
+    EXPECT_EQ(3, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_modern_source_stale_falls_back) {
+    for (auto shape : {MetadataOnlyMergeShape::kPrivate, MetadataOnlyMergeShape::kIdentical}) {
+        SCOPED_TRACE(static_cast<int>(shape));
+        auto result_or = publish_metadata_only_merge_fixture(shape, false, false, true, [shape](auto& sources) {
+            for (auto& source : sources) {
+                auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
+                sst->set_shared_rssid(5);
+                sst->set_max_rss_rowid(static_cast<uint64_t>(5) << 32);
+            }
+            if (shape == MetadataOnlyMergeShape::kPrivate) {
+                sources[1]->clear_sstable_meta();
+                lake::tablet_reshard_helper::set_rowset_uid(sources[0]->mutable_rowsets(0));
+                sources[1]->mutable_rowsets(0)->mutable_uid()->CopyFrom(sources[0]->rowsets(0).uid());
+                sources[1]->mutable_rowsets(0)->mutable_segment_metas(0)->set_segment_idx(4);
+            }
+        });
+        ASSERT_OK(result_or.status());
+        auto result = std::move(result_or).value();
+        const auto& target = result.published.at(result.target_tablet_id);
+        EXPECT_EQ(0, target.sstable_meta().sstables_size());
+        for (const auto& filename : result.source_sst_filenames) {
+            EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
+                                       [&](const auto& orphan) { return orphan.name() == filename; }));
+        }
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_modern_source_live_reuses) {
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(MetadataOnlyMergeShape::kPrivate, false, false, true));
+    const auto& target = result.published.at(result.target_tablet_id);
+    auto modern = std::find_if(target.sstable_meta().sstables().begin(), target.sstable_meta().sstables().end(),
+                               [](const auto& sst) { return sst.has_shared_rssid(); });
+    ASSERT_NE(target.sstable_meta().sstables().end(), modern);
+    EXPECT_EQ(1, modern->shared_rssid());
+    EXPECT_EQ(static_cast<uint64_t>(1) << 32, modern->max_rss_rowid());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_modern_mismatched_high_falls_back) {
+    for (auto shape : {MetadataOnlyMergeShape::kPrivate, MetadataOnlyMergeShape::kIdentical}) {
+        SCOPED_TRACE(static_cast<int>(shape));
+        ASSIGN_OR_ABORT(auto result, publish_metadata_only_merge_fixture(shape, false, false, true, [](auto& sources) {
+                            for (auto& source : sources) {
+                                auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
+                                if (sst->has_shared_rssid()) {
+                                    sst->set_max_rss_rowid(static_cast<uint64_t>(2) << 32);
+                                }
+                            }
+                        }));
+        const auto& target = result.published.at(result.target_tablet_id);
+        EXPECT_EQ(0, target.sstable_meta().sstables_size());
+        for (const auto& filename : result.source_sst_filenames) {
+            EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
+                                       [&](const auto& orphan) { return orphan.name() == filename; }));
+        }
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_negative_offset_falls_back) {
+    ASSIGN_OR_ABORT(auto result, publish_metadata_only_merge_fixture(
+                                         MetadataOnlyMergeShape::kPrivate, false, false, true, [](auto& sources) {
+                                             auto* legacy = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
+                                             legacy->set_rssid_offset(-1);
+                                         }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    EXPECT_EQ(0, target.sstable_meta().sstables_size());
+    for (const auto& filename : result.source_sst_filenames) {
+        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
+                                   [&](const auto& orphan) { return orphan.name() == filename; }));
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_compressed_gap_falls_back) {
+    ASSIGN_OR_ABORT(auto result, publish_metadata_only_merge_fixture(
+                                         MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
+                                             auto* extra = add_allocator_rowset(sources[1].get(), 100,
+                                                                                sources[1]->rowsets(0).version(),
+                                                                                "legacy_gap_100.dat", 0);
+                                             extra->mutable_segment_metas(0)->set_size(1);
+                                             sources[1]->set_next_rowset_id(101);
+                                             auto* legacy = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
+                                             legacy->set_rssid_offset(5);
+                                             legacy->set_max_rss_rowid(static_cast<uint64_t>(100) << 32);
+                                         }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    EXPECT_EQ(0, target.sstable_meta().sstables_size());
+    for (const auto& filename : result.source_sst_filenames) {
+        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
+                                   [&](const auto& orphan) { return orphan.name() == filename; }));
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_alias_interior_rejected_before_materialize) {
+    int materialize_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++materialize_count; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    auto result_or = publish_metadata_only_merge_fixture(
+            MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
+                lake::tablet_reshard_helper::set_rowset_uid(sources[0]->mutable_rowsets(0));
+                auto* alias = add_allocator_rowset(sources[1].get(), 7, sources[1]->rowsets(0).version(),
+                                                   sources[0]->rowsets(0).segment_metas(0).filename(), 0);
+                alias->mutable_segment_metas(0)->CopyFrom(sources[0]->rowsets(0).segment_metas(0));
+                alias->mutable_uid()->CopyFrom(sources[0]->rowsets(0).uid());
+                add_allocator_segment(sources[1]->mutable_rowsets(0), "legacy_alias_high.dat", 5);
+                sources[1]->set_next_rowset_id(11);
+                auto* legacy = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
+                legacy->set_rssid_offset(5);
+                legacy->set_max_rss_rowid(static_cast<uint64_t>(10) << 32);
+            });
+    EXPECT_TRUE(result_or.status().is_corruption()) << result_or.status();
+    EXPECT_EQ(0, materialize_count);
 }
 
 // Merge of two PK parents that both have cloud-native persistent index enabled.

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -10295,6 +10295,39 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_different_base_si
     EXPECT_TRUE(status.message().contains("physical base")) << status;
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_target_physical_slice_declaration_conflict_before_io) {
+    struct DeclarationConflict {
+        const char* name;
+        std::function<void(SegmentMetadataPB*)> apply;
+    };
+    const std::vector<DeclarationConflict> conflicts = {
+            {"bundle offset presence", [](SegmentMetadataPB* segment) { segment->set_bundle_file_offset(0); }},
+            {"size presence", [](SegmentMetadataPB* segment) { segment->clear_size(); }},
+            {"unknown field",
+             [](SegmentMetadataPB* segment) {
+                 segment->GetReflection()->MutableUnknownFields(segment)->AddVarint(1000, 1);
+             }},
+    };
+
+    for (const auto& conflict : conflicts) {
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("{}; {} declaration first", conflict.name,
+                                     reverse_sources ? "conflicting" : "canonical"));
+            const std::string filename = fmt::format("cross_target_slice_conflict_{}.dat", next_id());
+            auto canonical = make_preflight_sidecar_source(next_id(), filename);
+            auto conflicting = make_preflight_sidecar_source(next_id(), filename);
+            conflict.apply(conflicting->mutable_rowsets(0)->mutable_segment_metas(0));
+            std::vector<TabletMetadataPtr> sources = {canonical, conflicting};
+            if (reverse_sources) std::swap(sources[0], sources[1]);
+
+            MergePhaseCounts counts;
+            auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+            EXPECT_TRUE(status.message().contains("physical segment slice")) << status;
+            EXPECT_TRUE(status.message().contains(filename)) << status;
+        }
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_delvec_page_out_of_bounds_before_io) {
     auto source = make_preflight_sidecar_source(next_id(), "delvec_bounds.dat");
     DelVector delvec;

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -17,6 +17,7 @@
 #include <bvar/bvar.h>
 #include <fmt/format.h>
 #include <gmock/gmock.h>
+#include <google/protobuf/unknown_field_set.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -599,6 +600,99 @@ protected:
         auto metadata = _tablet_manager->get_tablet_metadata(tablet_id, version);
         EXPECT_TRUE(metadata.status().is_not_found()) << "target " << tablet_id << " version " << version
                                                       << " was unexpectedly published: " << metadata.status();
+    }
+
+    struct MergePhaseCounts {
+        int materialize = 0;
+        int dcg_writes = 0;
+        int delvec_writes = 0;
+        int source_flushes = 0;
+    };
+
+    StatusOr<MutableTabletMetadataPtr> merge_with_phase_counts(const std::vector<TabletMetadataPtr>& sources,
+                                                               int64_t target_tablet_id, int64_t target_version,
+                                                               MergePhaseCounts* counts,
+                                                               bool skip_sstable_merge = false) {
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++counts->materialize; });
+        sync->SetCallBack("merge_dcg_meta:after_write_cols", [&](void*) { ++counts->dcg_writes; });
+        sync->SetCallBack("merge_delvecs:writer_invocations",
+                          [&](void* arg) { counts->delvec_writes += *static_cast<int*>(arg); });
+        sync->SetCallBack("merge_sstables:source_pk_flush", [&](void*) { ++counts->source_flushes; });
+        sync->EnableProcessing();
+        DeferOp cleanup_sync_points([&] {
+            sync->ClearCallBack("materialize_planned_rowsets:entry");
+            sync->ClearCallBack("merge_dcg_meta:after_write_cols");
+            sync->ClearCallBack("merge_delvecs:writer_invocations");
+            sync->ClearCallBack("merge_sstables:source_pk_flush");
+            sync->DisableProcessing();
+        });
+
+        MergingTabletInfoPB merging;
+        for (const auto& source : sources) merging.add_old_tablet_ids(source->id());
+        merging.set_new_tablet_id(target_tablet_id);
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(next_id());
+        txn_info.set_commit_time(1);
+        txn_info.set_gtid(1);
+        return lake::merge_tablet(_tablet_manager.get(), sources, merging, target_version, txn_info,
+                                  skip_sstable_merge);
+    }
+
+    Status expect_physical_preflight_rejection(const std::vector<TabletMetadataPtr>& sources, int64_t target_tablet_id,
+                                               int64_t target_version, MergePhaseCounts* counts,
+                                               bool skip_sstable_merge = false) {
+        std::vector<std::string> source_pbs;
+        std::map<int64_t, std::set<std::string>> segment_inventories;
+        std::map<int64_t, std::set<std::string>> metadata_inventories;
+        for (const auto& source : sources) {
+            prepare_tablet_dirs(source->id());
+            source_pbs.emplace_back(source->SerializeAsString());
+            ASSIGN_OR_ABORT(segment_inventories[source->id()],
+                            directory_inventory(_location_provider->segment_root_location(source->id())));
+            ASSIGN_OR_ABORT(metadata_inventories[source->id()],
+                            directory_inventory(_location_provider->metadata_root_location(source->id())));
+        }
+        prepare_tablet_dirs(target_tablet_id);
+        ASSIGN_OR_ABORT(segment_inventories[target_tablet_id],
+                        directory_inventory(_location_provider->segment_root_location(target_tablet_id)));
+        ASSIGN_OR_ABORT(metadata_inventories[target_tablet_id],
+                        directory_inventory(_location_provider->metadata_root_location(target_tablet_id)));
+
+        auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts, skip_sstable_merge);
+
+        EXPECT_TRUE(merged.status().is_corruption()) << merged.status();
+        EXPECT_EQ(0, counts->materialize);
+        EXPECT_EQ(0, counts->dcg_writes);
+        EXPECT_EQ(0, counts->delvec_writes);
+        EXPECT_EQ(0, counts->source_flushes);
+        for (size_t i = 0; i < sources.size(); ++i) {
+            EXPECT_EQ(source_pbs[i], sources[i]->SerializeAsString());
+        }
+        for (const auto& [tablet_id, before] : segment_inventories) {
+            ASSIGN_OR_ABORT(auto after, directory_inventory(_location_provider->segment_root_location(tablet_id)));
+            EXPECT_EQ(before, after) << "segment inventory changed for tablet " << tablet_id;
+        }
+        for (const auto& [tablet_id, before] : metadata_inventories) {
+            ASSIGN_OR_ABORT(auto after, directory_inventory(_location_provider->metadata_root_location(tablet_id)));
+            EXPECT_EQ(before, after) << "metadata inventory changed for tablet " << tablet_id;
+        }
+        expect_target_version_not_published(target_tablet_id, target_version);
+        return merged.status();
+    }
+
+    std::shared_ptr<TabletMetadataPB> make_preflight_sidecar_source(int64_t tablet_id,
+                                                                    const std::string& segment_filename,
+                                                                    bool shared_segment = false,
+                                                                    bool common_rowset_uid = false) {
+        auto metadata = make_allocator_source(tablet_id, /*next_rowset_id=*/2);
+        auto* rowset = add_allocator_rowset(metadata.get(), /*rowset_id=*/1, /*version=*/1, segment_filename);
+        rowset->mutable_segment_metas(0)->set_shared(shared_segment);
+        if (common_rowset_uid) {
+            rowset->clear_uid();
+            stamp_physical_identity_uid(rowset, segment_filename);
+        }
+        return metadata;
     }
 
     void add_delvec(TabletMetadataPB* metadata, int64_t tablet_id, int64_t version, uint32_t segment_id,
@@ -6324,7 +6418,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_version_missing) {
     std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
     auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
                                               txn_info, false, tablet_metadatas, tablet_ranges);
-    EXPECT_TRUE(st.is_invalid_argument()) << st;
+    EXPECT_TRUE(st.is_corruption()) << st;
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) {
@@ -9202,6 +9296,435 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_no_independent_delete) 
     EXPECT_EQ(1, merged->delvec_meta().version_to_file_size());
     EXPECT_TRUE(merged->delvec_meta().version_to_file().find(new_version) !=
                 merged->delvec_meta().version_to_file().end());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_idg_invalid_shape) {
+    struct InvalidShape {
+        const char* name;
+        std::function<void(IndexDeltaGroupEntryPB*)> apply;
+    };
+    const std::vector<InvalidShape> invalid_shapes = {
+            {"missing filename", [](IndexDeltaGroupEntryPB* entry) { entry->clear_index_file(); }},
+            {"present empty filename", [](IndexDeltaGroupEntryPB* entry) { entry->set_index_file(""); }},
+            {"declared key missing col_unique_id",
+             [](IndexDeltaGroupEntryPB* entry) { entry->mutable_keys(0)->clear_col_unique_id(); }},
+            {"declared key missing index_type",
+             [](IndexDeltaGroupEntryPB* entry) { entry->mutable_keys(0)->clear_index_type(); }},
+            {"dropped key missing col_unique_id",
+             [](IndexDeltaGroupEntryPB* entry) {
+                 auto* key = entry->add_dropped_keys();
+                 key->set_index_type(BITMAP);
+             }},
+            {"dropped key missing index_type",
+             [](IndexDeltaGroupEntryPB* entry) {
+                 auto* key = entry->add_dropped_keys();
+                 key->set_col_unique_id(5);
+             }},
+            {"duplicate declared key",
+             [](IndexDeltaGroupEntryPB* entry) { entry->add_keys()->CopyFrom(entry->keys(0)); }},
+            {"present negative file_size", [](IndexDeltaGroupEntryPB* entry) { entry->set_file_size(-1); }},
+    };
+
+    for (const auto& invalid : invalid_shapes) {
+        SCOPED_TRACE(invalid.name);
+        auto source = make_preflight_sidecar_source(next_id(), fmt::format("idg_invalid_{}.dat", next_id()));
+        add_idg_with_key(source.get(), /*segment_id=*/1, "invalid.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
+                         /*shared_file=*/false);
+        invalid.apply(source->mutable_idg_meta()->mutable_idgs()->at(1).mutable_entries(0));
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("IDG")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_accepts_legacy_idg_optional_shape) {
+    auto source = make_preflight_sidecar_source(next_id(), "legacy_idg_optional.dat", /*shared_segment=*/true);
+    auto& idg = (*source->mutable_idg_meta()->mutable_idgs())[1];
+    auto* active = idg.add_entries();
+    active->set_index_file("legacy_active.idx");
+    auto* active_key = active->add_keys();
+    active_key->set_col_unique_id(5);
+    active_key->set_index_type(BITMAP);
+    auto* empty = idg.add_entries();
+    empty->set_index_file("legacy_empty.idx");
+
+    const int64_t target_id = next_id();
+    prepare_tablet_dirs(source->id());
+    prepare_tablet_dirs(target_id);
+    MergePhaseCounts counts;
+    ASSIGN_OR_ABORT(auto merged, merge_with_phase_counts({source}, target_id, /*target_version=*/2, &counts));
+
+    ASSERT_EQ(1, merged->idg_meta().idgs_size());
+    const auto& entries = merged->idg_meta().idgs().at(1).entries();
+    ASSERT_EQ(1, entries.size());
+    EXPECT_EQ("legacy_active.idx", entries.Get(0).index_file());
+    EXPECT_TRUE(entries.Get(0).shared_file());
+    EXPECT_FALSE(entries.Get(0).has_version());
+    EXPECT_FALSE(entries.Get(0).has_file_size());
+    EXPECT_FALSE(entries.Get(0).has_encryption_meta());
+    ASSERT_EQ(1, merged->orphan_files_size());
+    EXPECT_EQ("legacy_empty.idx", merged->orphan_files(0).name());
+    EXPECT_FALSE(merged->orphan_files(0).has_size());
+    EXPECT_TRUE(merged->orphan_files(0).shared());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_idg_same_file_declaration_conflict) {
+    ensure_kek_in_key_cache();
+    ASSIGN_OR_ABORT(auto encryption_a, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+    ASSIGN_OR_ABORT(auto encryption_b, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+    struct DeclarationConflict {
+        const char* name;
+        std::function<void(IndexDeltaGroupEntryPB*)> apply;
+    };
+    const std::vector<DeclarationConflict> conflicts = {
+            {"keys", [](IndexDeltaGroupEntryPB* entry) { entry->mutable_keys(0)->set_col_unique_id(50); }},
+            {"key order", [](IndexDeltaGroupEntryPB* entry) { entry->mutable_keys()->SwapElements(0, 1); }},
+            {"version", [](IndexDeltaGroupEntryPB* entry) { entry->set_version(2); }},
+            {"file size", [](IndexDeltaGroupEntryPB* entry) { entry->set_file_size(129); }},
+            {"encryption",
+             [&](IndexDeltaGroupEntryPB* entry) { entry->set_encryption_meta(encryption_b.encryption_meta); }},
+            {"version presence", [](IndexDeltaGroupEntryPB* entry) { entry->clear_version(); }},
+            {"file size presence", [](IndexDeltaGroupEntryPB* entry) { entry->clear_file_size(); }},
+            {"encryption presence", [](IndexDeltaGroupEntryPB* entry) { entry->clear_encryption_meta(); }},
+            {"unknown field",
+             [](IndexDeltaGroupEntryPB* entry) {
+                 entry->GetReflection()->MutableUnknownFields(entry)->AddVarint(1000, 1);
+             }},
+    };
+
+    for (const auto& conflict : conflicts) {
+        SCOPED_TRACE(conflict.name);
+        const std::string segment = fmt::format("idg_conflict_{}.dat", next_id());
+        auto source_a = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                      /*common_rowset_uid=*/true);
+        auto source_b = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                      /*common_rowset_uid=*/true);
+        for (auto* source : {source_a.get(), source_b.get()}) {
+            add_idg_with_key(source, /*segment_id=*/1, "conflicting.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
+                             /*shared_file=*/false);
+            add_idg_key(source, /*segment_id=*/1, /*col_uid=*/6, GIN);
+            auto* entry = source->mutable_idg_meta()->mutable_idgs()->at(1).mutable_entries(0);
+            entry->set_file_size(128);
+            entry->set_encryption_meta(encryption_a.encryption_meta);
+        }
+        conflict.apply(source_b->mutable_idg_meta()->mutable_idgs()->at(1).mutable_entries(0));
+
+        MergePhaseCounts counts;
+        auto status =
+                expect_physical_preflight_rejection({source_a, source_b}, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("IDG")) << status;
+        EXPECT_TRUE(status.message().contains("conflicting.idx")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_accepts_matching_idg_declaration) {
+    const std::string segment = "matching_idg_declaration.dat";
+    auto source_a = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/false,
+                                                  /*common_rowset_uid=*/true);
+    auto source_b = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                  /*common_rowset_uid=*/true);
+    add_idg_with_key(source_a.get(), /*segment_id=*/1, "matching.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
+                     /*shared_file=*/false);
+    add_idg_with_key(source_b.get(), /*segment_id=*/1, "matching.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
+                     /*shared_file=*/true);
+    source_a->mutable_idg_meta()->mutable_idgs()->at(1).mutable_entries(0)->set_file_size(128);
+    source_b->mutable_idg_meta()->mutable_idgs()->at(1).mutable_entries(0)->set_file_size(128);
+
+    const int64_t target_id = next_id();
+    prepare_tablet_dirs(source_a->id());
+    prepare_tablet_dirs(source_b->id());
+    prepare_tablet_dirs(target_id);
+    MergePhaseCounts counts;
+    auto merged_or = merge_with_phase_counts({source_a, source_b}, target_id, /*target_version=*/2, &counts);
+    if (!merged_or.ok()) {
+        ADD_FAILURE() << merged_or.status();
+        return;
+    }
+    auto merged = std::move(merged_or).value();
+    ASSERT_EQ(1, merged->idg_meta().idgs_size());
+    ASSERT_EQ(1, merged->idg_meta().idgs().at(1).entries_size());
+    EXPECT_TRUE(merged->idg_meta().idgs().at(1).entries(0).shared_file());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_source_live_idg_target_omission) {
+    auto source = make_preflight_sidecar_source(next_id(), "live_idg_omission.dat");
+    add_idg_with_key(source.get(), /*segment_id=*/1, "live_omission.idx", /*col_uid=*/5, BITMAP, /*version=*/1);
+    int omission_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_merge_test:force_idg_target_omission", [&](void* arg) {
+        ++omission_count;
+        *static_cast<bool*>(arg) = true;
+    });
+    DeferOp clear_omission([&] { sync->ClearCallBack("tablet_merge_test:force_idg_target_omission"); });
+
+    MergePhaseCounts counts;
+    auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+    EXPECT_EQ(1, omission_count);
+    EXPECT_TRUE(status.message().contains("IDG")) << status;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_source_live_delvec_target_omission) {
+    auto source = make_preflight_sidecar_source(next_id(), "live_delvec_omission.dat");
+    DelVector delvec;
+    const uint32_t deleted = 0;
+    delvec.init(/*version=*/1, &deleted, 1);
+    prepare_tablet_dirs(source->id());
+    add_delvec(source.get(), source->id(), /*version=*/1, /*segment_id=*/1, "live_omission.delvec", delvec.save());
+    int omission_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_merge_test:force_delvec_target_omission", [&](void* arg) {
+        ++omission_count;
+        *static_cast<bool*>(arg) = true;
+    });
+    DeferOp clear_omission([&] { sync->ClearCallBack("tablet_merge_test:force_delvec_target_omission"); });
+
+    MergePhaseCounts counts;
+    auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+    EXPECT_EQ(1, omission_count);
+    EXPECT_TRUE(status.message().contains("delvec")) << status;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_source_live_dcg_target_omission) {
+    auto source = make_preflight_sidecar_source(next_id(), "live_dcg_omission.dat");
+    add_dcg_with_columns(source.get(), /*segment_id=*/1, "live_omission.cols", {5}, /*version=*/1);
+    int omission_count = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_merge_test:force_dcg_target_omission", [&](void* arg) {
+        ++omission_count;
+        *static_cast<bool*>(arg) = true;
+    });
+    DeferOp clear_omission([&] { sync->ClearCallBack("tablet_merge_test:force_dcg_target_omission"); });
+
+    MergePhaseCounts counts;
+    auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+    EXPECT_EQ(1, omission_count);
+    EXPECT_TRUE(status.message().contains("DCG")) << status;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_allows_source_stale_idg_and_delvec) {
+    auto source = make_preflight_sidecar_source(next_id(), "stale_sidecar_source.dat");
+    auto* stale_entry = (*source->mutable_idg_meta()->mutable_idgs())[2].add_entries();
+    stale_entry->clear_index_file();
+    DelvecPagePB stale_page;
+    stale_page.set_version(999);
+    stale_page.set_offset(std::numeric_limits<uint64_t>::max());
+    stale_page.set_size(1);
+    (*source->mutable_delvec_meta()->mutable_delvecs())[2] = stale_page;
+
+    const int64_t target_id = next_id();
+    prepare_tablet_dirs(source->id());
+    prepare_tablet_dirs(target_id);
+    MergePhaseCounts counts;
+    ASSIGN_OR_ABORT(auto merged, merge_with_phase_counts({source}, target_id, /*target_version=*/2, &counts));
+    EXPECT_FALSE(merged->has_idg_meta());
+    EXPECT_FALSE(merged->has_delvec_meta());
+    EXPECT_EQ(0, merged->orphan_files_size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_source_stale_dcg_before_materialize) {
+    auto source = make_allocator_source(next_id(), /*next_rowset_id=*/4);
+    auto* rowset = add_allocator_rowset(source.get(), /*rowset_id=*/1, /*version=*/1, "stale_dcg_0.dat",
+                                        /*segment_idx=*/0);
+    add_allocator_segment(rowset, "stale_dcg_2.dat", /*segment_idx=*/2);
+    add_dcg_with_columns(source.get(), /*segment_id=*/2, "stale.cols", {5}, /*version=*/1);
+
+    MergePhaseCounts counts;
+    auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+    EXPECT_TRUE(status.message().contains("stale DCG")) << status;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecars_survive) {
+    auto source_a = make_preflight_sidecar_source(next_id(), "cross_target_shared_base.dat",
+                                                  /*shared_segment=*/false);
+    auto source_b = make_preflight_sidecar_source(next_id(), "cross_target_shared_base.dat",
+                                                  /*shared_segment=*/true);
+    add_dcg_with_columns(source_a.get(), /*segment_id=*/1, "cross_target.cols", {5}, /*version=*/1);
+    add_dcg_with_columns(source_b.get(), /*segment_id=*/1, "cross_target.cols", {5}, /*version=*/1);
+    add_idg_with_key(source_a.get(), /*segment_id=*/1, "cross_target.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
+                     /*shared_file=*/false);
+    add_idg_with_key(source_b.get(), /*segment_id=*/1, "cross_target.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
+                     /*shared_file=*/true);
+    add_idg_dropped_key(source_b.get(), /*segment_id=*/1, /*col_uid=*/5, BITMAP);
+
+    const int64_t target_id = next_id();
+    prepare_tablet_dirs(source_a->id());
+    prepare_tablet_dirs(source_b->id());
+    prepare_tablet_dirs(target_id);
+    MergePhaseCounts counts;
+    auto merged_or = merge_with_phase_counts({source_a, source_b}, target_id, /*target_version=*/2, &counts);
+    if (!merged_or.ok()) {
+        ADD_FAILURE() << merged_or.status();
+        return;
+    }
+    auto merged = std::move(merged_or).value();
+
+    ASSERT_EQ(2, merged->rowsets_size());
+    ASSERT_EQ(2, merged->dcg_meta().dcgs_size());
+    ASSERT_EQ(1, merged->idg_meta().idgs_size());
+    EXPECT_EQ("cross_target.idx", merged->idg_meta().idgs().begin()->second.entries(0).index_file());
+    EXPECT_TRUE(std::none_of(merged->orphan_files().begin(), merged->orphan_files().end(),
+                             [](const FileMetaPB& file) { return file.name() == "cross_target.idx"; }));
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_different_base_sidecars_rejected) {
+    auto source_a = make_preflight_sidecar_source(next_id(), "cross_target_base_a.dat");
+    auto source_b = make_preflight_sidecar_source(next_id(), "cross_target_base_b.dat");
+    add_dcg_with_columns(source_a.get(), /*segment_id=*/1, "cross_target_mismatch.cols", {5}, /*version=*/1);
+    add_dcg_with_columns(source_b.get(), /*segment_id=*/1, "cross_target_mismatch.cols", {5}, /*version=*/1);
+    add_idg_with_key(source_a.get(), /*segment_id=*/1, "cross_target_mismatch.idx", /*col_uid=*/5, BITMAP,
+                     /*version=*/1);
+    add_idg_with_key(source_b.get(), /*segment_id=*/1, "cross_target_mismatch.idx", /*col_uid=*/5, BITMAP,
+                     /*version=*/1);
+
+    MergePhaseCounts counts;
+    auto status = expect_physical_preflight_rejection({source_a, source_b}, next_id(), /*target_version=*/2, &counts);
+    EXPECT_TRUE(status.message().contains("physical base")) << status;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_delvec_page_out_of_bounds_before_io) {
+    auto source = make_preflight_sidecar_source(next_id(), "delvec_bounds.dat");
+    DelVector delvec;
+    const uint32_t deleted = 0;
+    delvec.init(/*version=*/1, &deleted, 1);
+    prepare_tablet_dirs(source->id());
+    add_delvec(source.get(), source->id(), /*version=*/1, /*segment_id=*/1, "bounds.delvec", delvec.save());
+    auto* page = &(*source->mutable_delvec_meta()->mutable_delvecs())[1];
+    page->set_offset(source->delvec_meta().version_to_file().at(1).size());
+    page->set_size(1);
+
+    MergePhaseCounts counts;
+    auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+    EXPECT_TRUE(status.message().contains("bounds.delvec")) << status;
+    EXPECT_TRUE(status.message().contains("bounds")) << status;
+}
+
+TEST_F(LakeTabletReshardTest,
+       test_tablet_merging_preflight_rejects_delvec_repeated_file_declaration_conflict_before_io) {
+    struct FileConflict {
+        const char* name;
+        bool empty_page;
+        std::function<void(FileMetaPB*)> apply;
+    };
+    const std::vector<FileConflict> conflicts = {
+            {"size", false, [](FileMetaPB* file) { file->set_size(file->size() + 1); }},
+            {"size presence", true, [](FileMetaPB* file) { file->clear_size(); }},
+            {"shared", false, [](FileMetaPB* file) { file->set_shared(true); }},
+            {"shared presence", false, [](FileMetaPB* file) { file->clear_shared(); }},
+    };
+
+    for (const auto& conflict : conflicts) {
+        SCOPED_TRACE(conflict.name);
+        const std::string segment = fmt::format("delvec_conflict_{}.dat", next_id());
+        const std::string filename = fmt::format("delvec_conflict_{}.delvec", next_id());
+        auto source_a = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                      /*common_rowset_uid=*/true);
+        auto source_b = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                      /*common_rowset_uid=*/true);
+        prepare_tablet_dirs(source_a->id());
+        prepare_tablet_dirs(source_b->id());
+        std::string content;
+        if (!conflict.empty_page) {
+            DelVector delvec;
+            const uint32_t deleted = 0;
+            delvec.init(/*version=*/1, &deleted, 1);
+            content = delvec.save();
+        }
+        add_delvec(source_a.get(), source_a->id(), /*version=*/1, /*segment_id=*/1, filename, content);
+        add_delvec(source_b.get(), source_b->id(), /*version=*/1, /*segment_id=*/1, filename, content);
+        (*source_a->mutable_delvec_meta()->mutable_version_to_file())[1].set_shared(false);
+        (*source_b->mutable_delvec_meta()->mutable_version_to_file())[1].set_shared(false);
+        conflict.apply(&(*source_b->mutable_delvec_meta()->mutable_version_to_file())[1]);
+
+        MergePhaseCounts counts;
+        auto status =
+                expect_physical_preflight_rejection({source_a, source_b}, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("metadata mismatch")) << status;
+        EXPECT_TRUE(status.message().contains(filename)) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_dcg_declaration_before_materialize) {
+    auto source = make_preflight_sidecar_source(next_id(), "late_dcg_declaration.dat");
+    add_dcg(source.get(), /*segment_id=*/1, "late_malformed.cols");
+
+    MergePhaseCounts counts;
+    auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+    EXPECT_TRUE(status.message().contains("DCG shape")) << status;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_sst_file_conflict_before_io) {
+    ensure_kek_in_key_cache();
+    ASSIGN_OR_ABORT(auto encryption_a, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+    ASSIGN_OR_ABORT(auto encryption_b, KeyCache::instance().create_encryption_meta_pair_using_current_kek());
+    struct SstConflict {
+        const char* name;
+        std::function<void(std::vector<std::shared_ptr<TabletMetadataPB>>&)> apply;
+    };
+    const std::vector<SstConflict> conflicts = {
+            {"size",
+             [](auto& sources) {
+                 auto* sst = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
+                 sst->set_filesize(sst->filesize() + 1);
+             }},
+            {"size presence",
+             [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->clear_filesize(); }},
+            {"encryption",
+             [&](auto& sources) {
+                 sources[1]->mutable_sstable_meta()->mutable_sstables(0)->set_encryption_meta(
+                         encryption_b.encryption_meta);
+             }},
+            {"encryption presence",
+             [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->clear_encryption_meta(); }},
+            {"empty filename",
+             [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->set_filename(""); }},
+            {"negative size",
+             [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->set_filesize(-1); }},
+            {"invalid range arity",
+             [](auto& sources) {
+                 auto* lower = sources[0]->mutable_range()->mutable_lower_bound();
+                 lower->add_values()->CopyFrom(lower->values(0));
+             }},
+    };
+
+    for (const auto& conflict : conflicts) {
+        SCOPED_TRACE(conflict.name);
+        const int64_t source_a_id = next_id();
+        const int64_t source_b_id = next_id();
+        const std::string segment = fmt::format("sst_preflight_{}.dat", next_id());
+        auto make_source = [&](int64_t tablet_id, int lower, int upper) {
+            auto source = make_preflight_sidecar_source(tablet_id, segment, /*shared_segment=*/true,
+                                                        /*common_rowset_uid=*/true);
+            set_int_primary_key_schema(source.get(), /*schema_id=*/4001);
+            source->set_enable_persistent_index(true);
+            source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+            source->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(lower));
+            source->mutable_range()->set_lower_bound_included(true);
+            source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(upper));
+            source->mutable_range()->set_upper_bound_included(false);
+            source->mutable_rowsets(0)->mutable_range()->CopyFrom(source->range());
+            auto* sst = source->mutable_sstable_meta()->add_sstables();
+            sst->set_filename("repeated_physical.sst");
+            sst->set_filesize(128);
+            sst->set_encryption_meta(encryption_a.encryption_meta);
+            sst->set_shared(true);
+            sst->set_shared_rssid(1);
+            sst->set_shared_version(1);
+            sst->set_max_rss_rowid(static_cast<uint64_t>(1) << 32);
+            sst->set_generation_version(1);
+            sst->mutable_range()->set_start_key(encode_int_primary_key(10));
+            sst->mutable_range()->set_end_key(encode_int_primary_key(90));
+            return source;
+        };
+        auto source_a = make_source(source_a_id, /*lower=*/0, /*upper=*/50);
+        auto source_b = make_source(source_b_id, /*lower=*/50, /*upper=*/100);
+        std::vector<std::shared_ptr<TabletMetadataPB>> sources = {source_a, source_b};
+        conflict.apply(sources);
+        std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("SST")) << status;
+    }
 }
 
 // --- DCG merge tests ---
@@ -13534,9 +14057,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_drops_fully_tombstoned) {
 
 // MERGE: a .idx that is fully-tombstoned under one target but still ACTIVE under another
 // target must NOT be orphaned (vacuum deletes orphan_files without checking live idg_meta).
-// This is defensive: uuid-unique .idx names make one-name-two-targets impossible in prod,
-// but the orphan set must be provably safe regardless. child_a keeps "same.idx" active at
-// its rssid; child_b (distinct uid => remapped rssid) has "same.idx" fully tombstoned.
+// The same physical .idx may be referenced under two target RSSIDs only when both resolve to
+// the same physical base segment. child_a keeps "same.idx" active at its rssid; child_b
+// (distinct uid => remapped rssid) has the same base and a fully tombstoned declaration.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_orphan_skips_still_referenced_file) {
     const int64_t base_version = 1, new_version = 2;
     const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
@@ -13544,7 +14067,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_orphan_skips_still_referen
     prepare_tablet_dirs(child_b);
     prepare_tablet_dirs(merged_tablet);
 
-    auto make_child = [&](int64_t tablet_id, const std::string& seg, bool tombstone) {
+    auto make_child = [&](int64_t tablet_id, bool tombstone) {
         auto meta = std::make_shared<TabletMetadataPB>();
         meta->set_id(tablet_id);
         meta->set_version(base_version);
@@ -13555,15 +14078,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_orphan_skips_still_referen
         rowset->set_num_rows(10);
         rowset->set_data_size(100);
         auto* sm = rowset->add_segment_metas();
-        sm->set_filename(seg);
+        sm->set_filename("same_base.dat");
         sm->set_size(100);
-        stamp_physical_identity_uid(rowset, seg); // distinct uid per child => both kept
+        lake::tablet_reshard_helper::set_rowset_uid(rowset); // distinct uid per child => both kept
         add_idg_with_key(meta.get(), 1, "same.idx", /*col_uid=*/5, BITMAP, 1);
         if (tombstone) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, "seg_a.dat", /*tombstone=*/false)));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, "seg_b.dat", /*tombstone=*/true)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_a, /*tombstone=*/false)));
+    EXPECT_OK(put_tablet_metadata(make_child(child_b, /*tombstone=*/true)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -10799,6 +10799,37 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_dcg_dec
     EXPECT_TRUE(status.message().contains("DCG shape")) << status;
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_dcg_message_unknown_fields_before_materialize) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(reverse_sources ? "unknown-field source first" : "canonical source first");
+        const std::string segment = fmt::format("dcg_unknown_field_{}.dat", next_id());
+        auto canonical = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                       /*common_rowset_uid=*/true);
+        auto with_unknown = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                          /*common_rowset_uid=*/true);
+        for (auto* source : {canonical.get(), with_unknown.get()}) {
+            add_dcg_with_columns(source, /*segment_id=*/1, "unknown_field.cols", {5}, /*version=*/1);
+        }
+        auto& unknown_dcg = with_unknown->mutable_dcg_meta()->mutable_dcgs()->at(1);
+        unknown_dcg.GetReflection()->MutableUnknownFields(&unknown_dcg)->AddVarint(1000, 1);
+
+        ASSERT_OK(put_tablet_metadata(canonical));
+        ASSERT_OK(put_tablet_metadata(with_unknown));
+        ASSIGN_OR_ABORT(auto persisted_canonical,
+                        _tablet_manager->get_tablet_metadata(canonical->id(), canonical->version()));
+        ASSIGN_OR_ABORT(auto persisted_with_unknown,
+                        _tablet_manager->get_tablet_metadata(with_unknown->id(), with_unknown->version()));
+        const auto& persisted_dcg = persisted_with_unknown->dcg_meta().dcgs().at(1);
+        ASSERT_EQ(1, persisted_dcg.GetReflection()->GetUnknownFields(persisted_dcg).field_count());
+
+        std::vector<TabletMetadataPtr> sources = {persisted_canonical, persisted_with_unknown};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("DCG message has unknown fields")) << status;
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_sst_invalid_form_or_range_before_io) {
     struct InvalidDeclaration {
         const char* name;

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -696,6 +696,36 @@ protected:
         return metadata;
     }
 
+    std::vector<std::shared_ptr<TabletMetadataPB>> make_preflight_sst_sources(const std::string& stem) {
+        const std::string segment = stem + ".dat";
+        auto source_a = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                      /*common_rowset_uid=*/true);
+        auto source_b = make_preflight_sidecar_source(next_id(), segment, /*shared_segment=*/true,
+                                                      /*common_rowset_uid=*/true);
+        for (int i = 0; i < 2; ++i) {
+            auto* source = i == 0 ? source_a.get() : source_b.get();
+            set_int_primary_key_schema(source, /*schema_id=*/4001);
+            source->set_enable_persistent_index(true);
+            source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+            source->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(i * 50));
+            source->mutable_range()->set_lower_bound_included(true);
+            source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key((i + 1) * 50));
+            source->mutable_range()->set_upper_bound_included(false);
+            source->mutable_rowsets(0)->mutable_range()->CopyFrom(source->range());
+            auto* sst = source->mutable_sstable_meta()->add_sstables();
+            sst->set_filename(stem + ".sst");
+            sst->set_filesize(128);
+            sst->set_shared(true);
+            sst->set_shared_rssid(1);
+            sst->set_shared_version(1);
+            sst->set_max_rss_rowid(static_cast<uint64_t>(1) << 32);
+            sst->set_generation_version(1);
+            sst->mutable_range()->set_start_key(encode_int_primary_key(10));
+            sst->mutable_range()->set_end_key(encode_int_primary_key(90));
+        }
+        return {std::move(source_a), std::move(source_b)};
+    }
+
     void add_delvec(TabletMetadataPB* metadata, int64_t tablet_id, int64_t version, uint32_t segment_id,
                     const std::string& file_name, const std::string& content) {
         FileMetaPB file_meta;
@@ -1590,6 +1620,15 @@ protected:
         }
     }
 
+    void expect_affine_sst_fallback_orphans(const MetadataOnlyMergeResult& result) {
+        const auto& target = result.published.at(result.target_tablet_id);
+        EXPECT_EQ(0, target.sstable_meta().sstables_size());
+        for (const auto& filename : result.source_sst_filenames) {
+            EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
+                                       [&](const auto& orphan) { return orphan.name() == filename; }));
+        }
+    }
+
     void expect_metadata_fallback_lifecycle(const MetadataOnlyMergeResult& result,
                                             const std::vector<std::pair<int32_t, int32_t>>& initial_rows,
                                             const std::vector<std::pair<int32_t, int32_t>>& rows_after_dml,
@@ -1636,12 +1675,15 @@ protected:
         }
     }
 
-    StatusOr<std::vector<std::pair<int32_t, int32_t>>> read_two_column_rows(const TabletMetadataPtr& metadata) {
+    StatusOr<std::vector<std::pair<int32_t, int32_t>>> read_two_column_rows_in_storage_order(
+            const TabletMetadataPtr& metadata, bool sorted_by_keys_per_tablet = false) {
         auto tablet_schema = TabletSchema::create(metadata->schema());
         auto schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
         auto reader = std::make_shared<lake::TabletReader>(_tablet_manager.get(), metadata, *schema);
         RETURN_IF_ERROR(reader->prepare());
-        RETURN_IF_ERROR(reader->open(TabletReaderParams()));
+        TabletReaderParams params;
+        params.sorted_by_keys_per_tablet = sorted_by_keys_per_tablet;
+        RETURN_IF_ERROR(reader->open(params));
 
         std::vector<std::pair<int32_t, int32_t>> rows;
         while (true) {
@@ -1653,6 +1695,11 @@ protected:
                 rows.emplace_back(chunk->get(i)[0].get_int32(), chunk->get(i)[1].get_int32());
             }
         }
+        return rows;
+    }
+
+    StatusOr<std::vector<std::pair<int32_t, int32_t>>> read_two_column_rows(const TabletMetadataPtr& metadata) {
+        ASSIGN_OR_RETURN(auto rows, read_two_column_rows_in_storage_order(metadata));
         std::sort(rows.begin(), rows.end());
         return rows;
     }
@@ -2647,12 +2694,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_metadata_only_private_uncertai
                  sources[1]->mutable_rowsets(0)->mutable_segment_metas(0)->CopyFrom(
                          sources[0]->rowsets(0).segment_metas(0));
              }},
-            {"malformed shared version",
-             [](auto& sources) {
-                 auto* sstable = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
-                 sstable->set_shared_version(7);
-                 sstable->clear_shared_rssid();
-             }},
             {"unresolved embedded delvec",
              [](auto& sources) {
                  auto* delvec = sources[0]->mutable_sstable_meta()->mutable_sstables(0)->mutable_delvec();
@@ -2846,20 +2887,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_metadata_only_identical_diverg
                  append_identical_second_sst(sources);
                  sources[1]->mutable_sstable_meta()->mutable_sstables()->SwapElements(0, 1);
              }},
-            {"range mismatch",
-             [](auto& sources) {
-                 sources[1]->mutable_sstable_meta()->mutable_sstables(0)->mutable_range()->set_end_key(
-                         "divergent range end");
-             }},
             {"generation mismatch",
              [](auto& sources) {
                  sources[1]->mutable_sstable_meta()->mutable_sstables(0)->set_generation_version(999);
-             }},
-            {"delvec mismatch",
-             [](auto& sources) {
-                 auto* delvec = sources[1]->mutable_sstable_meta()->mutable_sstables(0)->mutable_delvec();
-                 delvec->set_version(99);
-                 delvec->set_size(1);
              }},
             {"rowset UID mismatch",
              [](auto& sources) {
@@ -2911,28 +2941,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_metadata_only_identical_diverg
                  segment->set_segment_idx(1);
                  sources[1]->mutable_rowsets(0)->set_num_rows(2);
                  sources[1]->mutable_rowsets(0)->set_data_size(sources[1]->rowsets(0).data_size() + segment_size);
-             }},
-            {"projection mismatch",
-             [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->set_rssid_offset(1); }},
-            {"nonconvergent RSSID mapping",
-             [&](auto& sources) {
-                 const std::string segment_name = "metadata_only_identical_nonconvergent.dat";
-                 const uint64_t segment_size = write_two_column_segment(
-                         sources[1]->id(), segment_name, /*num_rows=*/1, [](int key) { return key * 10; }, 20);
-                 auto* rowset = sources[1]->add_rowsets();
-                 rowset->set_id(5);
-                 rowset->set_version(sources[1]->version());
-                 rowset->set_num_rows(1);
-                 rowset->set_data_size(segment_size);
-                 lake::tablet_reshard_helper::set_rowset_uid(rowset);
-                 auto* segment = rowset->add_segment_metas();
-                 segment->set_filename(segment_name);
-                 segment->set_size(segment_size);
-                 segment->set_num_rows(1);
-                 auto* sstable = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
-                 sstable->set_shared_rssid(5);
-                 sstable->set_max_rss_rowid(static_cast<uint64_t>(5) << 32);
-                 sources[1]->set_next_rowset_id(6);
              }},
     };
     for (const auto& test_case : cases) {
@@ -10108,22 +10116,47 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_source_stale
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecars_survive) {
-    auto source_a = make_preflight_sidecar_source(next_id(), "cross_target_shared_base.dat",
-                                                  /*shared_segment=*/false);
-    auto source_b = make_preflight_sidecar_source(next_id(), "cross_target_shared_base.dat",
-                                                  /*shared_segment=*/true);
-    add_dcg_with_columns(source_a.get(), /*segment_id=*/1, "cross_target.cols", {5}, /*version=*/1);
-    add_dcg_with_columns(source_b.get(), /*segment_id=*/1, "cross_target.cols", {5}, /*version=*/1);
-    add_idg_with_key(source_a.get(), /*segment_id=*/1, "cross_target.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
-                     /*shared_file=*/false);
-    add_idg_with_key(source_b.get(), /*segment_id=*/1, "cross_target.idx", /*col_uid=*/5, BITMAP, /*version=*/1,
-                     /*shared_file=*/true);
-    add_idg_dropped_key(source_b.get(), /*segment_id=*/1, /*col_uid=*/5, BITMAP);
-
+    const int64_t source_a_id = next_id();
+    const int64_t source_b_id = next_id();
     const int64_t target_id = next_id();
-    prepare_tablet_dirs(source_a->id());
-    prepare_tablet_dirs(source_b->id());
+    prepare_tablet_dirs(source_a_id);
+    prepare_tablet_dirs(source_b_id);
     prepare_tablet_dirs(target_id);
+    const std::string base_name = "cross_target_shared_base.dat";
+    const std::string cols_name = "cross_target.cols";
+    const std::string idx_name = "cross_target.idx";
+    const uint64_t base_size = write_two_column_segment(source_a_id, base_name, 2, [](int key) { return key * 10; });
+    const uint64_t cols_size =
+            write_c1_only_cols_file(source_a_id, cols_name, 2, [](int row) { return (row + 1) * 1000; });
+    const auto idx_file = write_sidecar_payload(_tablet_manager->segment_location(source_a_id, idx_name),
+                                                "cross-target-index", /*encrypted=*/false);
+
+    auto source_a = make_preflight_sidecar_source(source_a_id, base_name, /*shared_segment=*/false);
+    auto source_b = make_preflight_sidecar_source(source_b_id, base_name, /*shared_segment=*/true);
+    for (int i = 0; i < 2; ++i) {
+        auto* source = i == 0 ? source_a.get() : source_b.get();
+        set_two_column_pk_schema(source, /*schema_id=*/4001);
+        source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+        source->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(i));
+        source->mutable_range()->set_lower_bound_included(true);
+        source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(i + 1));
+        source->mutable_range()->set_upper_bound_included(false);
+        auto* rowset = source->mutable_rowsets(0);
+        rowset->set_num_rows(2);
+        rowset->set_data_size(base_size);
+        rowset->mutable_range()->CopyFrom(source->range());
+        rowset->mutable_segment_metas(0)->set_size(base_size);
+        rowset->mutable_segment_metas(0)->set_num_rows(2);
+        add_dcg_with_columns(source, /*segment_id=*/1, cols_name, {1002}, /*version=*/1);
+        auto* dcg = &(*source->mutable_dcg_meta()->mutable_dcgs())[1];
+        dcg->add_column_file_sizes(cols_size);
+        dcg->set_shared_files(0, false);
+        add_idg_with_key(source, /*segment_id=*/1, idx_name, /*col_uid=*/1002, BITMAP, /*version=*/1,
+                         /*shared_file=*/false);
+        auto* idg = (*source->mutable_idg_meta()->mutable_idgs())[1].mutable_entries(0);
+        idg->set_file_size(idx_file.filesize);
+    }
+
     MergePhaseCounts counts;
     auto merged_or = merge_with_phase_counts({source_a, source_b}, target_id, /*target_version=*/2, &counts);
     if (!merged_or.ok()) {
@@ -10134,10 +10167,93 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
 
     ASSERT_EQ(2, merged->rowsets_size());
     ASSERT_EQ(2, merged->dcg_meta().dcgs_size());
-    ASSERT_EQ(1, merged->idg_meta().idgs_size());
-    EXPECT_EQ("cross_target.idx", merged->idg_meta().idgs().begin()->second.entries(0).index_file());
+    ASSERT_EQ(2, merged->idg_meta().idgs_size());
+    for (const auto& rowset : merged->rowsets()) {
+        ASSERT_EQ(1, rowset.segment_metas_size());
+        EXPECT_TRUE(rowset.segment_metas(0).shared());
+    }
+    for (const auto& [rssid, dcg] : merged->dcg_meta().dcgs()) {
+        (void)rssid;
+        ASSERT_EQ(1, dcg.shared_files_size());
+        EXPECT_TRUE(dcg.shared_files(0));
+    }
+    for (const auto& [rssid, idg] : merged->idg_meta().idgs()) {
+        (void)rssid;
+        ASSERT_EQ(1, idg.entries_size());
+        EXPECT_EQ(idx_name, idg.entries(0).index_file());
+        EXPECT_TRUE(idg.entries(0).shared_file());
+    }
     EXPECT_TRUE(std::none_of(merged->orphan_files().begin(), merged->orphan_files().end(),
-                             [](const FileMetaPB& file) { return file.name() == "cross_target.idx"; }));
+                             [&](const FileMetaPB& file) { return file.name() == idx_name; }));
+
+    ASSERT_OK(put_tablet_metadata(merged));
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto reopened, _tablet_manager->get_tablet_metadata(target_id, merged->version()));
+    ASSIGN_OR_ABORT(auto reopened_rows, read_two_column_rows(reopened));
+    EXPECT_EQ((std::vector<std::pair<int32_t, int32_t>>{{0, 1000}, {1, 2000}}), reopened_rows);
+
+    TabletMetadataPB compacted(*reopened);
+    compacted.set_version(reopened->version() + 1);
+    compacted.set_prev_garbage_version(reopened->version());
+    RowsetMetadataPB retained;
+    for (const auto& rowset : compacted.rowsets()) {
+        if (rowset.id() == 2) retained.CopyFrom(rowset);
+    }
+    ASSERT_TRUE(retained.has_id());
+    compacted.clear_rowsets();
+    compacted.add_rowsets()->CopyFrom(retained);
+    const std::string compacted_name = "cross_target_compacted.dat";
+    const uint64_t compacted_size = write_two_column_segment(target_id, compacted_name, 1, [](int) { return 1000; });
+    auto* output = compacted.add_rowsets();
+    output->set_id(3);
+    output->set_version(compacted.version());
+    output->set_num_rows(1);
+    output->set_data_size(compacted_size);
+    output->set_overlapped(false);
+    output->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    output->mutable_range()->set_lower_bound_included(true);
+    output->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(1));
+    output->mutable_range()->set_upper_bound_included(false);
+    auto* output_segment = output->add_segment_metas();
+    output_segment->set_filename(compacted_name);
+    output_segment->set_size(compacted_size);
+    output_segment->set_num_rows(1);
+    lake::tablet_reshard_helper::set_rowset_uid(output);
+    compacted.set_next_rowset_id(4);
+    compacted.mutable_dcg_meta()->mutable_dcgs()->erase(1);
+    compacted.mutable_idg_meta()->mutable_idgs()->erase(1);
+    compacted.mutable_delvec_meta()->mutable_delvecs()->erase(1);
+    compacted.clear_orphan_files();
+    ASSERT_OK(put_tablet_metadata(compacted));
+
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto cold_compacted, _tablet_manager->get_tablet_metadata(target_id, compacted.version()));
+    ASSIGN_OR_ABORT(auto compacted_rows, read_two_column_rows(cold_compacted));
+    EXPECT_EQ((std::vector<std::pair<int32_t, int32_t>>{{0, 1000}, {1, 2000}}), compacted_rows);
+
+    VacuumRequest request;
+    VacuumResponse response;
+    auto* info = request.add_tablet_infos();
+    info->set_tablet_id(target_id);
+    info->set_min_version(compacted.version());
+    request.set_min_retain_version(compacted.version());
+    request.set_grace_timestamp(::time(nullptr) + 3600);
+    request.set_min_active_txn_id(std::numeric_limits<int64_t>::max());
+    request.set_enable_file_bundling(false);
+    request.set_enable_shared_file_cleanup(true);
+    request.set_delete_txn_log(false);
+    lake::vacuum(_tablet_manager.get(), request, &response);
+    ASSERT_TRUE(response.has_status());
+    ASSERT_EQ(0, response.status().status_code())
+            << (response.status().error_msgs_size() > 0 ? response.status().error_msgs(0) : "");
+    EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, base_name)));
+    EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, cols_name)));
+    EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, idx_name)));
+
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto reopened_after_vacuum, _tablet_manager->get_tablet_metadata(target_id, compacted.version()));
+    ASSIGN_OR_ABORT(auto rows_after_vacuum, read_two_column_rows(reopened_after_vacuum));
+    EXPECT_EQ((std::vector<std::pair<int32_t, int32_t>>{{0, 1000}, {1, 2000}}), rows_after_vacuum);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_different_base_sidecars_rejected) {
@@ -10224,6 +10340,84 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_dcg_dec
     MergePhaseCounts counts;
     auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
     EXPECT_TRUE(status.message().contains("DCG shape")) << status;
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_sst_invalid_form_or_range_before_io) {
+    struct InvalidDeclaration {
+        const char* name;
+        std::function<void(PersistentIndexSstablePB*)> apply;
+    };
+    const std::vector<InvalidDeclaration> invalid_declarations = {
+            {"legacy shared version without shared rssid",
+             [](PersistentIndexSstablePB* sst) {
+                 sst->clear_shared_rssid();
+                 sst->set_shared_version(7);
+             }},
+            {"legacy embedded delvec without shared rssid",
+             [](PersistentIndexSstablePB* sst) {
+                 sst->clear_shared_rssid();
+                 sst->clear_shared_version();
+                 sst->mutable_delvec()->set_version(1);
+                 sst->mutable_delvec()->set_size(1);
+             }},
+            {"modern effective rssid overflow",
+             [](PersistentIndexSstablePB* sst) {
+                 sst->set_shared_rssid(std::numeric_limits<uint32_t>::max());
+                 sst->set_rssid_offset(1);
+             }},
+            {"range missing start key", [](PersistentIndexSstablePB* sst) { sst->mutable_range()->clear_start_key(); }},
+            {"range missing end key", [](PersistentIndexSstablePB* sst) { sst->mutable_range()->clear_end_key(); }},
+            {"reversed range",
+             [](PersistentIndexSstablePB* sst) {
+                 sst->mutable_range()->set_start_key("z");
+                 sst->mutable_range()->set_end_key("a");
+             }},
+    };
+
+    for (const auto& invalid : invalid_declarations) {
+        SCOPED_TRACE(invalid.name);
+        auto sources = make_preflight_sst_sources(fmt::format("sst_invalid_{}", next_id()));
+        for (auto& source : sources) invalid.apply(source->mutable_sstable_meta()->mutable_sstables(0));
+        std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("SST")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_sst_same_file_form_or_range_conflict_before_io) {
+    struct DeclarationConflict {
+        const char* name;
+        std::function<void(PersistentIndexSstablePB*)> apply;
+    };
+    const std::vector<DeclarationConflict> conflicts = {
+            {"max rss rowid", [](PersistentIndexSstablePB* sst) { sst->set_max_rss_rowid(uint64_t{2} << 32); }},
+            {"shared rssid", [](PersistentIndexSstablePB* sst) { sst->set_shared_rssid(2); }},
+            {"shared version", [](PersistentIndexSstablePB* sst) { sst->set_shared_version(2); }},
+            {"shared version presence", [](PersistentIndexSstablePB* sst) { sst->clear_shared_version(); }},
+            {"rssid offset", [](PersistentIndexSstablePB* sst) { sst->set_rssid_offset(1); }},
+            {"embedded delvec",
+             [](PersistentIndexSstablePB* sst) {
+                 sst->mutable_delvec()->set_version(1);
+                 sst->mutable_delvec()->set_size(1);
+             }},
+            {"range start",
+             [&](PersistentIndexSstablePB* sst) { sst->mutable_range()->set_start_key(encode_int_primary_key(11)); }},
+            {"range end",
+             [&](PersistentIndexSstablePB* sst) { sst->mutable_range()->set_end_key(encode_int_primary_key(89)); }},
+            {"range presence", [](PersistentIndexSstablePB* sst) { sst->clear_range(); }},
+    };
+
+    for (const auto& conflict : conflicts) {
+        SCOPED_TRACE(conflict.name);
+        auto sources = make_preflight_sst_sources(fmt::format("sst_form_conflict_{}", next_id()));
+        conflict.apply(sources[1]->mutable_sstable_meta()->mutable_sstables(0));
+        std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("SST")) << status;
+        EXPECT_TRUE(status.message().contains("conflict")) << status;
+    }
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_sst_file_conflict_before_io) {
@@ -12309,21 +12503,49 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_segment_shared_flag
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_overlapped_without_segment_union_expansion) {
-    auto selected_source = make_allocator_source(next_id(), 12);
-    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "overlapped_same_0.dat", 0);
-    add_allocator_segment(selected, "overlapped_same_1.dat", 1);
+    const int64_t selected_id = next_id();
+    const int64_t duplicate_id = next_id();
+    prepare_tablet_dirs(selected_id);
+    prepare_tablet_dirs(duplicate_id);
+    const uint64_t high_size =
+            write_two_column_segment(selected_id, "overlapped_same_high.dat", 2, [](int key) { return key * 10; }, 1);
+    const uint64_t low_size =
+            write_two_column_segment(selected_id, "overlapped_same_low.dat", 2, [](int key) { return key * 10; });
+
+    auto selected_source = make_allocator_source(selected_id, 12);
+    set_two_column_pk_schema(selected_source.get(), /*schema_id=*/4001);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "overlapped_same_high.dat", 0);
+    selected->mutable_segment_metas(0)->set_size(high_size);
+    selected->mutable_segment_metas(0)->set_num_rows(2);
+    auto* low_segment = add_allocator_segment(selected, "overlapped_same_low.dat", 1);
+    low_segment->set_size(low_size);
+    low_segment->set_num_rows(2);
+    selected->set_num_rows(4);
+    selected->set_data_size(high_size + low_size);
     selected->set_overlapped(false);
 
-    auto duplicate_source = make_allocator_source(next_id(), 22);
-    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "overlapped_same_0.dat", 0);
-    add_allocator_segment(duplicate, "overlapped_same_1.dat", 1);
-    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    auto duplicate_source = make_allocator_source(duplicate_id, 22);
+    set_two_column_pk_schema(duplicate_source.get(), /*schema_id=*/4001);
+    auto* duplicate = duplicate_source->add_rowsets();
+    duplicate->CopyFrom(*selected);
+    duplicate->set_id(20);
     duplicate->set_overlapped(true);
 
     ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({selected_source, duplicate_source}));
     ASSERT_EQ(1, merged->rowsets_size());
     ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
-    EXPECT_FALSE(merged->rowsets(0).overlapped());
+    EXPECT_TRUE(merged->rowsets(0).overlapped());
+    const std::vector<std::pair<int32_t, int32_t>> expected = {{0, 0}, {1, 10}, {1, 10}, {2, 20}};
+    ASSIGN_OR_ABORT(auto rows, read_two_column_rows_in_storage_order(merged, /*sorted_by_keys_per_tablet=*/true));
+    EXPECT_EQ(expected, rows);
+
+    ASSERT_OK(put_tablet_metadata(merged));
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto reopened, _tablet_manager->get_tablet_metadata(merged->id(), merged->version()));
+    ASSERT_TRUE(reopened->rowsets(0).overlapped());
+    ASSIGN_OR_ABORT(auto reopened_rows,
+                    read_two_column_rows_in_storage_order(reopened, /*sorted_by_keys_per_tablet=*/true));
+    EXPECT_EQ(expected, reopened_rows);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_del_declaration_conflict) {
@@ -12554,12 +12776,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_modern_source_stale_fal
         });
         ASSERT_OK(result_or.status());
         auto result = std::move(result_or).value();
-        const auto& target = result.published.at(result.target_tablet_id);
-        EXPECT_EQ(0, target.sstable_meta().sstables_size());
-        for (const auto& filename : result.source_sst_filenames) {
-            EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
-                                       [&](const auto& orphan) { return orphan.name() == filename; }));
-        }
+        expect_affine_sst_fallback_orphans(result);
     }
 }
 
@@ -12585,12 +12802,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_modern_mismatched_high_
                                 }
                             }
                         }));
-        const auto& target = result.published.at(result.target_tablet_id);
-        EXPECT_EQ(0, target.sstable_meta().sstables_size());
-        for (const auto& filename : result.source_sst_filenames) {
-            EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
-                                       [&](const auto& orphan) { return orphan.name() == filename; }));
-        }
+        expect_affine_sst_fallback_orphans(result);
     }
 }
 
@@ -12600,12 +12812,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_negative_offset_
                                              auto* legacy = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
                                              legacy->set_rssid_offset(-1);
                                          }));
-    const auto& target = result.published.at(result.target_tablet_id);
-    EXPECT_EQ(0, target.sstable_meta().sstables_size());
-    for (const auto& filename : result.source_sst_filenames) {
-        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
-                                   [&](const auto& orphan) { return orphan.name() == filename; }));
-    }
+    expect_affine_sst_fallback_orphans(result);
     expect_metadata_fallback_lifecycle(result, {{10, 100}, {60, 600}}, {{10, 1010}}, {60});
 }
 
@@ -12624,12 +12831,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_compressed_gap_f
                                 legacy->set_rssid_offset(5);
                                 legacy->set_max_rss_rowid(static_cast<uint64_t>(100) << 32);
                             }));
-    const auto& target = result.published.at(result.target_tablet_id);
-    EXPECT_EQ(0, target.sstable_meta().sstables_size());
-    for (const auto& filename : result.source_sst_filenames) {
-        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
-                                   [&](const auto& orphan) { return orphan.name() == filename; }));
-    }
+    expect_affine_sst_fallback_orphans(result);
     expect_metadata_fallback_lifecycle(result, {{10, 100}, {60, 600}, {70, 700}}, {{10, 1010}, {70, 700}}, {60});
 }
 
@@ -12706,13 +12908,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_uint32_exclusive
                                              legacy->set_max_rss_rowid(
                                                      static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) << 32);
                                          }));
-    const auto& target = result.published.at(result.target_tablet_id);
-    EXPECT_EQ(0, target.sstable_meta().sstables_size());
+    expect_affine_sst_fallback_orphans(result);
     EXPECT_LE(classifier_visited_runs, 1) << "the widened [INT32_MAX, 2^32) domain must not be enumerated";
-    for (const auto& filename : result.source_sst_filenames) {
-        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
-                                   [&](const auto& orphan) { return orphan.name() == filename; }));
-    }
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_proof_visits_runs_not_rssids) {
@@ -12832,12 +13029,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_identical_occurrence_di
                                     sst->set_max_rss_rowid(static_cast<uint64_t>(6) << 32);
                                 }
                             }));
-    const auto& target = result.published.at(result.target_tablet_id);
-    EXPECT_EQ(0, target.sstable_meta().sstables_size());
-    for (const auto& filename : result.source_sst_filenames) {
-        EXPECT_EQ(1, std::count_if(target.orphan_files().begin(), target.orphan_files().end(),
-                                   [&](const auto& orphan) { return orphan.name() == filename; }));
-    }
+    expect_affine_sst_fallback_orphans(result);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_identical_prior_offset_reuses) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -58,6 +58,7 @@
 #include "storage/lake/delta_writer.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/index_delta_group_loader.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/location_provider.h"
@@ -2951,7 +2952,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_metadata_only_identical_diverg
                  sources[1]->set_next_rowset_id(8);
              }},
             {"segment index mismatch",
-             [](auto& sources) { sources[1]->mutable_rowsets(0)->mutable_segment_metas(0)->set_segment_idx(7); }},
+             [&](auto& sources) {
+                 const std::string segment_name = "metadata_only_identical_index_mismatch.dat";
+                 const uint64_t segment_size = write_two_column_segment(
+                         sources[1]->id(), segment_name, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
+                 auto* segment = sources[1]->mutable_rowsets(0)->mutable_segment_metas(0);
+                 segment->set_filename(segment_name);
+                 segment->set_size(segment_size);
+                 segment->set_segment_idx(7);
+             }},
             {"segment layout count mismatch",
              [&](auto& sources) {
                  const std::string segment_name = "metadata_only_identical_second_segment.dat";
@@ -10148,6 +10157,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     const std::string base_name = "cross_target_shared_base.dat";
     const std::string cols_name = "cross_target.cols";
     const std::string idx_name = "cross_target.idx";
+    const std::string dead_idx_name = "cross_target_dead.idx";
     const auto bundled_segments =
             write_two_column_bundled_segments(source_a_id, base_name, 2, [](int key) { return key * 10; });
     ASSERT_EQ(2, bundled_segments.size());
@@ -10159,6 +10169,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
             write_c1_only_cols_file(source_a_id, cols_name, 2, [](int row) { return (row + 1) * 1000; });
     const auto idx_file = write_sidecar_payload(_tablet_manager->segment_location(source_a_id, idx_name),
                                                 "cross-target-index", /*encrypted=*/false);
+    const auto dead_idx_file = write_sidecar_payload(_tablet_manager->segment_location(source_a_id, dead_idx_name),
+                                                     "cross-target-dead-index", /*encrypted=*/false);
 
     auto source_a = make_preflight_sidecar_source(source_a_id, base_name, /*shared_segment=*/false);
     auto source_b = make_preflight_sidecar_source(source_b_id, base_name, /*shared_segment=*/true);
@@ -10191,8 +10203,20 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
         dcg->set_shared_files(0, false);
         add_idg_with_key(source, /*segment_id=*/1, idx_name, /*col_uid=*/1002, BITMAP, /*version=*/1,
                          /*shared_file=*/false);
-        auto* idg = (*source->mutable_idg_meta()->mutable_idgs())[1].mutable_entries(0);
-        idg->set_file_size(idx_file.filesize);
+        add_idg_key(source, /*segment_id=*/1, /*col_uid=*/1003, BITMAP);
+        add_idg_with_key(source, /*segment_id=*/1, dead_idx_name, /*col_uid=*/1004, BITMAP, /*version=*/1,
+                         /*shared_file=*/false);
+        auto* idg = &(*source->mutable_idg_meta()->mutable_idgs())[1];
+        idg->mutable_entries(0)->set_file_size(idx_file.filesize);
+        idg->mutable_entries(1)->set_file_size(dead_idx_file.filesize);
+        if (i == 1) {
+            auto* partial_drop = idg->mutable_entries(0)->add_dropped_keys();
+            partial_drop->set_col_unique_id(1002);
+            partial_drop->set_index_type(BITMAP);
+            auto* full_drop = idg->mutable_entries(1)->add_dropped_keys();
+            full_drop->set_col_unique_id(1004);
+            full_drop->set_index_type(BITMAP);
+        }
     }
 
     MergePhaseCounts counts;
@@ -10219,13 +10243,21 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
         EXPECT_TRUE(dcg.shared_files(0));
     }
     for (const auto& [rssid, idg] : merged->idg_meta().idgs()) {
-        (void)rssid;
         ASSERT_EQ(1, idg.entries_size());
         EXPECT_EQ(idx_name, idg.entries(0).index_file());
         EXPECT_TRUE(idg.entries(0).shared_file());
+        lake::LakeIndexDeltaGroupLoader loader(merged);
+        lake::IndexDeltaGroupList loaded;
+        ASSERT_OK(loader.load(TabletSegmentId(target_id, rssid), merged->version(), &loaded));
+        ASSERT_EQ(1, loaded.size());
+        ASSERT_EQ(1, loaded[0].keys.size());
+        EXPECT_EQ(1003, loaded[0].keys[0].col_unique_id);
+        EXPECT_EQ(BITMAP, loaded[0].keys[0].index_type);
     }
     EXPECT_TRUE(std::none_of(merged->orphan_files().begin(), merged->orphan_files().end(),
                              [&](const FileMetaPB& file) { return file.name() == idx_name; }));
+    ASSERT_EQ(1, std::count_if(merged->orphan_files().begin(), merged->orphan_files().end(),
+                               [&](const FileMetaPB& file) { return file.name() == dead_idx_name; }));
 
     ASSERT_OK(put_tablet_metadata(merged));
     _tablet_manager->prune_metacache();
@@ -10273,13 +10305,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     };
     add_orphan(cols_name, cols_size, /*shared=*/true, /*version=*/1);
     add_orphan(idx_name, idx_file.filesize, /*shared=*/true, /*version=*/1);
+    add_orphan(dead_idx_name, dead_idx_file.filesize, /*shared=*/true, /*version=*/1);
     const std::string private_control_name = "cross_target_private_control.idx";
     const auto private_control = write_sidecar_payload(
             _tablet_manager->segment_location(target_id, private_control_name), "private-vacuum-control",
             /*encrypted=*/false);
     add_orphan(private_control_name, private_control.filesize, /*shared=*/false, compacted.version());
     ASSERT_EQ(1, compacted.compaction_inputs_size());
-    ASSERT_EQ(3, compacted.orphan_files_size());
+    ASSERT_EQ(4, compacted.orphan_files_size());
     ASSERT_OK(put_tablet_metadata(compacted));
 
     _tablet_manager->prune_metacache();
@@ -10306,6 +10339,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, base_name)));
     EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, cols_name)));
     EXPECT_OK(FileSystem::Default()->path_exists(_tablet_manager->segment_location(target_id, idx_name)));
+    EXPECT_TRUE(FileSystem::Default()
+                        ->path_exists(_tablet_manager->segment_location(target_id, dead_idx_name))
+                        .is_not_found());
     EXPECT_TRUE(FileSystem::Default()
                         ->path_exists(_tablet_manager->segment_location(target_id, private_control_name))
                         .is_not_found());
@@ -10553,6 +10589,58 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_canonical_overla
         auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
         EXPECT_TRUE(status.message().contains(filename)) << status;
         EXPECT_TRUE(status.message().contains("overlapping bundled slices")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_duplicate_segment_index_within_occurrence_before_io) {
+    for (bool reverse_segments : {false, true}) {
+        SCOPED_TRACE(fmt::format("{} segment first", reverse_segments ? "shared" : "private"));
+        auto source = make_preflight_sidecar_source(next_id(), fmt::format("duplicate_index_{}.dat", next_id()));
+        auto* rowset = source->mutable_rowsets(0);
+        auto* duplicate = rowset->add_segment_metas();
+        duplicate->CopyFrom(rowset->segment_metas(0));
+        duplicate->set_shared(true);
+        if (reverse_segments) rowset->mutable_segment_metas()->SwapElements(0, 1);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("duplicate effective segment index")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_duplicate_physical_slice_in_one_rowset_before_io) {
+    for (bool reverse_segments : {false, true}) {
+        SCOPED_TRACE(fmt::format("segment index {} first", reverse_segments ? 1 : 0));
+        const std::string filename = fmt::format("duplicate_rowset_slice_{}.dat", next_id());
+        auto source = make_preflight_sidecar_source(next_id(), filename);
+        auto* rowset = source->mutable_rowsets(0);
+        auto* duplicate = rowset->add_segment_metas();
+        duplicate->CopyFrom(rowset->segment_metas(0));
+        duplicate->set_segment_idx(1);
+        if (reverse_segments) rowset->mutable_segment_metas()->SwapElements(0, 1);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains(filename)) << status;
+        EXPECT_TRUE(status.message().contains("multiple segment indices")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_sibling_union_duplicate_physical_slice_before_io) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(fmt::format("segment index {} source first", reverse_sources ? 1 : 0));
+        const std::string filename = fmt::format("duplicate_union_slice_{}.dat", next_id());
+        auto first = make_preflight_sidecar_source(next_id(), filename);
+        auto second = make_preflight_sidecar_source(next_id(), filename);
+        second->mutable_rowsets(0)->mutable_segment_metas(0)->set_segment_idx(1);
+        second->mutable_rowsets(0)->mutable_uid()->CopyFrom(first->rowsets(0).uid());
+        std::vector<TabletMetadataPtr> sources = {first, second};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains(filename)) << status;
+        EXPECT_TRUE(status.message().contains("multiple segment indices")) << status;
     }
 }
 
@@ -15555,12 +15643,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_drops_fully_tombstoned) {
     EXPECT_TRUE(orphaned) << "fully-tombstoned .idx must be added to orphan_files";
 }
 
-// MERGE: a .idx that is fully-tombstoned under one target but still ACTIVE under another
-// target must NOT be orphaned (vacuum deletes orphan_files without checking live idg_meta).
-// The same physical .idx may be referenced under two target RSSIDs only when both resolve to
-// the same physical base segment. child_a keeps "same.idx" active at its rssid; child_b
-// (distinct uid => remapped rssid) has the same base and a fully tombstoned declaration.
-TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_orphan_skips_still_referenced_file) {
+// MERGE: DROP INDEX tombstones are table-wide monotonic for one .idx + physical base.
+// A tombstone under either co-referenced target therefore makes the single-key entry dead
+// under both targets; with no active reference, the physical .idx is orphaned exactly once.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_global_tombstone_orphans_without_active_reference) {
     const int64_t base_version = 1, new_version = 2;
     const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();
     prepare_tablet_dirs(child_a);
@@ -15604,17 +15690,16 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_orphan_skips_still_referen
                                               txn_info, false, tablet_metadatas, tablet_ranges));
 
     auto merged = tablet_metadatas.at(merged_tablet);
-    // same.idx is still active under child_a's target, so it must NOT be orphaned.
-    for (const auto& f : merged->orphan_files()) {
-        EXPECT_NE("same.idx", f.name()) << "a still-referenced .idx must not be orphaned";
-    }
-    bool active = false;
+    int active = 0;
     for (const auto& [rssid, ver] : merged->idg_meta().idgs()) {
+        (void)rssid;
         for (const auto& e : ver.entries()) {
-            if (e.index_file() == "same.idx") active = true;
+            if (e.index_file() == "same.idx") ++active;
         }
     }
-    EXPECT_TRUE(active) << "same.idx must remain an active entry";
+    EXPECT_EQ(0, active) << "the table-wide tombstone must remove every co-reference";
+    EXPECT_EQ(1, std::count_if(merged->orphan_files().begin(), merged->orphan_files().end(),
+                               [](const auto& file) { return file.name() == "same.idx"; }));
 }
 
 // MERGE: a source split before this fix can have segment.shared=true but a stale

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -470,8 +470,8 @@ protected:
         const bool identical = shape == MetadataOnlyMergeShape::kIdentical;
         const std::string segment_a = "metadata_only_a.dat";
         const std::string segment_b = identical ? segment_a : "metadata_only_b.dat";
-        const uint64_t segment_a_size =
-                write_two_column_segment(source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
+        const uint64_t segment_a_size = write_two_column_segment(
+                source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
         uint64_t segment_b_size = segment_a_size;
         if (!identical) {
             segment_b_size = write_two_column_segment(
@@ -2144,8 +2144,8 @@ protected:
         prepare_tablet_dirs(target_tablet_id);
         const uint64_t old_size = write_two_column_segment(child_a, old_segment, 1, [](int) { return 100; });
         const uint64_t tail_size = write_two_column_segment(child_a, tail_segment, 1, [](int) { return 200; });
-        const uint64_t sibling_size =
-                write_two_column_segment(child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
+        const uint64_t sibling_size = write_two_column_segment(
+                child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
         const uint32_t tombstone = std::numeric_limits<uint32_t>::max();
         const uint64_t tombstone_size =
                 write_versioned_pk_sstable(_tablet_manager->sst_location(child_a, tombstone_filename),
@@ -12289,8 +12289,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_near_rssid_boundary_remains_wr
     auto merged = tablet_metadatas.at(merged_tablet);
     ASSERT_EQ(2, merged->next_rowset_id());
 
-    const uint64_t write_segment_size =
-            write_two_column_segment(merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
+    const uint64_t write_segment_size = write_two_column_segment(
+            merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
     TxnLogPB write_log;
     write_log.set_tablet_id(merged_tablet);
     write_log.set_txn_id(2);
@@ -12854,8 +12854,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped
     duplicate_source->mutable_range()->set_lower_bound_included(true);
     duplicate_source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
     duplicate_source->mutable_range()->set_upper_bound_included(false);
-    const uint64_t selected_size = write_two_column_segment(selected_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
-    write_two_column_segment(duplicate_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t selected_size = write_two_column_segment(
+            selected_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
+    write_two_column_segment(
+            duplicate_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
     auto* selected = add_allocator_rowset(selected_source.get(), 41, 1, "rejoin.dat", 0);
     selected->mutable_segment_metas(0)->set_size(selected_size);
     selected->mutable_segment_metas(0)->set_shared(true);
@@ -12998,8 +13000,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_overlapped_without_s
     const int64_t duplicate_id = next_id();
     prepare_tablet_dirs(selected_id);
     prepare_tablet_dirs(duplicate_id);
-    const uint64_t high_size =
-            write_two_column_segment(selected_id, "overlapped_same_high.dat", 2, [](int key) { return key * 10; }, 1);
+    const uint64_t high_size = write_two_column_segment(
+            selected_id, "overlapped_same_high.dat", 2, [](int key) { return key * 10; }, 1);
     const uint64_t low_size =
             write_two_column_segment(selected_id, "overlapped_same_low.dat", 2, [](int key) { return key * 10; });
 
@@ -13165,10 +13167,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_equal_recovery_key_e
     source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
     source->set_enable_persistent_index(true);
     source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
-    const uint64_t first_size =
-            write_two_column_segment(source_id, "recovery_equal_a.dat", 1, [](int) { return 100; }, 10);
-    const uint64_t second_size =
-            write_two_column_segment(source_id, "recovery_equal_b.dat", 1, [](int) { return 200; }, 20);
+    const uint64_t first_size = write_two_column_segment(
+            source_id, "recovery_equal_a.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(
+            source_id, "recovery_equal_b.dat", 1, [](int) { return 200; }, 20);
     auto* first = add_allocator_rowset(source.get(), 798, 1, "recovery_equal_a.dat", 0);
     first->mutable_segment_metas(0)->set_size(first_size);
     first->set_max_compact_input_rowset_id(797);
@@ -13226,10 +13228,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_strict_recovery_orde
         source->set_enable_persistent_index(true);
         source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
     }
-    const uint64_t first_size =
-            write_two_column_segment(first_id, "recovery_strict_2.dat", 1, [](int) { return 100; }, 10);
-    const uint64_t second_size =
-            write_two_column_segment(second_id, "recovery_strict_20.dat", 1, [](int) { return 600; }, 60);
+    const uint64_t first_size = write_two_column_segment(
+            first_id, "recovery_strict_2.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(
+            second_id, "recovery_strict_20.dat", 1, [](int) { return 600; }, 60);
     auto* first_rowset = add_allocator_rowset(first.get(), 2, 1, "recovery_strict_2.dat", 0);
     first_rowset->mutable_segment_metas(0)->set_size(first_size);
     auto* second_rowset = add_allocator_rowset(second.get(), 20, 2, "recovery_strict_20.dat", 0);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -612,8 +612,7 @@ protected:
 
     StatusOr<MutableTabletMetadataPtr> merge_with_phase_counts(const std::vector<TabletMetadataPtr>& sources,
                                                                int64_t target_tablet_id, int64_t target_version,
-                                                               MergePhaseCounts* counts,
-                                                               bool skip_sstable_merge = false) {
+                                                               MergePhaseCounts* counts) {
         auto* sync = SyncPoint::GetInstance();
         sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++counts->materialize; });
         sync->SetCallBack("merge_dcg_meta:after_write_cols", [&](void*) { ++counts->dcg_writes; });
@@ -637,12 +636,11 @@ protected:
         txn_info.set_commit_time(1);
         txn_info.set_gtid(1);
         return lake::merge_tablet(_tablet_manager.get(), sources, merging, target_version, txn_info,
-                                  skip_sstable_merge);
+                                  /*skip_sstable_merge=*/false);
     }
 
     Status expect_physical_preflight_rejection(const std::vector<TabletMetadataPtr>& sources, int64_t target_tablet_id,
-                                               int64_t target_version, MergePhaseCounts* counts,
-                                               bool skip_sstable_merge = false) {
+                                               int64_t target_version, MergePhaseCounts* counts) {
         std::vector<std::string> source_pbs;
         std::map<int64_t, std::set<std::string>> segment_inventories;
         std::map<int64_t, std::set<std::string>> metadata_inventories;
@@ -660,7 +658,7 @@ protected:
         ASSIGN_OR_ABORT(metadata_inventories[target_tablet_id],
                         directory_inventory(_location_provider->metadata_root_location(target_tablet_id)));
 
-        auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts, skip_sstable_merge);
+        auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts);
 
         EXPECT_TRUE(merged.status().is_corruption()) << merged.status();
         EXPECT_EQ(0, counts->materialize);
@@ -10403,6 +10401,53 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_invalid_physical_segme
     }
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_invalid_physical_segment_filename_before_io) {
+    struct InvalidFilename {
+        const char* name;
+        std::function<void(SegmentMetadataPB*)> apply;
+    };
+    const std::vector<InvalidFilename> invalid_filenames = {
+            {"missing", [](SegmentMetadataPB* segment) { segment->clear_filename(); }},
+            {"present empty", [](SegmentMetadataPB* segment) { segment->set_filename(""); }},
+    };
+
+    for (const auto& invalid : invalid_filenames) {
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(
+                    fmt::format("{} filename; {} source first", invalid.name, reverse_sources ? "valid" : "invalid"));
+            auto malformed =
+                    make_preflight_sidecar_source(next_id(), fmt::format("invalid_filename_{}.dat", next_id()));
+            invalid.apply(malformed->mutable_rowsets(0)->mutable_segment_metas(0));
+            auto valid = make_preflight_sidecar_source(next_id(), fmt::format("valid_filename_{}.dat", next_id()));
+            std::vector<TabletMetadataPtr> sources = {malformed, valid};
+            if (reverse_sources) std::swap(sources[0], sources[1]);
+
+            MergePhaseCounts counts;
+            auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+            EXPECT_TRUE(status.message().contains("filename")) << status;
+        }
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_bundle_slice_end_overflow_before_io) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(fmt::format("{} source first", reverse_sources ? "valid" : "overflowing"));
+        auto overflowing =
+                make_preflight_sidecar_source(next_id(), fmt::format("overflowing_bundle_{}.dat", next_id()));
+        auto* segment = overflowing->mutable_rowsets(0)->mutable_segment_metas(0);
+        segment->set_bundle_file_offset(std::numeric_limits<int64_t>::max() - 7);
+        segment->set_size(8);
+        auto valid = make_preflight_sidecar_source(next_id(), fmt::format("valid_bundle_peer_{}.dat", next_id()));
+        std::vector<TabletMetadataPtr> sources = {overflowing, valid};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("bundle")) << status;
+        EXPECT_TRUE(status.message().contains("size")) << status;
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_delvec_page_out_of_bounds_before_io) {
     auto source = make_preflight_sidecar_source(next_id(), "delvec_bounds.dat");
     DelVector delvec;
@@ -13109,6 +13154,69 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_legacy_proof_visits_run
     EXPECT_EQ(2, legacy->rssid_offset());
     EXPECT_EQ(static_cast<uint64_t>(4097) << 32, legacy->max_rss_rowid());
     EXPECT_EQ(1, classifier_visited_runs) << "a 4096-RSSID affine domain must visit one translation run";
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_legacy_liveness_precompute_visits_each_live_rssid_once) {
+    constexpr int kSourceBLiveRssids = 32;
+    constexpr int kLegacySstables = 4;
+    constexpr int kExpectedContexts = 2;
+    constexpr int kExpectedLiveRssids = 1 + kSourceBLiveRssids;
+    int precomputed_contexts = 0;
+    int visited_live_rssids = 0;
+    int bounded_lookups = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("legacy_sstable_liveness_index:precompute_context", [&](void*) { ++precomputed_contexts; });
+    sync->SetCallBack("legacy_sstable_liveness_index:visited_live_rssid", [&](void*) { ++visited_live_rssids; });
+    sync->SetCallBack("legacy_sstable_liveness_index:bounded_lookup", [&](void*) { ++bounded_lookups; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearCallBack("legacy_sstable_liveness_index:precompute_context");
+        sync->ClearCallBack("legacy_sstable_liveness_index:visited_live_rssid");
+        sync->ClearCallBack("legacy_sstable_liveness_index:bounded_lookup");
+        sync->DisableProcessing();
+    });
+
+    ASSIGN_OR_ABORT(auto result,
+                    publish_metadata_only_merge_fixture(
+                            MetadataOnlyMergeShape::kPrivate, false, false, true, [&](auto& sources) {
+                                auto& source = sources[1];
+                                for (int i = 1; i < kSourceBLiveRssids; ++i) {
+                                    const std::string segment_name = fmt::format("legacy_liveness_{}.dat", i);
+                                    const uint64_t segment_size = write_two_column_segment(
+                                            source->id(), segment_name, 1, [](int key) { return key * 10; }, 60 + i);
+                                    auto* rowset =
+                                            add_allocator_rowset(source.get(), 5 + i, source->rowsets(0).version(),
+                                                                 segment_name, /*segment_idx=*/0);
+                                    rowset->mutable_segment_metas(0)->set_size(segment_size);
+                                }
+                                source->set_next_rowset_id(5 + kSourceBLiveRssids);
+
+                                const PersistentIndexSstablePB seed = source->sstable_meta().sstables(0);
+                                for (int i = 1; i < kLegacySstables; ++i) {
+                                    const uint32_t source_high =
+                                            i + 1 == kLegacySstables ? 5 + kSourceBLiveRssids - 1 : 5 + i * 10;
+                                    const std::string filename = fmt::format("legacy_liveness_{}.sst", i);
+                                    const auto file = write_raw_pk_sstable(
+                                            _tablet_manager->sst_location(source->id(), filename),
+                                            {{encode_int_primary_key(60 + i),
+                                              serialize_index_values({{source->version(), source_high - 5, 0}})}});
+                                    auto* sstable = source->mutable_sstable_meta()->add_sstables();
+                                    sstable->CopyFrom(seed);
+                                    sstable->set_filename(filename);
+                                    sstable->set_filesize(file.filesize);
+                                    sstable->set_encryption_meta(file.encryption_meta);
+                                    sstable->mutable_range()->CopyFrom(file.range);
+                                    sstable->set_rssid_offset(5);
+                                    sstable->set_max_rss_rowid(static_cast<uint64_t>(source_high) << 32);
+                                    sstable->mutable_fileset_id()->set_lo(0x6000 + i);
+                                }
+                            }));
+    const auto& target = result.published.at(result.target_tablet_id);
+    EXPECT_EQ(1 + kLegacySstables, target.sstable_meta().sstables_size());
+    EXPECT_EQ(kExpectedContexts, precomputed_contexts);
+    EXPECT_EQ(kExpectedLiveRssids, visited_live_rssids)
+            << "source-live RSSIDs must be visited once per context, not once per legacy SST";
+    EXPECT_EQ(kLegacySstables, bounded_lookups);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_affine_identical_common_nonzero_delta_reuses) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -10512,6 +10512,76 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_canonical_filena
     }
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_same_uid_overlapping_bundle_slices_before_io) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(fmt::format("{} source first", reverse_sources ? "later slice" : "earlier slice"));
+        const std::string filename = fmt::format("same_uid_overlapping_bundle_{}.dat", next_id());
+        auto earlier = make_preflight_sidecar_source(next_id(), filename);
+        auto later = make_preflight_sidecar_source(next_id(), filename);
+        auto* earlier_rowset = earlier->mutable_rowsets(0);
+        auto* later_rowset = later->mutable_rowsets(0);
+        earlier_rowset->mutable_segment_metas(0)->set_size(128);
+        earlier_rowset->mutable_segment_metas(0)->set_bundle_file_offset(0);
+        later_rowset->mutable_segment_metas(0)->set_size(128);
+        later_rowset->mutable_segment_metas(0)->set_bundle_file_offset(64);
+        later_rowset->mutable_segment_metas(0)->set_segment_idx(1);
+        later_rowset->mutable_uid()->CopyFrom(earlier_rowset->uid());
+        std::vector<TabletMetadataPtr> sources = {earlier, later};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains(filename)) << status;
+        EXPECT_TRUE(status.message().contains("overlapping bundled slices")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_canonical_overlapping_bundle_slices_before_io) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(fmt::format("{} source first", reverse_sources ? "later slice" : "earlier slice"));
+        const std::string filename = fmt::format("cross_canonical_overlapping_bundle_{}.dat", next_id());
+        auto earlier = make_preflight_sidecar_source(next_id(), filename);
+        auto later = make_preflight_sidecar_source(next_id(), filename);
+        earlier->mutable_rowsets(0)->mutable_segment_metas(0)->set_size(128);
+        earlier->mutable_rowsets(0)->mutable_segment_metas(0)->set_bundle_file_offset(0);
+        later->mutable_rowsets(0)->mutable_segment_metas(0)->set_size(128);
+        later->mutable_rowsets(0)->mutable_segment_metas(0)->set_bundle_file_offset(64);
+        std::vector<TabletMetadataPtr> sources = {earlier, later};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains(filename)) << status;
+        EXPECT_TRUE(status.message().contains("overlapping bundled slices")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_adjacent_and_disjoint_bundled_slices) {
+    for (int64_t later_offset : {int64_t{128}, int64_t{256}}) {
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("offset {}; {} source first", later_offset,
+                                     reverse_sources ? "later slice" : "earlier slice"));
+            const std::string filename = fmt::format("compatible_bundle_slices_{}.dat", next_id());
+            auto earlier = make_preflight_sidecar_source(next_id(), filename);
+            auto later = make_preflight_sidecar_source(next_id(), filename);
+            earlier->mutable_rowsets(0)->mutable_segment_metas(0)->set_size(128);
+            earlier->mutable_rowsets(0)->mutable_segment_metas(0)->set_bundle_file_offset(0);
+            later->mutable_rowsets(0)->mutable_segment_metas(0)->set_size(128);
+            later->mutable_rowsets(0)->mutable_segment_metas(0)->set_bundle_file_offset(later_offset);
+            std::vector<TabletMetadataPtr> sources = {earlier, later};
+            if (reverse_sources) std::swap(sources[0], sources[1]);
+
+            MergePhaseCounts counts;
+            ASSIGN_OR_ABORT(auto merged, merge_with_phase_counts(sources, next_id(), /*target_version=*/2, &counts));
+            ASSERT_EQ(2, merged->rowsets_size());
+            EXPECT_EQ(1, counts.materialize);
+            EXPECT_EQ(0, counts.dcg_writes);
+            EXPECT_EQ(0, counts.delvec_writes);
+            EXPECT_EQ(0, counts.source_flushes);
+        }
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_uniform_bundle_presence_after_segment_union) {
     for (bool bundled : {false, true}) {
         for (bool reverse_sources : {false, true}) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1725,25 +1725,23 @@ protected:
 
     StatusOr<uint32_t> repeated_merge_cursor_oracle(const std::vector<TabletMetadataPtr>& sources) {
         struct Family {
-            size_t selected_context = 0;
-            const RowsetMetadataPB* selected = nullptr;
+            size_t selected_context;
+            const RowsetMetadataPB* selected;
             uint32_t final_max_segment_idx = 0;
         };
         std::map<std::pair<int64_t, int64_t>, Family> families;
         for (size_t context_index = 0; context_index < sources.size(); ++context_index) {
             for (const auto& rowset : sources[context_index]->rowsets()) {
                 if (!rowset.has_uid()) return Status::Corruption("repeated lifecycle rowset is missing uid");
-                auto [it, inserted] = families.emplace(std::pair{rowset.uid().hi(), rowset.uid().lo()},
-                                                       Family{.selected_context = context_index, .selected = &rowset});
+                auto it = families.try_emplace(std::pair{rowset.uid().hi(), rowset.uid().lo()},
+                                               Family{.selected_context = context_index, .selected = &rowset})
+                                  .first;
                 auto& family = it->second;
                 for (int segment_index = 0; segment_index < rowset.segment_metas_size(); ++segment_index) {
                     const auto& segment = rowset.segment_metas(segment_index);
                     family.final_max_segment_idx = std::max(
                             family.final_max_segment_idx,
                             segment.has_segment_idx() ? segment.segment_idx() : static_cast<uint32_t>(segment_index));
-                }
-                if (!inserted && family.selected == nullptr) {
-                    return Status::Corruption("repeated lifecycle family has no selected rowset");
                 }
             }
         }
@@ -10334,6 +10332,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_target_physical_
             const std::string filename = fmt::format("cross_target_slice_conflict_{}.dat", next_id());
             auto canonical = make_preflight_sidecar_source(next_id(), filename);
             auto conflicting = make_preflight_sidecar_source(next_id(), filename);
+            canonical->mutable_rowsets(0)->mutable_segment_metas(0)->set_size(128);
+            conflicting->mutable_rowsets(0)->mutable_segment_metas(0)->set_size(128);
             conflict.apply(conflicting->mutable_rowsets(0)->mutable_segment_metas(0));
             std::vector<TabletMetadataPtr> sources = {canonical, conflicting};
             if (reverse_sources) std::swap(sources[0], sources[1]);
@@ -10359,6 +10359,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_invalid_physical_segme
             {"negative offset versus explicit zero", true, "bundle_file_offset",
              [](SegmentMetadataPB* left, SegmentMetadataPB* right) {
                  left->set_bundle_file_offset(0);
+                 left->set_size(128);
                  right->set_bundle_file_offset(-1);
              }},
             {"negative size", true, "size",
@@ -10435,8 +10436,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_bundle_slice_end_overf
         auto overflowing =
                 make_preflight_sidecar_source(next_id(), fmt::format("overflowing_bundle_{}.dat", next_id()));
         auto* segment = overflowing->mutable_rowsets(0)->mutable_segment_metas(0);
-        segment->set_bundle_file_offset(std::numeric_limits<int64_t>::max() - 7);
-        segment->set_size(8);
+        segment->set_bundle_file_offset(std::numeric_limits<int64_t>::max() - 11);
+        segment->set_size(12);
         auto valid = make_preflight_sidecar_source(next_id(), fmt::format("valid_bundle_peer_{}.dat", next_id()));
         std::vector<TabletMetadataPtr> sources = {overflowing, valid};
         if (reverse_sources) std::swap(sources[0], sources[1]);
@@ -10445,6 +10446,85 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_bundle_slice_end_overf
         auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
         EXPECT_TRUE(status.message().contains("bundle")) << status;
         EXPECT_TRUE(status.message().contains("size")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_mixed_bundle_presence_after_segment_union_before_io) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(fmt::format("{} source first", reverse_sources ? "standalone" : "bundled"));
+        auto bundled = make_preflight_sidecar_source(next_id(), fmt::format("mixed_bundle_{}.dat", next_id()));
+        auto standalone = make_preflight_sidecar_source(next_id(), fmt::format("mixed_standalone_{}.dat", next_id()));
+        auto* bundled_rowset = bundled->mutable_rowsets(0);
+        auto* standalone_rowset = standalone->mutable_rowsets(0);
+        bundled_rowset->mutable_segment_metas(0)->set_bundle_file_offset(0);
+        bundled_rowset->mutable_segment_metas(0)->set_size(128);
+        standalone_rowset->mutable_segment_metas(0)->set_segment_idx(1);
+        standalone_rowset->mutable_uid()->CopyFrom(bundled_rowset->uid());
+        std::vector<TabletMetadataPtr> sources = {bundled, standalone};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("bundled")) << status;
+        EXPECT_TRUE(status.message().contains("standalone")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_uniform_bundle_presence_after_segment_union) {
+    for (bool bundled : {false, true}) {
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("{}; {} source first", bundled ? "bundled" : "standalone",
+                                     reverse_sources ? "right" : "left"));
+            auto left = make_preflight_sidecar_source(next_id(), fmt::format("uniform_left_{}.dat", next_id()));
+            auto right = make_preflight_sidecar_source(next_id(), fmt::format("uniform_right_{}.dat", next_id()));
+            auto* left_rowset = left->mutable_rowsets(0);
+            auto* right_rowset = right->mutable_rowsets(0);
+            right_rowset->mutable_segment_metas(0)->set_segment_idx(1);
+            right_rowset->mutable_uid()->CopyFrom(left_rowset->uid());
+            if (bundled) {
+                left_rowset->mutable_segment_metas(0)->set_bundle_file_offset(0);
+                left_rowset->mutable_segment_metas(0)->set_size(128);
+                right_rowset->mutable_segment_metas(0)->set_bundle_file_offset(128);
+                right_rowset->mutable_segment_metas(0)->set_size(128);
+            }
+            std::vector<TabletMetadataPtr> sources = {left, right};
+            if (reverse_sources) std::swap(sources[0], sources[1]);
+
+            MergePhaseCounts counts;
+            ASSIGN_OR_ABORT(auto merged, merge_with_phase_counts(sources, next_id(), /*target_version=*/2, &counts));
+            ASSERT_EQ(1, merged->rowsets_size());
+            ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
+            EXPECT_EQ(bundled ? 2 : 0, std::count_if(merged->rowsets(0).segment_metas().begin(),
+                                                     merged->rowsets(0).segment_metas().end(), [](const auto& segment) {
+                                                         return segment.has_bundle_file_offset();
+                                                     }));
+            EXPECT_EQ(1, counts.materialize);
+            EXPECT_EQ(0, counts.dcg_writes);
+            EXPECT_EQ(0, counts.delvec_writes);
+            EXPECT_EQ(0, counts.source_flushes);
+        }
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_undersized_bundle_slice_before_io) {
+    for (int64_t size : {int64_t{0}, int64_t{1}, int64_t{11}}) {
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("size {}; {} source first", size,
+                                     reverse_sources ? "standalone" : "undersized bundled"));
+            auto undersized =
+                    make_preflight_sidecar_source(next_id(), fmt::format("undersized_bundle_{}.dat", next_id()));
+            auto* segment = undersized->mutable_rowsets(0)->mutable_segment_metas(0);
+            segment->set_bundle_file_offset(0);
+            segment->set_size(size);
+            auto standalone =
+                    make_preflight_sidecar_source(next_id(), fmt::format("undersized_peer_{}.dat", next_id()));
+            std::vector<TabletMetadataPtr> sources = {undersized, standalone};
+            if (reverse_sources) std::swap(sources[0], sources[1]);
+
+            MergePhaseCounts counts;
+            auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+            EXPECT_TRUE(status.message().contains("footer trailer")) << status;
+        }
     }
 }
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -10967,36 +10967,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_sst_fil
 
     for (const auto& conflict : conflicts) {
         SCOPED_TRACE(conflict.name);
-        const int64_t source_a_id = next_id();
-        const int64_t source_b_id = next_id();
-        const std::string segment = fmt::format("sst_preflight_{}.dat", next_id());
-        auto make_source = [&](int64_t tablet_id, int lower, int upper) {
-            auto source = make_preflight_sidecar_source(tablet_id, segment, /*shared_segment=*/true,
-                                                        /*common_rowset_uid=*/true);
-            set_int_primary_key_schema(source.get(), /*schema_id=*/4001);
-            source->set_enable_persistent_index(true);
-            source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
-            source->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(lower));
-            source->mutable_range()->set_lower_bound_included(true);
-            source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(upper));
-            source->mutable_range()->set_upper_bound_included(false);
-            source->mutable_rowsets(0)->mutable_range()->CopyFrom(source->range());
-            auto* sst = source->mutable_sstable_meta()->add_sstables();
+        auto sources = make_preflight_sst_sources(fmt::format("sst_preflight_{}", next_id()));
+        for (auto& source : sources) {
+            auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
             sst->set_filename("repeated_physical.sst");
-            sst->set_filesize(128);
             sst->set_encryption_meta(encryption_a.encryption_meta);
-            sst->set_shared(true);
-            sst->set_shared_rssid(1);
-            sst->set_shared_version(1);
-            sst->set_max_rss_rowid(static_cast<uint64_t>(1) << 32);
-            sst->set_generation_version(1);
-            sst->mutable_range()->set_start_key(encode_int_primary_key(10));
-            sst->mutable_range()->set_end_key(encode_int_primary_key(90));
-            return source;
-        };
-        auto source_a = make_source(source_a_id, /*lower=*/0, /*upper=*/50);
-        auto source_b = make_source(source_b_id, /*lower=*/50, /*upper=*/100);
-        std::vector<std::shared_ptr<TabletMetadataPB>> sources = {source_a, source_b};
+        }
         conflict.apply(sources);
         std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1192,10 +1192,9 @@ protected:
         return segment_file_size;
     }
 
-    std::pair<uint64_t, int64_t> write_two_column_bundled_segment(int64_t tablet_id, const std::string& bundle_name,
-                                                                  int num_rows,
-                                                                  const std::function<int(int)>& source_value_of,
-                                                                  int key_start = 0) {
+    std::vector<std::pair<uint64_t, int64_t>> write_two_column_bundled_segments(
+            int64_t tablet_id, const std::string& bundle_name, int num_rows,
+            const std::function<int(int)>& source_value_of, int key_start = 0) {
         const std::string slice_name = fmt::format("{}.slice_{}", bundle_name, next_id());
         const uint64_t slice_size =
                 write_two_column_segment(tablet_id, slice_name, num_rows, source_value_of, key_start);
@@ -1203,10 +1202,21 @@ protected:
         ASSIGN_OR_ABORT(auto reader, fs::new_random_access_file(slice_path));
         ASSIGN_OR_ABORT(auto slice_contents, reader->read_all());
 
+        const std::string empty_slice_name = fmt::format("{}.empty_slice_{}", bundle_name, next_id());
+        const uint64_t empty_slice_size =
+                write_two_column_segment(tablet_id, empty_slice_name, 0, source_value_of, key_start + num_rows);
+        const std::string empty_slice_path = _tablet_manager->segment_location(tablet_id, empty_slice_name);
+        ASSIGN_OR_ABORT(auto empty_reader, fs::new_random_access_file(empty_slice_path));
+        ASSIGN_OR_ABORT(auto empty_slice_contents, empty_reader->read_all());
+
         const std::string prefix = "tablet-merge-bundle-prefix";
-        write_file(_tablet_manager->segment_location(tablet_id, bundle_name), prefix + slice_contents);
+        const int64_t slice_offset = prefix.size();
+        const int64_t empty_slice_offset = slice_offset + static_cast<int64_t>(slice_size);
+        write_file(_tablet_manager->segment_location(tablet_id, bundle_name),
+                   prefix + slice_contents + empty_slice_contents);
         CHECK_OK(fs::delete_file(slice_path));
-        return {slice_size, static_cast<int64_t>(prefix.size())};
+        CHECK_OK(fs::delete_file(empty_slice_path));
+        return {{slice_size, slice_offset}, {empty_slice_size, empty_slice_offset}};
     }
 
     // Write a real .cols file for column c1 only, with `num_rows` entries.
@@ -10138,9 +10148,13 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     const std::string base_name = "cross_target_shared_base.dat";
     const std::string cols_name = "cross_target.cols";
     const std::string idx_name = "cross_target.idx";
-    const auto [base_size, base_offset] =
-            write_two_column_bundled_segment(source_a_id, base_name, 2, [](int key) { return key * 10; });
+    const auto bundled_segments =
+            write_two_column_bundled_segments(source_a_id, base_name, 2, [](int key) { return key * 10; });
+    ASSERT_EQ(2, bundled_segments.size());
+    const auto [base_size, base_offset] = bundled_segments[0];
+    const auto [empty_size, empty_offset] = bundled_segments[1];
     ASSERT_GT(base_offset, 0);
+    ASSERT_GT(empty_offset, base_offset);
     const uint64_t cols_size =
             write_c1_only_cols_file(source_a_id, cols_name, 2, [](int row) { return (row + 1) * 1000; });
     const auto idx_file = write_sidecar_payload(_tablet_manager->segment_location(source_a_id, idx_name),
@@ -10158,11 +10172,19 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
         source->mutable_range()->set_upper_bound_included(false);
         auto* rowset = source->mutable_rowsets(0);
         rowset->set_num_rows(2);
-        rowset->set_data_size(base_size);
+        rowset->set_data_size(base_size + empty_size);
         rowset->mutable_range()->CopyFrom(source->range());
         rowset->mutable_segment_metas(0)->set_size(base_size);
         rowset->mutable_segment_metas(0)->set_bundle_file_offset(base_offset);
         rowset->mutable_segment_metas(0)->set_num_rows(2);
+        auto* empty_segment = rowset->add_segment_metas();
+        empty_segment->set_filename(base_name);
+        empty_segment->set_size(empty_size);
+        empty_segment->set_bundle_file_offset(empty_offset);
+        empty_segment->set_num_rows(0);
+        empty_segment->set_segment_idx(1);
+        empty_segment->set_shared(rowset->segment_metas(0).shared());
+        source->set_next_rowset_id(3);
         add_dcg_with_columns(source, /*segment_id=*/1, cols_name, {1002}, /*version=*/1);
         auto* dcg = &(*source->mutable_dcg_meta()->mutable_dcgs())[1];
         dcg->add_column_file_sizes(cols_size);
@@ -10185,8 +10207,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     ASSERT_EQ(2, merged->dcg_meta().dcgs_size());
     ASSERT_EQ(2, merged->idg_meta().idgs_size());
     for (const auto& rowset : merged->rowsets()) {
-        ASSERT_EQ(1, rowset.segment_metas_size());
-        EXPECT_TRUE(rowset.segment_metas(0).shared());
+        ASSERT_EQ(2, rowset.segment_metas_size());
+        EXPECT_TRUE(std::all_of(rowset.segment_metas().begin(), rowset.segment_metas().end(),
+                                [](const auto& segment) { return segment.shared(); }));
+        EXPECT_TRUE(std::all_of(rowset.segment_metas().begin(), rowset.segment_metas().end(),
+                                [](const auto& segment) { return segment.has_bundle_file_offset(); }));
     }
     for (const auto& [rssid, dcg] : merged->dcg_meta().dcgs()) {
         (void)rssid;
@@ -10210,14 +10235,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
 
     TabletMetadataPB compacted(*reopened);
     compacted.set_version(reopened->version() + 1);
-    RowsetMetadataPB retired;
-    RowsetMetadataPB retained;
-    for (const auto& rowset : compacted.rowsets()) {
-        if (rowset.id() == 1) retired.CopyFrom(rowset);
-        if (rowset.id() == 2) retained.CopyFrom(rowset);
-    }
-    ASSERT_TRUE(retired.has_id());
-    ASSERT_TRUE(retained.has_id());
+    ASSERT_EQ(2, compacted.rowsets_size());
+    RowsetMetadataPB retired(compacted.rowsets(0));
+    RowsetMetadataPB retained(compacted.rowsets(1));
     compacted.clear_rowsets();
     compacted.add_rowsets()->CopyFrom(retained);
     compacted.clear_compaction_inputs();
@@ -10225,7 +10245,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     const std::string compacted_name = "cross_target_compacted.dat";
     const uint64_t compacted_size = write_two_column_segment(target_id, compacted_name, 1, [](int) { return 1000; });
     auto* output = compacted.add_rowsets();
-    output->set_id(3);
+    output->set_id(compacted.next_rowset_id());
     output->set_version(compacted.version());
     output->set_num_rows(1);
     output->set_data_size(compacted_size);
@@ -10239,10 +10259,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     output_segment->set_size(compacted_size);
     output_segment->set_num_rows(1);
     lake::tablet_reshard_helper::set_rowset_uid(output);
-    compacted.set_next_rowset_id(4);
-    compacted.mutable_dcg_meta()->mutable_dcgs()->erase(1);
-    compacted.mutable_idg_meta()->mutable_idgs()->erase(1);
-    compacted.mutable_delvec_meta()->mutable_delvecs()->erase(1);
+    compacted.set_next_rowset_id(output->id() + 1);
+    compacted.mutable_dcg_meta()->mutable_dcgs()->erase(retired.id());
+    compacted.mutable_idg_meta()->mutable_idgs()->erase(retired.id());
+    compacted.mutable_delvec_meta()->mutable_delvecs()->erase(retired.id());
     compacted.clear_orphan_files();
     auto add_orphan = [&](const std::string& name, int64_t size, bool shared, int64_t version) {
         auto* orphan = compacted.add_orphan_files();
@@ -10314,12 +10334,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_different_base_si
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_target_physical_slice_declaration_conflict_before_io) {
     struct DeclarationConflict {
         const char* name;
+        const char* expected_error;
         std::function<void(SegmentMetadataPB*)> apply;
     };
     const std::vector<DeclarationConflict> conflicts = {
-            {"bundle offset presence", [](SegmentMetadataPB* segment) { segment->set_bundle_file_offset(0); }},
-            {"size presence", [](SegmentMetadataPB* segment) { segment->clear_size(); }},
-            {"unknown field",
+            {"bundle offset presence", "bundled and standalone",
+             [](SegmentMetadataPB* segment) { segment->set_bundle_file_offset(0); }},
+            {"size presence", "physical segment slice", [](SegmentMetadataPB* segment) { segment->clear_size(); }},
+            {"unknown field", "physical segment slice",
              [](SegmentMetadataPB* segment) {
                  segment->GetReflection()->MutableUnknownFields(segment)->AddVarint(1000, 1);
              }},
@@ -10340,7 +10362,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_target_physical_
 
             MergePhaseCounts counts;
             auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
-            EXPECT_TRUE(status.message().contains("physical segment slice")) << status;
+            EXPECT_TRUE(status.message().contains(conflict.expected_error)) << status;
             EXPECT_TRUE(status.message().contains(filename)) << status;
         }
     }
@@ -10465,6 +10487,26 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_mixed_bundle_presence_
 
         MergePhaseCounts counts;
         auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("bundled")) << status;
+        EXPECT_TRUE(status.message().contains("standalone")) << status;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_canonical_filename_bundle_form_before_io) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(fmt::format("{} source first", reverse_sources ? "bundled" : "standalone"));
+        const std::string filename = fmt::format("cross_canonical_bundle_form_{}.dat", next_id());
+        auto standalone = make_preflight_sidecar_source(next_id(), filename);
+        auto bundled = make_preflight_sidecar_source(next_id(), filename);
+        auto* bundled_segment = bundled->mutable_rowsets(0)->mutable_segment_metas(0);
+        bundled_segment->set_size(128);
+        bundled_segment->set_bundle_file_offset(128);
+        std::vector<TabletMetadataPtr> sources = {standalone, bundled};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains(filename)) << status;
         EXPECT_TRUE(status.message().contains("bundled")) << status;
         EXPECT_TRUE(status.message().contains("standalone")) << status;
     }
@@ -12477,6 +12519,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_accepts_up
     auto source = make_allocator_source(next_id(), std::numeric_limits<uint32_t>::max());
     auto* rowset = add_allocator_rowset(source.get(), kSourceRowset, 1, "upper_half_0.dat", 0);
     add_allocator_segment(rowset, "upper_half_10.dat", 10);
+    rowset->set_max_compact_input_rowset_id(std::numeric_limits<uint32_t>::max());
+
+    ASSIGN_OR_ABORT(const uint32_t expected_cursor, repeated_merge_cursor_oracle({source}));
+    EXPECT_EQ(12, expected_cursor) << "[UINT32_MAX, 2^32) recovery atom must pack with the upper-half extent";
 
     auto merged_or = publish_allocator_merge({source});
     ASSERT_OK(merged_or.status());
@@ -12485,7 +12531,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_accepts_up
     EXPECT_EQ(1, merged->rowsets(0).id());
     ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
     EXPECT_EQ(11, merged->rowsets(0).id() + lake::get_segment_idx(merged->rowsets(0), 1));
-    EXPECT_EQ(12, merged->next_rowset_id());
+    ASSERT_TRUE(merged->rowsets(0).has_max_compact_input_rowset_id());
+    EXPECT_EQ(11, merged->rowsets(0).max_compact_input_rowset_id());
+    EXPECT_EQ(expected_cursor, merged->next_rowset_id());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_reserves_duplicate_high_segment_idx) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1194,6 +1194,23 @@ protected:
         return segment_file_size;
     }
 
+    std::pair<uint64_t, int64_t> write_two_column_bundled_segment(int64_t tablet_id, const std::string& bundle_name,
+                                                                  int num_rows,
+                                                                  const std::function<int(int)>& source_value_of,
+                                                                  int key_start = 0) {
+        const std::string slice_name = fmt::format("{}.slice_{}", bundle_name, next_id());
+        const uint64_t slice_size =
+                write_two_column_segment(tablet_id, slice_name, num_rows, source_value_of, key_start);
+        const std::string slice_path = _tablet_manager->segment_location(tablet_id, slice_name);
+        ASSIGN_OR_ABORT(auto reader, fs::new_random_access_file(slice_path));
+        ASSIGN_OR_ABORT(auto slice_contents, reader->read_all());
+
+        const std::string prefix = "tablet-merge-bundle-prefix";
+        write_file(_tablet_manager->segment_location(tablet_id, bundle_name), prefix + slice_contents);
+        CHECK_OK(fs::delete_file(slice_path));
+        return {slice_size, static_cast<int64_t>(prefix.size())};
+    }
+
     // Write a real .cols file for column c1 only, with `num_rows` entries.
     // cell_value(row) supplies the c1 value at segment row |row|.
     uint64_t write_c1_only_cols_file(int64_t tablet_id, const std::string& cols_filename, int num_rows,
@@ -10125,7 +10142,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     const std::string base_name = "cross_target_shared_base.dat";
     const std::string cols_name = "cross_target.cols";
     const std::string idx_name = "cross_target.idx";
-    const uint64_t base_size = write_two_column_segment(source_a_id, base_name, 2, [](int key) { return key * 10; });
+    const auto [base_size, base_offset] =
+            write_two_column_bundled_segment(source_a_id, base_name, 2, [](int key) { return key * 10; });
+    ASSERT_GT(base_offset, 0);
     const uint64_t cols_size =
             write_c1_only_cols_file(source_a_id, cols_name, 2, [](int row) { return (row + 1) * 1000; });
     const auto idx_file = write_sidecar_payload(_tablet_manager->segment_location(source_a_id, idx_name),
@@ -10146,6 +10165,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
         rowset->set_data_size(base_size);
         rowset->mutable_range()->CopyFrom(source->range());
         rowset->mutable_segment_metas(0)->set_size(base_size);
+        rowset->mutable_segment_metas(0)->set_bundle_file_offset(base_offset);
         rowset->mutable_segment_metas(0)->set_num_rows(2);
         add_dcg_with_columns(source, /*segment_id=*/1, cols_name, {1002}, /*version=*/1);
         auto* dcg = &(*source->mutable_dcg_meta()->mutable_dcgs())[1];
@@ -10324,6 +10344,61 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_cross_target_physical_
             auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
             EXPECT_TRUE(status.message().contains("physical segment slice")) << status;
             EXPECT_TRUE(status.message().contains(filename)) << status;
+        }
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_invalid_physical_segment_shape_before_io) {
+    struct InvalidShape {
+        const char* name;
+        bool same_filename;
+        const char* error_field;
+        std::function<void(SegmentMetadataPB*, SegmentMetadataPB*)> apply;
+    };
+    const std::vector<InvalidShape> invalid_shapes = {
+            {"negative offset versus absent", true, "bundle_file_offset",
+             [](SegmentMetadataPB*, SegmentMetadataPB* right) { right->set_bundle_file_offset(-1); }},
+            {"negative offset versus explicit zero", true, "bundle_file_offset",
+             [](SegmentMetadataPB* left, SegmentMetadataPB* right) {
+                 left->set_bundle_file_offset(0);
+                 right->set_bundle_file_offset(-1);
+             }},
+            {"negative size", true, "size",
+             [](SegmentMetadataPB* left, SegmentMetadataPB* right) {
+                 left->set_size(-1);
+                 right->set_size(-1);
+             }},
+            {"single bundled missing size", false, "size",
+             [](SegmentMetadataPB* left, SegmentMetadataPB*) {
+                 left->set_bundle_file_offset(0);
+                 left->clear_size();
+             }},
+            {"all bundled missing size", true, "size",
+             [](SegmentMetadataPB* left, SegmentMetadataPB* right) {
+                 for (auto* segment : {left, right}) {
+                     segment->set_bundle_file_offset(0);
+                     segment->clear_size();
+                 }
+             }},
+    };
+
+    for (const auto& invalid : invalid_shapes) {
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("{}; {} source first", invalid.name, reverse_sources ? "right" : "left"));
+            const std::string stem = fmt::format("invalid_segment_shape_{}", next_id());
+            auto left = make_preflight_sidecar_source(next_id(), stem + "_left.dat");
+            auto right = make_preflight_sidecar_source(next_id(), invalid.same_filename
+                                                                          ? left->rowsets(0).segment_metas(0).filename()
+                                                                          : stem + "_right.dat");
+            invalid.apply(left->mutable_rowsets(0)->mutable_segment_metas(0),
+                          right->mutable_rowsets(0)->mutable_segment_metas(0));
+            std::vector<TabletMetadataPtr> sources = {left, right};
+            if (reverse_sources) std::swap(sources[0], sources[1]);
+
+            MergePhaseCounts counts;
+            auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+            EXPECT_TRUE(status.message().contains("segment")) << status;
+            EXPECT_TRUE(status.message().contains(invalid.error_field)) << status;
         }
     }
 }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -362,7 +362,7 @@ protected:
         return tablet_metadatas.at(merged_tablet);
     }
 
-    std::shared_ptr<TabletMetadataPB> make_allocator_source(int64_t tablet_id, uint32_t next_rowset_id = 1) {
+    std::shared_ptr<TabletMetadataPB> make_allocator_source(int64_t tablet_id, uint32_t next_rowset_id) {
         auto metadata = std::make_shared<TabletMetadataPB>();
         metadata->set_id(tablet_id);
         metadata->set_version(1);
@@ -390,23 +390,21 @@ protected:
     }
 
     SegmentMetadataPB* add_allocator_segment(RowsetMetadataPB* rowset, const std::string& segment_name,
-                                             uint32_t segment_idx, bool explicit_segment_idx = true) {
+                                             uint32_t segment_idx) {
         auto* segment = rowset->add_segment_metas();
         segment->set_filename(segment_name);
         segment->set_size(1);
         segment->set_num_rows(1);
-        if (explicit_segment_idx) segment->set_segment_idx(segment_idx);
+        segment->set_segment_idx(segment_idx);
         rowset->set_num_rows(rowset->num_rows() + 1);
         rowset->set_data_size(rowset->data_size() + 1);
         return segment;
     }
 
     StatusOr<TabletMetadataPtr> publish_allocator_merge(
-            const std::vector<std::shared_ptr<TabletMetadataPB>>& mutable_sources,
-            const std::function<void()>& before_merge = {}, int64_t* attempted_target_id = nullptr) {
+            const std::vector<std::shared_ptr<TabletMetadataPB>>& mutable_sources) {
         if (mutable_sources.empty()) return Status::InvalidArgument("allocator merge fixture has no source");
         const int64_t target_id = next_id();
-        if (attempted_target_id != nullptr) *attempted_target_id = target_id;
         prepare_tablet_dirs(target_id);
         std::vector<TabletMetadataPtr> sources;
         sources.reserve(mutable_sources.size());
@@ -416,7 +414,7 @@ protected:
         }
         std::unordered_map<int64_t, TabletMetadataPtr> published;
         RETURN_IF_ERROR(publish_resharding_merge(sources, target_id, /*base_version=*/1, /*new_version=*/2,
-                                                 /*txn_id=*/next_id(), published, before_merge));
+                                                 /*txn_id=*/next_id(), published));
         auto target = published.find(target_id);
         if (target == published.end()) return Status::InternalError("allocator merge target was not published");
         return target->second;

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <cstdlib>
 #include <ctime>
 #include <functional>
 #include <limits>
@@ -870,6 +871,31 @@ protected:
         return result;
     }
 
+    RawPkSstableFile write_sidecar_payload(const std::string& path, const std::string& payload, bool encrypted) {
+        RawPkSstableFile result;
+        WritableFileOptions options{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        if (encrypted) {
+            ensure_kek_in_key_cache();
+            auto encryption_pair = KeyCache::instance().create_encryption_meta_pair_using_current_kek().value();
+            options.encryption_info = encryption_pair.info;
+            result.encryption_meta = std::move(encryption_pair.encryption_meta);
+        }
+        ASSIGN_OR_ABORT(auto writer, fs::new_writable_file(options, path));
+        CHECK_OK(writer->append(payload));
+        CHECK_OK(writer->close());
+        result.filesize = payload.size();
+        return result;
+    }
+
+    StatusOr<std::string> read_sidecar_payload(const std::string& path, const std::string& encryption_meta) {
+        RandomAccessFileOptions options;
+        if (!encryption_meta.empty()) {
+            ASSIGN_OR_RETURN(options.encryption_info, KeyCache::instance().unwrap_encryption_meta(encryption_meta));
+        }
+        ASSIGN_OR_RETURN(auto reader, fs::new_random_access_file(options, path));
+        return reader->read_all();
+    }
+
     struct BelowFloorLegacyFixture {
         static constexpr int64_t kBaseVersion = 1;
         static constexpr int64_t kMergedVersion = 2;
@@ -1141,7 +1167,8 @@ protected:
     // Write a real .cols file for column c1 only, with `num_rows` entries.
     // cell_value(row) supplies the c1 value at segment row |row|.
     uint64_t write_c1_only_cols_file(int64_t tablet_id, const std::string& cols_filename, int num_rows,
-                                     const std::function<int(int)>& cell_value) {
+                                     const std::function<int(int)>& cell_value, bool encrypted = false,
+                                     std::string* encryption_meta = nullptr) {
         TabletSchemaPB full_pb;
         full_pb.set_keys_type(PRIMARY_KEYS);
         full_pb.set_id(3001);
@@ -1166,6 +1193,14 @@ protected:
 
         auto cols_path = _tablet_manager->segment_location(tablet_id, cols_filename);
         WritableFileOptions fopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        if (encrypted) {
+            ensure_kek_in_key_cache();
+            auto encryption_pair = KeyCache::instance().create_encryption_meta_pair_using_current_kek().value();
+            fopts.encryption_info = encryption_pair.info;
+            if (encryption_meta != nullptr) *encryption_meta = std::move(encryption_pair.encryption_meta);
+        } else if (encryption_meta != nullptr) {
+            encryption_meta->clear();
+        }
         auto wfile_or = fs::new_writable_file(fopts, cols_path);
         CHECK_OK(wfile_or.status());
 
@@ -1622,6 +1657,405 @@ protected:
         return rows;
     }
 
+    static std::vector<std::pair<int32_t, int32_t>> repeated_expected_rows(const std::map<int32_t, int32_t>& expected) {
+        return {expected.begin(), expected.end()};
+    }
+
+    StatusOr<uint32_t> repeated_merge_cursor_oracle(const std::vector<TabletMetadataPtr>& sources) {
+        struct Family {
+            size_t selected_context = 0;
+            const RowsetMetadataPB* selected = nullptr;
+            uint32_t final_max_segment_idx = 0;
+        };
+        std::map<std::pair<int64_t, int64_t>, Family> families;
+        for (size_t context_index = 0; context_index < sources.size(); ++context_index) {
+            for (const auto& rowset : sources[context_index]->rowsets()) {
+                if (!rowset.has_uid()) return Status::Corruption("repeated lifecycle rowset is missing uid");
+                auto [it, inserted] = families.emplace(std::pair{rowset.uid().hi(), rowset.uid().lo()},
+                                                       Family{.selected_context = context_index, .selected = &rowset});
+                auto& family = it->second;
+                for (int segment_index = 0; segment_index < rowset.segment_metas_size(); ++segment_index) {
+                    const auto& segment = rowset.segment_metas(segment_index);
+                    family.final_max_segment_idx = std::max(
+                            family.final_max_segment_idx,
+                            segment.has_segment_idx() ? segment.segment_idx() : static_cast<uint32_t>(segment_index));
+                }
+                if (!inserted && family.selected == nullptr) {
+                    return Status::Corruption("repeated lifecycle family has no selected rowset");
+                }
+            }
+        }
+
+        using Atom = std::pair<uint64_t, uint64_t>;
+        std::vector<std::vector<Atom>> atoms(sources.size());
+        auto add_atom = [&](size_t context_index, uint64_t begin, uint64_t end) -> Status {
+            if (begin >= end || end > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1) {
+                return Status::InvalidArgument("repeated lifecycle atom is outside the source RSSID domain");
+            }
+            atoms[context_index].emplace_back(begin, end);
+            return Status::OK();
+        };
+        for (const auto& [uid, family] : families) {
+            (void)uid;
+            const auto& rowset = *family.selected;
+            const uint64_t extent = rowset.segment_metas_size() == 0 ? 1 : family.final_max_segment_idx + uint64_t{1};
+            RETURN_IF_ERROR(add_atom(family.selected_context, rowset.id(), uint64_t{rowset.id()} + extent));
+            if (rowset.has_max_compact_input_rowset_id()) {
+                const uint64_t recovery = rowset.max_compact_input_rowset_id();
+                RETURN_IF_ERROR(add_atom(family.selected_context, recovery, recovery + 1));
+            }
+            for (const auto& del : rowset.del_files()) {
+                const uint64_t offset = del.has_op_offset() ? del.op_offset() : family.final_max_segment_idx;
+                RETURN_IF_ERROR(add_atom(family.selected_context, del.origin_rowset_id(),
+                                         uint64_t{del.origin_rowset_id()} + offset + 1));
+            }
+        }
+
+        uint64_t cursor = 1;
+        for (auto& context_atoms : atoms) {
+            std::sort(context_atoms.begin(), context_atoms.end());
+            uint64_t union_begin = 0;
+            uint64_t union_end = 0;
+            for (const auto& [begin, end] : context_atoms) {
+                if (union_begin == union_end) {
+                    union_begin = begin;
+                    union_end = end;
+                } else if (begin <= union_end) {
+                    union_end = std::max(union_end, end);
+                } else {
+                    cursor += union_end - union_begin;
+                    union_begin = begin;
+                    union_end = end;
+                }
+            }
+            cursor += union_end - union_begin;
+        }
+        if (cursor > std::numeric_limits<int32_t>::max()) {
+            return Status::InvalidArgument("repeated lifecycle oracle exhausts the target RSSID domain");
+        }
+        return static_cast<uint32_t>(cursor);
+    }
+
+    StatusOr<int> repeated_merge_delfile_count_oracle(const std::vector<TabletMetadataPtr>& sources) {
+        std::set<std::pair<int64_t, int64_t>> selected_families;
+        int count = 0;
+        for (const auto& source : sources) {
+            for (const auto& rowset : source->rowsets()) {
+                if (!rowset.has_uid()) return Status::Corruption("repeated lifecycle rowset is missing uid");
+                if (selected_families.emplace(rowset.uid().hi(), rowset.uid().lo()).second) {
+                    count += rowset.del_files_size();
+                }
+            }
+        }
+        return count;
+    }
+
+    void add_repeated_sparse_sidecars(TabletMetadataPB* metadata, int cycle, int child_index, int32_t value,
+                                      bool enable_tde) {
+        ASSERT_GT(metadata->rowsets_size(), 0);
+        auto* rowset = metadata->mutable_rowsets(metadata->rowsets_size() - 1);
+        ASSERT_EQ(1, rowset->segment_metas_size());
+        auto* segment = rowset->mutable_segment_metas(0);
+        const uint32_t sparse_index = 600 + child_index * 300;
+        segment->set_segment_idx(sparse_index);
+        EXPECT_EQ(enable_tde, !segment->encryption_meta().empty());
+        const uint32_t sparse_rssid = rowset->id() + sparse_index;
+        metadata->set_next_rowset_id(std::max(metadata->next_rowset_id(), sparse_rssid + 1));
+
+        const std::string stem = fmt::format("repeated_{}_{}_{}", cycle, child_index, metadata->id());
+        auto* del = rowset->add_del_files();
+        del->set_name(stem + ".del");
+        del->set_origin_rowset_id(rowset->id());
+        del->set_op_offset(sparse_index);
+        del->set_version(metadata->version());
+        del->set_num_rows(0);
+        if (enable_tde) {
+            del->set_encryption_meta(write_encrypted_binary_del_file(metadata->id(), del->name(), {}));
+        } else {
+            write_binary_del_file(metadata->id(), del->name(), {});
+        }
+
+        ASSERT_FALSE(metadata->delvec_meta().version_to_file().contains(metadata->version()));
+        DelVector empty_delvec;
+        empty_delvec.init(metadata->version(), nullptr, 0);
+        add_delvec(metadata, metadata->id(), metadata->version(), sparse_rssid, stem + ".delvec", empty_delvec.save());
+
+        std::string dcg_encryption_meta;
+        const std::string dcg_file = stem + ".cols";
+        const uint64_t dcg_size = write_c1_only_cols_file(
+                metadata->id(), dcg_file, /*num_rows=*/1, [=](int) { return value; }, enable_tde, &dcg_encryption_meta);
+        auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[sparse_rssid];
+        dcg.add_column_files(dcg_file);
+        dcg.add_unique_column_ids()->add_column_ids(1002);
+        dcg.add_versions(metadata->version());
+        dcg.add_encryption_metas(dcg_encryption_meta);
+        dcg.add_shared_files(false);
+        dcg.add_column_file_sizes(dcg_size);
+
+        const std::string idg_file = stem + ".idx";
+        const std::string idg_payload = "repeated-idg:" + idg_file;
+        const auto idg_physical = write_sidecar_payload(_tablet_manager->segment_location(metadata->id(), idg_file),
+                                                        idg_payload, enable_tde);
+        add_idg_with_key(metadata, sparse_rssid, idg_file, /*col_uid=*/1002, BITMAP, metadata->version(),
+                         /*shared_file=*/false);
+        auto* idg = metadata->mutable_idg_meta()->mutable_idgs()->at(sparse_rssid).mutable_entries(0);
+        idg->set_file_size(idg_physical.filesize);
+        idg->set_encryption_meta(idg_physical.encryption_meta);
+    }
+
+    StatusOr<std::vector<TabletMetadataPtr>> repeated_split_three_way(const TabletMetadataPtr& parent) {
+        std::vector<int64_t> child_ids = {next_id(), next_id(), next_id()};
+        ReshardingTabletInfoPB resharding;
+        auto* splitting = resharding.mutable_splitting_tablet_info();
+        splitting->set_old_tablet_id(parent->id());
+        for (int child_index = 0; child_index < 3; ++child_index) {
+            const int64_t child_id = child_ids[child_index];
+            prepare_tablet_dirs(child_id);
+            splitting->add_new_tablet_ids(child_id);
+            auto* range = splitting->add_new_tablet_ranges();
+            range->mutable_lower_bound()->CopyFrom(generate_sort_key(child_index * 100));
+            range->set_lower_bound_included(true);
+            range->mutable_upper_bound()->CopyFrom(generate_sort_key((child_index + 1) * 100));
+            range->set_upper_bound_included(false);
+        }
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(next_id());
+        txn_info.set_commit_time(1);
+        txn_info.set_gtid(1);
+        std::unordered_map<int64_t, TabletMetadataPtr> published;
+        std::unordered_map<int64_t, TabletRangePB> ranges;
+        RETURN_IF_ERROR(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, parent->version(),
+                                                        parent->version() + 1, txn_info, false, published, ranges));
+        std::vector<TabletMetadataPtr> children;
+        for (int64_t child_id : child_ids) {
+            auto it = published.find(child_id);
+            if (it == published.end()) return Status::InternalError("repeated lifecycle split child is missing");
+            children.emplace_back(it->second);
+        }
+        return children;
+    }
+
+    void expect_repeated_merge_pb(const TabletMetadataPtr& metadata, uint32_t expected_cursor,
+                                  int expected_sidecar_count, int expected_del_file_count,
+                                  const std::set<std::string>& expected_sst_orphans, bool enable_tde) {
+        EXPECT_EQ(expected_cursor, metadata->next_rowset_id()) << "independent atom-union cursor";
+        std::set<uint32_t> live_rssids;
+        int del_file_count = 0;
+        for (const auto& rowset : metadata->rowsets()) {
+            EXPECT_LT(rowset.id(), metadata->next_rowset_id());
+            for (int segment_index = 0; segment_index < rowset.segment_metas_size(); ++segment_index) {
+                const auto& segment = rowset.segment_metas(segment_index);
+                const uint32_t effective_index = segment.has_segment_idx() ? segment.segment_idx() : segment_index;
+                const uint32_t rssid = rowset.id() + effective_index;
+                EXPECT_LT(rssid, metadata->next_rowset_id());
+                EXPECT_TRUE(live_rssids.insert(rssid).second) << "duplicate target RSSID " << rssid;
+                EXPECT_EQ(enable_tde, !segment.encryption_meta().empty());
+            }
+            for (const auto& del : rowset.del_files()) {
+                ++del_file_count;
+                EXPECT_LT(uint64_t{del.origin_rowset_id()} + del.op_offset(), metadata->next_rowset_id());
+                EXPECT_EQ(enable_tde, !del.encryption_meta().empty());
+            }
+        }
+        EXPECT_EQ(expected_del_file_count, del_file_count);
+        EXPECT_EQ(expected_sidecar_count, metadata->delvec_meta().delvecs_size());
+        EXPECT_EQ(expected_sidecar_count, metadata->dcg_meta().dcgs_size());
+        EXPECT_EQ(expected_sidecar_count, metadata->idg_meta().idgs_size());
+
+        for (const auto& [version, file] : metadata->delvec_meta().version_to_file()) {
+            (void)version;
+            EXPECT_TRUE(file.encryption_meta().empty());
+        }
+        LakeIOOptions io_options;
+        for (const auto& [rssid, page] : metadata->delvec_meta().delvecs()) {
+            (void)page;
+            EXPECT_TRUE(live_rssids.contains(rssid));
+            DelVector loaded;
+            ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *metadata, rssid, false, io_options, &loaded));
+            EXPECT_EQ(0, loaded.cardinality());
+        }
+        for (const auto& [rssid, dcg] : metadata->dcg_meta().dcgs()) {
+            EXPECT_TRUE(live_rssids.contains(rssid));
+            ASSERT_EQ(1, dcg.column_files_size());
+            ASSERT_EQ(1, dcg.encryption_metas_size());
+            EXPECT_EQ(enable_tde, !dcg.encryption_metas(0).empty());
+        }
+        for (const auto& [rssid, idg] : metadata->idg_meta().idgs()) {
+            EXPECT_TRUE(live_rssids.contains(rssid));
+            ASSERT_EQ(1, idg.entries_size());
+            const auto& entry = idg.entries(0);
+            EXPECT_EQ(enable_tde, !entry.encryption_meta().empty());
+            ASSIGN_OR_ABORT(auto payload,
+                            read_sidecar_payload(_tablet_manager->segment_location(metadata->id(), entry.index_file()),
+                                                 entry.encryption_meta()));
+            EXPECT_EQ("repeated-idg:" + entry.index_file(), payload);
+        }
+
+        EXPECT_EQ(0, metadata->sstable_meta().sstables_size());
+        std::set<std::string> actual_orphans;
+        for (const auto& orphan : metadata->orphan_files()) {
+            actual_orphans.insert(orphan.name());
+            EXPECT_TRUE(orphan.shared());
+            EXPECT_EQ(enable_tde, !orphan.encryption_meta().empty());
+        }
+        EXPECT_EQ(expected_sst_orphans, actual_orphans);
+    }
+
+    struct RepeatedLifecycleResult {
+        TabletMetadataPtr metadata;
+        std::vector<TabletMetadataPtr> final_sources;
+        std::map<int32_t, int32_t> expected;
+        std::vector<int32_t> deleted_keys;
+        std::set<std::string> final_sst_orphans;
+    };
+
+    StatusOr<RepeatedLifecycleResult> run_repeated_four_cycle_lifecycle(bool enable_tde) {
+        const bool old_tde = config::enable_transparent_data_encryption;
+        const bool old_parallel_compaction = config::enable_pk_index_parallel_compaction;
+        const int32_t old_min_segments = config::lake_pk_compaction_min_input_segments;
+        config::enable_transparent_data_encryption = enable_tde;
+        config::enable_pk_index_parallel_compaction = false;
+        config::lake_pk_compaction_min_input_segments = 1;
+        DeferOp restore_config([&] {
+            config::enable_transparent_data_encryption = old_tde;
+            config::enable_pk_index_parallel_compaction = old_parallel_compaction;
+            config::lake_pk_compaction_min_input_segments = old_min_segments;
+        });
+        if (enable_tde) ensure_kek_in_key_cache();
+        DeferOp wait_flush_pool(
+                [] { ExecEnv::GetInstance()->lake_services().pk_index_memtable_flush_thread_pool->wait(); });
+        set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+        set_failpoint_mode("skip_lake_pk_index_merge_source_flush", FailPointTriggerModeType::ENABLE);
+        DeferOp restore_failpoints([&] {
+            set_failpoint_mode("skip_lake_pk_index_merge_source_flush", FailPointTriggerModeType::DISABLE);
+            set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::ENABLE);
+        });
+
+        const char* force_projection_env = std::getenv("STARROCKS_TEST_FORCE_CONTEXT_SPAN_PROJECTION");
+        const bool force_context_span =
+                force_projection_env != nullptr && std::string_view(force_projection_env) == "1";
+        int context_span_hook_count = 0;
+        auto* sync = SyncPoint::GetInstance();
+        if (force_context_span) {
+            sync->SetCallBack("tablet_merge_test:force_context_span_projection", [&](void* arg) {
+                ++context_span_hook_count;
+                *static_cast<bool*>(arg) = true;
+            });
+            sync->EnableProcessing();
+        }
+        DeferOp cleanup_sync_point([&] {
+            if (force_context_span) {
+                sync->ClearCallBack("tablet_merge_test:force_context_span_projection");
+                sync->DisableProcessing();
+            }
+        });
+
+        std::map<int32_t, int32_t> expected = {{10, 100}, {110, 1100}, {210, 2100}};
+        std::set<int32_t> deleted;
+        std::vector<TabletMetadataPtr> initial_sources;
+        for (int child_index = 0; child_index < 3; ++child_index) {
+            const int32_t key = 10 + child_index * 100;
+            ASSIGN_OR_RETURN(auto source, create_lifecycle_source(next_id(), child_index * 100, (child_index + 1) * 100,
+                                                                  key, expected.at(key), /*include_delete=*/false));
+            initial_sources.emplace_back(std::move(source));
+        }
+        const int64_t initial_target = next_id();
+        prepare_tablet_dirs(initial_target);
+        ASSIGN_OR_RETURN(const uint32_t initial_cursor, repeated_merge_cursor_oracle(initial_sources));
+        std::unordered_map<int64_t, TabletMetadataPtr> initial_published;
+        int merge_count = 1;
+        RETURN_IF_ERROR(publish_resharding_merge(initial_sources, initial_target, initial_sources.front()->version(),
+                                                 initial_sources.front()->version() + 1, next_id(), initial_published));
+        auto current = initial_published.at(initial_target);
+        ASSIGN_OR_RETURN(const int initial_del_files, repeated_merge_delfile_count_oracle(initial_sources));
+        expect_repeated_merge_pb(current, initial_cursor, /*expected_sidecar_count=*/0, initial_del_files,
+                                 /*expected_sst_orphans=*/{}, enable_tde);
+        expect_lifecycle_oracle(current, repeated_expected_rows(expected), /*deleted_keys=*/{});
+
+        std::vector<TabletMetadataPtr> final_sources;
+        std::set<std::string> final_sst_orphans;
+        for (int cycle = 0; cycle < 4; ++cycle) {
+            SCOPED_TRACE(fmt::format("repeated lifecycle cycle {}", cycle));
+            const uint32_t prior_cursor = current->next_rowset_id();
+            const int32_t upsert_key = 40 + cycle;
+            const int32_t upsert_value = 4000 + cycle;
+            const int32_t delete_key = cycle < 3 ? 10 + cycle * 100 : 40;
+            _update_manager->unload_and_remove_primary_index(current->id());
+            ASSIGN_OR_RETURN(current, publish_followup_upsert_delete(current->id(), current->version(), upsert_key,
+                                                                     upsert_value, delete_key));
+            expected[upsert_key] = upsert_value;
+            expected.erase(delete_key);
+            deleted.insert(delete_key);
+            ASSIGN_OR_RETURN(current, compact_tablet(current->id(), current->version(), /*force_base=*/true));
+
+            ASSIGN_OR_RETURN(auto children, repeated_split_three_way(current));
+            std::vector<TabletMetadataPtr> merge_sources;
+            std::set<std::string> expected_sst_orphans;
+            for (int child_index = 0; child_index < 3; ++child_index) {
+                auto child = children[child_index];
+                const int32_t key = child_index * 100 + 20 + cycle;
+                const int32_t value = (cycle + 1) * 10000 + key;
+                _update_manager->unload_and_remove_primary_index(child->id());
+                ASSIGN_OR_RETURN(child, publish_followup_upsert_delete(child->id(), child->version(), key, value,
+                                                                       /*delete_key=*/0, /*include_delete=*/false));
+                expected[key] = value;
+                deleted.erase(key);
+                if (enable_tde) {
+                    ASSIGN_OR_RETURN(child, _update_manager->flush_pk_memtable(child, child->version()));
+                    RETURN_IF_ERROR(put_tablet_metadata(child));
+                    if (child->sstable_meta().sstables_size() == 0) {
+                        return Status::InternalError("TDE repeated lifecycle source flush emitted no SST");
+                    }
+                    assert_published_sstables_reopen(child);
+                }
+                auto mutable_child = std::make_shared<TabletMetadataPB>(*child);
+                for (auto& sstable : *mutable_child->mutable_sstable_meta()->mutable_sstables()) {
+                    if (enable_tde) {
+                        if (sstable.encryption_meta().empty()) {
+                            return Status::InternalError("TDE repeated lifecycle SST is plaintext");
+                        }
+                    }
+                    expected_sst_orphans.insert(sstable.filename());
+                    sstable.set_shared(true);
+                    sstable.clear_shared_rssid();
+                    sstable.clear_shared_version();
+                }
+                add_repeated_sparse_sidecars(mutable_child.get(), cycle, child_index, value, enable_tde);
+                _update_manager->unload_and_remove_primary_index(child->id());
+                merge_sources.emplace_back(std::move(mutable_child));
+            }
+
+            ASSIGN_OR_RETURN(const uint32_t expected_cursor, repeated_merge_cursor_oracle(merge_sources));
+            ASSIGN_OR_RETURN(const int expected_del_files, repeated_merge_delfile_count_oracle(merge_sources));
+            const int64_t target_id = next_id();
+            prepare_tablet_dirs(target_id);
+            std::unordered_map<int64_t, TabletMetadataPtr> published;
+            ++merge_count;
+            RETURN_IF_ERROR(publish_resharding_merge(merge_sources, target_id, merge_sources.front()->version(),
+                                                     merge_sources.front()->version() + 1, next_id(), published));
+            current = published.at(target_id);
+            EXPECT_LT(current->next_rowset_id(), uint64_t{prior_cursor} + 4096) << "bounded RSSID growth";
+            expect_repeated_merge_pb(current, expected_cursor, /*expected_sidecar_count=*/3, expected_del_files,
+                                     expected_sst_orphans, enable_tde);
+            std::vector<int32_t> deleted_keys(deleted.begin(), deleted.end());
+            expect_lifecycle_oracle(current, repeated_expected_rows(expected), deleted_keys);
+            if (cycle == 3) {
+                final_sst_orphans = std::move(expected_sst_orphans);
+                for (const auto& source : merge_sources) final_sources.emplace_back(published.at(source->id()));
+            }
+        }
+        EXPECT_EQ(force_context_span ? merge_count : 0, context_span_hook_count)
+                << "context-span hook must fire exactly once per MERGE";
+
+        RepeatedLifecycleResult result;
+        result.metadata = std::move(current);
+        result.final_sources = std::move(final_sources);
+        result.expected = std::move(expected);
+        result.deleted_keys.assign(deleted.begin(), deleted.end());
+        result.final_sst_orphans = std::move(final_sst_orphans);
+        return result;
+    }
+
     struct Issue11935MergeFixture {
         ReshardingTabletInfoPB resharding;
         TxnInfoPB txn_info;
@@ -1931,6 +2365,146 @@ protected:
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<lake::UpdateManager> _update_manager;
 };
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_repeated_four_cycle_lifecycle) {
+    ASSIGN_OR_ABORT(auto result, run_repeated_four_cycle_lifecycle(/*enable_tde=*/false));
+    EXPECT_EQ(result.final_sst_orphans.size(), static_cast<size_t>(result.metadata->orphan_files_size()));
+    for (const auto& orphan : result.metadata->orphan_files()) EXPECT_TRUE(orphan.encryption_meta().empty());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_repeated_tde_sidecar_vacuum_lifecycle) {
+    ASSIGN_OR_ABORT(auto result, run_repeated_four_cycle_lifecycle(/*enable_tde=*/true));
+    ASSERT_GE(result.final_sst_orphans.size(), 3);
+
+    const bool old_tde = config::enable_transparent_data_encryption;
+    const bool old_parallel_compaction = config::enable_pk_index_parallel_compaction;
+    config::enable_transparent_data_encryption = true;
+    config::enable_pk_index_parallel_compaction = false;
+    DeferOp restore_config([&] {
+        config::enable_transparent_data_encryption = old_tde;
+        config::enable_pk_index_parallel_compaction = old_parallel_compaction;
+    });
+    ensure_kek_in_key_cache();
+    set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+    DeferOp restore_flush([&] { set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::ENABLE); });
+
+    _update_manager->unload_and_remove_primary_index(result.metadata->id());
+    ASSIGN_OR_ABORT(auto reopened,
+                    _tablet_manager->get_tablet_metadata(result.metadata->id(), result.metadata->version()));
+    expect_lifecycle_oracle(reopened, repeated_expected_rows(result.expected), result.deleted_keys);
+
+    constexpr int32_t kTailUpsertKey = 77;
+    constexpr int32_t kTailDeleteKey = 120;
+    ASSIGN_OR_ABORT(auto after_dml, publish_followup_upsert_delete(reopened->id(), reopened->version(), kTailUpsertKey,
+                                                                   /*upsert_value=*/7700, kTailDeleteKey));
+    result.expected[kTailUpsertKey] = 7700;
+    result.expected.erase(kTailDeleteKey);
+    result.deleted_keys.push_back(kTailDeleteKey);
+    expect_lifecycle_oracle(after_dml, repeated_expected_rows(result.expected), result.deleted_keys);
+
+    _update_manager->unload_and_remove_primary_index(after_dml->id());
+    ASSIGN_OR_ABORT(auto reopened_after_dml,
+                    _tablet_manager->get_tablet_metadata(after_dml->id(), after_dml->version()));
+    expect_lifecycle_oracle(reopened_after_dml, repeated_expected_rows(result.expected), result.deleted_keys);
+    ASSIGN_OR_ABORT(auto compacted,
+                    compact_tablet(reopened_after_dml->id(), reopened_after_dml->version(), /*force_base=*/true));
+    EXPECT_EQ(reopened_after_dml->version() + 1, compacted->version());
+    for (const auto& rowset : compacted->rowsets()) {
+        for (const auto& segment : rowset.segment_metas()) EXPECT_FALSE(segment.encryption_meta().empty());
+    }
+    expect_lifecycle_oracle(compacted, repeated_expected_rows(result.expected), result.deleted_keys);
+
+    _update_manager->unload_and_remove_primary_index(compacted->id());
+    ASSIGN_OR_ABORT(auto reopened_compacted,
+                    _tablet_manager->get_tablet_metadata(compacted->id(), compacted->version()));
+    expect_lifecycle_oracle(reopened_compacted, repeated_expected_rows(result.expected), result.deleted_keys);
+
+    std::map<std::string, FileMetaPB> orphan_declarations;
+    int64_t orphan_bytes = 0;
+    for (const auto& orphan : result.metadata->orphan_files()) {
+        if (!result.final_sst_orphans.contains(orphan.name())) continue;
+        orphan_declarations.emplace(orphan.name(), orphan);
+        orphan_bytes += orphan.size();
+        EXPECT_FALSE(orphan.encryption_meta().empty());
+        ASSERT_OK(FileSystem::Default()->path_exists(
+                _tablet_manager->sst_location(result.metadata->id(), orphan.name())));
+    }
+    ASSERT_EQ(result.final_sst_orphans.size(), orphan_declarations.size());
+
+    auto run_vacuum = [&](const std::vector<std::pair<int64_t, int64_t>>& tablet_versions, int64_t min_retain_version) {
+        VacuumRequest request;
+        VacuumResponse response;
+        for (const auto& [tablet_id, min_version] : tablet_versions) {
+            auto* info = request.add_tablet_infos();
+            info->set_tablet_id(tablet_id);
+            info->set_min_version(min_version);
+        }
+        request.set_min_retain_version(min_retain_version);
+        request.set_grace_timestamp(::time(nullptr) + 3600);
+        request.set_min_active_txn_id(std::numeric_limits<int64_t>::max());
+        request.set_enable_file_bundling(false);
+        request.set_enable_shared_file_cleanup(true);
+        request.set_delete_txn_log(false);
+        lake::vacuum(_tablet_manager.get(), request, &response);
+        EXPECT_TRUE(response.has_status());
+        EXPECT_EQ(0, response.status().status_code())
+                << (response.status().error_msgs_size() > 0 ? response.status().error_msgs(0) : "");
+        return response;
+    };
+
+    std::vector<TabletMetadataPB> live_sources;
+    std::vector<std::pair<int64_t, int64_t>> live_versions = {{compacted->id(), compacted->version()}};
+    for (const auto& source : result.final_sources) {
+        TabletMetadataPB live(*source);
+        live.set_version(compacted->version());
+        live.set_prev_garbage_version(source->version());
+        live.clear_orphan_files();
+        ASSERT_GT(live.sstable_meta().sstables_size(), 0);
+        ASSERT_OK(put_tablet_metadata(live));
+        live_versions.emplace_back(source->id(), compacted->version());
+        live_sources.emplace_back(std::move(live));
+    }
+    _tablet_manager->prune_metacache();
+    auto noncovering = run_vacuum(live_versions, compacted->version());
+    EXPECT_TRUE(noncovering.has_status());
+    for (const auto& filename : result.final_sst_orphans) {
+        const auto status =
+                FileSystem::Default()->path_exists(_tablet_manager->sst_location(compacted->id(), filename));
+        EXPECT_OK(status);
+    }
+
+    const int64_t retirement_version = compacted->version() + 1;
+    TabletMetadataPB retired_target(*compacted);
+    retired_target.set_version(retirement_version);
+    retired_target.set_prev_garbage_version(compacted->version());
+    retired_target.clear_orphan_files();
+    ASSERT_OK(put_tablet_metadata(retired_target));
+    for (const auto& live : live_sources) {
+        TabletMetadataPB retired(live);
+        retired.set_version(retirement_version);
+        retired.set_prev_garbage_version(compacted->version());
+        retired.clear_sstable_meta();
+        retired.clear_orphan_files();
+        for (const auto& sstable : live.sstable_meta().sstables()) {
+            auto declaration = orphan_declarations.find(sstable.filename());
+            ASSERT_NE(orphan_declarations.end(), declaration);
+            retired.add_orphan_files()->CopyFrom(declaration->second);
+        }
+        ASSERT_OK(put_tablet_metadata(retired));
+    }
+    _tablet_manager->prune_metacache();
+
+    std::vector<std::pair<int64_t, int64_t>> retired_versions = {{compacted->id(), retirement_version}};
+    for (const auto& source : live_sources) retired_versions.emplace_back(source.id(), retirement_version);
+    auto covering = run_vacuum(retired_versions, retirement_version);
+    EXPECT_GE(covering.vacuumed_file_size(), orphan_bytes);
+    for (const auto& filename : result.final_sst_orphans) {
+        EXPECT_TRUE(FileSystem::Default()
+                            ->path_exists(_tablet_manager->sst_location(compacted->id(), filename))
+                            .is_not_found())
+                << "covering vacuum must reclaim a retired shared SST";
+    }
+}
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_metadata_only_private_complete_reuse) {
     int sstable_open_count = 0;

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -11706,24 +11706,24 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_hot_sibling_id_space_does_not_
         by_id[rowset.id()] = &rowset;
     }
 
-    // The complete carried floor is origin_rowset_id 766, so the hot tablet receives
-    // offset 12 - 766 = -754. Its live rowsets remain above every projected dead
-    // reference while the complete projected space starts at the cold tablet's ceiling.
+    // The cold context's atoms union into [10,12) and pack to [1,3). The hot
+    // context then packs its sparse runs from cursor 3, preserving every live
+    // rowset and direct-reference atom without allocating the intervening gaps.
     ASSERT_TRUE(by_id.count(2));
     ASSERT_TRUE(by_id.count(5));
     ASSERT_TRUE(by_id.count(6));
     ASSERT_TRUE(by_id.count(8));
 
-    // The two dead-reference fields are shifted by the same offset as the live ids.
-    // The minimum reference lands exactly at base.next_rowset_id instead of below zero.
+    // Direct references use their authoritative primary runs: raw max-compact 797
+    // maps to 4, while raw delete origin 766 maps to 3. Occurrence aliases do not
+    // participate in either mapping.
     const auto* compaction_output = by_id[6];
     EXPECT_EQ(4u, compaction_output->max_compact_input_rowset_id());
     ASSERT_EQ(1, compaction_output->del_files_size());
     EXPECT_EQ(3u, compaction_output->del_files(0).origin_rowset_id());
 
-    // Every value carried by the hot sibling must stay above the cold sibling's live
-    // rowset id. Under the old live-only floor, max_compact_input_rowset_id 797
-    // landed exactly on 11 and origin_rowset_id 766 underflowed to -20.
+    // Each hot run is packed after the cold run, so every carried value remains
+    // above the cold rowset's target RSSID without retaining sparse source gaps.
     for (const auto& rowset : merged->rowsets()) {
         if (rowset.id() == 2) continue;
         EXPECT_GT(rowset.id(), 2u);
@@ -11733,13 +11733,13 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_hot_sibling_id_space_does_not_
         }
     }
 
-    // Future writes must not reuse an occupied id.
+    // The packed-run cursor is authoritative for future writes.
     EXPECT_EQ(9u, merged->next_rowset_id());
 }
 
-// A later input's compacted-away reference can numerically equal an earlier
-// input's live rowset id. The reference must be included in the source floor so
-// the two unrelated identifiers remain disjoint in the merged namespace.
+// A later context's compacted-away reference can numerically equal an earlier
+// context's live rowset id. Both contribute primary atoms; packing the contexts'
+// runs in order keeps the unrelated identifiers disjoint in the target namespace.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_dead_reference_does_not_collide_with_earlier_live_rowset) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -11808,10 +11808,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dead_reference_does_not_collid
     EXPECT_EQ(8u, merged->next_rowset_id());
 }
 
-// A same-UID sibling copy is discarded by merge_rowsets, so its historical
-// references must not lower the later input's floor. Otherwise an ancient
-// reference on the discarded copy can force a positive lift that projects an
-// otherwise-valid high-ID rowset beyond the supported signed allocation domain.
+// A same-UID sibling occurrence is not emitted, so its historical references
+// contribute no primary atoms or target slots. Only its physical rowset/segment
+// occurrences alias to the selected canonical target; an unrelated high-ID
+// canonical therefore still packs inside the supported target domain.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_duplicate_does_not_lower_rssid_floor) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -11900,7 +11900,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     prepare_tablet_dirs(wide_tablet);
     prepare_tablet_dirs(merged_tablet);
 
-    // ctx[0]: data(v1) -> predicate(v10). Its next_rowset_id (3) is the base watermark.
+    // ctx[0]: data(v1) -> predicate(v10). Their two canonical singleton atoms pack first.
     TabletMetadataPB low_meta;
     low_meta.set_id(low_tablet);
     low_meta.set_version(base_version);
@@ -11910,8 +11910,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     ASSERT_OK(put_tablet_metadata(low_meta));
 
     // ctx[1]: the same v10 delete predicate, cross-published onto a sibling whose id
-    // counter ran far ahead. Predicates dedup by version, so this is the whole tablet
-    // and merge_rowsets emits nothing from it.
+    // counter ran far ahead. Predicates dedup by version, so this context contributes
+    // no canonical atom, run, occurrence alias, or target slot.
     constexpr uint32_t kFarAheadPredicateId = 2'100'000'000;
     TabletMetadataPB predicate_only_meta;
     predicate_only_meta.set_id(predicate_only_tablet);
@@ -11920,8 +11920,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     add_rowset_with_predicate(&predicate_only_meta, kFarAheadPredicateId, /*version=*/10, /*has_predicate=*/true);
     ASSERT_OK(put_tablet_metadata(predicate_only_meta));
 
-    // ctx[2]: two live rowsets ~1e8 ids apart. Lifting its floor (5) onto ctx[1]'s raw
-    // id would map the top one to 2'199'999'996 > INT32_MAX.
+    // ctx[2]: two live rowsets ~1e8 ids apart. They form two singleton runs, so the
+    // numeric gap and ctx[1]'s unused raw predicate id do not consume target space.
     constexpr uint32_t kWideSpanTopId = 100'000'000;
     TabletMetadataPB wide_meta;
     wide_meta.set_id(wide_tablet);
@@ -11967,9 +11967,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     }
     EXPECT_EQ(1, predicate_count);
 
-    // ctx[1]'s floor is its discarded predicate id, so it shifts down to the base
-    // watermark 3 and reserves exactly that one slot. ctx[2] is then lifted to 4
-    // instead of to 2'100'000'001, and its span survives intact.
+    // ctx[1] contributes nothing. ctx[2]'s two singleton runs pack at targets 3
+    // and 4, and the authoritative cursor advances to exactly 5.
     EXPECT_EQ((std::vector<uint32_t>{1, 2, 3, 4}), rowset_ids);
     EXPECT_EQ(5, merged->next_rowset_id());
 }
@@ -12030,6 +12029,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_reserves_d
     ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
     EXPECT_EQ(0, lake::get_segment_idx(merged->rowsets(0), 0));
     EXPECT_EQ(100, lake::get_segment_idx(merged->rowsets(0), 1));
+    EXPECT_TRUE(merged->rowsets(0).overlapped());
     EXPECT_EQ(102, merged->next_rowset_id());
 }
 
@@ -12306,6 +12306,24 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_segment_shared_flag
     ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({selected_source, duplicate_source}));
     ASSERT_EQ(1, merged->rowsets_size());
     EXPECT_TRUE(merged->rowsets(0).segment_metas(0).shared());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_overlapped_without_segment_union_expansion) {
+    auto selected_source = make_allocator_source(next_id(), 12);
+    auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "overlapped_same_0.dat", 0);
+    add_allocator_segment(selected, "overlapped_same_1.dat", 1);
+    selected->set_overlapped(false);
+
+    auto duplicate_source = make_allocator_source(next_id(), 22);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "overlapped_same_0.dat", 0);
+    add_allocator_segment(duplicate, "overlapped_same_1.dat", 1);
+    duplicate->mutable_uid()->CopyFrom(selected->uid());
+    duplicate->set_overlapped(true);
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({selected_source, duplicate_source}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
+    EXPECT_FALSE(merged->rowsets(0).overlapped());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_del_declaration_conflict) {
@@ -13121,18 +13139,9 @@ TEST_F(LakeTabletReshardTest, test_publish_resharding_tablet_slot_dedup) {
     }
 }
 
-// merge_sstables projects each child's sstable.max_rss_rowid by adding the
-// child's rssid_offset to the high word (tablet_merger.cpp:615-618). The
-// projected high word can exceed every rowset.id in the merged metadata —
-// e.g. a delete-only sstable from a child contributes a high rssid that has
-// no matching rowset. update_next_rowset_id must consider the projected
-// sstable highs; otherwise next_rowset_id is set too low and a SPLIT child
-// inheriting this metadata will write new sstables whose max_rss_rowid is
-// LESS than existing inherited sstables' projected max_rss_rowid, breaking
-// the ascending-order invariant that LakePersistentIndex::commit() enforces.
-// Downstream symptom: COMPACTION publish on the SPLIT child fails with
-// "sstables are not ordered, last_max_rss_rowid=A : max_rss_rowid=B" and
-// the next reshard job parks in PREPARING.
+// Both shared source segments resolve through occurrence aliases to the same
+// canonical target RSSID. With the canonical atoms and authoritative cursor
+// already fixed, identical DCG declarations deduplicate to one passthrough entry.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_preserves_passthrough) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -15106,9 +15115,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_skips_stale_source_entry) 
     }
 }
 
-// MERGE: two children with DISTINCT private segments each carry their own real .idx.
-// After merge both survive: one at the natural rssid, the other at the offset-remapped rssid
-// (proves a non-first-source entry is remapped, not dropped).
+// Two contexts with distinct private segments each contribute a canonical atom
+// [1,2). Their primary runs pack to different target RSSIDs, and both real .idx
+// entries survive under those targets rather than being dropped.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_remaps_private_segments) {
     const int64_t base_version = 1, new_version = 2;
     const int64_t child_a = next_id(), child_b = next_id(), merged_tablet = next_id();


### PR DESCRIPTION
## Why I'm doing:

Repeated tablet SPLIT/MERGE cycles can make `next_rowset_id` grow much faster than the number of live rowsets. SPLIT
inherits high watermarks, compaction leaves sparse historical references, and sibling tablets allocate independently;
the previous MERGE allocator preserved each source tablet's complete sparse numeric span. Real repeated workloads could
therefore push RSSIDs toward the signed limit even though only hundreds of rowsets remained.

The allocator also feeds persistent-index SST, delvec, DCG and IDG metadata. Compressing IDs is safe only when every
carried reference is mapped consistently and an unchanged SST's complete possible RSSID domain has one affine
translation.

## What I'm doing:

- Build the complete canonical rowset/delete/predicate plan before allocating target IDs.
- Pack occupied half-open RSSID intervals densely for every source context, including context 0, while preserving
  internal segment offsets and recovery comparator order.
- Separate primary references from duplicate physical-occurrence aliases and reject missing, conflicting, reversed or
  non-affine protected mappings before output.
- Preflight segment/bundle, delvec, DCG, IDG and persistent-index SST declarations before materialization or I/O.
- Reuse private/identical persistent-index SST metadata only when the complete stored domain has a proven affine mapping;
  otherwise keep the existing lazy native-rebuild fallback.
- Keep merged delvec files plaintext, preserve existing TDE behavior for delfile/segment/SST/DCG/IDG, and fail closed on
  DCG message-level protobuf unknown fields that cannot be attributed safely to an entry.
- Add real-file regressions for upper-half IDs, sparse segments/deletes, repeated split/merge lifecycle, recovery,
  bundle/physical aliases, sidecar ownership/orphans, compaction/vacuum and affine SST reuse/fallback.

This adds no protobuf/storage-format field, performs no segment/SST data rewrite, and does not change SPLIT, writer,
reader or vacuum APIs.

Local verification and review on signed head `594385a1a1f`:

- shared-data ASAN: full Reshard 244/244, dedicated allocator matrix 128/128, affected downstream 352/352;
- full shared-data Release build, CI formatter tree, diff, BE boundaries, generated AGENTS, two-file scope and 22/22 DCO passed;
- fresh full CORE review (correctness/tests/security/performance) and code-simplifier full discovery APPROVED;
- historical TSP on the byte-equivalent allocator implementation completed 311 MERGEs with bounded cursors and complete
  restart/DML/compaction/vacuum/cold-read lifecycle;
- TSP on production-equivalent head `30f3599f840` (the later local commits are test-only) completed controlled
  fallback/private/identical lifecycles and 102 no-delete MERGEs with exact
  COUNT/DISTINCT/SUM and zero SQL errors. It then wedged outside this diff when Starlet/S3 rejected a generated `.delvec`
  multipart upload with `EntityTooLarge` under near-full cache disks. This TSP run is recorded as blocked,
  not passed; upload sizing/retry handling is tracked separately in #78443. All owned clusters were released.

Related: #78032, #78288  
Follow-up: #78443

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
