### PR TITLE
[Enhancement] Let db_admin set warehouse properties

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/AuthorizationMgr.java
@@ -1881,6 +1881,51 @@ public class AuthorizationMgr {
         return new HashSet<>(getRoleNamesByRoleIds(resultSetIds));
     }
 
+    /**
+     * The role ids actually in effect for a session: the roles the user still owns, narrowed to the
+     * ones activated by `SET ROLE`, plus the roles mapped from `groups`, expanded over the role
+     * inheritance graph.
+     * <p>
+     * `activatedRoleIds` is what the session recorded when the roles were activated, and a role
+     * revoked since then is still listed there -- so it is re-checked against what the user owns
+     * right now. This mirrors steps 1 and 2 of {@link #loadPrivilegeCollection}; keep the two in
+     * sync.
+     */
+    public Set<Long> getEffectiveRoleIds(UserIdentity userIdentity, Set<String> groups, Set<Long> activatedRoleIds)
+            throws PrivilegeException {
+        // the user lock is held across the ownership snapshot and the expansion below: dropping it in
+        // between would let the two read incompatible states, so that a role revoked from the user and
+        // then granted `db_admin` still counts as inherited
+        userReadLock();
+        try {
+            Set<Long> validRoleIds;
+            if (userIdentity.isEphemeral()) {
+                // an ephemeral user owns no role of its own, so the activated set is all there is
+                validRoleIds = activatedRoleIds == null ? new HashSet<>() : new HashSet<>(activatedRoleIds);
+            } else {
+                validRoleIds = new HashSet<>(getUserPrivilegeCollectionUnlocked(userIdentity).getAllRoles());
+                if (activatedRoleIds != null) {
+                    validRoleIds.retainAll(activatedRoleIds);
+                }
+            }
+
+            if (groups != null) {
+                for (String group : groups) {
+                    validRoleIds.addAll(getRoleIdListByGroup(group));
+                }
+            }
+
+            roleReadLock();
+            try {
+                return getAllPredecessorRoleIdsUnlocked(validRoleIds);
+            } finally {
+                roleReadUnlock();
+            }
+        } finally {
+            userReadUnlock();
+        }
+    }
+
     public Set<String> getAllPredecessorRoleNamesByUser(UserIdentity userIdentity) throws PrivilegeException {
         Set<String> resultSet = new HashSet<>();
         getRoleIdsByUser(userIdentity).forEach(roleId -> resultSet.addAll(getAllPredecessorRoleNames(roleId)));

--- a/fe/fe-core/src/test/java/com/starrocks/epack/sql/analyzer/AlterWarehouseDbAdminPrivilegeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/epack/sql/analyzer/AlterWarehouseDbAdminPrivilegeTest.java
@@ -1,0 +1,169 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+
+package com.starrocks.epack.sql.analyzer;
+
+import com.google.common.collect.Sets;
+import com.starrocks.authorization.AuthorizationMgr;
+import com.starrocks.authorization.PrivilegeBuiltinConstants;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.ErrorReportException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+/**
+ * `db_admin` is exempted from the ALTER-on-warehouse check for `ALTER WAREHOUSE ... SET (...)`,
+ * so that a database administrator can tune warehouse properties without a cluster administrator.
+ *
+ * The exemption follows role inheritance, only counts roles the session actually activated, and
+ * must not leak into any other warehouse statement.
+ */
+public class AlterWarehouseDbAdminPrivilegeTest {
+    private static final String WAREHOUSE = WarehouseManager.DEFAULT_WAREHOUSE_NAME;
+
+    private static final String DIRECT_USER = "u_wh_db_admin";
+    private static final String NESTED_USER = "u_wh_nested";
+    private static final String PLAIN_USER = "u_wh_plain";
+    private static final String REVOKED_USER = "u_wh_revoked";
+
+    private static final String INNER_ROLE = "r_wh_inner";
+    private static final String OUTER_ROLE = "r_wh_outer";
+
+    private static ConnectContext ctx;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        ctx.setThreadLocalInfo();
+
+        // db_admin granted straight to the user
+        ddl("create user " + DIRECT_USER);
+        ddl("grant db_admin to user " + DIRECT_USER);
+
+        // db_admin reached through a chain of roles: outer -> inner -> db_admin
+        ddl("create user " + NESTED_USER);
+        ddl("create role " + INNER_ROLE);
+        ddl("create role " + OUTER_ROLE);
+        ddl("grant db_admin to role " + INNER_ROLE);
+        ddl("grant " + INNER_ROLE + " to role " + OUTER_ROLE);
+        ddl("grant " + OUTER_ROLE + " to user " + NESTED_USER);
+
+        // no warehouse-related role at all
+        ddl("create user " + PLAIN_USER);
+
+        // db_admin granted for now, revoked inside the test
+        ddl("create user " + REVOKED_USER);
+        ddl("grant db_admin to user " + REVOKED_USER);
+    }
+
+    @Test
+    public void testDbAdminMayAlterWarehouseProperties() throws Exception {
+        useUserWithAllRoles(DIRECT_USER);
+        checkPasses("alter warehouse " + WAREHOUSE + " set (\"compute_replica\" = \"2\")");
+        checkPasses("alter warehouse " + WAREHOUSE + " set (\"enable_query_queue\" = \"true\", " +
+                "\"query_queue_concurrency_limit\" = \"8\")");
+    }
+
+    @Test
+    public void testDbAdminMayAlterWarehouseSessionVariables() throws Exception {
+        useUserWithAllRoles(DIRECT_USER);
+        checkPasses("alter warehouse " + WAREHOUSE + " set (\"session.query_timeout\" = \"600\")");
+        checkPasses("alter warehouse " + WAREHOUSE + " set (\"session.query_timeout\" = \"600\", " +
+                "\"compute_replica\" = \"2\")");
+    }
+
+    @Test
+    public void testDbAdminInheritedThroughRoleChainIsAllowed() throws Exception {
+        useUserWithAllRoles(NESTED_USER);
+        checkPasses("alter warehouse " + WAREHOUSE + " set (\"compute_replica\" = \"2\")");
+    }
+
+    @Test
+    public void testDbAdminNotActivatedIsDenied() throws Exception {
+        // the user owns db_admin but activated no role at all, as after `SET ROLE NONE`
+        useUser(DIRECT_USER, Sets.newHashSet());
+        checkDenied("alter warehouse " + WAREHOUSE + " set (\"compute_replica\" = \"2\")");
+    }
+
+    @Test
+    public void testUserWithoutDbAdminIsDenied() throws Exception {
+        useUserWithAllRoles(PLAIN_USER);
+        checkDenied("alter warehouse " + WAREHOUSE + " set (\"compute_replica\" = \"2\")");
+        checkDenied("alter warehouse " + WAREHOUSE + " set (\"session.query_timeout\" = \"600\")");
+    }
+
+    @Test
+    public void testDbAdminRevokedMidSessionIsDenied() throws Exception {
+        useUserWithAllRoles(REVOKED_USER);
+        checkPasses("alter warehouse " + WAREHOUSE + " set (\"compute_replica\" = \"2\")");
+
+        // the session keeps listing db_admin as activated after the revoke, so the exemption has to
+        // re-check the roles the user still owns rather than trust the session's snapshot
+        Set<Long> staleRoleIds = ctx.getCurrentRoleIds();
+        Assertions.assertTrue(staleRoleIds.contains(PrivilegeBuiltinConstants.DB_ADMIN_ROLE_ID));
+
+        ctxAsRoot();
+        ddl("revoke db_admin from user " + REVOKED_USER);
+
+        useUser(REVOKED_USER, staleRoleIds);
+        checkDenied("alter warehouse " + WAREHOUSE + " set (\"compute_replica\" = \"2\")");
+    }
+
+    @Test
+    public void testExemptionDoesNotCoverOtherWarehouseStatements() throws Exception {
+        useUserWithAllRoles(DIRECT_USER);
+        // both need the very same ALTER-on-warehouse privilege the SET statement is exempted from
+        checkDenied("suspend warehouse " + WAREHOUSE);
+        checkDenied("resume warehouse " + WAREHOUSE);
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    private static void ddl(String sql) throws Exception {
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(sql, ctx), ctx);
+    }
+
+    private static void ctxAsRoot() {
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setQualifiedUser(UserIdentity.ROOT.getUser());
+        ctx.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+    }
+
+    /**
+     * Activate every role the user owns, which is what a login does when
+     * `activate_all_roles_on_login` is on.
+     */
+    private static void useUserWithAllRoles(String user) throws Exception {
+        UserIdentity identity = UserIdentity.createAnalyzedUserIdentWithIp(user, "%");
+        AuthorizationMgr authorizationMgr = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
+        useUser(user, authorizationMgr.getRoleIdsByUser(identity));
+    }
+
+    private static void useUser(String user, Set<Long> activatedRoleIds) {
+        ctx.setCurrentUserIdentity(UserIdentity.createAnalyzedUserIdentWithIp(user, "%"));
+        ctx.setQualifiedUser(user);
+        ctx.setCurrentRoleIds(activatedRoleIds);
+    }
+
+    private static void checkPasses(String sql) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        Authorizer.check(stmt, ctx);
+    }
+
+    private static void checkDenied(String sql) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        ErrorReportException e =
+                Assertions.assertThrows(ErrorReportException.class, () -> Authorizer.check(stmt, ctx), sql);
+        Assertions.assertTrue(e.getMessage().contains("Access denied"), e.getMessage());
+    }
+}

