### PR TITLE
[BugFix] Expose colocate group scheduling sample knobs in FE

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/FE_parameters/shared_lake_other.md
@@ -605,6 +605,42 @@ This topic introduces the following types of FE configurations:
 - Description:
 - Introduced in: -
 
+### `lake_scheduler_enable_colocate_group_sample`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether the tablet scheduler estimates a large colocate group's replica distribution by sampling its tablets, instead of scanning every tablet in the group. When a tablet that belongs to a colocate group is scheduled, the scheduler builds a per-Compute Node replica histogram over the whole group to decide where the new replica goes. For a group with tens of thousands of tablets, that full scan dominates the scheduling cost, even though a healthy colocate group is uniformly placed and every tablet in it reports the same signal. When this item is set to `true`, the scheduler instead draws `lake_scheduler_colocate_group_sample_size` random tablets from any group larger than `lake_scheduler_colocate_group_sample_threshold` and scales the sampled per-Compute Node counts up to the full group size. A healthy, fully placed colocate group has all of its tablets on the same Compute Nodes, so the sample reproduces the true distribution exactly; a group that is mid-rebalance incurs a bounded error that at worst produces a sub-optimal (never invalid) placement, which the background tablet balancer later reconciles. Only colocate groups are sampled. Set this item to `false` to always scan every tablet.
+- Introduced in: v4.1.5
+
+### `lake_scheduler_colocate_group_sample_threshold`
+
+- Default: 256
+- Type: Int
+- Unit: Count
+- Is mutable: Yes
+- Description: The minimum number of tablets a colocate group must exceed before the scheduler samples it. Groups at or below this size are always scanned in full, because the full scan is already cheap and sampling would only add error. This item takes effect only when `lake_scheduler_enable_colocate_group_sample` is set to `true`.
+- Introduced in: v4.1.5
+
+### `lake_scheduler_colocate_group_sample_size`
+
+- Default: 128
+- Type: Int
+- Unit: Count
+- Is mutable: Yes
+- Description: The number of tablets sampled when a colocate group exceeds `lake_scheduler_colocate_group_sample_threshold`. A larger sample reduces the estimation error for a skewed (mid-rebalance) group but costs more per scheduling decision, so it trades scheduling latency for placement precision. The value should stay well below `lake_scheduler_colocate_group_sample_threshold`, otherwise sampling saves little over a full scan. This item takes effect only when `lake_scheduler_enable_colocate_group_sample` is set to `true`.
+- Introduced in: v4.1.5
+
+### `lake_scheduler_colocate_group_sample_empty_fallback_percent`
+
+- Default: 40
+- Type: Int
+- Unit: Percent
+- Is mutable: Yes
+- Description: The density guard for colocate group sampling, expressed as the maximum tolerated percentage of empty draws. A sampled tablet is an empty draw when it holds no replica on a candidate Compute Node, that is, it is not placed yet or is not on that Compute Node. If more than this percentage of the sample is empty, the group is too sparsely placed for the sample to represent its true distribution, which is what happens while a group is still bulk filling from empty, so the scheduler discards the sample and falls back to a full scan. Equivalently, the sample is trusted only when at least (100 - this value)% of the sampled tablets are placed on a candidate Compute Node, so a lower value is more conservative and demands a denser group before sampling. A stable, fully placed group yields close to 0% empty draws and always takes the fast sampled path regardless of this value, so this item only governs the bulk-fill transient. Set it to `100` to never fall back. This item takes effect only when `lake_scheduler_enable_colocate_group_sample` is set to `true`.
+- Introduced in: v4.1.5
+
 ## Data Lake
 
 ### `files_enable_insert_push_down_column_type`

--- a/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/FE_parameters/shared_lake_other.md
@@ -606,6 +606,42 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description:
 - 導入時期：-
 
