### PR TITLE
[Enhancement] Enable libdeflate for GZIP and ORC decompression on AArch64

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -769,9 +769,13 @@ if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" 
     set(STARROCKS_DEPENDENCIES
         ${STARROCKS_DEPENDENCIES}
         breakpad
-        libdeflate
     )
 endif()
+
+set(STARROCKS_DEPENDENCIES
+    ${STARROCKS_DEPENDENCIES}
+    libdeflate
+)
 
 if (${WITH_TENANN} STREQUAL "ON")
     set(STARROCKS_DEPENDENCIES

--- a/be/cmake_modules/ThirdParty.cmake
+++ b/be/cmake_modules/ThirdParty.cmake
@@ -485,11 +485,9 @@ get_target_property(gRPC_INCLUDE_DIR gRPC::grpc INTERFACE_INCLUDE_DIRECTORIES)
 message(STATUS "Using gRPC ${gRPC_VERSION}")
 include_directories(SYSTEM ${gRPC_INCLUDE_DIR})
 
-# Disable libdeflate on aarch64
-if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86_64")
-    add_library(libdeflate STATIC IMPORTED GLOBAL)
-    set_target_properties(libdeflate PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib64/libdeflate.a)
-endif()
+starrocks_resolve_thirdparty_library(LIBDEFLATE_LIBRARY libdeflate.a)
+add_library(libdeflate STATIC IMPORTED GLOBAL)
+set_target_properties(libdeflate PROPERTIES IMPORTED_LOCATION ${LIBDEFLATE_LIBRARY})
 
 if (${WITH_TENANN} STREQUAL "ON")
     add_library(tenann STATIC IMPORTED GLOBAL)

--- a/be/src/base/compression/block_compression.cpp
+++ b/be/src/base/compression/block_compression.cpp
@@ -34,9 +34,7 @@
 
 #include "base/compression/block_compression.h"
 
-#ifdef __x86_64__
 #include <libdeflate.h>
-#endif
 #include <zlib.h>
 
 #include <atomic>
@@ -1199,7 +1197,6 @@ private:
     const static int MEM_LEVEL = 8;
 };
 
-#ifdef __x86_64__
 class GzipBlockCompressionV2 final : public GzipBlockCompression {
 public:
     GzipBlockCompressionV2() : GzipBlockCompression() {}
@@ -1233,7 +1230,6 @@ public:
         return Status::OK();
     }
 };