--- a/test/sql/test_rbac/R/test_alter_warehouse_db_admin
+++ b/test/sql/test_rbac/R/test_alter_warehouse_db_admin
@@ -1,0 +1,132 @@
+-- name: test_alter_warehouse_db_admin @native
+drop user if exists u_wh_db_admin;
+-- result:
+-- !result
+create user u_wh_db_admin;
+-- result:
+-- !result
+grant db_admin to user u_wh_db_admin;
+-- result:
+-- !result
+grant impersonate on user root to u_wh_db_admin;
+-- result:
+-- !result
+drop user if exists u_wh_nested;
+-- result:
+-- !result
+create user u_wh_nested;
+-- result:
+-- !result
+drop role if exists r_wh_inner;
+-- result:
+-- !result
+create role r_wh_inner;
+-- result:
+-- !result
+drop role if exists r_wh_outer;
+-- result:
+-- !result
+create role r_wh_outer;
+-- result:
+-- !result
+grant db_admin to role r_wh_inner;
+-- result:
+-- !result
+grant r_wh_inner to role r_wh_outer;
+-- result:
+-- !result
+grant r_wh_outer to user u_wh_nested;
+-- result:
+-- !result
+grant impersonate on user root to u_wh_nested;
+-- result:
+-- !result
+drop user if exists u_wh_plain;
+-- result:
+-- !result
+create user u_wh_plain;
+-- result:
+-- !result
+grant impersonate on user root to u_wh_plain;
+-- result:
+-- !result
+execute as u_wh_db_admin with no revert;
+-- result:
+-- !result
+set role all;
+-- result:
+-- !result
+alter warehouse default_warehouse set ("compute_replica" = "2");
+-- result:
+E: (5907, 'unsupported statement in shared_nothing mode')
+-- !result
+alter warehouse default_warehouse set ("session.query_timeout" = "600");
+-- result:
+E: (5907, 'unsupported statement in shared_nothing mode')
+-- !result
+alter warehouse default_warehouse set ("enable_query_queue" = "true", "session.pipeline_dop" = "8");
+-- result:
+E: (5907, 'unsupported statement in shared_nothing mode')
+-- !result
+suspend warehouse default_warehouse;
+-- result:
+E: (5203, 'Access denied; you need (at least one of) the ALTER privilege(s) on WAREHOUSE default_warehouse for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): [db_admin]. Inactivated role(s): NONE.')
+-- !result
+resume warehouse default_warehouse;
+-- result:
+E: (5203, 'Access denied; you need (at least one of) the ALTER privilege(s) on WAREHOUSE default_warehouse for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): [db_admin]. Inactivated role(s): NONE.')
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+execute as u_wh_db_admin with no revert;
+-- result:
+-- !result
+alter warehouse default_warehouse set ("compute_replica" = "2");
+-- result:
+E: (5203, 'Access denied; you need (at least one of) the ALTER privilege(s) on WAREHOUSE default_warehouse for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): [db_admin].')
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+execute as u_wh_nested with no revert;
+-- result:
+-- !result
+set role all;
+-- result:
+-- !result
+alter warehouse default_warehouse set ("compute_replica" = "2");
+-- result:
+E: (5907, 'unsupported statement in shared_nothing mode')
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+execute as u_wh_plain with no revert;
+-- result:
+-- !result
+set role all;
+-- result:
+-- !result
+alter warehouse default_warehouse set ("compute_replica" = "2");
+-- result:
+E: (5203, 'Access denied; you need (at least one of) the ALTER privilege(s) on WAREHOUSE default_warehouse for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): NONE. Inactivated role(s): NONE.')
+-- !result
+execute as root with no revert;
+-- result:
+-- !result
+drop user u_wh_db_admin;
+-- result:
+-- !result
+drop user u_wh_nested;
+-- result:
+-- !result
+drop user u_wh_plain;
+-- result:
+-- !result
+drop role r_wh_outer;
+-- result:
+-- !result
+drop role r_wh_inner;
+-- result:
+-- !result

