### PR TITLE
[BugFix] Encode Iceberg decimal manifest bounds using minimum-length two's-complement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -83,6 +83,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -596,6 +597,20 @@ public class IcebergApiConverter {
         }
     }
 
+    // Iceberg spec (Appendix D, single-value serialization) requires a decimal bound to be the unscaled
+    // value as two's-complement big-endian binary using the minimum number of bytes. BE always emits a
+    // fixed-width buffer (4/8 bytes for decimal32/64, or the Parquet FIXED_LEN_BYTE_ARRAY width for
+    // decimal128), so re-encode it here to the minimal form. `new BigInteger(bytes)` interprets its input
+    // as big-endian two's-complement of any length, and `toByteArray()` returns the canonical minimal form.
+    private static ByteBuffer trimDecimalBound(ByteBuffer buf) {
+        if (buf == null || buf.remaining() == 0) {
+            return buf;
+        }
+        byte[] bytes = new byte[buf.remaining()];
+        buf.duplicate().get(bytes);
+        return ByteBuffer.wrap(new BigInteger(bytes).toByteArray());
+    }
+
     public static Metrics buildDataFileMetrics(TIcebergDataFile dataFile, org.apache.iceberg.Table nativeTable) {
         Map<Integer, Long> columnSizes = new HashMap<>();
         Map<Integer, Long> valueCounts = new HashMap<>();
@@ -626,11 +641,17 @@ public class IcebergApiConverter {
             // the decimal128/uuid data sinked with physical type fixed_len_byte_array will be stored as big endian
             // decimal64/32 are sinked with physical type int as little endian
             // iceberg data file's upper/lower bound treat decimal/uuid's byte buffer as big endian.
-            if (dataFile.getFormat().equalsIgnoreCase("PARQUET")
-                    && field.type() instanceof Types.DecimalType && ((Types.DecimalType) field.type()).precision() <= 18) {
-                //change to BigEndian
-                reverseBuffer(lowerBounds.get(field.fieldId()));
-                reverseBuffer(upperBounds.get(field.fieldId()));
+            if (dataFile.getFormat().equalsIgnoreCase("PARQUET") && field.type() instanceof Types.DecimalType) {
+                int fieldId = field.fieldId();
+                if (((Types.DecimalType) field.type()).precision() <= 18) {
+                    //change to BigEndian
+                    reverseBuffer(lowerBounds.get(fieldId));
+                    reverseBuffer(upperBounds.get(fieldId));
+                }
+                // Trim the fixed-width buffer down to the spec-mandated minimum-length encoding, regardless
+                // of precision -- strict Iceberg REST catalogs (e.g. Unity Catalog) reject non-minimal bounds.
+                lowerBounds.computeIfPresent(fieldId, (id, buf) -> trimDecimalBound(buf));
+                upperBounds.computeIfPresent(fieldId, (id, buf) -> trimDecimalBound(buf));
             }
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -27,6 +27,8 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.thrift.TIcebergColumnStats;
+import com.starrocks.thrift.TIcebergDataFile;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.CharType;
@@ -44,13 +46,16 @@ import com.starrocks.type.VarcharType;
 import com.starrocks.type.VariantType;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortField;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.StructProjection;
@@ -59,9 +64,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -351,6 +361,92 @@ public class IcebergApiConverterTest {
         assertEquals(3, byteBuffer.get(2));
         assertEquals(2, byteBuffer.get(3));
         assertEquals(1, byteBuffer.get(4));
+    }
+
+    // Iceberg spec Appendix D (single-value serialization) requires a decimal bound to be the unscaled
+    // value as two's-complement big-endian binary using the minimum number of bytes. buildDataFileMetrics
+    // must re-encode BE's raw, fixed-width Parquet statistics (little-endian INT32/INT64 for
+    // decimal32/64, sign-extended big-endian FIXED_LEN_BYTE_ARRAY for decimal128) down to that minimal
+    // form for every precision, not just precision <= 18 -- a strict Iceberg REST catalog such as
+    // Databricks Unity Catalog rejects a non-minimal bound at commit.
+    @Test
+    public void testBuildDataFileMetricsDecimalBoundsAreMinimalEncoded() {
+        Schema schema = new Schema(
+                Types.NestedField.required(1, "id", Types.IntegerType.get()),
+                Types.NestedField.required(2, "d32", Types.DecimalType.of(9, 2)),
+                Types.NestedField.required(3, "d64", Types.DecimalType.of(18, 5)),
+                Types.NestedField.required(4, "d128", Types.DecimalType.of(38, 5)));
+        Table nativeTable = mock(Table.class);
+        when(nativeTable.schema()).thenReturn(schema);
+
+        long d32Lower = -12345L;
+        long d32Upper = 123456L;
+        long d64Lower = 150000L;
+        long d64Upper = 999999999999L;
+        long d128Lower = 150000L;
+        long d128Upper = 250000L;
+
+        Map<Integer, ByteBuffer> lowerBounds = new HashMap<>();
+        Map<Integer, ByteBuffer> upperBounds = new HashMap<>();
+        lowerBounds.put(2, rawLittleEndianStat(d32Lower, 4));
+        upperBounds.put(2, rawLittleEndianStat(d32Upper, 4));
+        lowerBounds.put(3, rawLittleEndianStat(d64Lower, 8));
+        upperBounds.put(3, rawLittleEndianStat(d64Upper, 8));
+        lowerBounds.put(4, rawPaddedBigEndianStat(d128Lower, 16));
+        upperBounds.put(4, rawPaddedBigEndianStat(d128Upper, 16));
+
+        TIcebergColumnStats columnStats = new TIcebergColumnStats();
+        columnStats.setLower_bounds(lowerBounds);
+        columnStats.setUpper_bounds(upperBounds);
+
+        TIcebergDataFile dataFile = new TIcebergDataFile();
+        dataFile.setFormat("parquet");
+        dataFile.setColumn_stats(columnStats);
+
+        Metrics metrics = IcebergApiConverter.buildDataFileMetrics(dataFile, nativeTable);
+
+        assertMinimalDecimalBound(metrics.lowerBounds().get(2), 9, 2, d32Lower);
+        assertMinimalDecimalBound(metrics.upperBounds().get(2), 9, 2, d32Upper);
+        assertMinimalDecimalBound(metrics.lowerBounds().get(3), 18, 5, d64Lower);
+        assertMinimalDecimalBound(metrics.upperBounds().get(3), 18, 5, d64Upper);
+        assertMinimalDecimalBound(metrics.lowerBounds().get(4), 38, 5, d128Lower);
+        assertMinimalDecimalBound(metrics.upperBounds().get(4), 38, 5, d128Upper);
+    }
+
+    // Mimics ParquetFileWriter::_statistics' EncodeMin/EncodeMax for decimal32/decimal64: the raw
+    // native-endian (little-endian) fixed-width Parquet INT32/INT64 physical statistic.
+    private static ByteBuffer rawLittleEndianStat(long unscaledValue, int width) {
+        ByteBuffer buf = ByteBuffer.allocate(width).order(ByteOrder.LITTLE_ENDIAN);
+        if (width == 4) {
+            buf.putInt((int) unscaledValue);
+        } else {
+            buf.putLong(unscaledValue);
+        }
+        buf.flip();
+        return buf;
+    }
+
+    // Mimics ParquetFileWriter::_statistics' EncodeMin/EncodeMax for decimal128: the raw, sign-extended,
+    // fixed-width big-endian Parquet FIXED_LEN_BYTE_ARRAY physical statistic.
+    private static ByteBuffer rawPaddedBigEndianStat(long unscaledValue, int width) {
+        byte[] minimal = BigInteger.valueOf(unscaledValue).toByteArray();
+        byte[] padded = new byte[width];
+        Arrays.fill(padded, (byte) (unscaledValue < 0 ? 0xFF : 0x00));
+        System.arraycopy(minimal, 0, padded, width - minimal.length, minimal.length);
+        return ByteBuffer.wrap(padded);
+    }
+
+    // Asserts a decimal bound follows spec Appendix D: the unscaled value as two's-complement
+    // big-endian binary using the minimum number of bytes, and decodes to the expected value.
+    private static void assertMinimalDecimalBound(ByteBuffer bound, int precision, int scale, long expectedUnscaled) {
+        assertNotNull(bound);
+        byte[] expectedMinimal = BigInteger.valueOf(expectedUnscaled).toByteArray();
+        byte[] actual = new byte[bound.remaining()];
+        bound.duplicate().get(actual);
+        Assertions.assertArrayEquals(expectedMinimal, actual,
+                "decimal(" + precision + "," + scale + ") bound must use the minimum number of bytes");
+        BigDecimal decoded = (BigDecimal) Conversions.fromByteBuffer(Types.DecimalType.of(precision, scale), bound);
+        assertEquals(new BigDecimal(BigInteger.valueOf(expectedUnscaled), scale), decoded);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -177,6 +177,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.HiveTableOperations;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.TableScanUtil;
 import org.junit.jupiter.api.Assertions;
@@ -188,9 +189,13 @@ import org.mockito.Mockito;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1392,6 +1397,120 @@ public class IcebergMetadataTest extends TableTestBase {
         Assertions.assertEquals(fileSize, dataFile.fileSizeInBytes());
         Assertions.assertEquals(4, dataFile.splitOffsets().get(0).longValue());
         Assertions.assertEquals(111L, dataFile.valueCounts().get(1).longValue());
+    }
+
+    // End-to-end regression for the decimal manifest bound encoding bug: BE reports raw, fixed-width
+    // Parquet statistics (little-endian INT32/INT64 for decimal32/64, sign-extended 16-byte
+    // FIXED_LEN_BYTE_ARRAY for decimal128) exactly as it does in production; this drives them through the
+    // real commit path (IcebergMetadata.finishSink -> IcebergApiConverter.buildDataFileMetrics -> a real
+    // Iceberg append/commit) and reads the committed DataFile back from a real manifest via
+    // TableScan#includeColumnStats, so it fails the same way a strict REST catalog (e.g. Unity Catalog)
+    // would if the bounds were not minimally encoded per spec Appendix D.
+    @Test
+    public void testFinishSinkDecimalManifestBoundsAreSpecCompliant() {
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog(CATALOG_NAME, new Configuration(), DEFAULT_CONFIG);
+
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), null);
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", CATALOG_NAME, "resource_name", "iceberg_db",
+                "iceberg_table", "", Lists.newArrayList(), mockedNativeTableDecimal, Maps.newHashMap());
+
+        new Expectations(metadata) {
+            {
+                metadata.getTable((ConnectContext) any, anyString, anyString);
+                result = icebergTable;
+                minTimes = 0;
+            }
+        };
+
+        // decimal(9,2) -> decimal32, physical type INT32
+        long d32Lower = -12345L;
+        long d32Upper = 123456L;
+        // decimal(18,5) -> decimal64, physical type INT64
+        long d64Lower = 150000L;
+        long d64Upper = 999999999999L;
+        // decimal(38,5) -> decimal128, physical type FIXED_LEN_BYTE_ARRAY(16); values match the
+        // 1.50000 / 2.50000 case from the reported Unity Catalog commit failure.
+        long d128Lower = 150000L;
+        long d128Upper = 250000L;
+
+        Map<Integer, ByteBuffer> lowerBounds = new HashMap<>();
+        Map<Integer, ByteBuffer> upperBounds = new HashMap<>();
+        lowerBounds.put(2, rawLittleEndianStat(d32Lower, 4));
+        upperBounds.put(2, rawLittleEndianStat(d32Upper, 4));
+        lowerBounds.put(3, rawLittleEndianStat(d64Lower, 8));
+        upperBounds.put(3, rawLittleEndianStat(d64Upper, 8));
+        lowerBounds.put(4, rawPaddedBigEndianStat(d128Lower, 16));
+        upperBounds.put(4, rawPaddedBigEndianStat(d128Upper, 16));
+
+        TIcebergColumnStats columnStats = new TIcebergColumnStats();
+        columnStats.setColumn_sizes(new HashMap<>());
+        columnStats.setValue_counts(new HashMap<>());
+        columnStats.setNull_value_counts(new HashMap<>());
+        columnStats.setLower_bounds(lowerBounds);
+        columnStats.setUpper_bounds(upperBounds);
+
+        TIcebergDataFile tIcebergDataFile = new TIcebergDataFile();
+        tIcebergDataFile.setPath(mockedNativeTableDecimal.location() + "/data/decimal-bounds.parquet");
+        tIcebergDataFile.setFormat("parquet");
+        tIcebergDataFile.setRecord_count(2);
+        tIcebergDataFile.setFile_size_in_bytes(1000);
+        tIcebergDataFile.setColumn_stats(columnStats);
+
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        tSinkCommitInfo.setIs_overwrite(false);
+        tSinkCommitInfo.setIceberg_data_file(tIcebergDataFile);
+
+        metadata.finishSink("iceberg_db", "iceberg_table", Lists.newArrayList(tSinkCommitInfo), null);
+        mockedNativeTableDecimal.refresh();
+
+        TableScan scan = mockedNativeTableDecimal.newScan().includeColumnStats();
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(scan.planFiles());
+        Assertions.assertEquals(1, fileScanTasks.size());
+        DataFile committed = fileScanTasks.get(0).file();
+
+        assertMinimalDecimalBound(committed.lowerBounds().get(2), 9, 2, d32Lower);
+        assertMinimalDecimalBound(committed.upperBounds().get(2), 9, 2, d32Upper);
+        assertMinimalDecimalBound(committed.lowerBounds().get(3), 18, 5, d64Lower);
+        assertMinimalDecimalBound(committed.upperBounds().get(3), 18, 5, d64Upper);
+        assertMinimalDecimalBound(committed.lowerBounds().get(4), 38, 5, d128Lower);
+        assertMinimalDecimalBound(committed.upperBounds().get(4), 38, 5, d128Upper);
+    }
+
+    // Mimics ParquetFileWriter::_statistics' EncodeMin/EncodeMax for decimal32/decimal64: the raw
+    // native-endian (little-endian) fixed-width Parquet INT32/INT64 physical statistic.
+    private static ByteBuffer rawLittleEndianStat(long unscaledValue, int width) {
+        ByteBuffer buf = ByteBuffer.allocate(width).order(ByteOrder.LITTLE_ENDIAN);
+        if (width == 4) {
+            buf.putInt((int) unscaledValue);
+        } else {
+            buf.putLong(unscaledValue);
+        }
+        buf.flip();
+        return buf;
+    }
+
+    // Mimics ParquetFileWriter::_statistics' EncodeMin/EncodeMax for decimal128: the raw, sign-extended,
+    // fixed-width big-endian Parquet FIXED_LEN_BYTE_ARRAY physical statistic.
+    private static ByteBuffer rawPaddedBigEndianStat(long unscaledValue, int width) {
+        byte[] minimal = BigInteger.valueOf(unscaledValue).toByteArray();
+        byte[] padded = new byte[width];
+        Arrays.fill(padded, (byte) (unscaledValue < 0 ? 0xFF : 0x00));
+        System.arraycopy(minimal, 0, padded, width - minimal.length, minimal.length);
+        return ByteBuffer.wrap(padded);
+    }
+
+    // Asserts a committed Iceberg manifest decimal bound follows spec Appendix D: the unscaled value as
+    // two's-complement big-endian binary using the minimum number of bytes, and decodes to the right value.
+    private static void assertMinimalDecimalBound(ByteBuffer bound, int precision, int scale, long expectedUnscaled) {
+        Assertions.assertNotNull(bound);
+        byte[] expectedMinimal = BigInteger.valueOf(expectedUnscaled).toByteArray();
+        byte[] actual = new byte[bound.remaining()];
+        bound.duplicate().get(actual);
+        Assertions.assertArrayEquals(expectedMinimal, actual,
+                "decimal(" + precision + "," + scale + ") bound must use the minimum number of bytes");
+        BigDecimal decoded = (BigDecimal) Conversions.fromByteBuffer(Types.DecimalType.of(precision, scale), bound);
+        Assertions.assertEquals(new BigDecimal(BigInteger.valueOf(expectedUnscaled), scale), decoded);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
@@ -81,6 +81,14 @@ public class TableTestBase {
                     required(2, "k1", Types.IntegerType.get()),
                     required(3, "k2", Types.StringType.get()));
 
+    // decimal32 (INT32 physical type), decimal64 (INT64) and decimal128 (FIXED_LEN_BYTE_ARRAY)
+    // boundary precisions, used to verify manifest lower/upper bound encoding for DECIMAL columns.
+    public static final Schema SCHEMA_DECIMAL =
+            new Schema(required(1, "id", Types.IntegerType.get()),
+                    required(2, "d32", Types.DecimalType.of(9, 2)),
+                    required(3, "d64", Types.DecimalType.of(18, 5)),
+                    required(4, "d128", Types.DecimalType.of(38, 5)));
+
     protected static final int BUCKETS_NUMBER = 16;
     protected static final int BUCKETS_NUMBER2 = 64;
 
@@ -272,6 +280,7 @@ public class TableTestBase {
     public TestTables.TestTable mockedNativeTableK = null;
     public TestTables.TestTable mockedNativeTableMultiPartition = null;
     public TestTables.TestTable mockedNativeTable2Bucket = null;
+    public TestTables.TestTable mockedNativeTableDecimal = null;
 
     protected final int formatVersion = 1;
 
@@ -295,6 +304,7 @@ public class TableTestBase {
         this.mockedNativeTableK = create(SCHEMA_E, SPEC_E_2, "tk", 1);
         this.mockedNativeTableMultiPartition = create(SCHEMA_I, SPEC_I, "tmp", 1);
         this.mockedNativeTable2Bucket = create(SCHEMA_J, SPEC_J, "twobucket", 1);
+        this.mockedNativeTableDecimal = create(SCHEMA_DECIMAL, PartitionSpec.unpartitioned(), "tdecimal", 2);
     }
 
     @AfterEach


### PR DESCRIPTION
## Why I'm doing:
Iceberg's spec (Appendix D) requires `lower_bounds`/`upper_bounds` for a `decimal(P,S)` column to be the unscaled value as two's-complement big-endian binary, using the **minimum number of bytes**. Our FE only reversed byte order for `decimal32`/`decimal64` (precision ≤ 18) and did nothing at all for `decimal128` (precision > 18) — in both cases the fixed-width, zero/sign-padded Parquet statistic buffer was written straight into the manifest instead of being trimmed to the minimal form.

This is harmless against lenient readers (`BigInteger` decodes the padded and minimal forms to the same value), so it stayed latent. It breaks hard against catalogs that validate bound length on commit — confirmed against Databricks Unity Catalog's Iceberg REST endpoint, where every `INSERT` into a table with a non-null `DECIMAL` column fails at commit (`500 / ErrorCode 2012`, `CommitStateUnknownException`), across every precision/scale tested. Cross-checked with PyIceberg committing a decimal successfully through the same REST endpoint into the same StarRocks-created table, which narrows the defect to the bound bytes we emit.

```
BE (Parquet stats, correct but not Iceberg-bound-shaped)
 decimal32/64 -> native little-endian INT32/INT64
 decimal128 -> fixed 16-byte big-endian FIXED_LEN_BYTE_ARRAY
 |
 v (Thrift, bytes passed through untouched)
FE IcebergApiConverter.buildDataFileMetrics <- bug is entirely here
 precision <= 18: byte-order flip only, no length trim
 precision > 18: no handling at all
 |
 v
Iceberg manifest lower_bounds/upper_bounds -> rejected by strict REST catalogs
```

## What I'm doing:
- In `IcebergApiConverter.buildDataFileMetrics`, re-encode every decimal bound (all precisions, not just ≤ 18) to the spec-mandated minimal two's-complement form via a new `trimDecimalBound` helper, which round-trips the raw bytes through `BigInteger` to drop the redundant padding while preserving sign.
- Added a focused unit test on `buildDataFileMetrics` covering decimal32/decimal64/decimal128 boundary precisions with representative BE-shaped raw bytes.
- Added an end-to-end test that drives a real commit through `IcebergMetadata.finishSink` against a local Iceberg table and reads the committed `DataFile` back from its manifest, asserting the bounds are minimally encoded and decode to the correct values.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5