### PR TITLE
[UT] Clear the shard filesystem cache between lake replication tests

### DIFF
--- a/be/src/compute_env/staros/starlet_filesystem.cpp
+++ b/be/src/compute_env/staros/starlet_filesystem.cpp
@@ -735,6 +735,12 @@ static Cache* get_shard_fs_cache() {
     return g_shard_fs_cache.get();
 }
 
+#ifdef BE_TEST
+void TEST_clear_shard_fs_cache() {
+    get_shard_fs_cache()->prune();
+}
+#endif
+
 std::shared_ptr<FileSystem> new_fs_starlet(int64_t shard_id, bool use_raw_path) {
     // The cache here is used to store fslib's shard fs which is used for cross cluster migration,
     // where each shard fs correspond to one storage volume on source cluster.

--- a/be/src/compute_env/staros/starlet_filesystem.h
+++ b/be/src/compute_env/staros/starlet_filesystem.h
@@ -67,6 +67,20 @@ FileSystemProvider new_starlet_file_system_provider(int priority = 30);
 //   - This is used for non-S3 storage types (OSS/Azure/HDFS/GFS)
 std::shared_ptr<FileSystem> new_fs_starlet(int64_t virtual_shard_id, bool use_raw_path);
 
+#ifdef BE_TEST
+// Drop every entry from the process-wide shard filesystem cache that new_fs_starlet(shard_id, ...)
+// consults before it creates anything.
+//
+// That cache is keyed by shard id only and lives for the life of the process, so a filesystem a test
+// injected through the "new_fs_starlet::get_shard_filesystem" sync point stays reachable by every
+// later test using the same shard id -- and because a cache HIT returns early, the later test's own
+// sync-point callback is never invoked. The next test then silently runs against its predecessor's
+// mock: one expecting filesystem creation to fail instead gets a working mock, and one reading file
+// content gets the previous test's bytes. Fixtures that inject a filesystem must clear the cache so
+// they neither inherit nor leak one.
+void TEST_clear_shard_fs_cache();
+#endif
+
 } // namespace starrocks
 
 #endif // USE_STAROS

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1939,6 +1939,11 @@ protected:
     void TearDown() override {
         SyncPoint::GetInstance()->ClearAllCallBacks();
         SyncPoint::GetInstance()->DisableProcessing();
+        // Clearing the callbacks is not enough: new_fs_starlet() caches the filesystem this test
+        // injected, keyed by shard id, for the life of the process. A later test using the same shard
+        // id gets a cache HIT and returns before its own callback runs, so it silently inherits this
+        // test's mock. Drop the cache with the callbacks that populated it.
+        TEST_clear_shard_fs_cache();
 
         StorageEngine::instance()->wait_storage_cleanup_tasks();
         ASSERT_OK(fs::remove_all(_test_dir));


### PR DESCRIPTION
new_fs_starlet() caches the shard filesystem process-wide, keyed by shard id, and returns early on a cache hit -- before the "new_fs_starlet::get_shard_filesystem" sync point runs. So the first test to inject a mock leaves it reachable by every later test using the same shard id, whose own callback is then never invoked. TearDown cleared the callbacks but not the cache they had populated.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5