--- a/test/sql/test_rbac/T/test_alter_warehouse_db_admin
+++ b/test/sql/test_rbac/T/test_alter_warehouse_db_admin
@@ -1,0 +1,57 @@
+-- name: test_alter_warehouse_db_admin @native
+drop user if exists u_wh_db_admin;
+create user u_wh_db_admin;
+grant db_admin to user u_wh_db_admin;
+grant impersonate on user root to u_wh_db_admin;
+
+drop user if exists u_wh_nested;
+create user u_wh_nested;
+drop role if exists r_wh_inner;
+create role r_wh_inner;
+drop role if exists r_wh_outer;
+create role r_wh_outer;
+grant db_admin to role r_wh_inner;
+grant r_wh_inner to role r_wh_outer;
+grant r_wh_outer to user u_wh_nested;
+grant impersonate on user root to u_wh_nested;
+
+drop user if exists u_wh_plain;
+create user u_wh_plain;
+grant impersonate on user root to u_wh_plain;
+
+-- with db_admin activated the ALTER-on-warehouse check is skipped, so the statement gets all the
+-- way to the shared-data-only guard instead of being rejected as access denied
+execute as u_wh_db_admin with no revert;
+set role all;
+alter warehouse default_warehouse set ("compute_replica" = "2");
+alter warehouse default_warehouse set ("session.query_timeout" = "600");
+alter warehouse default_warehouse set ("enable_query_queue" = "true", "session.pipeline_dop" = "8");
+
+-- the exemption is scoped to ALTER ... SET: every other warehouse statement still needs its own
+-- privilege, including the ones that ask for the very same ALTER on the warehouse
+suspend warehouse default_warehouse;
+resume warehouse default_warehouse;
+
+-- owning db_admin is not enough, the session has to have it activated
+execute as root with no revert;
+execute as u_wh_db_admin with no revert;
+alter warehouse default_warehouse set ("compute_replica" = "2");
+
+-- db_admin reached through a chain of roles counts as well
+execute as root with no revert;
+execute as u_wh_nested with no revert;
+set role all;
+alter warehouse default_warehouse set ("compute_replica" = "2");
+
+-- a user without db_admin is still rejected
+execute as root with no revert;
+execute as u_wh_plain with no revert;
+set role all;
+alter warehouse default_warehouse set ("compute_replica" = "2");
+
+execute as root with no revert;
+drop user u_wh_db_admin;
+drop user u_wh_nested;
+drop user u_wh_plain;
+drop role r_wh_outer;
+drop role r_wh_inner;