+### `lake_scheduler_enable_colocate_group_sample`
+
+- デフォルト：true
+- タイプ：Boolean
+- 単位：-
+- 変更可能：Yes
+- 説明：tablet スケジューラが大規模な colocate group のレプリカ分布を、group 内の全 tablet を走査する代わりに tablet のサンプリングによって推定するかどうか。colocate group に属する tablet をスケジュールする際、スケジューラは新しいレプリカの配置先を決めるために group 全体に対して Compute Node ごとのレプリカヒストグラムを構築します。数万個の tablet を含む group では、この全走査がスケジューリングコストの大部分を占めますが、正常な colocate group は均一に配置されており、その中のどの tablet も同じシグナルを返します。この項目が `true` に設定されている場合、スケジューラは `lake_scheduler_colocate_group_sample_threshold` を超える group について `lake_scheduler_colocate_group_sample_size` 個の tablet をランダムに抽出し、サンプリングした Compute Node ごとの件数を group 全体のサイズに線形にスケールアップします。正常で完全に配置された colocate group は全 tablet が同じ Compute Node 上にあるため、サンプルは真の分布を正確に再現します。リバランス中の group では誤差が生じますが、その誤差は有界であり、最悪でも準最適 (不正ではない) な配置になるだけで、バックグラウンドの tablet バランサーが後から調整します。サンプリングの対象は colocate group のみです。常に全 tablet を走査するには `false` に設定します。
+- 導入時期：v4.1.5
+
+### `lake_scheduler_colocate_group_sample_threshold`
+
+- デフォルト：256
+- タイプ：Int
+- 単位：Count
+- 変更可能：Yes
+- 説明：colocate group がサンプリングの対象になるために超えている必要がある tablet 数。このサイズ以下の group は常に全走査されます。全走査のコストがもともと低く、サンプリングは誤差を増やすだけだからです。この項目は `lake_scheduler_enable_colocate_group_sample` が `true` に設定されている場合にのみ有効です。
+- 導入時期：v4.1.5
+
+### `lake_scheduler_colocate_group_sample_size`
+
+- デフォルト：128
+- タイプ：Int
+- 単位：Count
+- 変更可能：Yes
+- 説明：colocate group が `lake_scheduler_colocate_group_sample_threshold` を超えたときにサンプリングされる tablet の数。サンプル数を増やすとリバランス中で偏った group に対する推定誤差は小さくなりますが、スケジューリング判断ごとのコストが増えるため、配置精度とスケジューリング遅延のトレードオフになります。この値は `lake_scheduler_colocate_group_sample_threshold` より十分に小さく保つべきです。そうでないと全走査に対する削減効果がほとんどなくなります。この項目は `lake_scheduler_enable_colocate_group_sample` が `true` に設定されている場合にのみ有効です。
+- 導入時期：v4.1.5
+
+### `lake_scheduler_colocate_group_sample_empty_fallback_percent`
+
+- デフォルト：40
+- タイプ：Int
+- 単位：Percent
+- 変更可能：Yes
+- 説明：colocate group サンプリングの密度ガードで、許容される空サンプルの最大割合をパーセントで表します。抽出された tablet が候補 Compute Node 上にレプリカを持たない場合 (まだ配置されていない、またはその Compute Node 上にない場合)、その抽出は空サンプルとみなされます。空サンプルの割合がこのパーセンテージを超える場合、その group は配置が疎すぎてサンプルが真の分布を表せない (group が空の状態から一括で埋められている最中に起こります) ため、スケジューラはサンプルを破棄して全走査にフォールバックします。言い換えると、抽出された tablet の少なくとも (100 - この値)% が候補 Compute Node 上に配置されている場合にのみサンプルが信頼されます。したがって値が小さいほど保守的になり、サンプリングを行うためにより密な group が必要になります。安定して完全に配置された group は空サンプルがほぼ 0% になり、この値にかかわらず常に高速なサンプリング経路を通るため、この項目は一括充填中の過渡期のみを制御します。フォールバックを完全に無効にするには `100` に設定します。この項目は `lake_scheduler_enable_colocate_group_sample` が `true` に設定されている場合にのみ有効です。
+- 導入時期：v4.1.5
+
 ## データレイク
 
 ### `files_enable_insert_push_down_column_type`

--- a/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/FE_parameters/shared_lake_other.md
@@ -606,6 +606,42 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述:
 - 引入版本: -
 
