### PR TITLE
[BugFix] Degrade to empty statistics when Hive Metastore/Glue denies column-stats permission

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -246,7 +246,13 @@ public class HiveMetastore implements IHiveMetastore {
         List<String> dataColumns = table.getSd().getCols().stream()
                 .map(FieldSchema::getName)
                 .collect(toImmutableList());
-        List<ColumnStatisticsObj> statisticsObjs = client.getTableColumnStats(dbName, tblName, dataColumns);
+        List<ColumnStatisticsObj> statisticsObjs;
+        try {
+            statisticsObjs = client.getTableColumnStats(dbName, tblName, dataColumns);
+        } catch (Exception e) {
+            LOG.warn("Failed to get table column statistics on [{}.{}], degrade to empty statistics", dbName, tblName, e);
+            statisticsObjs = ImmutableList.of();
+        }
         if (statisticsObjs.isEmpty() && Config.enable_reuse_spark_column_statistics) {
             // Try to use spark unpartitioned table column stats
             try {
@@ -319,8 +325,13 @@ public class HiveMetastore implements IHiveMetastore {
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().getRowNums()));
 
         ImmutableMap.Builder<String, HivePartitionStats> resultBuilder = ImmutableMap.builder();
-        Map<String, List<ColumnStatisticsObj>> partitionNameToColumnStatsObj =
-                client.getPartitionColumnStats(dbName, tblName, partitionNames, dataColumns);
+        Map<String, List<ColumnStatisticsObj>> partitionNameToColumnStatsObj;
+        try {
+            partitionNameToColumnStatsObj = client.getPartitionColumnStats(dbName, tblName, partitionNames, dataColumns);
+        } catch (Exception e) {
+            LOG.warn("Failed to get partition column statistics on [{}.{}], degrade to empty statistics", dbName, tblName, e);
+            partitionNameToColumnStatsObj = ImmutableMap.of();
+        }
 
         Map<String, Map<String, HiveColumnStats>> partitionColumnStats = HiveMetastoreApiConverter
                 .toPartitionColumnStatistics(partitionNameToColumnStatsObj, partitionRowNums);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -262,6 +262,49 @@ public class HiveMetastoreTest {
     }
 
     @Test
+    public void testGetTableStatisticsDegradesToEmptyWhenColumnStatsCallFails() {
+        HiveMetaClient client = new MockedHiveMetaClient() {
+            @Override
+            public List<ColumnStatisticsObj> getTableColumnStats(String dbName, String tableName, List<String> columns) {
+                throw new StarRocksConnectorException(
+                        "MetaException: User is not authorized to perform: glue:GetColumnStatisticsForTable");
+            }
+        };
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        HivePartitionStats statistics = Assertions.assertDoesNotThrow(
+                () -> metastore.getTableStatistics("db1", "table1"));
+        HiveCommonStats commonStats = statistics.getCommonStats();
+        Assertions.assertEquals(50, commonStats.getRowNums());
+        Assertions.assertEquals(100, commonStats.getTotalFileBytes());
+        Assertions.assertTrue(statistics.getColumnStats().isEmpty());
+    }
+
+    @Test
+    public void testGetPartitionStatisticsDegradesToEmptyWhenColumnStatsCallFails() {
+        HiveMetaClient client = new MockedHiveMetaClient() {
+            @Override
+            public Map<String, List<ColumnStatisticsObj>> getPartitionColumnStats(String dbName, String tableName,
+                                                                                   List<String> columns,
+                                                                                   List<String> partitionNames) {
+                throw new StarRocksConnectorException(
+                        "MetaException: User is not authorized to perform: glue:GetPartitionColumnStatistics");
+            }
+        };
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        com.starrocks.catalog.Table hiveTable = metastore.getTable("db1", "table1");
+        Map<String, HivePartitionStats> statistics = Assertions.assertDoesNotThrow(
+                () -> metastore.getPartitionStatistics(hiveTable, Lists.newArrayList("col1=1", "col1=2")));
+
+        HivePartitionStats stats1 = statistics.get("col1=1");
+        Assertions.assertEquals(50, stats1.getCommonStats().getRowNums());
+        Assertions.assertTrue(stats1.getColumnStats().isEmpty());
+
+        HivePartitionStats stats2 = statistics.get("col1=2");
+        Assertions.assertEquals(50, stats2.getCommonStats().getRowNums());
+        Assertions.assertTrue(stats2.getColumnStats().isEmpty());
+    }
+
+    @Test
     public void testUpdateTableStatistics() {
         HiveMetaClient client = new MockedHiveMetaClient();
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);


### PR DESCRIPTION
## Why I'm doing:
For Hive-family catalogs (Hive/Hudi/Delta Lake, since they share the same metastore code), fetching table/partition **column statistics** from the metastore (e.g. AWS Glue's `GetColumnStatisticsForTable` / `GetPartitionColumnStatistics`) is a separate authorizable action from fetching the table/partition metadata itself (`GetTable`/`GetPartitions`). A deployment can have the latter fully authorized while the former is not, which is common with Glue resource-link / Lake Formation setups where table-level access is shared but column-stats APIs are not covered by the same grant.

Today, if that column-stats call fails, the exception is not caught anywhere between the raw client call and the SQL executor for two entry points: `REFRESH EXTERNAL TABLE` and the implicit external-table auto-refresh that `INSERT... SELECT` triggers before planning. So a permission gap that never affects a plain `SELECT` (which only reads cached metadata) suddenly fails an otherwise-unrelated statement, with a misleading underlying error message inherited from the metastore/SDK.

## What I'm doing:
Added a `try/catch` around the two leaf calls that fetch column statistics in `HiveMetastore.getTableStatistics()` and `getPartitionStatistics()`: on failure, log a warning and degrade to empty column stats instead of propagating, mirroring the existing sibling `enable_reuse_spark_column_statistics` fallback in the same method. Row-count/size (common) stats are unaffected since they come from table/partition properties, not this call. Added unit tests covering both methods return valid common stats + empty column stats when the underlying client call throws.

This fix is intentionally placed at the lowest (leaf) layer so it protects every caller uniformly, including the one path that was genuinely unprotected before:

```
HiveMetastore.get{Table,Partition}Statistics() <-- fix applied here (leaf)
 |
 +--> CBO optimizer stats path (HiveMetadata.getTableStatistics)
 | already wrapped in try/catch -> degrades to unknown stats [was SAFE]
 |
 +--> background refresh daemon (ConnectorTableMetadataProcessor, every 10 min)
 | already wrapped in try/catch -> logs WARN only [was SAFE]
 |
 +--> CachingHiveMetastore.refreshTableWithoutSync()
 (unpartitioned table branch, synchronous, NO catch anywhere above it)
 -> REFRESH EXTERNAL TABLE
 -> INSERT...SELECT auto external-table refresh
 exception propagated straight to statement result [was UNSAFE, now fixed]
```

Scope intentionally excludes adding a catalog-level switch to skip column-stats collection entirely — that's a separate, larger design decision left for a follow-up if needed.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5