### PR DESCRIPTION
## Conflict Info:  
DU fe/fe-core/src/main/java/com/starrocks/epack/sql/analyzer/AuthorizerStmtVisitorEPack.java

### ⚠ modify/delete (DU): `fe/fe-core/src/main/java/com/starrocks/epack/sql/analyzer/AuthorizerStmtVisitorEPack.java`
<details><summary>content dropped by auto-resolve — verify it is ported to its new location</summary>

```
// Copyright 2021-present StarRocks, Inc. All rights reserved.

package com.starrocks.epack.sql.analyzer;

import com.starrocks.authorization.AccessDeniedException;
import com.starrocks.authorization.AuthorizationMgr;
import com.starrocks.authorization.ObjectType;
import com.starrocks.authorization.PrivilegeBuiltinConstants;
import com.starrocks.authorization.PrivilegeException;
import com.starrocks.authorization.PrivilegeType;
import com.starrocks.catalog.InternalCatalog;
import com.starrocks.common.util.PropertyAnalyzer;
import com.starrocks.epack.authorization.AuthorizerEPack;
import com.starrocks.epack.authorization.ObjectTypeEPack;
import com.starrocks.epack.authorization.PrivilegeTypeEPack;
import com.starrocks.epack.sql.ast.AlterFailoverGroupAddStmt;
import com.starrocks.epack.sql.ast.AlterFailoverGroupPrimaryStmt;
import com.starrocks.epack.sql.ast.AlterFailoverGroupRefreshStmt;
import com.starrocks.epack.sql.ast.AlterFailoverGroupRemoveStmt;
import com.starrocks.epack.sql.ast.AlterFailoverGroupResumeStmt;
import com.starrocks.epack.sql.ast.AlterFailoverGroupSetStmt;
import com.starrocks.epack.sql.ast.AlterFailoverGroupSuspendStmt;
import com.starrocks.epack.sql.ast.AlterPolicyStmt;
import com.starrocks.epack.sql.ast.AlterRoleMappingStatement;
import com.starrocks.epack.sql.ast.ApplyMaskingPolicyClause;
import com.starrocks.epack.sql.ast.ApplyRowAccessPolicyClause;
import com.starrocks.epack.sql.ast.AstVisitorEPack;
import com.starrocks.epack.sql.ast.CreatePasswordPolicyStmt;
import com.starrocks.epack.sql.ast.CreatePolicyStmt;
import com.starrocks.epack.sql.ast.CreatePrimaryFailoverGroupStmt;
import com.starrocks.epack.sql.ast.CreateRoleMappingStatement;
import com.starrocks.epack.sql.ast.CreateSecondaryFailoverGroupStmt;
import com.starrocks.epack.sql.ast.DescribeFailoverGroupStmt;
import com.starrocks.epack.sql.ast.DropFailoverGroupStmt;
import com.starrocks.epack.sql.ast.DropPasswordPolicyStmt;
import com.starrocks.epack.sql.ast.DropPolicyStmt;
import com.starrocks.epack.sql.ast.DropRoleMappingStatement;
import com.starrocks.epack.sql.ast.PolicyType;
import com.starrocks.epack.sql.ast.RefreshRoleMappingStatement;
import com.starrocks.epack.sql.ast.SetPasswordPolicyStmt;
import com.starrocks.epack.sql.ast.ShowCreatePolicyStmt;
import com.starrocks.epack.sql.ast.ShowFailoverGroupsStmt;
import com.starrocks.epack.sql.ast.ShowPolicyStmt;
import com.starrocks.epack.sql.ast.ShowRoleMappingStatement;
import com.starrocks.epack.sql.ast.UnsetPasswordPolicyStmt;
import com.starrocks.epack.sql.ast.WithRowAccessPolicy;
import com.starrocks.qe.ConnectContext;
import com.starrocks.qe.SessionVariable;
import com.starrocks.server.GlobalStateMgr;
import com.starrocks.server.WarehouseManager;
import com.starrocks.sql.analyzer.Authorizer;
import com.starrocks.sql.analyzer.AuthorizerStmtVisitor;
import com.starrocks.sql.ast.AlterClause;
import com.starrocks.sql.ast.AlterMaterializedViewStmt;
import com.starrocks.sql.ast.AlterRoutineLoadStmt;
import com.starrocks.sql.ast.AlterTableStmt;
import com.starrocks.sql.ast.AlterViewStmt;
import com.starrocks.sql.ast.CreateMaterializedViewStatement;
import com.starrocks.sql.ast.CreateRoutineLoadStmt;
import com.starrocks.sql.ast.CreateTableStmt;
import com.starrocks.sql.ast.CreateViewStmt;
import com.starrocks.sql.ast.HintNode;
import com.starrocks.sql.ast.LoadStmt;
import com.starrocks.sql.ast.PolicyName;
import com.starrocks.sql.ast.QueryStatement;
import com.starrocks.sql.ast.SelectRelation;
import com.starrocks.sql.ast.WithColumnMaskingPolicy;
import com.starrocks.sql.ast.expression.SetVarHint;
import com.starrocks.sql.ast.warehouse.AlterWarehouseStmt;
import org.apache.commons.collections4.CollectionUtils;

import java.util.ArrayList;
import java.util.Collections;
import java.util.List;
import java.util.Map;

public class AuthorizerStmtVisitorEPack extends AuthorizerStmtVisitor implements AstVisitorEPack<Void, ConnectContext> {
    public AuthorizerStmtVisitorEPack() {
    }

    private void checkWarehouseUsagePrivilege(String warehouseName, ConnectContext context) {
        try {
            AuthorizerEPack.checkWarehouseAction(context, warehouseName, PrivilegeType.USAGE);
        } catch (AccessDeniedException e) {
            AccessDeniedException.reportAccessDenied(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME,
                    context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
                    PrivilegeType.USAGE.name(), ObjectTypeEPack.WAREHOUSE.name(), warehouseName);
        }
    }

    // ---------------------------------------- Table Statement ---------------------------------------

    @Override
    public Void visitCreateTableStatement(CreateTableStmt statement, ConnectContext context) {
        super.visitCreateTableStatement(statement, context);
        checkPolicyApply(new ArrayList<>(statement.getMaskingPolicyContextMap().values()),
                statement.getWithRowAccessPolicies(), context);
        return null;
    }

    @Override
    public Void visitAlterTableStatement(AlterTableStmt statement, ConnectContext context) {
        super.visitAlterTableStatement(statement, context);
        for (AlterClause alterClause : statement.getAlterClauseList()) {
            checkAlterClausePolicyApply(alterClause, context);
        }

        return null;
    }

    // ---------------------------------------- View Statement ---------------------------------------

    @Override
    public Void visitCreateViewStatement(CreateViewStmt statement, ConnectContext context) {
        super.visitCreateViewStatement(statement, context);
        checkPolicyApply(new ArrayList<>(statement.getMaskingPolicyContextMap().values()),
                statement.getWithRowAccessPolicies(), context);
        return null;
    }

    @Override
    public Void visitAlterViewStatement(AlterViewStmt statement, ConnectContext context) {
        super.visitAlterViewStatement(statement, context);
        AlterClause alterClause = statement.getAlterClause();
        checkAlterClausePolicyApply(alterClause, context);
        return null;
    }

    // ---------------------------------------- Materialized View stmt --------------------------------

    @Override
    public Void visitCreateMaterializedViewStatement(CreateMaterializedViewStatement statement,
                                                     ConnectContext context) {
        super.visitCreateMaterializedViewStatement(statement, context);
        checkPolicyApply(new ArrayList<>(statement.getMaskingPolicyContextMap().values()),
                statement.getWithRowAccessPolicies(), context);
        // check warehouse privilege
        Map<String, String> properties = statement.getProperties();
        if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_WAREHOUSE)) {
            String warehouseName = properties.get(PropertyAnalyzer.PROPERTIES_WAREHOUSE);
            checkWarehouseUsagePrivilege(warehouseName, context);
        }
        return null;
    }

    @Override
    public Void visitAlterMaterializedViewStatement(AlterMaterializedViewStmt statement, ConnectContext context) {
        super.visitAlterMaterializedViewStatement(statement, context);
        checkAlterClausePolicyApply(statement.getAlterTableClause(), context);
        return null;
    }

    // ---------------------------------------- Security Policy Statement ---------------------------------------------------

    @Override
    public Void visitCreatePolicyStatement(CreatePolicyStmt statement, ConnectContext context) {
        PrivilegeType privilegeType = statement.getPolicyType().equals(PolicyType.MASKING) ?
                PrivilegeTypeEPack.CREATE_MASKING_POLICY : PrivilegeTypeEPack.CREATE_ROW_ACCESS_POLICY;
        try {
            Authorizer.checkDbAction(context, statement.getPolicyName().getCatalog(), statement.getPolicyName().getDbName(),
                    privilegeType);
        } catch (AccessDeniedException e) {
            AccessDen
```
</details>

