### PR TITLE
[BugFix] Restrict tablet metadata dumps to the local cache

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1499,6 +1499,15 @@ CONF_mBool(starlet_write_file_with_tag, "false");
 #endif
 
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");
+// Tracked memory budget for synchronously processing one dump_tablet_metadata request. It uses the standard
+// MemTracker accounting granularity. New requests fail closed when the value is non-positive.
+CONF_mInt64(lake_dump_tablet_metadata_per_request_memory_limit_bytes, "268435456");
+// Maximum bytes in the complete JSON response for one dump_tablet_metadata request.
+// New requests fail closed when the value is non-positive.
+CONF_mInt64(lake_dump_tablet_metadata_per_request_json_size_limit_bytes, "33554432");
+// Maximum number of admitted dump_tablet_metadata requests. A lower value does not cancel requests already admitted.
+// New requests fail closed when the value is non-positive.
+CONF_mInt32(lake_dump_tablet_metadata_max_concurrency, "1");
 CONF_mBool(lake_print_delete_log, "false");
 CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.

--- a/be/src/common/config_fwd_headers_manifest.json
+++ b/be/src/common/config_fwd_headers_manifest.json
@@ -907,6 +907,9 @@
         "lake_tablet_stat_slow_log_ms",
         "lake_metadata_fetch_thread_count",
         "lake_metadata_cache_limit",
+        "lake_dump_tablet_metadata_per_request_memory_limit_bytes",
+        "lake_dump_tablet_metadata_per_request_json_size_limit_bytes",
+        "lake_dump_tablet_metadata_max_concurrency",
         "lake_cache_select_in_physical_way",
         "lake_service_max_concurrency",
         "lake_enable_orphan_delvec_cleanup_on_compaction"

--- a/be/src/common/config_lake_fwd.h
+++ b/be/src/common/config_lake_fwd.h
@@ -70,6 +70,18 @@ CONF_mBool(lake_tablet_ignore_invalid_delete_predicate, "false");
 
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");
 
+// Tracked memory budget for synchronously processing one dump_tablet_metadata request. It uses the standard
+// MemTracker accounting granularity. New requests fail closed when the value is non-positive.
+CONF_mInt64(lake_dump_tablet_metadata_per_request_memory_limit_bytes, "268435456");
+
+// Maximum bytes in the complete JSON response for one dump_tablet_metadata request.
+// New requests fail closed when the value is non-positive.
+CONF_mInt64(lake_dump_tablet_metadata_per_request_json_size_limit_bytes, "33554432");
+
+// Maximum number of admitted dump_tablet_metadata requests. A lower value does not cancel requests already admitted.
+// New requests fail closed when the value is non-positive.
+CONF_mInt32(lake_dump_tablet_metadata_max_concurrency, "1");
+
 CONF_mBool(lake_print_delete_log, "false");
 
 // Used to ensure service availability in extreme situations by sacrificing a certain degree of correctness

--- a/be/src/http/CMakeLists.txt
+++ b/be/src/http/CMakeLists.txt
@@ -46,6 +46,7 @@ set(HTTP_SERVICE_FILES
   action/datacache_action.cpp
   action/pipeline_blocking_drivers_action.cpp
   action/lake/dump_tablet_metadata_action.cpp
+  action/lake/dump_tablet_metadata_serializer.cpp
   action/stop_be_action.cpp)
 
 if(STARROCKS_JIT_ENABLE)

--- a/be/src/http/action/lake/dump_tablet_metadata_action.cpp
+++ b/be/src/http/action/lake/dump_tablet_metadata_action.cpp
@@ -14,97 +14,258 @@
 
 #include "http/action/lake/dump_tablet_metadata_action.h"
 
-#include <event2/buffer.h>
-#include <event2/http.h>
-#include <json2pb/pb_to_json.h>
+#include <fmt/format.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
 
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "base/status.h"
 #include "base/string/string_parser.hpp"
-#include "exec/exec_env.h"
-#include "fs/fs.h"
-#include "fs/fs_factory.h"
+#include "common/config_lake_fwd.h"
+#include "common/logging.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "http/action/lake/dump_tablet_metadata_serializer.h"
 #include "platform/http/http_channel.h"
-#include "platform/http/http_headers.h"
 #include "platform/http/http_request.h"
 #include "platform/http/http_status.h"