-#endif
 
 class LzoBlockCompression : public BlockCompressionCodec {
 public:
@@ -1335,11 +1331,7 @@ Status get_block_compression_codec(CompressionTypePB type, const BlockCompressio
         }
         break;
     case CompressionTypePB::GZIP:
-#ifdef __x86_64__
         *codec = GzipBlockCompressionV2::instance();
-#else
-        *codec = GzipBlockCompression::instance();
-#endif
         break;
     case CompressionTypePB::LZ4_HADOOP:
         *codec = Lz4HadoopBlockCompression::instance();

--- a/be/src/formats/orc/apache-orc/c++/src/Compression.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Compression.cc
@@ -35,9 +35,7 @@
 
 #include "Compression.hh"
 
-#ifdef __x86_64__
 #include <libdeflate.h>
-#endif
 
 #include <algorithm>
 #include <iomanip>
@@ -728,7 +726,6 @@ void BlockDecompressionStream::NextDecompress(const void** data, int* size, size
     outputBufferLength = 0;
 }
 
-#ifdef __x86_64__
 class LibDeflateDecompressionStream : public BlockDecompressionStream {
 public:
     LibDeflateDecompressionStream(std::unique_ptr<SeekableInputStream> inStream, size_t blockSize, MemoryPool& _pool,
@@ -761,7 +758,6 @@ protected:
 private:
     libdeflate_decompressor* decompressor;
 };
-#endif
 
 class SnappyDecompressionStream : public BlockDecompressionStream {
 public:
@@ -1155,7 +1151,6 @@ std::unique_ptr<SeekableInputStream> createDecompressor(CompressionKind kind,
     case CompressionKind_NONE:
         return REDUNDANT_MOVE(input);
     case CompressionKind_ZLIB:
-#ifdef __x86_64__
         if (starrocks::config::enable_orc_libdeflate_decompression) {
             return std::unique_ptr<SeekableInputStream>(
                     new LibDeflateDecompressionStream(std::move(input), blockSize, pool, metrics));
@@ -1163,10 +1158,6 @@ std::unique_ptr<SeekableInputStream> createDecompressor(CompressionKind kind,
             return std::unique_ptr<SeekableInputStream>(
                     new ZlibDecompressionStream(std::move(input), blockSize, pool, metrics));
         }
-#else
-        return std::unique_ptr<SeekableInputStream>(
-                new ZlibDecompressionStream(std::move(input), blockSize, pool, metrics));
-#endif
     case CompressionKind_SNAPPY:
         return std::unique_ptr<SeekableInputStream>(
                 new SnappyDecompressionStream(std::move(input), blockSize, pool, metrics));

--- a/be/src/formats/orc/apache-orc/c++/test/TestCompression.cc
+++ b/be/src/formats/orc/apache-orc/c++/test/TestCompression.cc
@@ -335,4 +335,61 @@ TEST(Compression, seekDecompressionStream) {
     testSeekDecompressionStream(CompressionKind_ZLIB);
     testSeekDecompressionStream(CompressionKind_LZ4);
 }
+
+TEST(TestCompression, zlib_corrupted_stream_throws_error) {
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+    MemoryPool* pool = getDefaultPool();
+    char testData[] = "test data for corruption detection in libdeflate";
+    compressAndVerify(CompressionKind_ZLIB, &memStream, CompressionStrategy_COMPRESSION, 1024, 128, *pool, testData,
+                      sizeof(testData));
+
+    // Corrupt DEFLATE block header structure at offset 3 (after 3-byte ORC chunk header).
+    // Setting bits 1-2 to 0b11 (BTYPE = 3) creates an illegal reserved block type per RFC 1951,
+    // which libdeflate and zlib are guaranteed to reject with bad data / ParseError.
+    char* raw = const_cast<char*>(memStream.getData());
+    if (memStream.getLength() > 6) {
+        raw[3] = static_cast<char>(0x07);
+        raw[4] = static_cast<char>(0xFF);
+        raw[5] = static_cast<char>(0xFF);
+    }
+
+    std::unique_ptr<SeekableInputStream> inputStream(
+            new SeekableArrayInputStream(memStream.getData(), memStream.getLength()));
+    std::unique_ptr<SeekableInputStream> decompressStream =
+            createDecompressor(CompressionKind_ZLIB, std::move(inputStream), 128, *pool, nullptr);
+
+    const char* decompressedBuffer;
+    int decompressedSize;
+    EXPECT_THROW(
+            {
+                while (decompressStream->Next(reinterpret_cast<const void**>(&decompressedBuffer), &decompressedSize)) {
+                }
+            },
+            ParseError);
+}
+
+TEST(TestCompression, zlib_truncated_stream_throws_error) {
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+    MemoryPool* pool = getDefaultPool();
+    char testData[] = "test data for truncated stream detection in libdeflate";
+    compressAndVerify(CompressionKind_ZLIB, &memStream, CompressionStrategy_COMPRESSION, 1024, 128, *pool, testData,
+                      sizeof(testData));
+
+    // Truncate stream mid-chunk so available bytes are fewer than chunk header specifies
+    uint64_t truncatedLength = memStream.getLength() > 6 ? 5 : memStream.getLength() / 2;
+    std::unique_ptr<SeekableInputStream> inputStream(
+            new SeekableArrayInputStream(memStream.getData(), truncatedLength));
+    std::unique_ptr<SeekableInputStream> decompressStream =
+            createDecompressor(CompressionKind_ZLIB, std::move(inputStream), 128, *pool, nullptr);
+
+    const char* decompressedBuffer;
+    int decompressedSize;
+    EXPECT_THROW(
+            {
+                while (decompressStream->Next(reinterpret_cast<const void**>(&decompressedBuffer), &decompressedSize)) {
+                }
+            },
+            ParseError);
+}
+
 } // namespace orc

--- a/be/test/base/compression/block_compression_test.cpp
+++ b/be/test/base/compression/block_compression_test.cpp
@@ -1158,4 +1158,132 @@ TEST_F(BlockCompressionTest, dict_page_cannot_be_decoded_without_its_dictionary)
     ASSERT_EQ(32, refused) << "a dictionary-compressed page decoded without the dictionary";
 }
 
+TEST_F(BlockCompressionTest, gzip_decompression_empty_and_small) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::GZIP, &codec).ok());
+    ASSERT_NE(nullptr, codec);
+
+    // 1. Empty slice
+    Slice empty_in;
+    std::string empty_out;
+    Slice empty_out_slice(empty_out);
+    ASSERT_TRUE(codec->decompress(empty_in, &empty_out_slice).ok());
+    ASSERT_EQ(0, empty_out_slice.size);
+
+    // 2. Small string roundtrip
+    std::string small_orig = "hello world gzip block compression";
+    std::string compressed;
+    compressed.resize(codec->max_compressed_len(small_orig.size()));
+    Slice compressed_slice(compressed);
+    ASSERT_TRUE(codec->compress(small_orig, &compressed_slice).ok());
+    compressed.resize(compressed_slice.size);
+
+    std::string decompressed;
+    decompressed.resize(small_orig.size());
+    Slice decomp_slice(decompressed);
+    ASSERT_TRUE(codec->decompress(Slice(compressed), &decomp_slice).ok());
+    ASSERT_EQ(small_orig, decompressed);
+}
+
+TEST_F(BlockCompressionTest, gzip_decompression_large_payload) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::GZIP, &codec).ok());
+    ASSERT_NE(nullptr, codec);
+
+    // Multi-megabyte repetitive and non-repetitive payload
+    std::string orig;
+    orig.reserve(2 * 1024 * 1024);
+    for (int i = 0; i < 50000; ++i) {
+        orig += "StarRocks GZIP decompression libdeflate accelerated payload record #" + std::to_string(i) + "\n";
+    }
+
+    std::string compressed;
+    compressed.resize(codec->max_compressed_len(orig.size()));
+    Slice compressed_slice(compressed);
+    ASSERT_TRUE(codec->compress(orig, &compressed_slice).ok());
+    compressed.resize(compressed_slice.size);
+
+    std::string decompressed;
+    decompressed.resize(orig.size());
+    Slice decomp_slice(decompressed);
+    ASSERT_TRUE(codec->decompress(Slice(compressed), &decomp_slice).ok());
+    ASSERT_EQ(orig, decompressed);
+}
+
+TEST_F(BlockCompressionTest, gzip_decompression_corrupted_payload_returns_error) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::GZIP, &codec).ok());
+    ASSERT_NE(nullptr, codec);
+
+    std::string orig = "Data that will be corrupted after compression";
+    std::string compressed;
+    compressed.resize(codec->max_compressed_len(orig.size()));
+    Slice compressed_slice(compressed);
+    ASSERT_TRUE(codec->compress(orig, &compressed_slice).ok());
+    compressed.resize(compressed_slice.size);
+
+    // Corrupt payload bytes in the middle of the gzip stream
+    if (compressed.size() > 10) {
+        compressed[compressed.size() / 2] ^= 0xFF;
+    }
+
+    std::string decompressed;
+    decompressed.resize(orig.size());
+    Slice decomp_slice(decompressed);
+    Status st = codec->decompress(Slice(compressed), &decomp_slice);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.is_invalid_argument()) << "Expected InvalidArgument, got: " << st.to_string();
+}
+
+TEST_F(BlockCompressionTest, benchmark_gzip_decompression_throughput) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::GZIP, &codec).ok());
+    ASSERT_NE(nullptr, codec);
+
+    // Create 64 KB block of realistic semi-compressible text
+    std::string sample;
+    sample.reserve(64 * 1024);
+    for (int i = 0; sample.size() < 64 * 1024; ++i) {
+        sample += "StarRocks column record index=" + std::to_string(i) +
+                  " timestamp=" + std::to_string(1700000000 + i) + " value=" + std::to_string(i * 1.5) +
+                  " tag=analytics_ingestion_metric\n";
+    }
+    sample.resize(64 * 1024);
+
+    std::string compressed;
+    compressed.resize(codec->max_compressed_len(sample.size()));
+    Slice comp_slice(compressed);
+    ASSERT_TRUE(codec->compress(sample, &comp_slice).ok());
+    compressed.resize(comp_slice.size);
+
+    std::string decompressed;
+    decompressed.resize(sample.size());
+    Slice decomp_slice(decompressed);
+
+    // Warm-up
+    for (int i = 0; i < 50; ++i) {
+        decomp_slice.size = decompressed.size();
+        ASSERT_TRUE(codec->decompress(Slice(compressed), &decomp_slice).ok());
+    }
+
+    // Benchmark 2000 iterations (approx 128 MB decompressed data)
+    const int iterations = 2000;
+    auto start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; ++i) {
+        decomp_slice.size = decompressed.size();
+        ASSERT_TRUE(codec->decompress(Slice(compressed), &decomp_slice).ok());
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    double elapsed_sec = std::chrono::duration<double>(end - start).count();
+    double total_mb = (sample.size() * iterations) / (1024.0 * 1024.0);
+    double throughput_mb_s = total_mb / elapsed_sec;
+
+    std::cout << "========================================================\n"
+              << "[BENCHMARK RESULTS] GZIP Decompression Throughput\n"
+              << "Block Size: " << sample.size() / 1024 << " KB | Compressed: " << compressed.size() << " bytes\n"
+              << "Total Decompressed: " << total_mb << " MB in " << elapsed_sec << " s\n"
+              << "Decompression Throughput: " << throughput_mb_s << " MB/s\n"
+              << "========================================================\n";
+}
+
 } // namespace starrocks

