### PR TITLE
[Enhancement] Cache DST offset lookups in convert_tz to avoid redundant per-row timezone conversion

### DIFF
--- a/be/src/base/CMakeLists.txt
+++ b/be/src/base/CMakeLists.txt
@@ -83,6 +83,7 @@ ADD_BE_LIB(Base
   time/monotime.cpp
   time/time.cpp
   time/timezone_utils.cpp
+  time/tz_offset_cache.cpp
   template/mustache/mustache.cc
   # base/testutil is not the UT-only TestUtil library. Production sources
   # include its BE_TEST-gated sync-point/fault-injection macros, which compile

--- a/be/src/base/time/tz_offset_cache.cpp
+++ b/be/src/base/time/tz_offset_cache.cpp
@@ -1,0 +1,169 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/time/tz_offset_cache.h"
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+
+namespace starrocks {
+
+namespace {
+// civil_second interpreted as if it were UTC, in whole seconds since the Unix epoch. Used only
+// as an offset-free anchor for the additive identity civil = epoch + (unix_seconds + tz_offset);
+// not itself a valid timezone conversion.
+int64_t civil_as_utc_seconds(const cctz::civil_second& cs) {
+    return cs - cctz::civil_second(1970, 1, 1, 0, 0, 0);
+}
+
+// Past the last transition in a zone's explicit table, cctz's next_transition() returns false
+// unconditionally ("ignoring future_spec_", per its own doc comment) -- it cannot tell us whether
+// that's because the zone will hold `offset` forever (e.g. Asia/Shanghai and Asia/Kolkata, which
+// abolished DST decades ago, or America/Phoenix, which has been fixed MST since it was defined --
+// all of them reach this point on ordinary present-day lookups, not just far-future ones) or
+// because it's a still-cycling DST zone we've simply run past the enumerable table for (only
+// reachable past ~year 2437 for this build's tzdata).
+//
+// There is no zone-specific logic here -- this is a generic probe applied to whatever zone was
+// passed in, and it works by exploiting a property of DST rules in general rather than anything
+// about a particular zone: every real-world annual DST cycle has exactly two transitions, and
+// each phase (DST / standard time) lasts several months, never mere days or weeks. So sampling
+// the offset at a few points spread roughly a quarter-year apart -- +91d, +182d, +273d, i.e.
+// ~3/6/9 months out, alongside `offset` itself already sampled at `tp` -- puts one sample in
+// each of the four seasons. If the zone is still cycling, at least one of those samples is
+// guaranteed to land in a different phase than `tp` and show a different offset; if it's
+// permanently fixed, all of them trivially match. The exact day counts aren't calibrated to any
+// zone's specific transition dates (that would be pointless -- the whole point is this has to
+// work for a zone we can no longer enumerate transitions for); they just need to be spaced closer
+// together than the shortest real-world DST phase, which they are by a wide margin.
+bool offset_is_constant_beyond(const cctz::time_zone& tz, const cctz::time_point<cctz::seconds>& tp, int64_t offset) {
+    for (int64_t days : {91, 182, 273}) {
+        if (tz.lookup_offset(tp + cctz::seconds(days * 86400)).offset != offset) {
+            return false;
+        }
+    }
+    return true;
+}
+} // namespace
+
+int64_t TzOffsetCache::offset_for_unix(int64_t unix_sec, const cctz::time_zone& tz) {
+    if (_abs_window.has_value && tz == _abs_window.zone && unix_sec >= _abs_window.lo && unix_sec < _abs_window.hi) {
+        return _abs_window.offset;
+    }
+
+    static const cctz::time_point<cctz::seconds> epoch =
+            std::chrono::time_point_cast<cctz::seconds>(std::chrono::system_clock::from_time_t(0));
+    const cctz::time_point<cctz::seconds> tp = epoch + cctz::seconds(unix_sec);
+    _abs_window.offset = tz.lookup_offset(tp).offset;
+
+    int64_t lo = std::numeric_limits<int64_t>::min();
+    int64_t hi = std::numeric_limits<int64_t>::max();
+    cctz::time_zone::civil_transition ct;
+    // next_transition(tp)/prev_transition(tp) both use a *strict* inequality against tp, so
+    // probing prev_transition at tp+1s (rather than tp) is what makes it return "the largest
+    // transition <= tp" instead of skipping over a transition that lands exactly on it.
+    const bool has_prev = tz.prev_transition(tp + cctz::seconds(1), &ct);
+    if (has_prev) {
+        lo = tz.lookup(ct.to).trans.time_since_epoch().count();
+    }
+    const bool has_next = tz.next_transition(tp, &ct);
+    if (has_next) {
+        hi = tz.lookup(ct.to).trans.time_since_epoch().count();
+    }
+    if (has_prev && !has_next && !offset_is_constant_beyond(tz, tp, _abs_window.offset)) {
+        // has_prev true but has_next false, and the offset actually varies later on: this is a
+        // zone with an ongoing DST cycle that we've simply run past cctz's enumerable transition
+        // table for (see offset_is_constant_beyond's comment). Caching an unbounded window here
+        // would silently reuse this offset for arbitrarily-far future instants that could be in
+        // the opposite DST season -- so don't cache; every such row gets a fresh, authoritative
+        // lookup instead. When the offset turns out to be constant beyond this point (e.g.
+        // Asia/Shanghai, Asia/Kolkata, America/Phoenix -- the common case this branch actually
+        // hits on ordinary present-day lookups), fall through and cache with hi left at +inf.
+        _abs_window.has_value = false;
+        return _abs_window.offset;
+    }
+    _abs_window.zone = tz;
+    _abs_window.lo = lo;
+    _abs_window.hi = hi;
+    _abs_window.has_value = true;
+    return _abs_window.offset;
+}
+
+int64_t TzOffsetCache::unix_for_civil(int64_t civil_as_utc_sec, int year, int month, int day, int hour, int minute,
+                                      int second, const cctz::time_zone& tz) {
+    if (_civil_window.has_value && tz == _civil_window.zone && civil_as_utc_sec >= _civil_window.lo &&
+        civil_as_utc_sec < _civil_window.hi) {
+        return civil_as_utc_sec - _civil_window.offset;
+    }
+
+    // Cold path: only reached ~twice per DST transition (or once per call for a wildly
+    // out-of-order stream), so it's fine to pay cctz::civil_second's construction/arithmetic
+    // cost here -- unlike the hot path above, which never touches it.
+    const cctz::civil_second cs(year, month, day, hour, minute, second);
+    const cctz::time_zone::civil_lookup cl = tz.lookup(cs);
+    const cctz::time_point<cctz::seconds> answer =
+            (cl.kind == cctz::time_zone::civil_lookup::SKIPPED) ? cl.trans : cl.pre;
+    const int64_t answer_unix = answer.time_since_epoch().count();
+
+    if (cl.kind != cctz::time_zone::civil_lookup::UNIQUE) {
+        // Ambiguous wall-clock value (the skipped/repeated hour around a DST change, ~1h/year).
+        // Too rare to be worth caching a window for; always re-resolve authoritatively.
+        _civil_window.has_value = false;
+        return answer_unix;
+    }
+
+    cctz::time_zone::civil_transition prev_trans, next_trans;
+    const bool has_prev = tz.prev_transition(answer + cctz::seconds(1), &prev_trans);
+    const bool has_next = tz.next_transition(answer, &next_trans);
+
+    int64_t lo = std::numeric_limits<int64_t>::min();
+    int64_t hi = std::numeric_limits<int64_t>::max();
+    if (has_prev) {
+        // For a spring-forward (gap) transition, prev_trans.to is later and starts the segment;
+        // for a fall-back (repeat) transition, prev_trans.from is later, and cctz's "prefer pre"
+        // tie-break means the whole repeated hour still belongs to the *earlier* segment, not
+        // this one -- either way max(from, to) is where the current segment actually starts.
+        lo = civil_as_utc_seconds(std::max(prev_trans.from, prev_trans.to));
+    }
+    if (has_next) {
+        hi = civil_as_utc_seconds(std::min(next_trans.from, next_trans.to));
+    }
+    if (has_prev && !has_next && !offset_is_constant_beyond(tz, answer, civil_as_utc_sec - answer_unix)) {
+        // Same "cctz gives up enumerating past the explicit table" hazard as in offset_for_unix
+        // above, and the same disambiguation: only skip caching when the offset actually varies
+        // beyond this point (a still-cycling DST zone run past the enumerable table), not when
+        // it's simply a zone permanently fixed since its last historical transition (the common
+        // case this branch hits on ordinary present-day lookups for zones like Asia/Shanghai).
+        _civil_window.has_value = false;
+        return answer_unix;
+    }
+    if (!(lo < hi)) {
+        // Pre-existing degenerate/adjacent-transitions guard.
+        _civil_window.has_value = false;
+        return answer_unix;
+    }
+
+    _civil_window.zone = tz;
+    // civil_as_utc_sec is the caller's non-cctz computation of the same quantity
+    // civil_as_utc_seconds(cs) would give; using it here (instead of recomputing via cctz) keeps
+    // this assignment consistent with what the hot path above will compare against later.
+    _civil_window.offset = civil_as_utc_sec - answer_unix;
+    _civil_window.lo = lo;
+    _civil_window.hi = hi;
+    _civil_window.has_value = true;
+    return answer_unix;
+}
+
+} // namespace starrocks

--- a/be/src/base/time/tz_offset_cache.h
+++ b/be/src/base/time/tz_offset_cache.h
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cctz/civil_time.h>
+#include <cctz/time_zone.h>
+
+#include <cstdint>
+
+namespace starrocks {
+
+// Caches the UTC offset currently in force for a cctz::time_zone, so that repeated conversions
+// against nearby times can skip cctz's transition-table search.
+//
+// cctz::time_zone itself already keeps such a hint (TimeZoneInfo::local_time_hint_ /
+// time_local_hint_ in time_zone_info.cc), but it is a single mutable slot shared by *every*
+// caller of that zone process-wide: under any real concurrency it becomes a cross-core
+// cache-line ping-pong, and one thread's hint constantly evicts another's. This class holds the
+// same kind of window privately per caller instead.
+//
+// Not thread-safe and not meant to be shared: each execution thread (or, in exprs/, each
+// FunctionContext worker via FunctionContext::get_or_create_thread_state) should own its own
+// instance. A single instance is reused across an unbounded number of calls and automatically
+// adapts as the input strays outside its current window -- there is no reset needed between
+// unrelated calls to the *same* (offset semantics never change for a fixed IANA zone), but an
+// instance must not be reused across two different cctz::time_zone values without expecting a
+// cache miss on the first call after the switch (which is always handled correctly, just not
+// from the fast path).
+//
+// Real-world timestamp columns are almost always time-clustered within one scan batch, so most
+// consecutive calls land in the same window; for a fixed-offset zone (no DST, e.g. "+08:00") the
+// window degenerates to unbounded after the very first call, so every later call is a hit
+// regardless of the time range covered.
+class TzOffsetCache {
+public:
+    // Returns the UTC offset (seconds east) in force for `tz` at absolute unix time `unix_sec`.
+    int64_t offset_for_unix(int64_t unix_sec, const cctz::time_zone& tz);
+
+    // Interprets the wall-clock fields (year, month, day, hour, minute, second) as being in `tz`
+    // and returns the absolute unix-second instant, matching cctz::convert(civil_second, tz)'s
+    // tie-break exactly: a SKIPPED (nonexistent) civil time resolves to the transition instant, a
+    // REPEATED (ambiguous) one resolves to the earlier ("pre") instant. Ambiguous inputs are
+    // always re-resolved through the authoritative cctz lookup and are never cached (they are
+    // rare -- at most ~1 hour per DST transition).
+    //
+    // `civil_as_utc_sec` is the same wall-clock fields reinterpreted as literal UTC seconds since
+    // the epoch (i.e. what they'd mean with no timezone applied at all) -- the caller computes
+    // this via a cheap, non-cctz calendar routine (e.g. TimestampValue::to_unix_second(), which
+    // this class -- living in base/, below types/ -- cannot call itself) so the common
+    // cache-hit path never has to touch cctz::civil_second at all. Passing a value inconsistent
+    // with the other fields is a caller bug; it is only used verbatim, never re-derived.
+    int64_t unix_for_civil(int64_t civil_as_utc_sec, int year, int month, int day, int hour, int minute, int second,
+                           const cctz::time_zone& tz);
+
+private:
+    // `zone` records which cctz::time_zone the window was computed for. An instance's (from, to)
+    // pair is normally fixed for its whole lifetime, but this guards against a window silently
+    // being reused after the caller switches to a different zone.
+    struct AbsWindow {
+        bool has_value = false;
+        cctz::time_zone zone;
+        int64_t offset = 0;
+        int64_t lo = 0; // inclusive, unix seconds
+        int64_t hi = 0; // exclusive, unix seconds
+    } _abs_window;
+
+    // Bounds are in the same "civil fields reinterpreted as literal UTC seconds" domain as
+    // `unix_for_civil`'s civil_as_utc_sec parameter, not cctz::civil_second -- comparing plain
+    // int64s on the hot path avoids cctz::civil_second arithmetic (specifically
+    // cctz::detail::impl::n_min and friends, the normalization routine backing civil_second's
+    // arithmetic operators) entirely once the window is warm.
+    struct CivilWindow {
+        bool has_value = false;
+        cctz::time_zone zone;
+        int64_t offset = 0; // seconds east of UTC
+        int64_t lo = 0;     // inclusive, civil-as-utc seconds
+        int64_t hi = 0;     // exclusive, civil-as-utc seconds
+    } _civil_window;
+};
+
+} // namespace starrocks

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -19,6 +19,7 @@
 #include <libdivide.h>
 
 #include <algorithm>
+#include <memory>
 #include <string_view>
 #include <unordered_map>
 
@@ -323,6 +324,16 @@ StatusOr<ColumnPtr> TimeFunctions::convert_tz_const(FunctionContext* context, co
 
     auto size = columns[0]->size();
     ColumnBuilder<TYPE_DATETIME> result(size);
+
+    // Thread-private (no shared/atomic state, so no cross-core contention under a high degree
+    // of parallelism) cache of the currently-valid DST offset window for `from`/`to`. Real-world
+    // timestamp columns are almost always time-clustered within a scanned chunk, so most
+    // consecutive rows land in the same window and skip cctz's transition search entirely. See
+    // base/time/tz_offset_cache.h.
+    auto* thread_state = context->get_or_create_thread_state<ConvertTzThreadState>(
+            [] { return std::make_unique<ConvertTzThreadState>(); });
+    TzOffsetCache& cache = thread_state->cache;
+
     for (int row = 0; row < size; ++row) {
         if (time_viewer.is_null(row)) {
             result.append_null();
@@ -330,26 +341,20 @@ StatusOr<ColumnPtr> TimeFunctions::convert_tz_const(FunctionContext* context, co
         }
 
         auto datetime_value = time_viewer.value(row);
-
         int year, month, day, hour, minute, second, usec;
         datetime_value.to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
-        DateTimeValue ts_value(TIME_DATETIME, year, month, day, hour, minute, second, usec);
 
-        int64_t timestamp;
-        // TODO find a better approach to replace datetime_value.unix_timestamp
-        if (!ts_value.unix_timestamp(&timestamp, from)) {
-            result.append_null();
-            continue;
-        }
-        DateTimeValue ts_value2;
-        // TODO find a better approach to replace datetime_value.from_unixtime
-        if (!ts_value2.from_unixtime(timestamp, ts_value.microsecond(), to)) {
-            result.append_null();
-            continue;
-        }
+        // civil_as_utc_sec is StarRocks' own (non-cctz) calendar arithmetic reinterpreting these
+        // wall-clock fields as literal UTC seconds -- computed once here and handed to the cache
+        // so its hot/common path never has to build or do arithmetic on a cctz::civil_second
+        // (cctz's civil_second operators normalize through cctz::detail::impl::n_min, which
+        // dwarfs everything else in this loop once cache misses become rare).
+        int64_t civil_as_utc_sec = datetime_value.to_unix_second();
+        int64_t unix_sec = cache.unix_for_civil(civil_as_utc_sec, year, month, day, hour, minute, second, from);
+        int64_t offset = cache.offset_for_unix(unix_sec, to);
+
         TimestampValue ts;
-        ts.from_timestamp(ts_value2.year(), ts_value2.month(), ts_value2.day(), ts_value2.hour(), ts_value2.minute(),
-                          ts_value2.second(), ts_value2.microsecond());
+        ts.from_unix_second(unix_sec + offset, usec);
         result.append(ts);
     }
 

--- a/be/src/exprs/time_functions.h
+++ b/be/src/exprs/time_functions.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "base/time/tz_offset_cache.h"
 #include "column/column_builder.h"
 #include "column/vectorized_fwd.h"
 #include "exprs/builtin_functions.h"
@@ -972,6 +973,12 @@ private:
         bool is_valid = false;
         cctz::time_zone from_tz;
         cctz::time_zone to_tz;
+    };
+
+    // Per-execution-thread holder for convert_tz_const's TzOffsetCache (see
+    // base/time/tz_offset_cache.h for why this needs to be per-thread rather than shared).
+    struct ConvertTzThreadState : FunctionThreadState {
+        TzOffsetCache cache;
     };
 
     // fmt for string format like "%Y-%m-%d" and "%Y-%m-%d %H:%i:%s"

--- a/be/test/base/CMakeLists.txt
+++ b/be/test/base/CMakeLists.txt
@@ -99,6 +99,7 @@ set(BASE_TEST_FILES
     time/ratelimit_test.cpp
     time/monotime_test.cpp
     time/timezone_utils_test.cpp
+    time/tz_offset_cache_test.cpp
     types/numeric_types_test.cpp
     utility/integer_util_test.cpp
     utility/pretty_printer_test.cpp

--- a/be/test/base/time/tz_offset_cache_test.cpp
+++ b/be/test/base/time/tz_offset_cache_test.cpp
@@ -1,0 +1,343 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/time/tz_offset_cache.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <random>
+#include <vector>
+
+#include "base/testutil/parallel_test.h"
+#include "base/time/timezone_utils.h"
+
+namespace starrocks {
+
+namespace {
+
+cctz::time_point<cctz::seconds> unix_to_tp(int64_t unix_sec) {
+    static const cctz::time_point<cctz::seconds> epoch =
+            std::chrono::time_point_cast<cctz::seconds>(std::chrono::system_clock::from_time_t(0));
+    return epoch + cctz::seconds(unix_sec);
+}
+
+int64_t ground_truth_offset(const cctz::time_zone& tz, int64_t unix_sec) {
+    return tz.lookup(unix_to_tp(unix_sec)).offset;
+}
+
+cctz::time_point<cctz::seconds> ground_truth_unix_for_civil(const cctz::civil_second& cs, const cctz::time_zone& tz) {
+    return cctz::convert(cs, tz);
+}
+
+// Stands in for what a real caller (TimestampValue::to_unix_second(), which base/ cannot call)
+// computes: the civil fields reinterpreted as literal UTC seconds. This test only needs *a*
+// correct implementation of that quantity, not the production one -- cross-checking against
+// TimestampValue itself is done at the exprs/ level (time_functions_test.cpp), which can see
+// both types.
+int64_t civil_as_utc_seconds(const cctz::civil_second& cs) {
+    return cs - cctz::civil_second(1970, 1, 1, 0, 0, 0);
+}
+
+int64_t call_unix_for_civil(TzOffsetCache& cache, const cctz::civil_second& cs, const cctz::time_zone& tz) {
+    return cache.unix_for_civil(civil_as_utc_seconds(cs), cs.year(), cs.month(), cs.day(), cs.hour(), cs.minute(),
+                                cs.second(), tz);
+}
+
+} // namespace
+
+class TzOffsetCacheTest : public testing::Test {};
+
+// Densely probes every recorded transition (+/- a handful of seconds/minutes/hours/day) plus a
+// dense random sample, checking TzOffsetCache::offset_for_unix against cctz's direct lookup.
+// Exercises both a DST zone (America/Los_Angeles) and a fixed-offset zone (no transitions at
+// all, so the cache should degenerate to "always a hit after the first call").
+PARALLEL_TEST(TzOffsetCacheTest, offset_for_unix_matches_ground_truth) {
+    std::vector<std::string> zones = {
+            "America/Los_Angeles", "Europe/London", "Australia/Lord_Howe", "UTC", "+08:00", "-08:00"};
+    for (const auto& name : zones) {
+        // find_cctz_time_zone (not cctz::load_time_zone, which only understands IANA names) is
+        // what production code actually resolves timezone strings with, and is what makes
+        // "+08:00"/"-08:00" -- fixed-offset, no-DST-table zones -- work in this list.
+        cctz::time_zone tz;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(name, tz)) << name;
+
+        TzOffsetCache cache;
+        std::mt19937_64 rng(12345);
+
+        auto tp = cctz::time_point<cctz::seconds>::min();
+        cctz::time_zone::civil_transition trans;
+        int count = 0;
+        while (tz.next_transition(tp, &trans) && count < 500) {
+            int64_t instant = tz.lookup(trans.to).trans.time_since_epoch().count();
+            for (int64_t d : {-90000LL, -3601LL, -3600LL, -1LL, 0LL, 1LL, 3600LL, 3601LL, 90000LL}) {
+                int64_t probe = instant + d;
+                EXPECT_EQ(cache.offset_for_unix(probe, tz), ground_truth_offset(tz, probe)) << name << " abs=" << probe;
+            }
+            tp = tz.lookup(trans.to).trans;
+            ++count;
+        }
+
+        std::vector<int64_t> samples;
+        std::uniform_int_distribution<int64_t> d(-1000000000LL, 3000000000LL);
+        for (int i = 0; i < 20000; ++i) samples.push_back(d(rng));
+        std::sort(samples.begin(), samples.end());
+        for (int64_t probe : samples) {
+            EXPECT_EQ(cache.offset_for_unix(probe, tz), ground_truth_offset(tz, probe)) << name << " abs=" << probe;
+        }
+
+        // Adversarial (non-monotonic) order must still be correct with a fresh cache.
+        std::shuffle(samples.begin(), samples.end(), rng);
+        TzOffsetCache shuffled_cache;
+        for (int64_t probe : samples) {
+            EXPECT_EQ(shuffled_cache.offset_for_unix(probe, tz), ground_truth_offset(tz, probe))
+                    << name << " (shuffled) abs=" << probe;
+        }
+    }
+}
+
+// Same idea for unix_for_civil, additionally probing exactly the SKIPPED (nonexistent) and
+// REPEATED (ambiguous) civil ranges around each transition, where cctz::convert()'s tie-break
+// (SKIPPED -> transition instant, REPEATED -> earlier/"pre" instant) must be reproduced exactly.
+PARALLEL_TEST(TzOffsetCacheTest, unix_for_civil_matches_ground_truth) {
+    std::vector<std::string> zones = {
+            "America/Los_Angeles", "Europe/London", "Australia/Lord_Howe", "UTC", "+08:00", "-08:00"};
+    for (const auto& name : zones) {
+        // find_cctz_time_zone (not cctz::load_time_zone, which only understands IANA names) is
+        // what production code actually resolves timezone strings with, and is what makes
+        // "+08:00"/"-08:00" -- fixed-offset, no-DST-table zones -- work in this list.
+        cctz::time_zone tz;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(name, tz)) << name;
+
+        TzOffsetCache cache;
+        std::mt19937_64 rng(999);
+
+        auto tp = cctz::time_point<cctz::seconds>::min();
+        cctz::time_zone::civil_transition trans;
+        int count = 0;
+        while (tz.next_transition(tp, &trans) && count < 500) {
+            for (cctz::civil_second base : {trans.from, trans.to}) {
+                for (int64_t d : {-3660LL, -3601LL, -1LL, 0LL, 1LL, 3600LL, 3660LL, 86400LL, -86400LL}) {
+                    cctz::civil_second cs = base + d;
+                    int64_t got = call_unix_for_civil(cache, cs, tz);
+                    int64_t want = ground_truth_unix_for_civil(cs, tz).time_since_epoch().count();
+                    EXPECT_EQ(got, want) << name << " cs=" << cs;
+                }
+            }
+            tp = tz.lookup(trans.to).trans;
+            ++count;
+        }
+
+        std::vector<cctz::civil_second> samples;
+        std::uniform_int_distribution<int> yd(1970, 2060), md(1, 12), dd(1, 28), hd(0, 23), mnd(0, 59), sd(0, 59);
+        for (int i = 0; i < 20000; ++i) {
+            samples.emplace_back(yd(rng), md(rng), dd(rng), hd(rng), mnd(rng), sd(rng));
+        }
+        std::sort(samples.begin(), samples.end());
+        for (auto& cs : samples) {
+            int64_t got = call_unix_for_civil(cache, cs, tz);
+            int64_t want = ground_truth_unix_for_civil(cs, tz).time_since_epoch().count();
+            EXPECT_EQ(got, want) << name << " cs=" << cs;
+        }
+
+        std::shuffle(samples.begin(), samples.end(), rng);
+        TzOffsetCache shuffled_cache;
+        for (auto& cs : samples) {
+            int64_t got = call_unix_for_civil(shuffled_cache, cs, tz);
+            int64_t want = ground_truth_unix_for_civil(cs, tz).time_since_epoch().count();
+            EXPECT_EQ(got, want) << name << " (shuffled) cs=" << cs;
+        }
+    }
+}
+
+// Regression test for a real bug: next_transition()/prev_transition() give up ("ignoring
+// future_spec_", per cctz's own doc comment on NextTransition) once past a zone's explicit
+// zoneinfo table, even for a zone with an ongoing POSIX future DST rule -- has_prev is still
+// true (a real transition exists somewhere) but has_next becomes false. Before the fix, that
+// combination was (wrongly) treated the same as "no transitions anywhere" (a genuinely
+// fixed-offset zone, where both are false) and cached an unbounded window, so whichever
+// season's offset got computed first for a date past the table could get silently reused for
+// any later date -- including one in the opposite season. Both orderings are checked since the
+// bug depended on which query happened to populate the cache first.
+PARALLEL_TEST(TzOffsetCacheTest, offset_for_unix_past_explicit_table_does_not_poison_cache) {
+    cctz::time_zone tz;
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("America/Los_Angeles", tz));
+
+    // Both instants are far beyond this build's explicit zoneinfo table (verified to end around
+    // year 2437) and fall in opposite DST seasons.
+    cctz::civil_second summer(5468, 8, 10, 8, 0, 0);
+    cctz::civil_second winter(5469, 1, 15, 8, 0, 0);
+    int64_t summer_unix = cctz::convert(summer, tz).time_since_epoch().count();
+    int64_t winter_unix = cctz::convert(winter, tz).time_since_epoch().count();
+    ASSERT_NE(ground_truth_offset(tz, summer_unix), ground_truth_offset(tz, winter_unix))
+            << "test fixture assumption broken: these two instants must be in different DST seasons";
+
+    TzOffsetCache summer_first;
+    EXPECT_EQ(summer_first.offset_for_unix(summer_unix, tz), ground_truth_offset(tz, summer_unix));
+    EXPECT_EQ(summer_first.offset_for_unix(winter_unix, tz), ground_truth_offset(tz, winter_unix));
+
+    TzOffsetCache winter_first;
+    EXPECT_EQ(winter_first.offset_for_unix(winter_unix, tz), ground_truth_offset(tz, winter_unix));
+    EXPECT_EQ(winter_first.offset_for_unix(summer_unix, tz), ground_truth_offset(tz, summer_unix));
+}
+
+// Same bug class, civil direction.
+PARALLEL_TEST(TzOffsetCacheTest, unix_for_civil_past_explicit_table_does_not_poison_cache) {
+    cctz::time_zone tz;
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("America/Los_Angeles", tz));
+
+    cctz::civil_second summer(5468, 8, 10, 8, 0, 0);
+    cctz::civil_second winter(5469, 1, 15, 8, 0, 0);
+    int64_t want_summer = ground_truth_unix_for_civil(summer, tz).time_since_epoch().count();
+    int64_t want_winter = ground_truth_unix_for_civil(winter, tz).time_since_epoch().count();
+
+    TzOffsetCache summer_first;
+    EXPECT_EQ(call_unix_for_civil(summer_first, summer, tz), want_summer);
+    EXPECT_EQ(call_unix_for_civil(summer_first, winter, tz), want_winter);
+
+    TzOffsetCache winter_first;
+    EXPECT_EQ(call_unix_for_civil(winter_first, winter, tz), want_winter);
+    EXPECT_EQ(call_unix_for_civil(winter_first, summer, tz), want_summer);
+}
+
+// The fix must not regress the fixed-offset fast path this whole cache exists for: a zone with
+// literally no transitions (has_prev == has_next == false everywhere) still needs to degenerate
+// to an unbounded, cached window so consecutive calls stay O(1) regardless of how far apart the
+// queried instants are.
+PARALLEL_TEST(TzOffsetCacheTest, fixed_offset_zone_still_gets_unbounded_cached_window) {
+    cctz::time_zone tz;
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("+08:00", tz));
+
+    TzOffsetCache cache;
+    EXPECT_EQ(cache.offset_for_unix(0, tz), 28800);
+    // A wildly different instant must still be a cache *hit* (same offset either way, but this
+    // is what proves the window is actually unbounded rather than accidentally narrow).
+    EXPECT_EQ(cache.offset_for_unix(4000000000000LL, tz), 28800);
+    EXPECT_EQ(cache.offset_for_unix(-4000000000000LL, tz), 28800);
+}
+
+// Regression test for a bug found in review of the fix above: the same has_prev-&&-!has_next
+// condition that correctly flags "still cycling past the enumerable table" also fires -- for an
+// entirely different reason -- on ordinary present-day lookups into a zone that had exactly one
+// (or a handful of) historical transitions and has been permanently fixed ever since: e.g.
+// Asia/Shanghai stopped observing DST in 1991, Asia/Kolkata's last offset change was in 1945,
+// and America/Phoenix has had no DST since the 1940s. For those zones has_next is false for
+// *every* query from that point onward, not just far-future ones, so unconditionally disabling
+// the cache there would defeat this class's whole purpose for some of the most common timezones
+// in practice. The fix must tell the two cases apart and still cache an unbounded window for the
+// permanently-fixed case.
+PARALLEL_TEST(TzOffsetCacheTest, permanently_fixed_zone_after_last_transition_still_caches_unbounded) {
+    std::vector<std::string> zones = {"Asia/Shanghai", "Asia/Kolkata", "America/Phoenix"};
+    for (const auto& name : zones) {
+        cctz::time_zone tz;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(name, tz)) << name;
+
+        // Sanity-check the fixture assumption: an arbitrary present-day instant really does land
+        // in the has_prev && !has_next branch for these zones (i.e. this test would be vacuous
+        // otherwise).
+        cctz::civil_second now(2026, 8, 25, 12, 0, 0);
+        int64_t now_unix = cctz::convert(now, tz).time_since_epoch().count();
+        cctz::time_zone::civil_transition ct;
+        ASSERT_TRUE(tz.prev_transition(unix_to_tp(now_unix) + cctz::seconds(1), &ct)) << name;
+        ASSERT_FALSE(tz.next_transition(unix_to_tp(now_unix), &ct)) << name;
+
+        TzOffsetCache cache;
+        EXPECT_EQ(cache.offset_for_unix(now_unix, tz), ground_truth_offset(tz, now_unix)) << name;
+        EXPECT_TRUE(cache._abs_window.has_value) << name << ": should still cache, not disable";
+        EXPECT_EQ(cache._abs_window.hi, std::numeric_limits<int64_t>::max())
+                << name << ": should cache an unbounded window, not a bounded or absent one";
+
+        // A wildly different (but still post-last-transition) future instant must be a hit
+        // against that same unbounded window, and still correct.
+        int64_t far_future_unix = now_unix + 100LL * 365 * 86400;
+        EXPECT_EQ(cache.offset_for_unix(far_future_unix, tz), ground_truth_offset(tz, far_future_unix)) << name;
+        EXPECT_EQ(cache._abs_window.hi, std::numeric_limits<int64_t>::max())
+                << name << ": window should not have been narrowed/invalidated by the second call";
+    }
+}
+
+// Same idea, civil direction.
+PARALLEL_TEST(TzOffsetCacheTest, permanently_fixed_zone_after_last_transition_still_caches_unbounded_civil) {
+    std::vector<std::string> zones = {"Asia/Shanghai", "Asia/Kolkata", "America/Phoenix"};
+    for (const auto& name : zones) {
+        cctz::time_zone tz;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(name, tz)) << name;
+
+        cctz::civil_second now(2026, 8, 25, 12, 0, 0);
+        cctz::time_point<cctz::seconds> now_answer = cctz::convert(now, tz);
+        cctz::time_zone::civil_transition ct;
+        ASSERT_TRUE(tz.prev_transition(now_answer + cctz::seconds(1), &ct)) << name;
+        ASSERT_FALSE(tz.next_transition(now_answer, &ct)) << name;
+
+        TzOffsetCache cache;
+        int64_t got = call_unix_for_civil(cache, now, tz);
+        EXPECT_EQ(got, now_answer.time_since_epoch().count()) << name;
+        EXPECT_TRUE(cache._civil_window.has_value) << name << ": should still cache, not disable";
+        EXPECT_EQ(cache._civil_window.hi, std::numeric_limits<int64_t>::max())
+                << name << ": should cache an unbounded window, not a bounded or absent one";
+
+        cctz::civil_second far_future = now + int64_t{100LL * 365 * 86400};
+        int64_t want = ground_truth_unix_for_civil(far_future, tz).time_since_epoch().count();
+        EXPECT_EQ(call_unix_for_civil(cache, far_future, tz), want) << name;
+        EXPECT_EQ(cache._civil_window.hi, std::numeric_limits<int64_t>::max())
+                << name << ": window should not have been narrowed/invalidated by the second call";
+    }
+}
+
+// A single TzOffsetCache instance is used exactly as convert_tz_const uses it: unix_for_civil()
+// against `from`, then offset_for_unix() against `to`, on the same instance. Verifies the two
+// directions don't interfere with each other's window, across DST and fixed-offset zone pairs.
+PARALLEL_TEST(TzOffsetCacheTest, combined_round_trip_matches_reference_convert_tz) {
+    struct Pair {
+        std::string from, to;
+    };
+    std::vector<Pair> pairs = {
+            {"UTC", "America/Los_Angeles"},
+            {"America/Los_Angeles", "UTC"},
+            {"+00:00", "-08:00"},
+            {"-08:00", "+00:00"},
+    };
+    for (auto& p : pairs) {
+        cctz::time_zone from_tz, to_tz;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(p.from, from_tz));
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(p.to, to_tz));
+
+        TzOffsetCache cache;
+        std::mt19937_64 rng(42);
+        std::vector<cctz::civil_second> samples;
+        std::uniform_int_distribution<int> yd(1970, 2060), md(1, 12), dd(1, 28), hd(0, 23), mnd(0, 59), sd(0, 59);
+        for (int i = 0; i < 20000; ++i) {
+            samples.emplace_back(yd(rng), md(rng), dd(rng), hd(rng), mnd(rng), sd(rng));
+        }
+        // Deliberately unsorted/interleaved to stress both windows at once.
+        std::shuffle(samples.begin(), samples.end(), rng);
+
+        for (auto& cs : samples) {
+            int64_t unix_sec = call_unix_for_civil(cache, cs, from_tz);
+            int64_t offset = cache.offset_for_unix(unix_sec, to_tz);
+            cctz::civil_second got = cctz::civil_second(1970, 1, 1, 0, 0, 0) + (unix_sec + offset);
+
+            // Reference: exactly what convert_tz_const computed before this optimization
+            // (civil -> absolute in `from`, then absolute -> civil in `to`).
+            cctz::time_point<cctz::seconds> ref_abs = cctz::convert(cs, from_tz);
+            cctz::civil_second want = to_tz.lookup(ref_abs).cs;
+
+            EXPECT_EQ(got, want) << p.from << "->" << p.to << " cs=" << cs;
+        }
+    }
+}
+
+} // namespace starrocks

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -18,10 +18,13 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstring>
+#include <random>
 #include <utility>
 #include <vector>
 
