### PR TITLE
[BugFix] metric: Add a BE metric for NotFound lake tablet metadata reads

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -58,11 +58,7 @@
 #include "storage/metadata_util.h"
 #include "storage/protobuf_file.h"
 #include "storage/rowset/segment.h"
-<<<<<<< HEAD
-=======
-#include "storage/storage_env.h"
 #include "storage/storage_metrics.h"
->>>>>>> 83a7e8c49f3 ([BugFix] metric: Add a BE metric for NotFound lake tablet metadata reads (#60948))
 #include "storage/tablet_schema_map.h"
 #include "storage/utils.h"
 #include "storage_primitive/tablet_basic_info.h"

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -58,6 +58,11 @@
 #include "storage/metadata_util.h"
 #include "storage/protobuf_file.h"
 #include "storage/rowset/segment.h"
+<<<<<<< HEAD
+=======
+#include "storage/storage_env.h"
+#include "storage/storage_metrics.h"
+>>>>>>> 83a7e8c49f3 ([BugFix] metric: Add a BE metric for NotFound lake tablet metadata reads (#60948))
 #include "storage/tablet_schema_map.h"
 #include "storage/utils.h"
 #include "storage_primitive/tablet_basic_info.h"
@@ -92,6 +97,10 @@ static Status save_lake_protobuf(const std::string& path, const ::google::protob
 
 // Load a lake metadata/txn-log protobuf. Auto-detects the checksummed header format and
 // falls back to legacy headerless protobuf, regardless of lake_enable_protobuf_file_checksum.
+//
+// This is the unmetered loader, correct for txn logs. To read a tablet metadata object,
+// call TabletManager::load_tablet_metadata_file_with_meter instead, or
+// lake_tablet_metadata_get_not_found_total will under-report.
 static Status load_lake_protobuf(const std::string& path, ::google::protobuf::Message* message, bool fill_cache,
                                  const std::shared_ptr<FileSystem>& fs = nullptr) {
     ProtobufFileWithHeader file(path, fs, LAKE_META_HEADER_MAGIC_NUMBER, /*allow_plain_protobuf_fallback=*/true);
@@ -728,13 +737,13 @@ StatusOr<TabletMetadataPtr> TabletManager::load_tablet_metadata(const string& me
     TEST_ERROR_POINT("TabletManager::load_tablet_metadata");
     auto t0 = butil::gettimeofday_us();
     auto metadata = std::make_shared<TabletMetadataPB>();
-    auto s = load_lake_protobuf(metadata_location, metadata.get(), fill_data_cache, fs);
+    auto s = load_tablet_metadata_file_with_meter(metadata_location, metadata.get(), fill_data_cache, fs);
     if (!s.ok()) {
         RETURN_IF_ERROR(corrupted_tablet_meta_handler(s, metadata_location));
         // reset metadata
         metadata = std::make_shared<TabletMetadataPB>();
-        // read again
-        RETURN_IF_ERROR(load_lake_protobuf(metadata_location, metadata.get(), fill_data_cache, fs));
+        // read again, into the freshly allocated metadata
+        RETURN_IF_ERROR(load_tablet_metadata_file_with_meter(metadata_location, metadata.get(), fill_data_cache, fs));
     }
 
     // Back-fill segment_metas from the deprecated legacy arrays for rowsets written by a
@@ -934,17 +943,37 @@ StatusOr<BundleTabletMetadataPtr> TabletManager::parse_bundle_tablet_metadata(co
     return bundle_metadata;
 }
 
+Status TabletManager::load_tablet_metadata_file_with_meter(const std::string& path, TabletMetadataPB* metadata,
+                                                           bool fill_cache, const std::shared_ptr<FileSystem>& fs) {
+    auto status = load_lake_protobuf(path, metadata, fill_cache, fs);
+    if (status.is_not_found()) {
+        StorageMetrics::instance()->lake_tablet_metadata_get_not_found_total.increment(1);
+    }
+    return status;
+}
+
+StatusOr<std::string> TabletManager::read_bundle_metadata_file_with_meter(FileSystem* fs, const std::string& path,
+                                                                          bool skip_fill_local_cache) {
+    RandomAccessFileOptions opts{.skip_fill_local_cache = skip_fill_local_cache};
+    auto read_result = [&]() -> StatusOr<std::string> {
+        ASSIGN_OR_RETURN(auto input_file, fs->new_random_access_file(opts, path));
+        return input_file->read_all();
+    }();
+    if (!read_result.ok() && read_result.status().is_not_found()) {
+        StorageMetrics::instance()->lake_tablet_metadata_get_not_found_total.increment(1);
+    }
+    return read_result;
+}
+
 StatusOr<TabletMetadataPtrs> TabletManager::get_metas_from_bundle_tablet_metadata(const std::string& location,
                                                                                   FileSystem* input_fs) {
-    std::unique_ptr<RandomAccessFile> input_file;
-    RandomAccessFileOptions opts{.skip_fill_local_cache = true};
+    std::shared_ptr<FileSystem> owned_fs;
     if (input_fs == nullptr) {
-        ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(location));
-        ASSIGN_OR_RETURN(input_file, fs->new_random_access_file(opts, location));
-    } else {
-        ASSIGN_OR_RETURN(input_file, input_fs->new_random_access_file(opts, location));
+        ASSIGN_OR_RETURN(owned_fs, FileSystemFactory::CreateSharedFromString(location));
+        input_fs = owned_fs.get();
     }
-    ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
+    ASSIGN_OR_RETURN(auto serialized_string,
+                     read_bundle_metadata_file_with_meter(input_fs, location, /*skip_fill_local_cache=*/true));
 
     auto file_size = serialized_string.size();
     ASSIGN_OR_RETURN(auto bundle_metadata, TabletManager::parse_bundle_tablet_metadata(location, serialized_string));
@@ -1008,20 +1037,20 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     } else {
         file_system = fs;
     }
-    RandomAccessFileOptions opts{.skip_fill_local_cache = !cache_opts.fill_data_cache};
     // TODO(zhangqiang)
     // `read_all` only need to one api call and not increase the IOPS
     // but it will incur additional IO bandwidth overhead
     // Perhaps we need to consider the additional costs of IO bandwidth and IOPS later.
     g_read_bundle_tablet_meta_cnt << 1;
     auto t0 = butil::gettimeofday_us();
+    auto read_bundle_metadata_from_remote = [&]() -> StatusOr<std::string> {
+        g_read_bundle_tablet_meta_real_access_cnt << 1;
+        return read_bundle_metadata_file_with_meter(file_system.get(), path,
+                                                    /*skip_fill_local_cache=*/!cache_opts.fill_data_cache);
+    };
     // use real path as key, so that every tablet can share a same path of bundle tablet meta.
     ASSIGN_OR_RETURN(auto serialized_string,
-                     _bundle_tablet_metadata_group.Do(real_path, [&]() -> StatusOr<std::string> {
-                         g_read_bundle_tablet_meta_real_access_cnt << 1;
-                         ASSIGN_OR_RETURN(auto input_file, file_system->new_random_access_file(opts, path));
-                         return input_file->read_all();
-                     }));
+                     _bundle_tablet_metadata_group.Do(real_path, read_bundle_metadata_from_remote));
     g_read_bundle_tablet_meta_latency << (butil::gettimeofday_us() - t0);
 
     auto file_size = serialized_string.size();
@@ -1030,8 +1059,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     if (!bundle_metadata_status.ok()) {
         RETURN_IF_ERROR(corrupted_tablet_meta_handler(bundle_metadata_status.status(), path));
         // read bundle metadata again
-        ASSIGN_OR_RETURN(auto input_file, file_system->new_random_access_file(opts, path));
-        ASSIGN_OR_RETURN(serialized_string, input_file->read_all());
+        ASSIGN_OR_RETURN(serialized_string, read_bundle_metadata_from_remote());
         file_size = serialized_string.size();
         ASSIGN_OR_RETURN(bundle_metadata, parse_bundle_tablet_metadata(path, serialized_string));
     } else {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -151,6 +151,21 @@ public:
     static StatusOr<BundleTabletMetadataPtr> parse_bundle_tablet_metadata(const std::string& path,
                                                                           const std::string& serialized_string);
 
+    // A lake tablet's metadata lives in exactly one of two remote locations, never in
+    // both: its own metadata object, or a bundle file shared with the other tablets of
+    // an aggregated partition. The two `_with_meter` helpers below are the only
+    // sanctioned way to read either location; both record NotFound outcomes into
+    // lake_tablet_metadata_get_not_found_total. Reading a tablet metadata file through
+    // anything else makes that metric silently under-report.
+    //
+    // Note that txn logs deliberately do NOT go through these: they share the underlying
+    // protobuf loader but are not tablet metadata, so they must stay unmetered.
+    static Status load_tablet_metadata_file_with_meter(const std::string& path, TabletMetadataPB* metadata,
+                                                       bool fill_cache, const std::shared_ptr<FileSystem>& fs);
+
+    static StatusOr<std::string> read_bundle_metadata_file_with_meter(FileSystem* fs, const std::string& path,
+                                                                      bool skip_fill_local_cache);
+
     static StatusOr<TabletMetadataPtrs> get_metas_from_bundle_tablet_metadata(const std::string& location,
                                                                               FileSystem* input_fs = nullptr);
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1470,11 +1470,10 @@ static bool can_bundle_meta_file_to_be_deleted(const BundleTabletMetaState& stat
 
 static StatusOr<BundleTabletMetaState> check_bundle_tablet_meta_state(
         const std::string& meta_path, const std::vector<int64_t>& to_delete_tablet_ids) {
-    RandomAccessFileOptions opts{.skip_fill_local_cache = true};
     ASSIGN_OR_RETURN(auto fs, FileSystemFactory::CreateSharedFromString(meta_path));
-    ASSIGN_OR_RETURN(auto input_file, fs->new_random_access_file(opts, meta_path));
     // Read the entire file content into a string.
-    ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
+    ASSIGN_OR_RETURN(auto serialized_string, TabletManager::read_bundle_metadata_file_with_meter(
+                                                     fs.get(), meta_path, /*skip_fill_local_cache=*/true));
     // Parse the bundle tablet metadata from the serialized string.
     ASSIGN_OR_RETURN(auto bundle_metadata, TabletManager::parse_bundle_tablet_metadata(meta_path, serialized_string));
     bool shared_meta_contains_deleted_tablet = false;

--- a/be/src/storage/storage_metrics.cpp
+++ b/be/src/storage/storage_metrics.cpp
@@ -107,6 +107,7 @@ void StorageMetrics::install(MetricRegistry* registry) {
     REGISTER_ENGINE_REQUEST_METRIC(lake_add_index, failed, lake_add_index_requests_failed);
     REGISTER_ENGINE_REQUEST_METRIC(lake_drop_index, total, lake_drop_index_requests_total);
     REGISTER_STORAGE_METRIC(lake_idg_files_written_total);
+    REGISTER_STORAGE_METRIC(lake_tablet_metadata_get_not_found_total);
     REGISTER_ENGINE_REQUEST_METRIC(base_compaction, total, base_compaction_request_total);
     REGISTER_ENGINE_REQUEST_METRIC(base_compaction, failed, base_compaction_request_failed);
     REGISTER_ENGINE_REQUEST_METRIC(cumulative_compaction, total, cumulative_compaction_request_total);

--- a/be/src/storage/storage_metrics.h
+++ b/be/src/storage/storage_metrics.h
@@ -113,6 +113,12 @@ public:
     METRIC_DEFINE_INT_COUNTER(lake_add_index_requests_failed, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(lake_drop_index_requests_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(lake_idg_files_written_total, MetricUnit::OPERATIONS);
+    // Counts remote lake tablet metadata read attempts that return NotFound,
+    // including each failed fallback attempt. A tablet's metadata lives either
+    // in its own metadata object or in a bundled metadata file, never in both,
+    // and reads of either location count. Replication reads of a source
+    // cluster and restore reads of a snapshot are not counted.
+    METRIC_DEFINE_INT_COUNTER(lake_tablet_metadata_get_not_found_total, MetricUnit::REQUESTS);
 
     METRIC_DEFINE_INT_COUNTER(base_compaction_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(base_compaction_request_failed, MetricUnit::REQUESTS);

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -40,6 +40,7 @@
 #include "storage/lake/update_manager.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/rowset/segment.h"
+#include "storage/storage_metrics.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 
@@ -1161,6 +1162,39 @@ TEST_F(LakeTabletManagerTest, get_tablet_metadata_skip_meta_cache_cache_only) {
     // Same contract on the single-tablet (bundle) read path.
     res = _tablet_manager->get_single_tablet_metadata(tablet_id, 2, skip_cache_opts);
     EXPECT_TRUE(res.status().is_not_found()) << res.status();
+}
+
+// Each remote metadata read that returns NotFound is counted, including
+// fallback reads; hits must leave the metric alone.
+TEST_F(LakeTabletManagerTest, get_tablet_metadata_not_found_metric) {
+    auto& not_found_metric = StorageMetrics::instance()->lake_tablet_metadata_get_not_found_total;
+    auto not_found_before = not_found_metric.value();
+
+    // A missing version 2 probes both the per-tablet metadata object and the
+    // bundled metadata fallback in remote storage.
+    auto res = _tablet_manager->get_tablet_metadata(next_id(), 2);
+    ASSERT_TRUE(res.status().is_not_found()) << res.status();
+    EXPECT_EQ(not_found_before + 2, not_found_metric.value());
+
+    auto metadata = std::make_shared<TabletMetadata>();
+    auto tablet_id = next_id();
+    metadata->set_id(tablet_id);
+    metadata->set_version(2);
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+    EXPECT_OK(_tablet_manager->get_tablet_metadata(tablet_id, 2).status());
+    EXPECT_EQ(not_found_before + 2, not_found_metric.value());
+}
+
+// The bundle file is the other location a tablet's metadata can live in, so the
+// bulk bundle reader used by vacuum shares the same accounting.
+TEST_F(LakeTabletManagerTest, get_metas_from_bundle_tablet_metadata_not_found_metric) {
+    auto& not_found_metric = StorageMetrics::instance()->lake_tablet_metadata_get_not_found_total;
+    auto not_found_before = not_found_metric.value();
+
+    auto missing_bundle = _tablet_manager->bundle_tablet_metadata_location(next_id(), 2);
+    auto res = lake::TabletManager::get_metas_from_bundle_tablet_metadata(missing_bundle);
+    ASSERT_TRUE(res.status().is_not_found()) << res.status();
+    EXPECT_EQ(not_found_before + 1, not_found_metric.value());
 }
 
 // With a durable copy present, skip_meta_cache reads it from storage (not the

--- a/be/test/storage/storage_metrics_test.cpp
+++ b/be/test/storage/storage_metrics_test.cpp
@@ -110,6 +110,9 @@ TEST(StorageMetricsTest, InstallRegistersLoadMetrics) {
 
     metrics.lake_idg_files_written_total.increment(47);
     assert_metric_value(&registry, "lake_idg_files_written_total", "47");
+
+    metrics.lake_tablet_metadata_get_not_found_total.increment(48);
+    assert_metric_value(&registry, "lake_tablet_metadata_get_not_found_total", "48");
 }
 
 TEST(StorageMetricsTest, InstallRegistersCompactionMetrics) {

--- a/docs/en/administration/management/monitoring/metric_details/s.md
+++ b/docs/en/administration/management/monitoring/metric_details/s.md
@@ -189,6 +189,12 @@ description: "Alphabetical s"
 - Type: Cumulative
 - Description: Total number of rows appended to `FlatJsonColumnWriter` (counted at `append()`, before actual flattening).
 
+## `starrocks_be_lake_tablet_metadata_get_not_found_total`
+
+- Unit: Count
+- Type: Cumulative
+- Description: Shared-data only. Total number of remote storage read attempts for lake tablet metadata that return `NotFound`. A tablet's metadata lives either in its own metadata object or inside a bundled metadata file, never in both, and reads of either location are counted, including the bundle reads issued by vacuum. Each failed fallback read is counted separately. Cache misses and successful reads do not increment this metric. Reads of a source cluster's metadata during replication and of snapshot metadata during restore are not counted.
+
 ## `starrocks_be_mem_pool_mem_limit_bytes`
 
 - Unit: Bytes

--- a/docs/ja/administration/management/monitoring/metric_details/s.md
+++ b/docs/ja/administration/management/monitoring/metric_details/s.md
@@ -183,6 +183,12 @@ description: "Alphabetical s"
 - タイプ: 累積値
 - 説明: `FlatJsonColumnWriter` に追加された行数（`append()` 時点でカウント、実際のフラット化の前）。
 
+## `starrocks_be_lake_tablet_metadata_get_not_found_total`
+
+- 単位: カウント
+- タイプ: 累積値
+- 説明: 共有データモード専用。Lake tablet metadata をリモートストレージから読み取り、`NotFound` が返された試行の総数。tablet の metadata は個別の metadata ファイルか bundle metadata ファイルのいずれか一方にのみ存在し、両方に存在することはありません。いずれの読み取りもカウント対象で、vacuum が発行する bundle 読み取りも含まれます。失敗したフォールバック読み取りはそれぞれ個別にカウントされます。キャッシュミスおよび読み取り成功時には、このメトリクスは増加しません。レプリケーションでのソースクラスタ metadata の読み取り、およびリストアでのスナップショット metadata の読み取りはカウントされません。
+
 ## `starrocks_be_mem_pool_mem_limit_bytes`
 
 - 単位: バイト

--- a/docs/zh/administration/management/monitoring/metric_details/s.md
+++ b/docs/zh/administration/management/monitoring/metric_details/s.md
@@ -209,6 +209,12 @@ description: "Alphabetical s"
 - 类型: 累积值
 - 描述: 进入 `FlatJsonColumnWriter` 的行数（在 `append()` 处统计，实际扁平化之前）。
 
+## `starrocks_be_lake_tablet_metadata_get_not_found_total`
+
+- 单位: 计数
+- 类型: 累积值
+- 描述: 仅存算分离模式。从远程存储读取 Lake Tablet 元数据时返回 `NotFound` 的尝试总数。Tablet 元数据要么存放在其独立的元数据文件中，要么存放在 Bundle 元数据文件中，二者必居其一且不会同时存在；对这两种位置的读取均会计入该指标，包括 Vacuum 流程发起的 Bundle 文件读取。每次失败的回退读取均会单独计数。缓存未命中和读取成功不会增加该指标。复制流程中对源集群元数据的读取、以及恢复流程中对快照元数据的读取不计入该指标。
+
 ## `starrocks_be_mem_pool_mem_limit_bytes`
 
 - 单位: 字节


### PR DESCRIPTION
## Conflict Info:  
UU be/src/storage/lake/tablet_manager.cpp
Add the cumulative counter lake_tablet_metadata_get_not_found_total and increment it from both remote read paths: the per-tablet metadata object load in TabletManager::load_tablet_metadata and the bundled metadata read in TabletManager::get_single_tablet_metadata.

Routing the bundle retry through that shared lambda also makes the retry increment lake_read_bundle_tablet_meta_real_access_cnt, which the previous inline read did not, so that counter now matches the number of remote reads actually issued.

Document the new metric in docs/en, docs/zh, and docs/ja.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5