## Why I'm doing:

`ALTER WAREHOUSE <wh> SET (...)` is gated on the `ALTER` privilege on the warehouse object, which out of the box only `root` and `cluster_admin` hold — `db_admin` has no warehouse privilege at all. But most of what that statement sets is database-administration work rather than cluster administration: the query queue knobs (`enable_query_queue`, `query_queue_concurrency_limit`, `query_queue_max_queued_queries`, `query_queue_pending_timeout_second`), the warehouse-level session variables (`session.*`), and the cache/replica knobs. Today a DBA has to go find a cluster administrator to change any of them.

## What I'm doing:

Let a session whose activated roles include `db_admin` run `ALTER WAREHOUSE... SET (...)` without holding `ALTER` on the warehouse.

- **Activated, not merely owned.** The check reads the roles the session actually activated (login default roles or `SET ROLE`). Owning `db_admin` without activating it is not enough — same rule as every other privilege.
- **Follows role inheritance.** Activating a role that was granted `db_admin` through a chain of roles counts, matching how the normal privilege path expands roles.
- **Re-validated against current ownership.** A session keeps listing a role as activated after it has been revoked, so the activated set is intersected with the roles the user still owns — the same re-validation `AuthorizationMgr#loadPrivilegeCollection` does, so revoking `db_admin` takes effect on live sessions.
- **Scoped to this one statement.** `DROP` / `SUSPEND` / `RESUME WAREHOUSE` and the `CNGROUP` statements keep requiring their own privilege. `SUSPEND` and `RESUME` ask for the very same `ALTER` on the warehouse and are still rejected, which is asserted in both test suites.
- The whole property list is covered, `session.*` included.

Implementation: `AuthorizerStmtVisitorEPack#visitAlterWarehouseStatement` short-circuits before delegating to the base check, and a new `AuthorizationMgr#getEffectiveRoleIds` resolves the session's effective role set. The short-circuit sits above the access-control backend, so it applies under Ranger as well as native authorization.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5