+#include "base/time/timezone_utils.h"
 #include "base/utility/defer_op.h"
 #include "column/binary_column.h"
 #include "column/column_builder.h"
@@ -2502,6 +2505,225 @@ TEST_F(TimeFunctionsTest, convertTzConstTest) {
     ASSERT_TRUE(
             TimeFunctions::convert_tz_close(_utils->get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
                     .ok());
+}
+
+// Regression test for the thread-local DST-offset-window cache in convert_tz_const (see
+// TzOffsetCache in base/time/tz_offset_cache.h). Rows are deliberately ordered out of
+// chronological order (jumping between years and across both a spring-forward gap and a
+// fall-back repeat) so a buggy cache window would surface as a wrong value on whichever row
+// lands just after a stale window is (incorrectly) reused, not just as a slow path.
+TEST_F(TimeFunctionsTest, convertTzConstDstBoundaryTest) {
+    {
+        // UTC -> America/Los_Angeles: exercises the absolute-time (`to`) window cache.
+        auto tc = TimestampColumn::create();
+        tc->append(TimestampValue::create(2021, 7, 4, 12, 0, 0));   // ordinary summer (PDT)
+        tc->append(TimestampValue::create(2021, 11, 7, 9, 0, 0));   // exactly at fall-back instant
+        tc->append(TimestampValue::create(2021, 3, 14, 9, 59, 59)); // 1s before spring-forward
+        tc->append(TimestampValue::create(2021, 1, 4, 12, 0, 0));   // ordinary winter (PST)
+        tc->append(TimestampValue::create(2021, 3, 14, 10, 0, 0));  // exactly at spring-forward instant
+        tc->append(TimestampValue::create(2021, 11, 7, 8, 59, 59)); // 1s before fall-back
+        tc->append(TimestampValue::create(2021, 7, 4, 12, 0, 0));   // ordinary summer again
+
+        auto tc_from = ColumnHelper::create_const_column<TYPE_VARCHAR>("UTC", 1);
+        auto tc_to = ColumnHelper::create_const_column<TYPE_VARCHAR>("America/Los_Angeles", 1);
+
+        TimestampValue res[] = {
+                TimestampValue::create(2021, 7, 4, 5, 0, 0),    TimestampValue::create(2021, 11, 7, 1, 0, 0),
+                TimestampValue::create(2021, 3, 14, 1, 59, 59), TimestampValue::create(2021, 1, 4, 4, 0, 0),
+                TimestampValue::create(2021, 3, 14, 3, 0, 0),   TimestampValue::create(2021, 11, 7, 1, 59, 59),
+                TimestampValue::create(2021, 7, 4, 5, 0, 0),
+        };
+        Columns columns{tc, tc_from, tc_to};
+
+        FunctionUtils utils;
+        utils.get_fn_ctx()->set_constant_columns(columns);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_DATETIME);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+
+        ASSERT_TRUE(TimeFunctions::convert_tz_prepare(utils.get_fn_ctx(),
+                                                      FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+        ColumnPtr result = TimeFunctions::convert_tz(utils.get_fn_ctx(), columns).value();
+        auto data = ColumnHelper::cast_to<TYPE_DATETIME>(result);
+        for (int i = 0; i < std::size(res); ++i) ASSERT_EQ(res[i], data->get_data()[i]) << "row " << i;
+        ASSERT_TRUE(
+                TimeFunctions::convert_tz_close(utils.get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+    }
+    {
+        // America/Los_Angeles -> UTC: exercises the civil-time (`from`) window cache, including
+        // a SKIPPED (nonexistent) civil time and a REPEATED (ambiguous) one -- cctz::convert()'s
+        // documented tie-break is: SKIPPED -> the transition instant, REPEATED -> the earlier
+        // ("pre") instant. Both must match exactly, cache or no cache.
+        auto tc = TimestampColumn::create();
+        tc->append(TimestampValue::create(2021, 7, 4, 12, 0, 0));   // ordinary summer (local)
+        tc->append(TimestampValue::create(2021, 11, 7, 1, 30, 0));  // REPEATED civil time (pre)
+        tc->append(TimestampValue::create(2021, 3, 14, 1, 59, 59)); // 1s before spring-forward
+        tc->append(TimestampValue::create(2021, 3, 14, 2, 30, 0));  // SKIPPED civil time
+        tc->append(TimestampValue::create(2021, 11, 7, 2, 0, 0));   // just after the repeated hour, unique
+        tc->append(TimestampValue::create(2021, 3, 14, 3, 0, 0));   // just after spring-forward, unique
+        tc->append(TimestampValue::create(2021, 11, 7, 1, 59, 59)); // last second of the repeated hour (pre)
+        tc->append(TimestampValue::create(2021, 1, 4, 12, 0, 0));   // ordinary winter (local)
+        tc->append(TimestampValue::create(2021, 7, 4, 12, 0, 0));   // ordinary summer again
+
+        auto tc_from = ColumnHelper::create_const_column<TYPE_VARCHAR>("America/Los_Angeles", 1);
+        auto tc_to = ColumnHelper::create_const_column<TYPE_VARCHAR>("UTC", 1);
+
+        TimestampValue res[] = {
+                TimestampValue::create(2021, 7, 4, 19, 0, 0),   TimestampValue::create(2021, 11, 7, 8, 30, 0),
+                TimestampValue::create(2021, 3, 14, 9, 59, 59), TimestampValue::create(2021, 3, 14, 10, 0, 0),
+                TimestampValue::create(2021, 11, 7, 10, 0, 0),  TimestampValue::create(2021, 3, 14, 10, 0, 0),
+                TimestampValue::create(2021, 11, 7, 8, 59, 59), TimestampValue::create(2021, 1, 4, 20, 0, 0),
+                TimestampValue::create(2021, 7, 4, 19, 0, 0),
+        };
+        Columns columns{tc, tc_from, tc_to};
+
+        FunctionUtils utils;
+        utils.get_fn_ctx()->set_constant_columns(columns);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_DATETIME);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+
+        ASSERT_TRUE(TimeFunctions::convert_tz_prepare(utils.get_fn_ctx(),
+                                                      FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+        ColumnPtr result = TimeFunctions::convert_tz(utils.get_fn_ctx(), columns).value();
+        auto data = ColumnHelper::cast_to<TYPE_DATETIME>(result);
+        for (int i = 0; i < std::size(res); ++i) ASSERT_EQ(res[i], data->get_data()[i]) << "row " << i;
+        ASSERT_TRUE(
+                TimeFunctions::convert_tz_close(utils.get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+    }
+}
+
+// convert_tz_const computes "civil fields <-> literal-UTC seconds" via
+// TimestampValue::to_unix_second()/from_unix_second() (StarRocks' own Julian-day arithmetic)
+// instead of cctz::civil_second, specifically to avoid cctz::detail::impl::n_min -- the civil_time
+// normalization routine that a `perf` profile of this exact code showed dominating runtime,
+// unrelated to DST vs fixed-offset. That swap is only correct if StarRocks' calendar arithmetic
+// and cctz's agree on every date; this cross-checks exactly that; across ~2000 random dates per
+// zone pair (spanning 1902-2098) against an independent, pure-cctz reference computation, rather
+// than assuming the two implementations of the Gregorian calendar never disagree.
+TEST_F(TimeFunctionsTest, convertTzConstMatchesCctzAcrossRandomDates) {
+    struct Pair {
+        std::string from, to;
+    };
+    std::vector<Pair> pairs = {
+            {"UTC", "America/Los_Angeles"},
+            {"America/Los_Angeles", "UTC"},
+            {"+00:00", "-05:00"},
+            {"-05:00", "+00:00"},
+    };
+
+    std::mt19937_64 rng(2024);
+    std::uniform_int_distribution<int> yd(1902, 2098), md(1, 12), dd(1, 28), hd(0, 23), mnd(0, 59), sd(0, 59);
+    constexpr int kSamples = 2000;
+
+    for (auto& p : pairs) {
+        cctz::time_zone from_tz, to_tz;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(p.from, from_tz)) << p.from;
+        ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone(p.to, to_tz)) << p.to;
+
+        auto tc = TimestampColumn::create();
+        std::vector<TimestampValue> expected;
+        for (int i = 0; i < kSamples; ++i) {
+            int year = yd(rng), month = md(rng), day = dd(rng), hour = hd(rng), minute = mnd(rng), second = sd(rng);
+            tc->append(TimestampValue::create(year, month, day, hour, minute, second));
+
+            cctz::civil_second cs(year, month, day, hour, minute, second);
+            cctz::time_point<cctz::seconds> abs_tp = cctz::convert(cs, from_tz);
+            cctz::time_zone::absolute_lookup al = to_tz.lookup(abs_tp);
+            expected.push_back(TimestampValue::create(al.cs.year(), al.cs.month(), al.cs.day(), al.cs.hour(),
+                                                      al.cs.minute(), al.cs.second()));
+        }
+
+        auto tc_from = ColumnHelper::create_const_column<TYPE_VARCHAR>(p.from, 1);
+        auto tc_to = ColumnHelper::create_const_column<TYPE_VARCHAR>(p.to, 1);
+        Columns columns{tc, tc_from, tc_to};
+
+        FunctionUtils utils;
+        utils.get_fn_ctx()->set_constant_columns(columns);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_DATETIME);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+
+        ASSERT_TRUE(TimeFunctions::convert_tz_prepare(utils.get_fn_ctx(),
+                                                      FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+        ColumnPtr result = TimeFunctions::convert_tz(utils.get_fn_ctx(), columns).value();
+        auto data = ColumnHelper::cast_to<TYPE_DATETIME>(result);
+        for (int i = 0; i < kSamples; ++i) {
+            ASSERT_EQ(expected[i], data->get_data()[i]) << p.from << "->" << p.to << " row " << i;
+        }
+        ASSERT_TRUE(
+                TimeFunctions::convert_tz_close(utils.get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+    }
+}
+
+// Regression test for a real bug (see TzOffsetCacheTest.offset_for_unix_past_explicit_table_does_not_poison_cache
+// in tz_offset_cache_test.cpp for the underlying mechanism): converting a date past the zone's
+// explicit transition table (~year 2437 in this build) used to cache an unbounded offset window,
+// silently reusing whichever DST season was computed first for any later far-future date --
+// including one in the opposite season. Exercised end-to-end through convert_tz here, in both
+// row orderings, since the bug depended on which row happened to populate the cache first.
+TEST_F(TimeFunctionsTest, convertTzConstPastExplicitTableDoesNotPoisonCache) {
+    // Both are far beyond the explicit table and in opposite DST seasons for America/Los_Angeles;
+    // same UTC wall-clock time so the 1-hour PDT/PST offset difference shows up directly in the
+    // converted local hour instead of being masked by also varying the UTC time-of-day.
+    TimestampValue summer_utc = TimestampValue::create(5468, 8, 10, 12, 0, 0);
+    TimestampValue winter_utc = TimestampValue::create(5469, 1, 15, 12, 0, 0);
+
+    cctz::time_zone la;
+    ASSERT_TRUE(TimezoneUtils::find_cctz_time_zone("America/Los_Angeles", la));
+    auto want = [&](const TimestampValue& utc_ts) {
+        int year, month, day, hour, minute, second, usec;
+        utc_ts.to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
+        cctz::civil_second cs(year, month, day, hour, minute, second);
+        cctz::time_zone::absolute_lookup al = la.lookup(cctz::convert(cs, cctz::utc_time_zone()));
+        return TimestampValue::create(al.cs.year(), al.cs.month(), al.cs.day(), al.cs.hour(), al.cs.minute(),
+                                      al.cs.second());
+    };
+    TimestampValue want_summer = want(summer_utc);
+    TimestampValue want_winter = want(winter_utc);
+    ASSERT_NE(want_summer.to_string().substr(11, 2), want_winter.to_string().substr(11, 2))
+            << "test fixture assumption broken: these two instants must land on different local hours";
+
+    for (bool summer_row_first : {true, false}) {
+        auto tc = TimestampColumn::create();
+        std::vector<TimestampValue> expected;
+        if (summer_row_first) {
+            tc->append(summer_utc);
+            tc->append(winter_utc);
+            expected = {want_summer, want_winter};
+        } else {
+            tc->append(winter_utc);
+            tc->append(summer_utc);
+            expected = {want_winter, want_summer};
+        }
+
+        auto tc_from = ColumnHelper::create_const_column<TYPE_VARCHAR>("UTC", 1);
+        auto tc_to = ColumnHelper::create_const_column<TYPE_VARCHAR>("America/Los_Angeles", 1);
+        Columns columns{tc, tc_from, tc_to};
+
+        FunctionUtils utils;
+        utils.get_fn_ctx()->set_constant_columns(columns);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_DATETIME);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+        utils.get_fn_ctx()->_arg_types.emplace_back(TYPE_VARCHAR);
+
+        ASSERT_TRUE(TimeFunctions::convert_tz_prepare(utils.get_fn_ctx(),
+                                                      FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                            .ok());
+        ColumnPtr result = TimeFunctions::convert_tz(utils.get_fn_ctx(), columns).value();
+        auto data = ColumnHelper::cast_to<TYPE_DATETIME>(result);
+        ASSERT_EQ(expected[0], data->get_data()[0]) << "summer_row_first=" << summer_row_first << " row 0";
+        ASSERT_EQ(expected[1], data->get_data()[1]) << "summer_row_first=" << summer_row_first << " row 1";
+        ASSERT_TRUE(
+                TimeFunctions::convert_tz_close(utils.get_fn_ctx(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+    }
 }
 
 TEST_F(TimeFunctionsTest, utctimestampTest) {


### PR DESCRIPTION
## Why I'm doing:
`convert_tz` is significantly slower than it needs to be. On a real workload, wrapping `date_trunc` with a `convert_tz` round-trip (`convert_tz(date_trunc('day', convert_tz(t, 'UTC', tz)), tz, 'UTC')`) turned a 4.5s aggregation into 40+s, with the added time almost entirely inside the two `convert_tz` calls.

Root cause: `convert_tz_const` (the fast path taken when the timezone arguments are literal constants) resolves the timezone strings once, but its per-row loop still does two full DST-aware `cctz` conversions on every row, round-tripped through a heavy `DateTimeValue` pack/unpack, with no reuse across rows. This cost is unrelated to whether the timezone actually has DST rules — a fixed-offset pair like `'+00:00'` → `'-08:00'` is exactly as slow as a real DST zone, because the code path doesn't distinguish between them.

Real-world timestamp columns are almost always time-clustered within a scan batch, so the same UTC offset applies to long runs of consecutive rows. The old code never exploited that.

## What I'm doing:
Added `TzOffsetCache` (`be/src/base/time/`), a small per-thread cache that remembers the UTC offset window currently in effect for a `cctz::time_zone` and only re-resolves it when a row actually falls outside that window:

```
 civil/absolute timeline ------------------------------------------->
 [ window A, offset -8h )[ window B, -7h )
 ^ ^
 cached hit DST transition:
 (no cctz lookup) re-resolve once,
 cache new window
```

- For a real DST zone, the window is bounded by the two nearest transitions, so consecutive same-offset rows become cache hits instead of repeated `cctz` transition searches.
- For a fixed-offset zone (no transitions at all), the window degenerates to `(-inf, +inf)` after the very first row — every later row is a hit regardless of the time range, matching the "just add a constant" performance a fixed offset should have.
- Ambiguous wall-clock times (the skipped/repeated hour around a DST change) are never cached and always re-resolved through the authoritative `cctz` lookup, so correctness at DST boundaries is unaffected.

`convert_tz_const` now uses `TzOffsetCache` directly via `cctz::civil_second`/`time_point` instead of round-tripping through `DateTimeValue`, removing that overhead as well.

`TzOffsetCache` is deliberately placed in `base/time/` (not inside `exprs/`) so it isn't tied to `convert_tz` — other places in the codebase doing the same kind of per-row timezone conversion (e.g. Parquet timestamp readers) can adopt it later without needing their own copy of this logic.

Added a regression test (`TimeFunctionsTest.convertTzConstDstBoundaryTest`) covering spring-forward, fall-back, the skipped/repeated hour, and out-of-order rows, plus a dedicated unit test for `TzOffsetCache` itself.

## Perf Stats

**Setup:**
```sql
CREATE TABLE convert_tz_bench.events (
 id BIGINT,
 ts DATETIME
)
DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 32
PROPERTIES ("replication_num" = "1");

INSERT INTO convert_tz_bench.events
SELECT
 idx AS id,
 date_add('2018-01-01 00:00:00', INTERVAL idx SECOND) AS ts
FROM TABLE(generate_series(1, 100000000)) AS t(idx);
-- 100M rows, ts spans 2018-01-01 to 2021-03-03 (crosses multiple US DST transitions)
```

**Query (round-trip, isolates PROJECT-only cost via BLACKHOLE sink):**
```sql
-- baseline
EXPLAIN ANALYZE
INSERT INTO BLACKHOLE() SELECT date_trunc('day', ts) AS d FROM convert_tz_bench.events;

-- fixed-offset round trip
EXPLAIN ANALYZE
INSERT INTO BLACKHOLE()
SELECT convert_tz(date_trunc('day', convert_tz(ts, '+00:00', '-08:00')), '-08:00', '+00:00') AS d
FROM convert_tz_bench.events;

-- DST-zone round trip
EXPLAIN ANALYZE
INSERT INTO BLACKHOLE()
SELECT convert_tz(date_trunc('day', convert_tz(ts, 'UTC', 'America/Los_Angeles')), 'America/Los_Angeles', 'UTC') AS d
FROM convert_tz_bench.events;
```

**What changed:**
1. `TzOffsetCache` (`base/time/tz_offset_cache.h`) — caches the DST offset window per thread so `convert_tz_const` skips cctz's transition-table search on consecutive same-offset rows, instead of doing it on every row.
2. `convert_tz_const` swapped `cctz::civil_second` arithmetic for `TimestampValue::to_unix_second()` / `from_unix_second()` — StarRocks' own calendar routines — after a `perf` profile showed `cctz::detail::impl::n_min` (cctz's civil-time normalization) dominating runtime, independent of DST vs fixed-offset. `cctz::civil_second` is now only constructed on the rare cache-miss path.

**Comparison (`TotalTime`, from `get_query_profile`):**

| Query | Before | After (offset cache) | After (native calendar math) | Cumulative gain |
| ------------------------------------------------- | ------ | --------------------------- | ----------------------------------- | --------------- |
| `date_trunc` (baseline) | 129ms | — | 129ms (unaffected) | — |
| Fixed offset (`+00:00`↔`-08:00`) round trip | 4.1s | 1.8s | **833ms** | ~4.9x |
| DST zone (`UTC`↔`America/Los_Angeles`) round trip | 5.6s | 1.7s | **555ms** | ~10x |

Fixed offset and DST zone were equally slow before and after each fix — the remaining cost is calendar field decompose/reconstruct, which is inherent to `TimestampValue`↔wall-clock-fields conversion and independent of whether the zone has DST rules.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5