-#include "platform/http/http_stream_channel.h"
-#include "storage/lake/filenames.h"
-#include "storage/lake/join_path.h"
-#include "storage/lake/location_provider.h"
+#include "runtime/current_thread.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_env.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/storage_env.h"
 
 namespace starrocks::lake {
+namespace {
 
-static const char* const kParamPretty = "pretty";
+std::string serialize_status(const Status& status) {
+    rapidjson::StringBuffer buffer;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+    const std::string code = status.code_as_string();
+    const std::string_view message = status.message();
+    writer.StartObject();
+    writer.Key("status");
+    writer.String(code.data(), static_cast<rapidjson::SizeType>(code.size()));
+    writer.Key("message");
+    writer.String(message.empty() ? "" : message.data(), static_cast<rapidjson::SizeType>(message.size()));
+    writer.EndObject();
+    return {buffer.GetString(), buffer.GetSize()};
+}
+
+void send_status_response(HttpRequest* req, const Status& status) {
+    HttpChannel::send_reply_json(req, HttpStatus::OK, serialize_status(status));
+}
+
+struct DumpTabletMetadataRequestContext {
+    int64_t tablet_id = 0;
+    int64_t version = 0;
+    int64_t memory_limit_bytes = 0;
+    int64_t json_size_limit_bytes = 0;
+    std::atomic<int32_t>* active_requests = nullptr;
+
+    DumpTabletMetadataRequestContext() = default;
+    ~DumpTabletMetadataRequestContext() {
+        if (active_requests != nullptr) {
+            active_requests->fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
+    DumpTabletMetadataRequestContext(const DumpTabletMetadataRequestContext&) = delete;
+    DumpTabletMetadataRequestContext& operator=(const DumpTabletMetadataRequestContext&) = delete;
+};
+
+bool parse_positive_int64(std::string_view value, int64_t* result) {
+    StringParser::ParseResult parse_result;
+    const int64_t parsed =
+            StringParser::string_to_int<int64_t>(value.data(), static_cast<int>(value.size()), &parse_result);
+    if (parse_result != StringParser::PARSE_SUCCESS || parsed <= 0) {
+        return false;
+    }
+    *result = parsed;
+    return true;
+}
+
+bool try_acquire_admission(std::atomic<int32_t>* active_requests, int32_t max_concurrency,
+                           int32_t* active_at_rejection) {
+    int32_t active = active_requests->load(std::memory_order_relaxed);
+    while (active < max_concurrency) {
+        if (active_requests->compare_exchange_weak(active, active + 1, std::memory_order_acq_rel,
+                                                   std::memory_order_relaxed)) {
+            return true;
+        }
+    }
+    *active_at_rejection = active;
+    return false;
+}
+
+StatusOr<std::string> prepare_cached_metadata(TabletManager* tablet_manager,
+                                              const DumpTabletMetadataRequestContext& request_context) {
+    if (tablet_manager == nullptr) {
+        return Status::ServiceUnavailable("lake tablet manager is unavailable on this compute node");
+    }
+
+    MemTracker request_tracker(
+            request_context.memory_limit_bytes,
+            fmt::format("dump_tablet_metadata-{}-{}", request_context.tablet_id, request_context.version),
+            RuntimeEnv::GetInstance()->process_mem_tracker());
+    SCOPED_THREAD_LOCAL_MEM_SETTER(&request_tracker, true);
+
+    TRY_CATCH_ALLOC_SCOPE_START()
+    const std::string key =
+            tablet_manager->tablet_metadata_location(request_context.tablet_id, request_context.version);
+    auto metadata = tablet_manager->metacache()->lookup_tablet_metadata(key);
+    if (metadata == nullptr) {
+        return Status::NotFound(
+                "tablet metadata is not cached on this compute node; this API only inspects the current compute "
+                "node's in-memory metadata cache. To inspect metadata in object storage, download the file with "
+                "the AWS CLI and parse it with meta_tool");
+    }
+    if (metadata->id() != request_context.tablet_id || metadata->version() != request_context.version) {
+        return Status::Corruption(fmt::format(
+                "cached tablet metadata identity does not match the request: requested tablet_id={} version={}, "
+                "cached tablet_id={} version={}",
+                request_context.tablet_id, request_context.version, metadata->id(), metadata->version()));
+    }
+
+    auto json_or = serialize_dump_tablet_metadata(*metadata);
+    if (!json_or.ok()) {
+        LOG(WARNING) << "failed to serialize cached tablet metadata tablet_id=" << request_context.tablet_id
+                     << " version=" << request_context.version << " status=" << json_or.status();
+        return json_or.status();
+    }
+    auto response = std::move(json_or).value();
+    if (response.size() > static_cast<size_t>(request_context.json_size_limit_bytes)) {
+        return Status::CapacityLimitExceed(
+                fmt::format("JSON size limit is {} bytes", request_context.json_size_limit_bytes));
+    }
+    return response;
+    TRY_CATCH_ALLOC_SCOPE_END()
+}
+
+Status send_cached_metadata(HttpRequest* req, TabletManager* tablet_manager,
+                            const DumpTabletMetadataRequestContext& request_context) {
+    auto response_or = prepare_cached_metadata(tablet_manager, request_context);
+    if (!response_or.ok()) {
+        if (response_or.status().is_mem_limit_exceeded()) {
+            LOG(WARNING) << "memory limit exceeded while preparing tablet metadata diagnostic tablet_id="
+                         << request_context.tablet_id << " version=" << request_context.version
+                         << " status=" << response_or.status();
+            return Status::MemoryLimitExceeded(
+                    fmt::format("per-request memory limit is {} bytes", request_context.memory_limit_bytes));
+        }
+        if (response_or.status().code() == TStatusCode::RUNTIME_ERROR) {
+            LOG(WARNING) << "runtime error while preparing tablet metadata diagnostic tablet_id="
+                         << request_context.tablet_id << " version=" << request_context.version
+                         << " status=" << response_or.status();
+            return Status::RuntimeError("tablet metadata diagnostic failed unexpectedly");
+        }
+        return response_or.status();
+    }
+
+    HttpChannel::send_reply_json(req, HttpStatus::OK, response_or.value());
+    return Status::OK();
+}
+
+} // namespace
+
+int DumpTabletMetadataAction::on_header(HttpRequest* req) {
+    const auto start = std::chrono::steady_clock::now();
+    const auto& query = req->query_params();
+    int64_t tablet_id = 0;
+    int64_t version = 0;
+    if (!parse_positive_int64(req->param("TabletId"), &tablet_id)) {
+        send_status_response(req, Status::InvalidArgument("TabletId must be a positive 64-bit integer"));
+        return -1;
+    }
+
+    const auto version_it = query.find("version");
+    if (version_it == query.end()) {
+        send_status_response(req,
+                             Status::InvalidArgument(query.empty() ? "version query parameter is required"
+                                                                   : "only the version query parameter is supported"));
+        return -1;
+    }
+    if (query.size() != 1) {
+        send_status_response(req, Status::InvalidArgument("only the version query parameter is supported"));
+        return -1;
+    }
+    if (!parse_positive_int64(version_it->second, &version)) {
+        send_status_response(req, Status::InvalidArgument("version must be a positive 64-bit integer"));
+        return -1;
+    }
+
+    auto context = std::make_unique<DumpTabletMetadataRequestContext>();
+    context->tablet_id = tablet_id;
+    context->version = version;
+    context->memory_limit_bytes = config::lake_dump_tablet_metadata_per_request_memory_limit_bytes;
+    context->json_size_limit_bytes = config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes;
+    const int32_t max_concurrency = config::lake_dump_tablet_metadata_max_concurrency;
+    auto reject_invalid_config = [req](std::string_view config_name, int64_t config_value) {
+        send_status_response(req, Status::ServiceUnavailable(fmt::format(
+                                          "configuration {} has value {}, but the minimum allowed value is 1",
+                                          config_name, config_value)));
+    };
+    if (context->memory_limit_bytes <= 0) {
+        reject_invalid_config("lake_dump_tablet_metadata_per_request_memory_limit_bytes", context->memory_limit_bytes);
+        return -1;
+    }
+    if (context->json_size_limit_bytes <= 0) {
+        reject_invalid_config("lake_dump_tablet_metadata_per_request_json_size_limit_bytes",
+                              context->json_size_limit_bytes);
+        return -1;
+    }
+    if (max_concurrency <= 0) {
+        reject_invalid_config("lake_dump_tablet_metadata_max_concurrency", max_concurrency);
+        return -1;
+    }
+    int32_t active_at_rejection = 0;
+    if (!try_acquire_admission(&_active_requests, max_concurrency, &active_at_rejection)) {
+        const Status status = Status::ResourceBusy(
+                fmt::format("tablet metadata diagnostic has {} active requests, reaching the configured maximum of {}",
+                            active_at_rejection, max_concurrency));
+        send_status_response(req, status);
+        const auto elapsed_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+        LOG(INFO) << "dump_tablet_metadata tablet_id=" << tablet_id << " version=" << version
+                  << " result=" << status.code_as_string() << " elapsed_ms=" << elapsed_ms << " busy=true";
+        return -1;
+    }
+    context->active_requests = &_active_requests;
+
+    req->set_handler_ctx(context.release());
+    return 0;
+}
 
 void DumpTabletMetadataAction::handle(HttpRequest* req) {
-    std::string tablet_id_str = req->param("TabletId");
-    StringParser::ParseResult result;
-    auto tablet_id = StringParser::string_to_int<int64_t>(tablet_id_str.data(), tablet_id_str.size(), &result);
-    if (result != StringParser::PARSE_SUCCESS) {
-        HttpChannel::send_error(req, HttpStatus::BAD_REQUEST);
+    const auto start = std::chrono::steady_clock::now();
+    auto* context = static_cast<DumpTabletMetadataRequestContext*>(req->handler_ctx());
+    if (context == nullptr) {
+        send_status_response(req, Status::InternalError("tablet metadata diagnostic request context is missing"));
         return;
     }
-    const auto& pretty_str = req->param(kParamPretty);
-    bool pretty = true;
-    if (!pretty_str.empty()) {
-        pretty = StringParser::string_to_bool(pretty_str.data(), pretty_str.size(), &result);
-        if (result != StringParser::PARSE_SUCCESS) {
-            HttpChannel::send_error(req, HttpStatus::BAD_REQUEST);
-            return;
-        }
+    const int64_t tablet_id = context->tablet_id;
+    const int64_t version = context->version;
+
+    TabletManager* tablet_manager = _tablet_manager;
+    if (tablet_manager == nullptr) {
+        tablet_manager = StorageEnv::GetInstance()->lake_tablet_manager();
     }
-
-    TabletManager* tablet_mgr = StorageEnv::GetInstance()->lake_tablet_manager();
-    if (tablet_mgr == nullptr) {
-        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, "Not built with --use-staros");
-        return;
+    Status result = send_cached_metadata(req, tablet_manager, *context);
+    if (!result.ok()) {
+        send_status_response(req, result);
     }
+    const auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+    LOG(INFO) << "dump_tablet_metadata tablet_id=" << tablet_id << " version=" << version << " result=" << result
+              << " elapsed_ms=" << elapsed_ms << " busy=false";
+}
 
-    auto location = tablet_mgr->location_provider()->metadata_root_location(tablet_id);
-    auto fs_or = FileSystemFactory::CreateSharedFromString(location);
-    if (!fs_or.ok()) {
-        HttpChannel::send_reply(req, HttpStatus::INTERNAL_SERVER_ERROR, fs_or.status().to_string());
-        return;
-    }
-    auto fs = std::move(fs_or).value();
-
-    HttpStreamChannel response(req);
-    response.start();
-    response.write("[\n");
-    bool first_object = true;
-    auto st = fs->iterate_dir(location, [&](std::string_view name) {
-        if (is_tablet_metadata(name)) {
-            if (!first_object) {
-                response.write(",\n");
-            } else {
-                first_object = false;
-            }
-            auto path = join_path(location, name);
-            auto metadata_or = tablet_mgr->get_tablet_metadata(path, false);
-            if (!metadata_or.ok() && !metadata_or.status().is_not_found()) {
-                response.write(R"({"error": ")").write(metadata_or.status().to_string()).write("\"}");
-            } else if (metadata_or.ok()) {
-                auto metadata = std::move(metadata_or).value();
-                json2pb::Pb2JsonOptions options;
-                options.pretty_json = pretty;
-                std::string json;
-                std::string error;
-                if (!json2pb::ProtoMessageToJson(*metadata, &json, options, &error)) {
-                    response.write(R"({"error": ")").write(error).write("\"}");
-                } else {
-                    response.write(json);
-                }
-            }
-        }
-        return true;
-    });
-
-    if (!st.ok()) {
-        response.write(R"({"error": ")").write(st.to_string()).write("\"}");
-    }
-
-    response.write("\n]\n");
+void DumpTabletMetadataAction::free_handler_ctx(void* handler_ctx) {
+    delete static_cast<DumpTabletMetadataRequestContext*>(handler_ctx);
 }
 
 } // namespace starrocks::lake

--- a/be/src/http/action/lake/dump_tablet_metadata_action.h
+++ b/be/src/http/action/lake/dump_tablet_metadata_action.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+
 #include "gutil/macros.h"
 #include "platform/http/http_handler.h"
 
@@ -24,16 +27,50 @@ class HttpRequest;
 
 namespace starrocks::lake {
 
+class TabletManager;
+
+/**
+ * Returns one exact TabletMetadataPB from this compute node's in-memory metadata cache.
+ *
+ * The tablet id comes from the request path and the metadata version comes from the `version` query parameter. A
+ * cache miss does not fall back to StarOS, object storage, the FE, or another compute node. To inspect metadata stored
+ * in object storage, download the object with the AWS CLI and parse it with meta_tool.
+ *
+ * Example request:
+ *   GET /api/cloudnative/dump_tablet_metadata/12345?version=2
+ *
+ * Abbreviated success response (other TabletMetadataPB fields are omitted):
+ * {
+ *   "status": "OK",
+ *   "message": "",
+ *   "metadata": {
+ *     "id": 12345,
+ *     "version": 2,
+ *     "schema": {"id": 10001},
+ *     "rowsets": [{"id": 1, "num_rows": 10, "data_size": 1024}]
+ *   }
+ * }
+ *
+ * Encryption metadata is redacted before serialization. Per-request memory, JSON response size, and concurrency are
+ * bounded by the lake_dump_tablet_metadata_* configurations. Access requires the OPERATE privilege.
+ */
 class DumpTabletMetadataAction : public HttpHandler {
 public:
-    explicit DumpTabletMetadataAction(ExecEnv*) {}
+    explicit DumpTabletMetadataAction(ExecEnv*, TabletManager* tablet_manager = nullptr)
+            : _tablet_manager(tablet_manager) {}
     ~DumpTabletMetadataAction() override = default;
 
     DISALLOW_COPY_AND_MOVE(DumpTabletMetadataAction);
 
+    int on_header(HttpRequest* req) override;
     void handle(HttpRequest* req) override;
+    void free_handler_ctx(void* handler_ctx) override;
 
     RequiredPrivilege required_privilege() const override { return RequiredPrivilege::OPERATE; }
+
+private:
+    TabletManager* _tablet_manager;
+    std::atomic<int32_t> _active_requests{0};
 };
 
 } // namespace starrocks::lake

--- a/be/src/http/action/lake/dump_tablet_metadata_serializer.cpp
+++ b/be/src/http/action/lake/dump_tablet_metadata_serializer.cpp
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/lake/dump_tablet_metadata_serializer.h"
+
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#include <google/protobuf/message.h>
+#include <json2pb/pb_to_json.h>
+
+#include <optional>
+#include <vector>
+
+#include "gen_cpp/lake_types.pb.h"
+namespace starrocks::lake {
+namespace dump_tablet_metadata_internal {
+
+bool contains_encryption_metadata(const google::protobuf::Message& message) {
+    const auto* reflection = message.GetReflection();
+    std::vector<const google::protobuf::FieldDescriptor*> present_fields;
+    reflection->ListFields(message, &present_fields);
+    for (const auto* field : present_fields) {
+        if (field->name().find("encryption_meta") != std::string::npos) {
+            return true;
+        }
+        if (field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            continue;
+        }
+        if (field->is_repeated()) {
+            const int count = reflection->FieldSize(message, field);
+            for (int i = 0; i < count; ++i) {
+                if (contains_encryption_metadata(reflection->GetRepeatedMessage(message, field, i))) {
+                    return true;
+                }
+            }
+        } else if (contains_encryption_metadata(reflection->GetMessage(message, field))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void redact_encryption_metadata(google::protobuf::Message* message) {
+    const auto* reflection = message->GetReflection();
+    std::vector<const google::protobuf::FieldDescriptor*> present_fields;
+    reflection->ListFields(*message, &present_fields);
+    for (const auto* field : present_fields) {
+        if (field->name().find("encryption_meta") != std::string::npos) {
+            reflection->ClearField(message, field);
+            continue;
+        }
+        if (field->cpp_type() != google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            continue;
+        }
+        if (field->is_repeated()) {
+            const int count = reflection->FieldSize(*message, field);
+            for (int i = 0; i < count; ++i) {
+                redact_encryption_metadata(reflection->MutableRepeatedMessage(message, field, i));
+            }
+        } else {
+            redact_encryption_metadata(reflection->MutableMessage(message, field));
+        }
+    }
+}
+
+} // namespace dump_tablet_metadata_internal
+
+StatusOr<std::string> serialize_dump_tablet_metadata(const TabletMetadataPB& metadata) {
+    std::optional<TabletMetadataPB> redacted_metadata;
+    const TabletMetadataPB* output_metadata = &metadata;
+    const bool has_encryption_metadata = dump_tablet_metadata_internal::contains_encryption_metadata(metadata);
+    if (has_encryption_metadata) {
+        redacted_metadata.emplace(metadata);
+        dump_tablet_metadata_internal::redact_encryption_metadata(&*redacted_metadata);
+        output_metadata = &*redacted_metadata;
+    }
+
+    std::string response = R"({"status":"OK","message":"","metadata":)";
+    {
+        json2pb::Pb2JsonOptions options;
+        options.pretty_json = false;
+        options.bytes_to_base64 = true;
+        google::protobuf::io::StringOutputStream output(&response);
+        if (!json2pb::ProtoMessageToJson(*output_metadata, &output, options)) {
+            return Status::InternalError("failed to serialize tablet metadata JSON");
+        }
+    }
+
+    response.push_back('}');
+    return response;
+}
+
+} // namespace starrocks::lake

--- a/be/src/http/action/lake/dump_tablet_metadata_serializer.h
+++ b/be/src/http/action/lake/dump_tablet_metadata_serializer.h
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "base/statusor.h"
+
+namespace starrocks {
+class TabletMetadataPB;
+} // namespace starrocks
+
+namespace starrocks::lake {
+
+StatusOr<std::string> serialize_dump_tablet_metadata(const TabletMetadataPB& metadata);
+
+} // namespace starrocks::lake

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -122,6 +122,7 @@ set(EXEC_FILES
         ./formats/parquet/dict_encoding_test.cpp
         ./formats/parquet/statistics_helper_test.cpp
         ./http/default_path_handlers_test.cpp
+        ./http/dump_tablet_metadata_action_test.cpp
         ./http/handler_required_privilege_test.cpp
         ./http/metrics_action_test.cpp
         ./http/stop_be_action_test.cpp

--- a/be/test/http/dump_tablet_metadata_action_test.cpp
+++ b/be/test/http/dump_tablet_metadata_action_test.cpp
@@ -1,0 +1,766 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "http/action/lake/dump_tablet_metadata_action.h"
+
+#include <event2/http.h>
+#include <event2/keyvalq_struct.h>
+#include <glog/logging.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/dynamic_message.h>
+#include <gtest/gtest.h>
+#include <rapidjson/document.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "base/testutil/assert.h"
+#include "base/url_coding.h"
+#include "common/config_lake_fwd.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "http/action/lake/dump_tablet_metadata_serializer.h"
+#include "platform/http/http_channel.h"
+#include "platform/http/http_request.h"
+#include "platform/http/http_status.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/metacache.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/storage_env.h"
+
+namespace starrocks {
+extern void (*s_injected_send_reply)(HttpRequest*, HttpStatus, std::string_view);
+} // namespace starrocks
+
+namespace starrocks::lake {
+namespace dump_tablet_metadata_internal {
+bool contains_encryption_metadata(const google::protobuf::Message& message);
+void redact_encryption_metadata(google::protobuf::Message* message);
+} // namespace dump_tablet_metadata_internal
+
+namespace {
+
+HttpStatus g_response_status = HttpStatus::OK;
+std::string g_response_body;
+
+void capture_reply(HttpRequest* request, HttpStatus status, std::string_view body) {
+    g_response_status = status;
+    g_response_body.assign(body);
+}
+
+struct SyntheticRequest {
+    explicit SyntheticRequest(DumpTabletMetadataAction* action) {
+        ev_req = evhttp_request_new(nullptr, nullptr);
+        request = std::make_unique<HttpRequest>(ev_req);
+        request->set_handler(action);
+        request->set_method(HttpMethod::GET);
+    }
+
+    SyntheticRequest(SyntheticRequest&& other) noexcept
+            : ev_req(std::exchange(other.ev_req, nullptr)), request(std::move(other.request)) {}
+    SyntheticRequest& operator=(SyntheticRequest&&) = delete;
+    SyntheticRequest(const SyntheticRequest&) = delete;
+    SyntheticRequest& operator=(const SyntheticRequest&) = delete;
+
+    ~SyntheticRequest() {
+        request.reset();
+        if (ev_req != nullptr) {
+            evhttp_request_free(ev_req);
+        }
+    }
+
+    void set_route(std::string tablet_id) { request->add_param("TabletId", tablet_id); }
+
+    void add_query(std::string key, std::string value) {
+        request->_query_params.emplace(std::move(key), std::move(value));
+    }
+
+    evhttp_request* ev_req = nullptr;
+    std::unique_ptr<HttpRequest> request;
+};
+
+SyntheticRequest valid_request(DumpTabletMetadataAction* action, std::string tablet_id = "17",
+                               std::string version = "2") {
+    SyntheticRequest holder(action);
+    holder.set_route(std::move(tablet_id));
+    holder.add_query("version", std::move(version));
+    return holder;
+}
+
+struct ScopedReplyCapture {
+    ScopedReplyCapture() {
+        g_response_status = HttpStatus::OK;
+        g_response_body.clear();
+        s_injected_send_reply = capture_reply;
+    }
+    ~ScopedReplyCapture() { s_injected_send_reply = nullptr; }
+};
+
+class DiagnosticLogSink final : public google::LogSink {
+public:
+    void send(google::LogSeverity, const char*, const char*, int, const google::LogMessageTime&, const char* message,
+              size_t message_len) override {
+        std::lock_guard lock(_mutex);
+        _messages.emplace_back(message, message_len);
+    }
+
+    bool contains(std::string_view first, std::string_view second) const {
+        std::lock_guard lock(_mutex);
+        return std::any_of(_messages.begin(), _messages.end(), [&](const std::string& message) {
+            return message.find(first) != std::string::npos && message.find(second) != std::string::npos;
+        });
+    }
+
+private:
+    mutable std::mutex _mutex;
+    std::vector<std::string> _messages;
+};
+
+class ScopedDiagnosticLogSink {
+public:
+    ScopedDiagnosticLogSink() { google::AddLogSink(&_sink); }
+    ~ScopedDiagnosticLogSink() { google::RemoveLogSink(&_sink); }
+
+    const DiagnosticLogSink& sink() const { return _sink; }
+
+private:
+    DiagnosticLogSink _sink;
+};
+
+class ScopedDeathTestStyle {
+public:
+    ScopedDeathTestStyle() : _previous(::testing::FLAGS_gtest_death_test_style) {
+        ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    }
+    ~ScopedDeathTestStyle() { ::testing::FLAGS_gtest_death_test_style = _previous; }
+
+private:
+    std::string _previous;
+};
+
+void expect_json_content_type_without_diagnostic_headers(evhttp_request* request) {
+    auto* headers = evhttp_request_get_output_headers(request);
+    ASSERT_NE(nullptr, evhttp_find_header(headers, "Content-Type"));
+    EXPECT_STREQ("application/json", evhttp_find_header(headers, "Content-Type"));
+    EXPECT_EQ(nullptr, evhttp_find_header(headers, "Cache-Control"));
+    EXPECT_EQ(nullptr, evhttp_find_header(headers, "X-Content-Type-Options"));
+}
+
+rapidjson::Document parse_captured_response() {
+    rapidjson::Document document;
+    document.Parse(g_response_body.data(), g_response_body.size());
+    return document;
+}
+
+void expect_string_member(const rapidjson::Value& document, const char* name, std::string_view expected) {
+    ASSERT_TRUE(document.IsObject());
+    ASSERT_TRUE(document.HasMember(name)) << name;
+    const auto& value = document[name];
+    ASSERT_TRUE(value.IsString()) << name;
+    EXPECT_EQ(expected, std::string_view(value.GetString(), value.GetStringLength())) << name;
+}
+
+void expect_status_response(std::string_view status, std::string_view message) {
+    auto document = parse_captured_response();
+    ASSERT_FALSE(document.HasParseError()) << g_response_body;
+    ASSERT_TRUE(document.IsObject());
+    EXPECT_EQ(2, document.MemberCount());
+    expect_string_member(document, "status", status);
+    expect_string_member(document, "message", message);
+}
+
+void expect_cache_miss_response() {
+    expect_status_response(
+            "Not found",
+            "tablet metadata is not cached on this compute node; this API only inspects the current compute node's "
+            "in-memory metadata cache. To inspect metadata in object storage, download the file with the AWS CLI and "
+            "parse it with meta_tool");
+}
+
+constexpr std::array<const char*, 7> kExpectedRedactedFields = {
+        "starrocks.DelfileWithRowsetId.encryption_meta",
+        "starrocks.DeltaColumnGroupVerPB.encryption_metas",
+        "starrocks.FileMetaPB.encryption_meta",
+        "starrocks.IndexDeltaGroupEntryPB.encryption_meta",
+        "starrocks.PersistentIndexSstablePB.encryption_meta",
+        "starrocks.RowsetMetadataPB.deprecated_segment_encryption_metas",
+        "starrocks.SegmentMetadataPB.encryption_meta",
+};
+
+void collect_reachable_encryption_fields(const google::protobuf::Descriptor* descriptor,
+                                         std::unordered_set<const google::protobuf::Descriptor*>* visited,
+                                         std::set<std::string>* fields) {
+    if (!visited->insert(descriptor).second) {
+        return;
+    }
+    for (int i = 0; i < descriptor->field_count(); ++i) {
+        const auto* field = descriptor->field(i);
+        if (field->name().find("encryption_meta") != std::string::npos) {
+            fields->insert(field->full_name());
+        }
+        if (field->cpp_type() == google::protobuf::FieldDescriptor::CPPTYPE_MESSAGE) {
+            collect_reachable_encryption_fields(field->message_type(), visited, fields);
+        }
+    }
+}
+
+TabletMetadataPB metadata_with_all_encryption_fields(std::vector<std::string>* secrets) {
+    TabletMetadataPB metadata;
+    metadata.set_id(11979);
+    metadata.set_version(23);
+
+    auto next_secret = [&]() -> const std::string& {
+        secrets->emplace_back("secret-material-" + std::to_string(secrets->size()));
+        return secrets->back();
+    };
+    metadata.mutable_sstable_meta()->add_sstables()->set_encryption_meta(next_secret());
+    metadata.add_orphan_files()->set_encryption_meta(next_secret());
+    (*metadata.mutable_delvec_meta()->mutable_version_to_file())[11].set_encryption_meta(next_secret());
+    (*metadata.mutable_dcg_meta()->mutable_dcgs())[12].add_encryption_metas(next_secret());
+    (*metadata.mutable_idg_meta()->mutable_idgs())[13].add_entries()->set_encryption_meta(next_secret());
+    auto* rowset = metadata.add_rowsets();
+    rowset->add_del_files()->set_encryption_meta(next_secret());
+    rowset->add_segment_metas()->set_encryption_meta(next_secret());
+    rowset->add_deprecated_segment_encryption_metas(next_secret());
+    // Exercise the second route into RowsetMetadataPB as well.
+    metadata.add_compaction_inputs()->add_segment_metas()->set_encryption_meta(next_secret());
+    return metadata;
+}
+
+TEST(DumpTabletMetadataSerializerTest, RedactsEveryReachableEncryptionFieldWithoutMutatingInput) {
+    std::vector<std::string> secrets;
+    TabletMetadataPB metadata = metadata_with_all_encryption_fields(&secrets);
+    const std::string original = metadata.SerializeAsString();
+
+    auto result = serialize_dump_tablet_metadata(metadata);
+    ASSERT_TRUE(result.ok()) << result.status();
+    EXPECT_EQ(original, metadata.SerializeAsString());
+
+    rapidjson::Document document;
+    ASSERT_FALSE(document.Parse(result->data(), result->size()).HasParseError());
+    ASSERT_TRUE(document.IsObject());
+    EXPECT_EQ(3, document.MemberCount());
+    expect_string_member(document, "status", "OK");
+    expect_string_member(document, "message", "");
+    ASSERT_TRUE(document.HasMember("metadata"));
+    ASSERT_TRUE(document["metadata"].IsObject());
+    ASSERT_TRUE(document["metadata"]["id"].IsInt64());
+    ASSERT_TRUE(document["metadata"]["version"].IsInt64());
+    EXPECT_EQ(11979, document["metadata"]["id"].GetInt64());
+    EXPECT_EQ(23, document["metadata"]["version"].GetInt64());
+    EXPECT_EQ(std::string::npos, result->find('\n'));
+    rapidjson::StringBuffer compact;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(compact);
+    ASSERT_TRUE(document.Accept(writer));
+    EXPECT_EQ(*result, std::string(compact.GetString(), compact.GetSize()));
+    for (const auto& secret : secrets) {
+        std::string encoded;
+        base64_encode(secret, &encoded);
+        EXPECT_EQ(std::string::npos, result->find(secret));
+        EXPECT_EQ(std::string::npos, result->find(encoded));
+    }
+}
+
+TEST(DumpTabletMetadataSerializerTest, ReachableEncryptionFieldPolicyIsComplete) {
+    std::unordered_set<const google::protobuf::Descriptor*> visited;
+    std::set<std::string> actual;
+    collect_reachable_encryption_fields(TabletMetadataPB::descriptor(), &visited, &actual);
+    const std::set<std::string> expected(kExpectedRedactedFields.begin(), kExpectedRedactedFields.end());
+    EXPECT_EQ(expected, actual);
+}
+
+TEST(DumpTabletMetadataSerializerTest, RedactionMatchesFieldNameRegardlessOfScalarRepeatedOrMessageType) {
+    google::protobuf::FileDescriptorProto schema;
+    schema.set_name("dump_tablet_metadata_redaction_test.proto");
+    schema.set_package("starrocks.lake.redaction_test");
+    schema.set_syntax("proto2");
+
+    auto* nested_proto = schema.add_message_type();
+    nested_proto->set_name("SyntheticNested");
+    auto* nested_secret_proto = nested_proto->add_field();
+    nested_secret_proto->set_name("encryption_meta_inner");
+    nested_secret_proto->set_number(1);
+    nested_secret_proto->set_label(google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
+    nested_secret_proto->set_type(google::protobuf::FieldDescriptorProto::TYPE_STRING);
+    auto* nested_safe_proto = nested_proto->add_field();
+    nested_safe_proto->set_name("safe_value");
+    nested_safe_proto->set_number(2);
+    nested_safe_proto->set_label(google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
+    nested_safe_proto->set_type(google::protobuf::FieldDescriptorProto::TYPE_STRING);
+
+    auto* root_proto = schema.add_message_type();
+    root_proto->set_name("SyntheticMetadata");
+    auto add_root_field = [&](const char* name, int number, google::protobuf::FieldDescriptorProto::Label label,
+                              google::protobuf::FieldDescriptorProto::Type type) {
+        auto* field = root_proto->add_field();
+        field->set_name(name);
+        field->set_number(number);
+        field->set_label(label);
+        field->set_type(type);
+        return field;
+    };
+    add_root_field("encryption_meta_text", 1, google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL,
+                   google::protobuf::FieldDescriptorProto::TYPE_STRING);
+    add_root_field("encryption_metas_numbers", 2, google::protobuf::FieldDescriptorProto::LABEL_REPEATED,
+                   google::protobuf::FieldDescriptorProto::TYPE_INT64);
+    auto* matching_message_proto =
+            add_root_field("encryption_metadata_message", 3, google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL,
+                           google::protobuf::FieldDescriptorProto::TYPE_MESSAGE);
+    matching_message_proto->set_type_name(".starrocks.lake.redaction_test.SyntheticNested");
+    auto* safe_message_proto = add_root_field("safe_nested", 4, google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL,
+                                              google::protobuf::FieldDescriptorProto::TYPE_MESSAGE);
+    safe_message_proto->set_type_name(".starrocks.lake.redaction_test.SyntheticNested");
+
+    google::protobuf::DescriptorPool pool;
+    const auto* file = pool.BuildFile(schema);
+    ASSERT_NE(nullptr, file);
+    const auto* descriptor = file->FindMessageTypeByName("SyntheticMetadata");
+    ASSERT_NE(nullptr, descriptor);
+    const auto* nested_descriptor = file->FindMessageTypeByName("SyntheticNested");
+    ASSERT_NE(nullptr, nested_descriptor);
+
+    google::protobuf::DynamicMessageFactory factory;
+    const auto* prototype = factory.GetPrototype(descriptor);
+    ASSERT_NE(nullptr, prototype);
+    std::unique_ptr<google::protobuf::Message> message(prototype->New());
+    const auto* reflection = message->GetReflection();
+    const auto* text_secret = descriptor->FindFieldByName("encryption_meta_text");
+    const auto* repeated_secret = descriptor->FindFieldByName("encryption_metas_numbers");
+    const auto* message_secret = descriptor->FindFieldByName("encryption_metadata_message");
+    const auto* safe_nested = descriptor->FindFieldByName("safe_nested");
+    const auto* nested_secret = nested_descriptor->FindFieldByName("encryption_meta_inner");
+    const auto* nested_safe = nested_descriptor->FindFieldByName("safe_value");
+    ASSERT_NE(nullptr, text_secret);
+    ASSERT_NE(nullptr, repeated_secret);
+    ASSERT_NE(nullptr, message_secret);
+    ASSERT_NE(nullptr, safe_nested);
+    ASSERT_NE(nullptr, nested_secret);
+    ASSERT_NE(nullptr, nested_safe);
+
+    EXPECT_FALSE(dump_tablet_metadata_internal::contains_encryption_metadata(*message));
+
+    reflection->SetString(message.get(), text_secret, "future-string-secret");
+    reflection->AddInt64(message.get(), repeated_secret, 9007199254740993LL);
+    auto* matching_message = reflection->MutableMessage(message.get(), message_secret);
+    matching_message->GetReflection()->SetString(matching_message, nested_safe, "future-message-secret");
+    auto* ordinary_message = reflection->MutableMessage(message.get(), safe_nested);
+    ordinary_message->GetReflection()->SetString(ordinary_message, nested_secret, "nested-secret");
+    ordinary_message->GetReflection()->SetString(ordinary_message, nested_safe, "keep");
+
+    EXPECT_TRUE(dump_tablet_metadata_internal::contains_encryption_metadata(*message));
+
+    dump_tablet_metadata_internal::redact_encryption_metadata(message.get());
+
+    EXPECT_FALSE(dump_tablet_metadata_internal::contains_encryption_metadata(*message));
+
+    EXPECT_FALSE(reflection->HasField(*message, text_secret));
+    EXPECT_EQ(0, reflection->FieldSize(*message, repeated_secret));
+    EXPECT_FALSE(reflection->HasField(*message, message_secret));
+    ASSERT_TRUE(reflection->HasField(*message, safe_nested));
+    const auto& sanitized_nested = reflection->GetMessage(*message, safe_nested);
+    EXPECT_FALSE(sanitized_nested.GetReflection()->HasField(sanitized_nested, nested_secret));
+    EXPECT_EQ("keep", sanitized_nested.GetReflection()->GetString(sanitized_nested, nested_safe));
+}
+
+TEST(DumpTabletMetadataSerializerTest, ReturnsEmptyMessageWhenNoEncryptionMaterialIsPresent) {
+    TabletMetadataPB metadata;
+    metadata.set_id(7);
+    metadata.set_version(9);
+
+    auto result = serialize_dump_tablet_metadata(metadata);
+    ASSERT_TRUE(result.ok()) << result.status();
+    rapidjson::Document document;
+    ASSERT_FALSE(document.Parse(result->data(), result->size()).HasParseError());
+    ASSERT_TRUE(document.IsObject());
+    EXPECT_EQ(3, document.MemberCount());
+    expect_string_member(document, "status", "OK");
+    expect_string_member(document, "message", "");
+    EXPECT_TRUE(document.HasMember("metadata"));
+    EXPECT_FALSE(document["metadata"].IsArray());
+    EXPECT_EQ(std::string::npos, result->find('\n'));
+}
+
+class DumpTabletMetadataActionTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _saved_memory_limit = config::lake_dump_tablet_metadata_per_request_memory_limit_bytes;
+        _saved_json_limit = config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes;
+        _saved_max_concurrency = config::lake_dump_tablet_metadata_max_concurrency;
+        config::lake_dump_tablet_metadata_per_request_memory_limit_bytes = 256LL << 20;
+        config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes = 32LL << 20;
+        config::lake_dump_tablet_metadata_max_concurrency = 1;
+        _root = "/tmp/starrocks-dump-tablet-metadata-action-" + std::to_string(getpid());
+        (void)fs::remove_all(_root);
+        ASSERT_OK(fs::create_directories(join_path(_root, kMetadataDirectoryName)));
+        _provider = std::make_shared<FixedLocationProvider>(_root);
+        _tablet_manager = std::make_unique<TabletManager>(_provider, 1LL << 30);
+        s_injected_send_reply = capture_reply;
+    }
+
+    void TearDown() override {
+        s_injected_send_reply = nullptr;
+        _tablet_manager.reset();
+        _provider.reset();
+        (void)fs::remove_all(_root);
+        config::lake_dump_tablet_metadata_per_request_memory_limit_bytes = _saved_memory_limit;
+        config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes = _saved_json_limit;
+        config::lake_dump_tablet_metadata_max_concurrency = _saved_max_concurrency;
+    }
+
+    void put_metadata(int64_t tablet_id, int64_t version) {
+        TabletMetadataPB metadata;
+        metadata.set_id(tablet_id);
+        metadata.set_version(version);
+        metadata.mutable_schema()->set_id(700);
+        metadata.mutable_schema()->set_keys_type(DUP_KEYS);
+        ASSERT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    }
+
+    std::string _root;
+    std::shared_ptr<FixedLocationProvider> _provider;
+    std::unique_ptr<TabletManager> _tablet_manager;
+    int64_t _saved_memory_limit = 0;
+    int64_t _saved_json_limit = 0;
+    int32_t _saved_max_concurrency = 0;
+};
+
+TEST_F(DumpTabletMetadataActionTest, RejectsEveryInputOutsideTheExactCacheReadContractBeforeAdmission) {
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    struct InvalidRequest {
+        const char* tablet_id;
+        const char* version;
+        const char* unexpected_query = nullptr;
+        const char* expected_message;
+    };
+    const std::vector<InvalidRequest> invalid = {
+            {nullptr, "2", nullptr, "TabletId must be a positive 64-bit integer"},
+            {"", "2", nullptr, "TabletId must be a positive 64-bit integer"},
+            {"0", "2", nullptr, "TabletId must be a positive 64-bit integer"},
+            {"-1", "2", nullptr, "TabletId must be a positive 64-bit integer"},
+            {"0x10", "2", nullptr, "TabletId must be a positive 64-bit integer"},
+            {"9223372036854775808", "2", nullptr, "TabletId must be a positive 64-bit integer"},
+            {"17", nullptr, nullptr, "version query parameter is required"},
+            {"17", "", nullptr, "version must be a positive 64-bit integer"},
+            {"17", "0", nullptr, "version must be a positive 64-bit integer"},
+            {"17", "-2", nullptr, "version must be a positive 64-bit integer"},
+            {"17", "0x2", nullptr, "version must be a positive 64-bit integer"},
+            {"17", "9223372036854775808", nullptr, "version must be a positive 64-bit integer"},
+            {"17", "2", "is_bundle", "only the version query parameter is supported"},
+            {"17", "2", "pretty", "only the version query parameter is supported"},
+    };
+
+    for (const auto& test_case : invalid) {
+        SCOPED_TRACE(
+                testing::Message() << "tablet=" << (test_case.tablet_id == nullptr ? "<missing>" : test_case.tablet_id)
+                                   << " version=" << (test_case.version == nullptr ? "<missing>" : test_case.version)
+                                   << " unexpected_query="
+                                   << (test_case.unexpected_query == nullptr ? "<none>" : test_case.unexpected_query));
+        SyntheticRequest request(&action);
+        if (test_case.tablet_id != nullptr) {
+            request.set_route(test_case.tablet_id);
+        }
+        if (test_case.version != nullptr) {
+            request.add_query("version", test_case.version);
+        }
+        if (test_case.unexpected_query != nullptr) {
+            request.add_query(test_case.unexpected_query, "true");
+        }
+        g_response_status = HttpStatus::OK;
+        g_response_body.clear();
+        EXPECT_EQ(-1, action.on_header(request.request.get()));
+        EXPECT_EQ(HttpStatus::OK, g_response_status);
+        expect_status_response("Invalid argument", test_case.expected_message);
+        EXPECT_EQ(nullptr, request.request->handler_ctx());
+        expect_json_content_type_without_diagnostic_headers(request.ev_req);
+    }
+}
+
+TEST_F(DumpTabletMetadataActionTest, AcceptsStringParserCompatiblePositiveIntegers) {
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    SyntheticRequest request(&action);
+    request.set_route("+17");
+    request.add_query("version", " 2 ");
+
+    ASSERT_EQ(0, action.on_header(request.request.get()));
+    action.handle(request.request.get());
+
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+    expect_cache_miss_response();
+}
+
+TEST_F(DumpTabletMetadataActionTest, ReturnsDirectlyCachedRequestedMetadataAsJson) {
+    constexpr int64_t kTabletId = 11979;
+    constexpr int64_t kVersion = 23;
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    metadata->set_id(kTabletId);
+    metadata->set_version(kVersion);
+    metadata->mutable_schema()->set_id(702);
+    metadata->mutable_schema()->set_keys_type(DUP_KEYS);
+    _tablet_manager->metacache()->cache_tablet_metadata(_tablet_manager->tablet_metadata_location(kTabletId, kVersion),
+                                                        metadata);
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    auto request = valid_request(&action, std::to_string(kTabletId), std::to_string(kVersion));
+
+    ASSERT_EQ(0, action.on_header(request.request.get()));
+    action.handle(request.request.get());
+
+    ASSERT_EQ(HttpStatus::OK, g_response_status);
+    rapidjson::Document document;
+    ASSERT_FALSE(document.Parse(g_response_body.data(), g_response_body.size()).HasParseError()) << g_response_body;
+    ASSERT_TRUE(document.IsObject());
+    EXPECT_EQ(3, document.MemberCount());
+    expect_string_member(document, "status", "OK");
+    expect_string_member(document, "message", "");
+    ASSERT_TRUE(document.HasMember("metadata"));
+    EXPECT_FALSE(document["metadata"].IsArray());
+    ASSERT_TRUE(document["metadata"]["id"].IsInt64());
+    ASSERT_TRUE(document["metadata"]["version"].IsInt64());
+    EXPECT_EQ(kTabletId, document["metadata"]["id"].GetInt64());
+    EXPECT_EQ(kVersion, document["metadata"]["version"].GetInt64());
+    EXPECT_FALSE(document.HasMember("num"));
+    EXPECT_FALSE(document.HasMember("is_bundle"));
+    EXPECT_EQ(std::string::npos, g_response_body.find('\n'));
+    expect_json_content_type_without_diagnostic_headers(request.ev_req);
+}
+
+TEST_F(DumpTabletMetadataActionTest, DoesNotApplyRetiredProtobufSizeLimit) {
+    constexpr int64_t kTabletId = 11979;
+    constexpr int64_t kVersion = 23;
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    metadata->set_id(kTabletId);
+    metadata->set_version(kVersion);
+    metadata->GetReflection()
+            ->MutableUnknownFields(metadata.get())
+            ->AddLengthDelimited(9999, std::string(17 << 20, 'x'));
+    ASSERT_GT(metadata->ByteSizeLong(), 16 << 20);
+    _tablet_manager->metacache()->cache_tablet_metadata(_tablet_manager->tablet_metadata_location(kTabletId, kVersion),
+                                                        metadata);
+    ASSERT_NE(nullptr, _tablet_manager->metacache()->lookup_tablet_metadata(
+                               _tablet_manager->tablet_metadata_location(kTabletId, kVersion)));
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    auto request = valid_request(&action, std::to_string(kTabletId), std::to_string(kVersion));
+
+    ASSERT_EQ(0, action.on_header(request.request.get()));
+    action.handle(request.request.get());
+
+    ASSERT_EQ(HttpStatus::OK, g_response_status);
+    rapidjson::Document document;
+    ASSERT_FALSE(document.Parse(g_response_body.data(), g_response_body.size()).HasParseError()) << g_response_body;
+    EXPECT_EQ(kTabletId, document["metadata"]["id"].GetInt64());
+    EXPECT_EQ(kVersion, document["metadata"]["version"].GetInt64());
+}
+
+TEST_F(DumpTabletMetadataActionTest, SnapshotsMutableJsonLimitForEachRequest) {
+    constexpr int64_t kTabletId = 11979;
+    constexpr int64_t kVersion = 23;
+    constexpr std::string_view kSerializedMetadata =
+            R"({"status":"OK","message":"","metadata":{"id":11979,"version":23}})";
+    constexpr int64_t kJsonLimit = kSerializedMetadata.size() - 1;
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    metadata->set_id(kTabletId);
+    metadata->set_version(kVersion);
+    _tablet_manager->metacache()->cache_tablet_metadata(_tablet_manager->tablet_metadata_location(kTabletId, kVersion),
+                                                        metadata);
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+
+    config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes = 1024;
+    auto admitted = valid_request(&action, std::to_string(kTabletId), std::to_string(kVersion));
+    ASSERT_EQ(0, action.on_header(admitted.request.get()));
+    config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes = kJsonLimit;
+    action.handle(admitted.request.get());
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+
+    admitted.request.reset();
+    auto limited = valid_request(&action, std::to_string(kTabletId), std::to_string(kVersion));
+    ASSERT_EQ(0, action.on_header(limited.request.get()));
+    action.handle(limited.request.get());
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+    expect_status_response("Capacity limit exceeded", "JSON size limit is " + std::to_string(kJsonLimit) + " bytes");
+}
+
+TEST_F(DumpTabletMetadataActionTest, RejectsNonPositiveResourceConfigurationWithoutAdmissionLeak) {
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    enum class ConfigUnderTest { kMemory, kJson, kConcurrency };
+    struct InvalidConfig {
+        ConfigUnderTest config;
+        const char* name;
+    };
+    for (const auto& test_case :
+         {InvalidConfig{ConfigUnderTest::kMemory, "lake_dump_tablet_metadata_per_request_memory_limit_bytes"},
+          InvalidConfig{ConfigUnderTest::kJson, "lake_dump_tablet_metadata_per_request_json_size_limit_bytes"},
+          InvalidConfig{ConfigUnderTest::kConcurrency, "lake_dump_tablet_metadata_max_concurrency"}}) {
+        config::lake_dump_tablet_metadata_per_request_memory_limit_bytes = 256LL << 20;
+        config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes = 32LL << 20;
+        config::lake_dump_tablet_metadata_max_concurrency = 1;
+        switch (test_case.config) {
+        case ConfigUnderTest::kMemory:
+            config::lake_dump_tablet_metadata_per_request_memory_limit_bytes = 0;
+            break;
+        case ConfigUnderTest::kJson:
+            config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes = 0;
+            break;
+        case ConfigUnderTest::kConcurrency:
+            config::lake_dump_tablet_metadata_max_concurrency = 0;
+            break;
+        }
+
+        auto rejected = valid_request(&action);
+        EXPECT_EQ(-1, action.on_header(rejected.request.get()));
+        EXPECT_EQ(HttpStatus::OK, g_response_status);
+        expect_status_response("Service unavailable", std::string("configuration ") + test_case.name +
+                                                              " has value 0, but the minimum allowed value is 1");
+        EXPECT_EQ(nullptr, rejected.request->handler_ctx());
+
+        config::lake_dump_tablet_metadata_per_request_memory_limit_bytes = 256LL << 20;
+        config::lake_dump_tablet_metadata_per_request_json_size_limit_bytes = 32LL << 20;
+        config::lake_dump_tablet_metadata_max_concurrency = 1;
+        auto accepted = valid_request(&action);
+        EXPECT_EQ(0, action.on_header(accepted.request.get()));
+        EXPECT_NE(nullptr, accepted.request->handler_ctx());
+    }
+}
+
+TEST_F(DumpTabletMetadataActionTest, ReturnsCacheScopeErrorWhenDurableMetadataIsNotCached) {
+    constexpr int64_t kTabletId = 11979;
+    constexpr int64_t kVersion = 23;
+    put_metadata(kTabletId, kVersion);
+    const std::string key = _tablet_manager->tablet_metadata_location(kTabletId, kVersion);
+    _tablet_manager->metacache()->erase(key);
+    ASSERT_EQ(nullptr, _tablet_manager->metacache()->lookup_tablet_metadata(key));
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    auto request = valid_request(&action, std::to_string(kTabletId), std::to_string(kVersion));
+
+    ScopedDiagnosticLogSink logs;
+    ASSERT_EQ(0, action.on_header(request.request.get()));
+    action.handle(request.request.get());
+
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+    expect_cache_miss_response();
+    expect_json_content_type_without_diagnostic_headers(request.ev_req);
+    EXPECT_TRUE(logs.sink().contains("result=Not found: tablet metadata is not cached on this compute node",
+                                     "elapsed_ms="));
+}
+
+TEST_F(DumpTabletMetadataActionTest, ReportsRequestedAndCachedIdentityWhenCachedMetadataDoesNotMatch) {
+    constexpr int64_t kRequestedTabletId = 11979;
+    constexpr int64_t kRequestedVersion = 23;
+    constexpr int64_t kCachedTabletId = 11980;
+    constexpr int64_t kCachedVersion = 24;
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    metadata->set_id(kCachedTabletId);
+    metadata->set_version(kCachedVersion);
+    _tablet_manager->metacache()->cache_tablet_metadata(
+            _tablet_manager->tablet_metadata_location(kRequestedTabletId, kRequestedVersion), metadata);
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    auto request = valid_request(&action, std::to_string(kRequestedTabletId), std::to_string(kRequestedVersion));
+
+    ASSERT_EQ(0, action.on_header(request.request.get()));
+    action.handle(request.request.get());
+
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+    expect_status_response(
+            "Corruption", "cached tablet metadata identity does not match the request: requested tablet_id=" +
+                                  std::to_string(kRequestedTabletId) + " version=" + std::to_string(kRequestedVersion) +
+                                  ", cached tablet_id=" + std::to_string(kCachedTabletId) +
+                                  " version=" + std::to_string(kCachedVersion));
+}
+
+TEST_F(DumpTabletMetadataActionTest, ReturnsDiagnosticUnavailableWhenNoTabletManagerExists) {
+    ScopedDeathTestStyle death_test_style;
+    ASSERT_EXIT(
+            {
+                StorageEnv::GetInstance()->destroy();
+                if (StorageEnv::GetInstance()->lake_tablet_manager() != nullptr) {
+                    _exit(1);
+                }
+                DumpTabletMetadataAction action(nullptr);
+                auto request = valid_request(&action);
+                if (action.on_header(request.request.get()) != 0) {
+                    _exit(1);
+                }
+                action.handle(request.request.get());
+                _exit(g_response_status == HttpStatus::OK &&
+                                      g_response_body ==
+                                              R"({"status":"Service unavailable","message":"lake tablet manager is unavailable on this compute node"})"
+                              ? 0
+                              : 1);
+            },
+            ::testing::ExitedWithCode(0), "");
+}
+
+TEST_F(DumpTabletMetadataActionTest, ReturnsInternalErrorWhenHandlerContextIsMissing) {
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    SyntheticRequest request(&action);
+
+    action.handle(request.request.get());
+
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+    expect_status_response("Internal error", "tablet metadata diagnostic request context is missing");
+}
+
+TEST_F(DumpTabletMetadataActionTest, AppliesMutableConcurrencyLimitToNewAdmissionsUntilRequestFree) {
+    DumpTabletMetadataAction action(nullptr, _tablet_manager.get());
+    config::lake_dump_tablet_metadata_max_concurrency = 1;
+    auto first = std::make_unique<SyntheticRequest>(valid_request(&action));
+    ASSERT_EQ(0, action.on_header(first->request.get()));
+    action.handle(first->request.get());
+
+    ScopedDiagnosticLogSink logs;
+    auto second = valid_request(&action);
+    EXPECT_EQ(-1, action.on_header(second.request.get()));
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+    expect_status_response("Resource busy",
+                           "tablet metadata diagnostic has 1 active requests, reaching the configured maximum of 1");
+    EXPECT_EQ(nullptr, second.request->handler_ctx());
+    expect_json_content_type_without_diagnostic_headers(second.ev_req);
+    EXPECT_TRUE(logs.sink().contains("result=Resource busy", "elapsed_ms="));
+
+    config::lake_dump_tablet_metadata_max_concurrency = 2;
+    auto third = std::make_unique<SyntheticRequest>(valid_request(&action));
+    EXPECT_EQ(0, action.on_header(third->request.get()));
+    EXPECT_NE(nullptr, third->request->handler_ctx());
+
+    config::lake_dump_tablet_metadata_max_concurrency = 1;
+    auto fourth = valid_request(&action);
+    EXPECT_EQ(-1, action.on_header(fourth.request.get()));
+    EXPECT_EQ(HttpStatus::OK, g_response_status);
+    expect_status_response("Resource busy",
+                           "tablet metadata diagnostic has 2 active requests, reaching the configured maximum of 1");
+
+    first.reset();
+    auto fifth = valid_request(&action);
+    EXPECT_EQ(-1, action.on_header(fifth.request.get()));
+
+    third.reset();
+    auto sixth = valid_request(&action);
+    EXPECT_EQ(0, action.on_header(sixth.request.get()));
+    EXPECT_NE(nullptr, sixth.request->handler_ctx());
+}
+
+} // namespace
+} // namespace starrocks::lake

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -86,6 +86,33 @@ This topic introduces the following types of BE configurations:
 - Description: The reader's remote I/O buffer size for cloud-native table compaction in a shared-data cluster. The default value is 1MB. You can increase this value to accelerate compaction process.
 - Introduced in: v3.2.3
 
+### lake_dump_tablet_metadata_per_request_memory_limit_bytes
+
+- Default: 268435456
+- Type: Long
+- Unit: Bytes
+- Is mutable: Yes
+- Description: The tracked memory budget for synchronous allocations made while processing one `/api/cloudnative/dump_tablet_metadata` request on a CN. It uses the standard MemTracker accounting granularity rather than enforcing a byte-exact ceiling. It covers metadata inspection, sensitive-field redaction, and JSON serialization, but not the metadata already stored in the CN metadata cache or the asynchronous HTTP output buffer. Each request uses the value captured when it is admitted. If this value is less than or equal to `0`, new requests fail closed.
+- Introduced in: v26.2
+
+### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
+
+- Default: 33554432
+- Type: Long
+- Unit: Bytes
+- Is mutable: Yes
+- Description: The maximum size of the complete JSON response for one `/api/cloudnative/dump_tablet_metadata` request. The size is checked before the response is handed to the HTTP output buffer. Each request uses the value captured when it is admitted. If this value is less than or equal to `0`, new requests fail closed.
+- Introduced in: v26.2
+
+### lake_dump_tablet_metadata_max_concurrency
+
+- Default: 1
+- Type: Int
+- Unit: Requests
+- Is mutable: Yes
+- Description: The maximum number of `/api/cloudnative/dump_tablet_metadata` requests admitted concurrently on one CN. A request continues to occupy one slot until its HTTP request is released. Increasing the value applies immediately to new requests. Decreasing it does not cancel admitted requests, and new requests are rejected until the active count is below the new limit. If this value is less than or equal to `0`, new requests fail closed.
+- Introduced in: v26.2
+
 ### lake_enable_del_file_crc_check
 
 - Default: true

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -93,7 +93,7 @@ This topic introduces the following types of BE configurations:
 - Unit: Bytes
 - Is mutable: Yes
 - Description: The tracked memory budget for synchronous allocations made while processing one `/api/cloudnative/dump_tablet_metadata` request on a CN. It uses the standard MemTracker accounting granularity rather than enforcing a byte-exact ceiling. It covers metadata inspection, sensitive-field redaction, and JSON serialization, but not the metadata already stored in the CN metadata cache or the asynchronous HTTP output buffer. Each request uses the value captured when it is admitted. If this value is less than or equal to `0`, new requests fail closed.
-- Introduced in: v26.2
+- Introduced in: v4.2
 
 ### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
 
@@ -102,7 +102,7 @@ This topic introduces the following types of BE configurations:
 - Unit: Bytes
 - Is mutable: Yes
 - Description: The maximum size of the complete JSON response for one `/api/cloudnative/dump_tablet_metadata` request. The size is checked before the response is handed to the HTTP output buffer. Each request uses the value captured when it is admitted. If this value is less than or equal to `0`, new requests fail closed.
-- Introduced in: v26.2
+- Introduced in: v4.2
 
 ### lake_dump_tablet_metadata_max_concurrency
 
@@ -111,7 +111,7 @@ This topic introduces the following types of BE configurations:
 - Unit: Requests
 - Is mutable: Yes
 - Description: The maximum number of `/api/cloudnative/dump_tablet_metadata` requests admitted concurrently on one CN. A request continues to occupy one slot until its HTTP request is released. Increasing the value applies immediately to new requests. Decreasing it does not cancel admitted requests, and new requests are rejected until the active count is below the new limit. If this value is less than or equal to `0`, new requests fail closed.
-- Introduced in: v26.2
+- Introduced in: v4.2
 
 ### lake_enable_del_file_crc_check
 

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -86,6 +86,33 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 共有データクラスタでのクラウドネイティブテーブルコンパクションのためのリーダーのリモート I/O バッファサイズ。デフォルト値は 1MB です。この値を増やすことでコンパクションプロセスを加速できます。
 - 導入バージョン: v3.2.3
 
+### lake_dump_tablet_metadata_per_request_memory_limit_bytes
+
+- デフォルト: 268435456
+- タイプ: Long
+- 単位: バイト
+- 変更可能: はい
+- 説明: CN が 1 件の `/api/cloudnative/dump_tablet_metadata` リクエストを同期処理するときの追跡対象メモリ予算です。バイト単位の厳密な上限ではなく、標準の MemTracker の集計粒度を使用します。メタデータの検査、機密フィールドのマスキング、JSON シリアライズを対象としますが、CN のメタデータキャッシュに既に格納されているメタデータと非同期 HTTP 出力バッファは対象外です。各リクエストは受付時に取得した値を使用します。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
+- 導入バージョン: v26.2
+
+### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
+
+- デフォルト: 33554432
+- タイプ: Long
+- 単位: バイト
+- 変更可能: はい
+- 説明: 1 件の `/api/cloudnative/dump_tablet_metadata` リクエストが返す完全な JSON レスポンスの最大バイト数です。HTTP 出力バッファへ渡す前にサイズを検査します。各リクエストは受付時に取得した値を使用します。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
+- 導入バージョン: v26.2
+
+### lake_dump_tablet_metadata_max_concurrency
+
+- デフォルト: 1
+- タイプ: Int
+- 単位: リクエスト
+- 変更可能: はい
+- 説明: 1 台の CN で同時に受け付ける `/api/cloudnative/dump_tablet_metadata` リクエスト数の上限です。各リクエストは HTTP request が解放されるまで 1 スロットを使用します。値を増やすと新しいリクエストに直ちに反映されます。値を減らしても受付済みのリクエストはキャンセルされず、アクティブ数が新しい上限未満になるまで新しいリクエストは拒否されます。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
+- 導入バージョン: v26.2
+
 ### lake_enable_del_file_crc_check
 
 - デフォルト: true

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -93,7 +93,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: バイト
 - 変更可能: はい
 - 説明: CN が 1 件の `/api/cloudnative/dump_tablet_metadata` リクエストを同期処理するときの追跡対象メモリ予算です。バイト単位の厳密な上限ではなく、標準の MemTracker の集計粒度を使用します。メタデータの検査、機密フィールドのマスキング、JSON シリアライズを対象としますが、CN のメタデータキャッシュに既に格納されているメタデータと非同期 HTTP 出力バッファは対象外です。各リクエストは受付時に取得した値を使用します。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
-- 導入バージョン: v26.2
+- 導入バージョン: v4.2
 
 ### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
 
@@ -102,7 +102,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: バイト
 - 変更可能: はい
 - 説明: 1 件の `/api/cloudnative/dump_tablet_metadata` リクエストが返す完全な JSON レスポンスの最大バイト数です。HTTP 出力バッファへ渡す前にサイズを検査します。各リクエストは受付時に取得した値を使用します。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
-- 導入バージョン: v26.2
+- 導入バージョン: v4.2
 
 ### lake_dump_tablet_metadata_max_concurrency
 
@@ -111,7 +111,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: リクエスト
 - 変更可能: はい
 - 説明: 1 台の CN で同時に受け付ける `/api/cloudnative/dump_tablet_metadata` リクエスト数の上限です。各リクエストは HTTP request が解放されるまで 1 スロットを使用します。値を増やすと新しいリクエストに直ちに反映されます。値を減らしても受付済みのリクエストはキャンセルされず、アクティブ数が新しい上限未満になるまで新しいリクエストは拒否されます。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
-- 導入バージョン: v26.2
+- 導入バージョン: v4.2
 
 ### lake_enable_del_file_crc_check
 

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -83,6 +83,33 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：存算分离集群 Compaction 任务在远程 FS 读 I/O 阶段的 Buffer 大小。默认值为 1MB。您可以适当增大该配置项取值以加速 Compaction 任务。
 - 引入版本：v3.2.3
 
+### lake_dump_tablet_metadata_per_request_memory_limit_bytes
+
+- 默认值：268435456
+- 类型：Long
+- 单位：Bytes
+- 是否动态：是
+- 描述：CN 同步处理单个 `/api/cloudnative/dump_tablet_metadata` 请求时的受跟踪内存预算。该预算使用标准 MemTracker 统计粒度，并非精确到字节的硬上限。该限制覆盖元数据检查、敏感字段脱敏和 JSON 序列化，但不包含 CN 元数据缓存中已存在的元数据，也不包含异步 HTTP 输出缓冲区。每个请求使用其被接纳时读取到的配置值。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
+- 引入版本：v26.2
+
+### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
+
+- 默认值：33554432
+- 类型：Long
+- 单位：Bytes
+- 是否动态：是
+- 描述：单个 `/api/cloudnative/dump_tablet_metadata` 请求完整 JSON 响应的最大字节数。响应交给 HTTP 输出缓冲区之前会检查该限制。每个请求使用其被接纳时读取到的配置值。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
+- 引入版本：v26.2
+
+### lake_dump_tablet_metadata_max_concurrency
+
+- 默认值：1
+- 类型：Int
+- 单位：请求
+- 是否动态：是
+- 描述：单个 CN 上可同时接纳的 `/api/cloudnative/dump_tablet_metadata` 请求数上限。请求在其 HTTP request 被释放之前一直占用一个并发名额。调大配置会立即影响新请求；调小配置不会取消已接纳的请求，在活跃请求数降到新上限以下之前会拒绝新请求。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
+- 引入版本：v26.2
+
 ### lake_enable_del_file_crc_check
 
 - 默认值：true

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -90,7 +90,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：Bytes
 - 是否动态：是
 - 描述：CN 同步处理单个 `/api/cloudnative/dump_tablet_metadata` 请求时的受跟踪内存预算。该预算使用标准 MemTracker 统计粒度，并非精确到字节的硬上限。该限制覆盖元数据检查、敏感字段脱敏和 JSON 序列化，但不包含 CN 元数据缓存中已存在的元数据，也不包含异步 HTTP 输出缓冲区。每个请求使用其被接纳时读取到的配置值。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
-- 引入版本：v26.2
+- 引入版本：v4.2
 
 ### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
 
@@ -99,7 +99,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：Bytes
 - 是否动态：是
 - 描述：单个 `/api/cloudnative/dump_tablet_metadata` 请求完整 JSON 响应的最大字节数。响应交给 HTTP 输出缓冲区之前会检查该限制。每个请求使用其被接纳时读取到的配置值。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
-- 引入版本：v26.2
+- 引入版本：v4.2
 
 ### lake_dump_tablet_metadata_max_concurrency
 
@@ -108,7 +108,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：请求
 - 是否动态：是
 - 描述：单个 CN 上可同时接纳的 `/api/cloudnative/dump_tablet_metadata` 请求数上限。请求在其 HTTP request 被释放之前一直占用一个并发名额。调大配置会立即影响新请求；调小配置不会取消已接纳的请求，在活跃请求数降到新上限以下之前会拒绝新请求。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
-- 引入版本：v26.2
+- 引入版本：v4.2
 
 ### lake_enable_del_file_crc_check
 

--- a/test/sql/test_dump_tablet_metadata/R/test_dump_tablet_metadata
+++ b/test/sql/test_dump_tablet_metadata/R/test_dump_tablet_metadata
@@ -1,0 +1,34 @@
+-- name: test_dump_tablet_metadata_cache_local_reads @cloud @sequential
+CREATE DATABASE db_${uuid0};
+-- result:
+-- !result
+USE db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE standalone_meta (k INT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num"="1", "file_bundling"="false",
+           "light_weight_tablet_creation"="true");
+-- result:
+-- !result
+CREATE TABLE bundled_meta (k INT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num"="1", "file_bundling"="true",
+           "light_weight_tablet_creation"="true");
+-- result:
+-- !result
+INSERT INTO standalone_meta VALUES (1);
+-- result:
+-- !result
+INSERT INTO bundled_meta VALUES (1);
+-- result:
+-- !result
+shell: env mysql_cmd="${mysql_cmd}" database=db_${uuid0} bash ${root_path}/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
+-- result:
+0
+non_bundled=PASS
+bundled=PASS
+-- !result
+CLEANUP {
+    DROP DATABASE IF EXISTS ${db[0]} FORCE;
+} END CLEANUP

--- a/test/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
+++ b/test/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
@@ -1,8 +1,31 @@
 #!/usr/bin/env bash
 
+# Shared-data CI workers may appear in SHOW BACKENDS, SHOW COMPUTE NODES, or both.
+# Match test/lib/sr_sql_lib.py::_get_backend_http_endpoints and identify columns by
+# header name so added SHOW columns do not shift IP/HttpPort/Alive.
+collect_endpoints() {
+    {
+        ${mysql_cmd} -e "SHOW BACKENDS"
+        ${mysql_cmd} -e "SHOW COMPUTE NODES"
+    } | awk -F '\t' '
+        $1 == "BackendId" || $1 == "ComputeNodeId" {
+            ip = http = alive = 0
+            for (i = 1; i <= NF; i++) {
+                if ($i == "IP") ip = i
+                if ($i == "HttpPort") http = i
+                if ($i == "Alive") alive = i
+            }
+            next
+        }
+        ip && http && alive && $alive == "true" && $ip != "" && $http != "" {
+            print $ip ":" $http
+        }
+    ' | sort -u
+}
+
 check_table() {
     local table=$1
-    local tablet_id version endpoints endpoint attempt
+    local tablet_id version endpoints endpoint attempt body
 
     tablet_id=$(${mysql_cmd} -D"${database}" -e "SHOW TABLETS FROM ${table} LIMIT 1" | awk -F '\t' '
         NR == 1 {
@@ -21,16 +44,34 @@ check_table() {
         }
     ')
     version=$(${mysql_cmd} -Ne "SELECT VISIBLE_VERSION FROM information_schema.partitions_meta WHERE DB_NAME='${database}' AND TABLE_NAME='${table}' LIMIT 1")
-    [ -n "${tablet_id}" ] && [ -n "${version}" ] || return 1
+    tablet_id=${tablet_id//$'\r'/}
+    version=${version//$'\r'/}
+    if [ -z "${tablet_id}" ] || [ -z "${version}" ]; then
+        echo "failed to resolve tablet metadata identity: table=${table} tablet_id='${tablet_id}' version='${version}'" >&2
+        return 1
+    fi
 
     for attempt in $(seq 1 10); do
-        ${mysql_cmd} -D"${database}" -Ne "SELECT COUNT(*) FROM ${table}" >/dev/null || return 1
-        endpoints=$(${mysql_cmd} -Ne "SHOW COMPUTE NODES" | awk -F '\t' '$9 == "true" { print $2 ":" $5 }')
+        # A real predicate scan loads lake tablet metadata into the CN metacache.
+        # COUNT(*) can be rewritten to a meta-scan/FE stats path and may not cache
+        # the versioned key this API looks up. Parallel CI can also evict the cache
+        # left behind by INSERT, so refresh it immediately before the dump.
+        ${mysql_cmd} -D"${database}" -Ne "SELECT k FROM ${table} WHERE k = 1" >/dev/null || return 1
+        endpoints=$(collect_endpoints)
         for endpoint in ${endpoints}; do
-            curl -fsS --connect-timeout 1 --max-time 3 -u root: "http://${endpoint}/api/cloudnative/dump_tablet_metadata/${tablet_id}?version=${version}" |
-                jq -e '.status == "OK"' >/dev/null && return 0
+            body=$(curl -sS --connect-timeout 2 --max-time 10 -u root: \
+                "http://${endpoint}/api/cloudnative/dump_tablet_metadata/${tablet_id}?version=${version}" || true)
+            echo "${body}" | jq -e '.status == "OK"' >/dev/null && return 0
         done
         [ "${attempt}" -eq 10 ] || sleep 1
+    done
+
+    echo "dump_tablet_metadata cache miss: table=${table} tablet_id=${tablet_id} version=${version} endpoints=${endpoints:-<none>}" >&2
+    for endpoint in ${endpoints}; do
+        echo "response from ${endpoint}:" >&2
+        curl -sS --connect-timeout 2 --max-time 10 -u root: \
+            "http://${endpoint}/api/cloudnative/dump_tablet_metadata/${tablet_id}?version=${version}" >&2 || true
+        echo >&2
     done
     return 1
 }

--- a/test/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
+++ b/test/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+check_table() {
+    local table=$1
+    local tablet_id version endpoints endpoint attempt
+
+    tablet_id=$(${mysql_cmd} -D"${database}" -e "SHOW TABLETS FROM ${table} LIMIT 1" | awk -F '\t' '
+        NR == 1 {
+            for (i = 1; i <= NF; i++) {
+                if ($i == "TabletId") column = i
+            }
+            if (column == 0) {
+                print "TabletId column not found" > "/dev/stderr"
+                exit 1
+            }
+            next
+        }
+        NR == 2 {
+            print $column
+            exit
+        }
+    ')
+    version=$(${mysql_cmd} -Ne "SELECT VISIBLE_VERSION FROM information_schema.partitions_meta WHERE DB_NAME='${database}' AND TABLE_NAME='${table}' LIMIT 1")
+    [ -n "${tablet_id}" ] && [ -n "${version}" ] || return 1
+
+    for attempt in $(seq 1 10); do
+        ${mysql_cmd} -D"${database}" -Ne "SELECT COUNT(*) FROM ${table}" >/dev/null || return 1
+        endpoints=$(${mysql_cmd} -Ne "SHOW COMPUTE NODES" | awk -F '\t' '$9 == "true" { print $2 ":" $5 }')
+        for endpoint in ${endpoints}; do
+            curl -fsS --connect-timeout 1 --max-time 3 -u root: "http://${endpoint}/api/cloudnative/dump_tablet_metadata/${tablet_id}?version=${version}" |
+                jq -e '.status == "OK"' >/dev/null && return 0
+        done
+        [ "${attempt}" -eq 10 ] || sleep 1
+    done
+    return 1
+}
+
+check_table standalone_meta && echo non_bundled=PASS &&
+    check_table bundled_meta && echo bundled=PASS

--- a/test/sql/test_dump_tablet_metadata/T/test_dump_tablet_metadata
+++ b/test/sql/test_dump_tablet_metadata/T/test_dump_tablet_metadata
@@ -1,0 +1,18 @@
+-- name: test_dump_tablet_metadata_cache_local_reads @cloud @sequential
+
+CREATE DATABASE db_${uuid0};
+USE db_${uuid0};
+CREATE TABLE standalone_meta (k INT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num"="1", "file_bundling"="false",
+           "light_weight_tablet_creation"="true");
+CREATE TABLE bundled_meta (k INT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES("replication_num"="1", "file_bundling"="true",
+           "light_weight_tablet_creation"="true");
+INSERT INTO standalone_meta VALUES (1);
+INSERT INTO bundled_meta VALUES (1);
+shell: env mysql_cmd="${mysql_cmd}" database=db_${uuid0} bash ${root_path}/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
+CLEANUP {
+    DROP DATABASE IF EXISTS ${db[0]} FORCE;
+} END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

The existing `/api/cloudnative/dump_tablet_metadata` diagnostic endpoint lists metadata objects in object storage and returns every metadata version found for a tablet. This combines metadata discovery, remote I/O, parsing, and response generation in one endpoint, which makes its cost and output difficult to bound.

Diagnostic APIs will increasingly be called by agents, so this endpoint should provide one narrow and predictable capability: inspect an exact tablet metadata version only when it is already present in the selected CN's in-memory metadata cache. Durable metadata discovery and inspection remain available through the AWS CLI and `meta_tool`.

## What I'm doing:

- Change the request contract to:

 ```text
 GET /api/cloudnative/dump_tablet_metadata/{TabletId}?version=<positive-int64>
 ```

- Look up only the exact `(tablet_id, version)` key in the current CN's in-memory metadata cache.
- Do not list metadata versions, read StarOS or object storage, contact the FE, or fall back to another CN.
- Reject unsupported query parameters such as `pretty` and `is_bundle`.
- Return compact JSON with `status` and `message`; successful responses additionally contain `metadata`.
- Recursively remove populated protobuf fields whose names contain `encryption_meta` before serialization. The cached protobuf is copied only when redaction is needed.
- Add mutable per-CN safeguards:
 - `lake_dump_tablet_metadata_per_request_memory_limit_bytes` (default: 256 MiB)
 - `lake_dump_tablet_metadata_per_request_json_size_limit_bytes` (default: 32 MiB)
 - `lake_dump_tablet_metadata_max_concurrency` (default: 1)
- Preserve the existing authentication behavior and `OPERATE` privilege requirement.
- Add focused BE tests, a cloud SQL chain test for both `file_bundling=false` and `file_bundling=true`, and synchronized EN/JA/ZH configuration documentation.

This is an intentional behavior and interface change. The previous endpoint enumerated object-storage metadata and returned an array, while the new endpoint returns one exact cache-local metadata object. The `pretty` option and object-storage reads are removed.

Application responses produced by this handler use HTTP 200; callers inspect `status` and `message`. Authentication is performed by the existing HTTP authentication layer before the handler and keeps its existing HTTP status behavior.

## Example:

Request an exact metadata version from a selected CN:

```bash
curl -u root: \
 'http://cn-host:8040/api/cloudnative/dump_tablet_metadata/12345?version=2'
```

A representative cache-hit response is shown below. It is formatted and shortened for readability; the endpoint emits compact JSON, and optional protobuf fields vary by table and tablet history.

```json
{
 "status": "OK",
 "message": "",
 "metadata": {
 "id": 12345,
 "version": 2,
 "schema": {
 "id": 10001
 },
 "rowsets": [
 {
 "id": 1,
 "num_rows": 10,
 "data_size": 1024
 }
 ]
 }
}
```

Unset protobuf fields and empty repeated fields are omitted. If encryption metadata is present, those fields are removed from the serialized copy and are not included in the response.

If the exact version is not cached on the selected CN, the handler returns HTTP 200 with an actionable cache-scope error:

```json
{
 "status": "Not found",
 "message": "tablet metadata is not cached on this compute node; this API only inspects the current compute node's in-memory metadata cache. To inspect metadata in object storage, download the file with the AWS CLI and parse it with meta_tool"
}
```

## Testing:

- Focused BE action and serializer tests: 15/15 passed.
- The existing `OPERATE` privilege test passed in focused BE coverage.
- A full shared-data FE+BE build passed earlier in the branch. The final BE/CN rebuild also passed after the latest BE changes: `./build.sh --be --without-java-ext --enable-shared-data --with-compress-debug-symbol OFF -j 30`.
- Focused cloud SQL integration passed against a freshly deployed CN: one case, `Ran 1 test`, `OK`; it exercised both `file_bundling=false` and `file_bundling=true` tables.
- `git diff --check` and the SQL helper's `bash -n` syntax check passed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
 - [x] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5