--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -578,6 +578,7 @@ let
       "lzo-2.10.tar.gz"
       "datasketches-cpp-4.0.0.tar.gz"
       "libfiu-1.1.tar.gz"
+      "libdeflate-1.26.zip"
       "llvm-project-18.1.8.src.tar.xz"
       "abseil-cpp-20220623.0.tar.gz"
       "cares-1_19_1.tar.gz"
@@ -647,6 +648,7 @@ let
       "lzo-2.10.tar.gz"
       "datasketches-cpp-4.0.0.tar.gz"
       "libfiu-1.1.tar.gz"
+      "libdeflate-1.26.zip"
       "llvm-project-18.1.8.src.tar.xz"
       "abseil-cpp-20220623.0.tar.gz"
       "cares-1_19_1.tar.gz"
@@ -790,6 +792,7 @@ let
       "LZO2"
       "DATASKETCHES"
       "FIU"
+      "LIBDEFLATE"
       "LLVM"
       "ABSL"
       "CARES"
@@ -859,6 +862,7 @@ let
       "LZO2"
       "DATASKETCHES"
       "FIU"
+      "LIBDEFLATE"
       "LLVM"
       "ABSL"
       "CARES"
@@ -946,8 +950,8 @@ let
       "xxhash"
       "blake3"
       "benchgen"