+### `lake_scheduler_enable_colocate_group_sample`
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: Tablet 调度器是否通过抽样 Tablet 来估算大型 Colocate Group 的副本分布，而不是扫描该 Group 中的全部 Tablet。调度一个属于 Colocate Group 的 Tablet 时，调度器需要在整个 Group 上构建各 Compute Node 的副本直方图，以决定新副本的落点。对于包含数万个 Tablet 的 Group，这次全量扫描会成为调度开销的主要来源，而健康的 Colocate Group 本身分布均匀，其中每个 Tablet 给出的信号都相同。当该配置项设置为 `true` 时，对于 Tablet 数超过 `lake_scheduler_colocate_group_sample_threshold` 的 Group，调度器改为随机抽取 `lake_scheduler_colocate_group_sample_size` 个 Tablet，并将抽样得到的各 Compute Node 计数按 Group 实际大小等比放大。健康且已完全放置的 Colocate Group，其全部 Tablet 位于相同的 Compute Node 上，因此抽样结果与真实分布完全一致；正在均衡中的 Group 会引入有界误差，最坏情况下只会产生次优（而非非法）的放置，后续由后台 Tablet 均衡流程修正。抽样仅适用于 Colocate Group。设置为 `false` 表示始终扫描全部 Tablet。
+- 引入版本: v4.1.5
+
+### `lake_scheduler_colocate_group_sample_threshold`
+
+- 默认值: 256
+- 类型: Int
+- 单位: 个
+- 是否可变: Yes
+- 描述: Colocate Group 的 Tablet 数超过该值后才会被抽样。Tablet 数不超过该值的 Group 始终全量扫描，因为此时全量扫描本身开销很低，抽样只会额外引入误差。该配置项仅在 `lake_scheduler_enable_colocate_group_sample` 设置为 `true` 时生效。
+- 引入版本: v4.1.5
+
+### `lake_scheduler_colocate_group_sample_size`
+
+- 默认值: 128
+- 类型: Int
+- 单位: 个
+- 是否可变: Yes
+- 描述: 当 Colocate Group 的 Tablet 数超过 `lake_scheduler_colocate_group_sample_threshold` 时，抽样的 Tablet 数量。抽样数越大，对分布倾斜（正在均衡中）的 Group 估算误差越小，但每次调度决策的开销也越高，即以调度延迟换取放置精度。该值应明显小于 `lake_scheduler_colocate_group_sample_threshold`，否则抽样相比全量扫描节省有限。该配置项仅在 `lake_scheduler_enable_colocate_group_sample` 设置为 `true` 时生效。
+- 引入版本: v4.1.5
+
+### `lake_scheduler_colocate_group_sample_empty_fallback_percent`
+
+- 默认值: 40
+- 类型: Int
+- 单位: 百分比
+- 是否可变: Yes
+- 描述: Colocate Group 抽样的密度保护阈值，以允许的最大空采样百分比表示。如果某个被抽中的 Tablet 在候选 Compute Node 上没有副本（尚未放置，或不在该 Compute Node 上），则该次采样为空采样。当空采样占比超过该百分比时，说明该 Group 放置过于稀疏，抽样结果无法代表其真实分布（Group 正在从空状态批量填充时即为此种情况），调度器会丢弃本次抽样并回退到全量扫描。换言之，只有当至少 (100 - 该值)% 的抽样 Tablet 已放置在候选 Compute Node 上时，抽样结果才被采信，因此该值越小越保守，要求 Group 更稠密才允许抽样。稳定且已完全放置的 Group 空采样比例接近 0%，无论该值为多少都会走抽样快路径，因此该配置项只影响批量填充的过渡阶段。设置为 `100` 表示永不回退。该配置项仅在 `lake_scheduler_enable_colocate_group_sample` 设置为 `true` 时生效。
+- 引入版本: v4.1.5
+
 ## 数据湖
 
 ### `files_enable_insert_push_down_column_type`

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3824,6 +3824,31 @@ public class Config extends ConfigBase {
                     "if f > lake_balance_tablets_threshold, balancing will be triggered. Default: 0.15")
     public static double lake_balance_tablets_threshold = 0.15;
 
