### PR TITLE
[Tool] Select the rows, the column and the chunk size when dumping a segment

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -38,6 +38,7 @@
 #include <thrift/transport/TBufferTransports.h>
 #include <thrift/transport/TSocket.h>
 
+#include <charconv>
 #include <cinttypes>
 #include <fstream>
 #include <iostream>
@@ -70,6 +71,7 @@
 #include "gutil/strings/escaping.h"
 #include "gutil/strings/numbers.h"
 #include "gutil/strings/split.h"
+#include "gutil/strings/strip.h"
 #include "gutil/strings/substitute.h"
 #include "json2pb/pb_to_json.h"
 #include "platform/aws/aws_sdk_guard.h"
@@ -100,6 +102,7 @@
 #include "storage/tablet_meta.h"
 #include "storage/tablet_meta_manager.h"
 #include "storage_primitive/key_coder.h"
+#include "storage_primitive/range.h"
 #include "storage_primitive/storage_stats.h"
 #include "storage_primitive/zone_map_detail.h"
 #include "types/olap_type_infra.h"
@@ -145,6 +148,10 @@ DEFINE_string(pb_meta_path, "", "pb meta file path");
 DEFINE_string(tablet_file, "", "file to save a set of tablets");
 DEFINE_string(file, "", "segment file path");
 DEFINE_int32(column_index, -1, "column index");
+DEFINE_int32(chunk_size, 4096, "rows read per chunk (for dump_segment_data, dump_column_size, calc_checksum)");
+DEFINE_string(rows, "",
+              "rows to dump: comma-separated row ids and inclusive ranges, e.g. \"7,100-200,40000-\" "
+              "(for dump_segment_data)");
 DEFINE_int32(key_column_count, 0, "key column count");
 DEFINE_int64(expired_sec, 86400, "expired seconds");
 DEFINE_string(conf_file, "", "conf file path");