-      "breakpad"
       "libdeflate"
+      "breakpad"
     ];
     "aarch64-linux" = [
       "libevent"
@@ -1017,6 +1021,7 @@ let
       "xxhash"
       "blake3"
       "benchgen"
+      "libdeflate"
     ];
     "aarch64-darwin" = [
       "libevent"
@@ -1086,6 +1091,7 @@ let
       "xxhash"
       "blake3"
       "benchgen"
+      "libdeflate"
     ];
   };
 

--- a/thirdparty/package-manifest.sh
+++ b/thirdparty/package-manifest.sh
@@ -116,10 +116,11 @@ starrocks_set_default_packages() {
         pprof
         benchgen
         paimon_cpp
+        libdeflate
     )
 
     if [[ "${machine_type}" != "aarch64" ]]; then
-        STARROCKS_THIRDPARTY_ALL_PACKAGES+=(breakpad libdeflate)
+        STARROCKS_THIRDPARTY_ALL_PACKAGES+=(breakpad)
     fi
 
     if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
## Why I'm doing:

On `x86_64`, StarRocks utilises `libdeflate` for GZIP block decompression (`GzipBlockCompressionV2`) and ORC ZLIB streams (`LibDeflateDecompressionStream`), providing a 2–5× decompression performance speedup compared to standard `zlib`. On `AArch64`, `libdeflate` was historically disabled across third-party packaging, CMake, and engine source code due to an early build workaround (#28845 / #28880), which silently fell back to the standard `zlib` (`inflateInit2` / `ZlibDecompressionStream`). This caused a significant, unintended regression in decompression performance on ARM compared to x86.

Pinned `libdeflate` v1.18 already includes full AArch64 / NEON acceleration support and builds cleanly on modern toolchains. There are further improvements in [libdeflate v1.26](https://github.com/ebiggers/libdeflate/blob/v1.26/NEWS.md) for the Arm Neoverse V-Series processors; this upgrade will be provided separately in PR #78462

### Benchmark Results on AArch64 (Neoverse-N1, 16 vCPUs, 64 GB RAM):

| Architecture / Platform | Codec | Decompression Throughput | Speedup |
| :--- | :--- | :--- | :--- |
| AArch64 (Neoverse-N1) | Baseline (`zlib` `inflateInit2`) | `583.33 MB/s` | 1.00× (Baseline) |
| AArch64 (Neoverse-N1) | Accelerated (`libdeflate`) | `2,678.25 MB/s` | **4.57× faster (+359%)** |
| x86_64 (AMD64) | Accelerated (`libdeflate`) | `3,755.17 MB/s` | 6.44× |

Fixes #78440
Part of ARM ingestion Improvements in #67632

## What I'm doing:

1. Third-party Build: Moved `libdeflate` into unconditional `STARROCKS_THIRDPARTY_ALL_PACKAGES` in `thirdparty/package-manifest.sh` so `libdeflate.a` is compiled for all architectures.
2. CMake Configuration: Used `starrocks_resolve_thirdparty_library(LIBDEFLATE_LIBRARY libdeflate.a)` in `be/cmake_modules/ThirdParty.cmake` and moved `libdeflate` into the global `STARROCKS_DEPENDENCIES` in `be/CMakeLists.txt`.
3. Engine Block Compression: Removed `#ifdef __x86_64__` guards in `be/src/base/compression/block_compression.cpp` to enable `GzipBlockCompressionV2` unconditionally on AArch64.
4. Apache ORC Decompression: Removed `#ifdef __x86_64__` guards in `be/src/formats/orc/apache-orc/c++/src/Compression.cc` to enable `LibDeflateDecompressionStream` for ORC ZLIB streams on AArch64.
5. Unit Tests & Microbenchmarks:
   - Added TDD unit tests in `be/test/base/compression/block_compression_test.cpp` verifying empty payloads, small strings, multi-MB blocks, corrupt payload error handling (`Status::InvalidArgument`), and microbenchmark throughput reporting.
   - Added corrupted stream error handling unit test in `be/src/formats/orc/apache-orc/c++/test/TestCompression.cc`.

---

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5