+    @ConfField(mutable = true, comment =
+            "Whether the tablet scheduler estimates a large colocate group's replica distribution " +
+                    "from a random sample of its tablets instead of scanning every tablet, which " +
+                    "markedly cuts the per-schedule cost in shared-data clusters. Default: true")
+    public static boolean lake_scheduler_enable_colocate_group_sample = true;
+
+    @ConfField(mutable = true, comment =
+            "A colocate group is sampled only when it holds more than this many tablets. Takes " +
+                    "effect only when lake_scheduler_enable_colocate_group_sample is true. " +
+                    "Default: 256")
+    public static int lake_scheduler_colocate_group_sample_threshold = 256;
+
+    @ConfField(mutable = true, comment =
+            "Number of tablets sampled when a colocate group exceeds " +
+                    "lake_scheduler_colocate_group_sample_threshold. Larger values reduce the " +
+                    "sampling error at a higher scan cost. Default: 128")
+    public static int lake_scheduler_colocate_group_sample_size = 128;
+
+    @ConfField(mutable = true, comment =
+            "Density guard for colocate group sampling: if more than this percentage of the sampled " +
+                    "tablets hold no replica on a candidate compute node, the group is too sparsely " +
+                    "placed for the sample to be representative, so the scheduler discards it and " +
+                    "falls back to a full scan. Lower is more conservative. Default: 40")
+    public static int lake_scheduler_colocate_group_sample_empty_fallback_percent = 40;
+
     /**
      * Default lake compaction txn timeout
      */

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -168,6 +168,11 @@ public class StarMgrServer {
         com.staros.util.Config.ENABLE_BALANCE_SHARD_NUM_BETWEEN_WORKERS = Config.lake_enable_balance_tablets_between_workers;
         com.staros.util.Config.BALANCE_WORKER_SHARDS_THRESHOLD_IN_PERCENT = Config.lake_balance_tablets_threshold;
         com.staros.util.Config.SHARD_DEAD_REPLICA_EXPIRE_SECS = (int) Config.tablet_sched_be_down_tolerate_time_s;
+        com.staros.util.Config.SCHEDULER_ENABLE_PACK_GROUP_SAMPLE = Config.lake_scheduler_enable_colocate_group_sample;
+        com.staros.util.Config.SCHEDULER_PACK_GROUP_SAMPLE_THRESHOLD = Config.lake_scheduler_colocate_group_sample_threshold;
+        com.staros.util.Config.SCHEDULER_PACK_GROUP_SAMPLE_SIZE = Config.lake_scheduler_colocate_group_sample_size;
+        com.staros.util.Config.SCHEDULER_PACK_GROUP_SAMPLE_EMPTY_FALLBACK_PERCENT =
+                Config.lake_scheduler_colocate_group_sample_empty_fallback_percent;
 
         grpcExecutor = ThreadPoolManager.newDaemonFixedThreadPool(Config.starmgr_grpc_server_max_worker_threads,
                         Integer.MAX_VALUE, "starmgr-grpc-default-executor", true);
@@ -184,6 +189,11 @@ public class StarMgrServer {
             com.staros.util.Config.ENABLE_BALANCE_SHARD_NUM_BETWEEN_WORKERS = Config.lake_enable_balance_tablets_between_workers;
             com.staros.util.Config.BALANCE_WORKER_SHARDS_THRESHOLD_IN_PERCENT = Config.lake_balance_tablets_threshold;
             com.staros.util.Config.SHARD_DEAD_REPLICA_EXPIRE_SECS = (int) Config.tablet_sched_be_down_tolerate_time_s;
+            com.staros.util.Config.SCHEDULER_ENABLE_PACK_GROUP_SAMPLE = Config.lake_scheduler_enable_colocate_group_sample;
+            com.staros.util.Config.SCHEDULER_PACK_GROUP_SAMPLE_THRESHOLD = Config.lake_scheduler_colocate_group_sample_threshold;
+            com.staros.util.Config.SCHEDULER_PACK_GROUP_SAMPLE_SIZE = Config.lake_scheduler_colocate_group_sample_size;
+            com.staros.util.Config.SCHEDULER_PACK_GROUP_SAMPLE_EMPTY_FALLBACK_PERCENT =
+                    Config.lake_scheduler_colocate_group_sample_empty_fallback_percent;
             ThreadPoolManager.setFixedThreadPoolSize(grpcExecutor, Config.starmgr_grpc_server_max_worker_threads);
         });
         // set the following config, in order to provide a customized worker group definition


### PR DESCRIPTION
StarOS a4b57161 taught the shard scheduler to estimate a large colocate group's replica distribution from a random sample of its members instead of scanning every one, which removes the full-group scan that dominated per-schedule cost for groups holding tens of thousands of tablets. The four controls it added live in StarMgr's own Config, so nothing could reach them from a running cluster.

Mirror them as mutable FE configs and push the values into StarMgr both at StarMgrServer startup and from the ConfigRefreshDaemon listener, so ADMIN SET FRONTEND CONFIG lands within the daemon's 10s interval. The scheduler reads each value per scheduling call rather than caching it, so a mid-flight change takes effect on the next tablet scheduled.

Two deliberate deviations from the upstream definitions. First, lake_scheduler_enable_colocate_group_sample defaults to true where StarOS ships false: sampling only engages above 256 members, and the density guard falls back to a full scan while a group is still bulk filling, so the residual exposure is a large mid-rebalance group where the worst case is a sub-optimal placement the background balancer later reconciles. The remaining three keep the upstream defaults. Second, the FE names and descriptions use colocate group, tablet and Compute Node rather than StarOS's PACK group, shard and worker; PACK, EXCLUDE and SPREAD are internal placement policies that carry no meaning at the FE boundary, so StarMgrServer is the only place the two vocabularies meet.

Document all four in the en, zh and ja shared-data parameter references, including why a healthy group samples exactly, what a mid-rebalance group risks, and which direction of the density guard is conservative.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5