@@ -202,9 +209,14 @@ std::string get_usage(const std::string& progname) {
     show_segment_footer:
       {progname} --operation=show_segment_footer --file=</path/to/segment/file>
     dump_segment_data:
-      {progname} --operation=dump_segment_data --file=</path/to/segment/file>
+      {progname} --operation=dump_segment_data --file=</path/to/segment/file> [--column_index=<index>]
+               [--chunk_size=<rows>] [--rows=<row ids>]
+      (--rows takes a comma-separated list of row ids and inclusive ranges, where "7" is a single row,
+       "100-200" is 101 rows and "40000-" runs to row 40000 and every row after it. The list may be
+       unordered and may overlap, and spaces around its items are ignored. Every row is labelled with
+       its row id in the segment, so a full dump is labelled exactly as before.)
     dump_column_size:
-      {progname} --operation=dump_column_size --file=</path/to/segment/file>
+      {progname} --operation=dump_column_size --file=</path/to/segment/file> [--chunk_size=<rows>]
     print_pk_dump:
       {progname} --operation=print_pk_dump --file=</path/to/pk/dump/file>
     dump_short_key_index:
@@ -212,7 +224,8 @@ std::string get_usage(const std::string& progname) {
     dump_zonemap:
       {progname} --operation=dump_zonemap --file=</path/to/segment/file> [--column_index=<index>]
     calc_checksum:
-      {progname} --operation=calc_checksum [--column_index=<index>] --file=</path/to/segment/file>
+      {progname} --operation=calc_checksum [--column_index=<index>] [--chunk_size=<rows>]
+               --file=</path/to/segment/file>
     check_table_meta_consistency:
       {progname} --operation=check_table_meta_consistency --root_path=</path/to/storage/path> --table_id=<tableid>
     scan_dcgs:
@@ -943,6 +956,12 @@ void dump_ordinal_index(const std::string& file_name, const int32_t column_index
         return;
     }
 
+    if (column_index < 0 || column_index >= footer.columns_size()) {
+        std::cout << "invalid column_index " << column_index << ", segment has " << footer.columns_size() << " columns"
+                  << std::endl;
+        return;
+    }
+
     ColumnMetaPB column_meta = footer.columns(column_index);
     dump_ordinal_index(column_meta, input_file.get());
 
@@ -1154,7 +1173,11 @@ namespace starrocks {
 
 class SegmentDump {
 public:
-    SegmentDump(std::string path, int32_t column_index = -1) : _path(std::move(path)), _column_index(column_index) {}
+    SegmentDump(std::string path, int32_t column_index = -1, int32_t chunk_size = 4096, std::string row_spec = "")
+            : _path(std::move(path)),
+              _column_index(column_index),
+              _chunk_size(chunk_size),
+              _row_spec(std::move(row_spec)) {}
     ~SegmentDump() = default;
 
     Status dump_segment_data();
@@ -1191,6 +1214,8 @@ private:
     const size_t _max_short_key_size = 36;
     const size_t _max_short_key_col_cnt = 3;
     int32_t _column_index = 0;
+    int32_t _chunk_size = 4096;
+    std::string _row_spec;
 };
 
 std::shared_ptr<Schema> SegmentDump::_init_query_schema(const std::shared_ptr<TabletSchema>& tablet_schema) {
@@ -1375,6 +1400,7 @@ Status SegmentDump::calc_checksum() {
     SegmentReadOptions seg_opts;
     seg_opts.fs = _fs;
     seg_opts.use_page_cache = false;
+    seg_opts.chunk_size = _chunk_size;
     OlapReaderStatistics stats;
     seg_opts.stats = &stats;
     auto seg_res = _segment->new_iterator(schema, seg_opts);
@@ -1386,7 +1412,7 @@ Status SegmentDump::calc_checksum() {
 
     int64_t checksum = 0;
 
-    auto chunk = ChunkFactory::new_chunk(schema, config::vector_chunk_size);
+    auto chunk = ChunkFactory::new_chunk(schema, _chunk_size);
     st = seg_iter->get_next(chunk.get());
     while (st.ok()) {
         size_t size = chunk->num_rows();
@@ -1487,6 +1513,61 @@ Status SegmentDump::dump_short_key_index(size_t key_column_count) {
     return Status::OK();
 }
 
+StatusOr<rowid_t> parse_row_id(std::string_view text, rowid_t num_rows) {
+    rowid_t row_id = 0;
+    const char* text_end = text.data() + text.size();
+    auto [stop, ec] = std::from_chars(text.data(), text_end, row_id);
+    if (ec != std::errc() || stop != text_end) {
+        return Status::InvalidArgument(fmt::format("'{}' is not a row id", text));
+    }
+    if (row_id >= num_rows) {
+        return Status::InvalidArgument(fmt::format("row id {} is out of range, segment has {} rows", row_id, num_rows));
+    }
+    return row_id;
+}
+
+// Parses --rows into the row ids to dump. SparseRange sorts and merges what it is given, so an
+// unordered or overlapping list needs no preprocessing here.
+StatusOr<SparseRangePtr> parse_row_ranges(const std::string& spec, rowid_t num_rows) {
+    auto row_ids = std::make_shared<SparseRange<>>();
+    for (auto item : strings::Split(spec, ",", strings::SkipWhitespace())) {
+        StripWhiteSpace(&item);
+        std::string_view range(item);
+        const size_t dash = range.find('-');
+        if (dash == std::string_view::npos) {
+            auto only = parse_row_id(range, num_rows);
+            if (!only.ok()) {
+                return only.status();
+            }
+            row_ids->add(Range<>(only.value(), only.value() + 1));
+            continue;
+        }
+
+        auto first = parse_row_id(range.substr(0, dash), num_rows);
+        if (!first.ok()) {
+            return first.status();
+        }
+        // An open end, as in "40000-", runs to the last row of the segment.
+        rowid_t last = num_rows - 1;
+        std::string_view last_text = range.substr(dash + 1);
+        if (!last_text.empty()) {
+            auto given_last = parse_row_id(last_text, num_rows);
+            if (!given_last.ok()) {
+                return given_last.status();
+            }
+            last = given_last.value();
+        }
+        if (first.value() > last) {
+            return Status::InvalidArgument(fmt::format("row range {} starts after it ends", range));
+        }
+        row_ids->add(Range<>(first.value(), last + 1));
+    }
+    if (row_ids->empty()) {
+        return Status::InvalidArgument("no row id given");
+    }
+    return row_ids;
+}
+
 Status SegmentDump::dump_segment_data() {
     Status st = _init();
     if (!st.ok()) {
@@ -1495,12 +1576,37 @@ Status SegmentDump::dump_segment_data() {
     }
 
     // convert schema
-    auto schema = _init_query_schema(_tablet_schema);
+    // The default column index of -1 dumps every column.
+    std::shared_ptr<Schema> schema;
+    if (_column_index == -1) {
+        schema = _init_query_schema(_tablet_schema);
+    } else if (_column_index < 0 || _column_index >= static_cast<int32_t>(_tablet_schema->num_columns())) {
+        return Status::InvalidArgument(fmt::format("invalid column_index {}, segment has {} columns", _column_index,
+                                                   _tablet_schema->num_columns()));
+    } else {
+        schema = _init_query_schema_by_column_id(_tablet_schema, _column_index);
+    }
     SegmentReadOptions seg_opts;
     seg_opts.fs = _fs;
     seg_opts.use_page_cache = false;
+    // The iterator caps each get_next() at this many rows, so it is what --chunk_size has to reach.
+    seg_opts.chunk_size = _chunk_size;
     OlapReaderStatistics stats;
     seg_opts.stats = &stats;
+    const auto num_rows = static_cast<rowid_t>(_segment->num_rows());
+    SparseRangePtr rows_to_dump;
+    if (_row_spec.empty()) {
+        rows_to_dump = std::make_shared<SparseRange<>>(0, num_rows);
+    } else {
+        auto res = parse_row_ranges(_row_spec, num_rows);
+        if (!res.ok()) {
+            return res.status();
+        }
+        rows_to_dump = std::move(res).value();
+        // Restricting the scan range makes the column readers seek over the pages outside it.
+        seg_opts.rowid_range_option = rows_to_dump;
+    }
+
     auto seg_res = _segment->new_iterator(*schema, seg_opts);
     if (!seg_res.ok()) {
         std::cout << "new segment iterator failed: " << seg_res.status() << std::endl;
@@ -1509,8 +1615,10 @@ Status SegmentDump::dump_segment_data() {
     auto seg_iter = std::move(seg_res.value());
 
     // iter chunk
-    size_t row = 0;
-    auto chunk = ChunkFactory::new_chunk(*schema, 4096);
+    // The iterator returns the requested rows in ascending order, so walking the same ranges
+    // alongside it gives each row its row id in the segment.
+    SparseRangeIterator<> row_ids = rows_to_dump->new_iterator();
+    auto chunk = ChunkFactory::new_chunk(*schema, _chunk_size);
     do {
         st = seg_iter->get_next(chunk.get());
         if (!st.ok()) {
@@ -1521,9 +1629,18 @@ Status SegmentDump::dump_segment_data() {
             return st;
         }
 
-        for (size_t i = 0; i < chunk->num_rows(); i++) {
-            std::cout << "ROW: (" << row << "): " << chunk->debug_row(i) << std::endl;
-            row++;
+        size_t dumped = 0;
+        while (dumped < chunk->num_rows() && row_ids.has_more()) {
+            Range<> rows = row_ids.next(static_cast<rowid_t>(chunk->num_rows() - dumped));
+            for (rowid_t row_id = rows.begin(); row_id < rows.end(); row_id++) {
+                std::cout << "ROW: (" << row_id << "): " << chunk->debug_row(dumped) << std::endl;
+                dumped++;
+            }
+        }
+        if (dumped < chunk->num_rows()) {
+            std::cout << "the iterator returned " << chunk->num_rows() - dumped << " rows beyond the requested ones"
+                      << std::endl;
+            return Status::InternalError("more rows than requested");
         }
         chunk->reset();
     } while (true);
@@ -1549,6 +1666,7 @@ Status SegmentDump::dump_column_size() {
         SegmentReadOptions seg_opts;
         seg_opts.fs = _fs;
         seg_opts.use_page_cache = false;
+        seg_opts.chunk_size = _chunk_size;
         OlapReaderStatistics stats;
         seg_opts.stats = &stats;
 
@@ -1561,7 +1679,7 @@ Status SegmentDump::dump_column_size() {
             auto seg_iter = std::move(seg_res.value());
 
             // iter chunk
-            auto chunk = ChunkFactory::new_chunk(*schema, 4096);
+            auto chunk = ChunkFactory::new_chunk(*schema, _chunk_size);
             do {
                 st = seg_iter->get_next(chunk.get());
                 if (!st.ok()) {
@@ -1787,6 +1905,11 @@ int meta_tool_main(int argc, char** argv) {
         return -1;
     }
 
+    if (FLAGS_chunk_size <= 0) {
+        std::cout << "invalid chunk_size " << FLAGS_chunk_size << ", must be positive" << std::endl;
+        return -1;
+    }
+
     if (FLAGS_operation == "show_meta") {
         show_meta();
     } else if (FLAGS_operation == "batch_delete_meta") {
@@ -1839,7 +1962,7 @@ int meta_tool_main(int argc, char** argv) {
             std::cout << "no file flag for dump segment file" << std::endl;
             return -1;
         }
-        starrocks::SegmentDump segment_dump(FLAGS_file);
+        starrocks::SegmentDump segment_dump(FLAGS_file, FLAGS_column_index, FLAGS_chunk_size, FLAGS_rows);
         Status st = segment_dump.dump_segment_data();
         if (!st.ok()) {
             std::cout << "dump segment data failed: " << st << std::endl;
@@ -1850,7 +1973,7 @@ int meta_tool_main(int argc, char** argv) {
             std::cout << "no file flag for dump segment file" << std::endl;
             return -1;
         }
-        starrocks::SegmentDump segment_dump(FLAGS_file);
+        starrocks::SegmentDump segment_dump(FLAGS_file, /*column_index=*/-1, FLAGS_chunk_size);
         Status st = segment_dump.dump_column_size();
         if (!st.ok()) {
             std::cout << "dump column size failed: " << st << std::endl;
@@ -1907,7 +2030,7 @@ int meta_tool_main(int argc, char** argv) {
             std::cout << "no file flag for calc checksum" << std::endl;
             return -1;
         }
-        starrocks::SegmentDump segment_dump(FLAGS_file, FLAGS_column_index);
+        starrocks::SegmentDump segment_dump(FLAGS_file, FLAGS_column_index, FLAGS_chunk_size);
         Status st = segment_dump.calc_checksum();
         if (!st.ok()) {
             std::cout << "dump segment data failed: " << st.message() << std::endl;


### PR DESCRIPTION
## Why I'm doing:

Three gaps in `meta_tool`'s segment operations:

1. `dump_segment_data` always dumps every column and every row. Looking at one column, or at the rows around a suspect ordinal, means dumping the whole segment and grepping — and the scan reads every page of every column to produce output that is thrown away.
2. The rows-per-chunk is not settable. `dump_segment_data` and `dump_column_size` hardcode 4096; `calc_checksum` reads `config::vector_chunk_size`, which looks configurable but is not — `meta_tool` loads a conf file only for `lake_datafile_gc`, so it is always the compiled-in 4096.
3. `dump_ordinal_index` indexes the segment footer with `--column_index` without checking the range. In a release build protobuf's `DCHECK` is compiled out, so an out-of-range index reads past the repeated field: the tool dies with SIGSEGV and prints nothing, which reads like "the tool is broken" rather than "that column does not exist".

## What I'm doing:

- `dump_segment_data` honours `--column_index`. A valid index projects the read down to that column (via the existing `_init_query_schema_by_column_id`), and `-1` (the default) keeps dumping every column.
- New `--rows` on `dump_segment_data`: a comma-separated list of row ids and inclusive ranges, e.g. `7`, `100-200`, or `40000-` for row 40000 to the last one. The list may be unordered and may overlap — it becomes a `SparseRange`, which sorts and merges it, and is handed to `SegmentReadOptions::rowid_range_option`. The segment iterator intersects that with its scan range (`SegmentIterator::_get_row_ranges_by_rowid_range`), the same path intra-tablet parallel scan uses, so the pages outside the requested rows are never read.
- Rows are labelled with their row id in the segment instead of a running counter, walked with a `SparseRangeIterator` alongside the iterator. A full dump is labelled exactly as before.
- New `--chunk_size` (default 4096, validated once in `meta_tool_main`), threaded into `dump_segment_data`, `dump_column_size` and `calc_checksum`. It sets both the output chunk's capacity and `SegmentReadOptions::chunk_size`, which is what caps each `get_next()` — sizing only the output chunk leaves the read running in 4096-row batches. `calc_checksum`'s `config::vector_chunk_size` is replaced by it; the default is the same value, so behaviour without the flag is unchanged.
- `dump_ordinal_index` bounds-checks `--column_index` and prints `invalid column_index N, segment has M columns`, matching what `dump_page_footer` already does.
- Out-of-range rows and columns are rejected with the segment's row or column count, reported through the returned `Status` so a failure prints one line. `--help` documents the new flags on the operations that accept them.

Verified against three real segments written by a shared-data cluster and read with a locally built `starrocks_be meta_tool`.

A 5-row, 5-column segment (INT, INT, VARCHAR, DATE, DOUBLE):

- `--column_index=0 / 2 / 4` each dump exactly that column; the column identity was cross-checked against the tablet schema file and against the footer's column order decoded independently of this tool.
- `--rows=3`, `--rows=0,4`, `--rows=1-3`, `--rows=3-` and the unordered, overlapping `--rows=3-4,0,2-3` all select the expected rows, and compose with `--column_index`.
- Spaces around the items of `--rows` are ignored: `0, 2`, ` 1-2 `, a tab separator and `0,,2` all parse, and on the 50k-row segment `100-200,49999` and ` 100-200, 49999 ` dump byte-identical rows.
- Rejected with one line and rc=255: `--column_index=5`, `--column_index=-3`, `--rows=5`, `--rows=2-9`, `--rows=3-1`, `--rows=1,abc`, `--rows=,`, `--chunk_size=0`.
- `dump_ordinal_index --column_index=5 / 99 / 1000000`: SIGSEGV (rc=139, no output) before this change, `invalid column_index...` after. Measured by temporarily reverting only the bounds check and rebuilding.

A 50k-row segment, which exercises the many-read-batches path the 5-row one cannot:

- `--rows=100-200` returns 101 rows byte-identical to the corresponding slice of the full dump, and `--rows=49990-,0-9,25000` returns the 21 expected rows in row-id order.
- `dump_segment_data` returns the same 50000 rows with the same md5 at `--chunk_size` 7, 100, 4096 and 100000; `--rows=100-200` is identical at `--chunk_size` 1, 7 and 4096; `calc_checksum` returns the same checksum at 7, 100 and the default.
- The chunk size reaches the iterator: `calc_checksum` best-of-3 runtime is 43/45/46 ms at `--chunk_size=1/7/4096` without `SegmentReadOptions::chunk_size` set (flat — the flag did nothing) and 78/47/41 ms with it.

A 1M-row segment, where the cost of a row selection is visible: it does not depend on how many rows are asked for, or where they sit, so the pages outside the selection are skipped rather than read and filtered. 50 ms is this binary's start-up floor.

| command | best of 3 |
| --- | --- |
| full dump (1,000,000 rows) | 2355 ms |
| `--rows=0` | 51 ms |
| `--rows=999999` | 50 ms |
| `--rows=500000-500009` | 50 ms |
| `--rows=0-` (the whole segment again) | 2360 ms |

No test cases are added: `meta_tool` is a standalone binary driven through `starrocks_be meta_tool`, with no unit-test harness in `be/test`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5