### PR TITLE
[BugFix] Fix wasted reads and stray v1 deletes in grace-blocked vacuum

### DIFF
--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -65,6 +65,12 @@ struct VacuumTabletMetaVerionRange {
     // any tablet still retains.
     bool intersect_low = false;
 
+    // True when nothing is deletable: either no tablet ever merged a range (the initial {0, 0} -- e.g.
+    // the grace period stopped every tablet from advancing), or the merged range came out degenerate
+    // (low >= high, e.g. an empty intersection across tablets). Callers must check this before acting
+    // on |min_version| / |max_version|: on an empty range they carry no meaning.
+    bool empty() const { return min_version >= max_version; }
+
     /*
     * if tablet a has version range [1, ..., 10) ,
     * and tablet b has version range [5, ..., 15),
@@ -513,6 +519,12 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     // or when the very first read returns NotFound, i.e. the metadata at and below the retain
     // boundary has already been vacuumed away by a previous run.
     bool read_any_metadata = false;
+    // Whether the walk stopped because a metadata read returned NotFound rather than because the loop
+    // guard dropped below |min_version|. Combined with |read_any_metadata| it identifies an ANCHORED
+    // NotFound: the walk read a real metadata and then followed its |prev_garbage_version| to a version
+    // that no longer exists. That pointer links only materialized versions, so such a NotFound is the
+    // genuine chain bottom -- nothing exists at or below it.
+    bool walk_hit_missing_version = false;
     size_t extra_file_size = 0;
     int64_t prepare_vacuum_file_size = 0;
     // Starting at |*final_retain_version|, read the tablet metadata forward along
@@ -527,6 +539,7 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
                 vacuum_version_range != nullptr /* fill data cache when enable file bundle */);
         TEST_SYNC_POINT_CALLBACK("collect_files_to_vacuum:get_tablet_metadata", &res);
         if (res.status().is_not_found()) {
+            walk_hit_missing_version = true;
             break;
         } else if (!res.ok()) {
             return res.status();
@@ -598,6 +611,27 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
             // never below `final_retain_version` (which itself no longer exists).
             *vacuumed_version = std::max<int64_t>(final_retain_version, min_version - 1);
             return Status::OK();
+        }
+        // The grace period stopped this round from deleting anything, so |final_retain_version| must NOT
+        // become the new floor: the versions between the walk terminus and the retain boundary still
+        // exist and still reference garbage files that a later round must collect once they age past the
+        // grace timestamp. Advancing the floor past them would strand that work forever.
+        //
+        // But an ANCHORED NotFound did prove something the next round can reuse: the chain bottom sits at
+        // |version|, so nothing exists at or below it. Without recording it, the BE echoes back the floor
+        // the FE sent, the next round re-walks the same versions and re-pays the same NotFound, once per
+        // tablet per round for as long as the partition keeps being written inside the grace window.
+        //
+        // |version + 1| is the only bound the walk established -- the very same bound the success path
+        // feeds to vacuum_version_range->merge(version + 1, final_retain_version). std::max keeps the
+        // floor monotonic so a stale request can never move it backwards.
+        //
+        // Deliberately restricted to the anchored case. An un-anchored NotFound (the first read, handled
+        // by the branch above) is NOT proof of a chain bottom: |min_retain_version| can be lowered to a
+        // bookmark fence version that this tablet never materialized because batch publish folded it into
+        // a later snapshot, and treating that hole as the bottom would strand every version below it.
+        if (walk_hit_missing_version) {
+            tablet_info.set_min_version(std::max<int64_t>(min_version, version + 1));
         }
         // All tablet metadata files encountered were created after the grace timestamp, there were no files to delete
         // The final_retain_version is set to min_retain_version or minmum exist version which has garbage files.
@@ -703,7 +737,15 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
         // if a table enables shared cleanup and finished alter job, the new created tablet will create initial tablet metadata
         // its own tablet_id to avoid overwriting the initial tablet metadata.
         // After that, we need to vacuum these metadata file using its own tablet_id
-        if (vacuum_version_range->min_version <= 1) {
+        //
+        // Only when version 1 actually falls inside the deletable range. Testing `min_version <= 1` alone
+        // also matched the empty range {0, 0} -- the normal state when the grace period stopped every
+        // tablet from advancing -- and vacuum then issued a speculative delete of every tablet's version-1
+        // metadata and reported them as vacuumed, even though nothing was deletable this round. For a
+        // freshly created partition still inside the grace window that file is the tablet's only metadata.
+        // A merged range always has min_version >= 1 (it is a `version + 1`), so a non-empty range with
+        // min_version <= 1 is exactly one that contains version 1.
+        if (!vacuum_version_range->empty() && vacuum_version_range->min_version <= 1) {
             for (auto& tablet_info : tablet_infos) {
                 RETURN_IF_ERROR(metafile_deleter.delete_file(
                         join_path(meta_dir, tablet_metadata_filename(tablet_info.tablet_id(), 1))));

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -5056,7 +5056,9 @@ TEST_P(LakeVacuumTest, test_vacuum_bundle_metadata) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(2, response.vacuumed_files());
+        // The grace period stopped every tablet from advancing, so the partition-level version range is
+        // empty and vacuum must not speculatively delete each tablet's version-1 metadata.
+        EXPECT_EQ(0, response.vacuumed_files());
         // The size of deleted metadata files is not counted in vacuumed_file_size.
         EXPECT_EQ(0, response.vacuumed_file_size());
 
@@ -5345,7 +5347,9 @@ TEST_P(LakeVacuumTest, test_vacuum_shared_data_files) {
         vacuum(_tablet_mgr.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
-        EXPECT_EQ(2, response.vacuumed_files());
+        // The grace period stopped every tablet from advancing, so the partition-level version range is
+        // empty and vacuum must not speculatively delete each tablet's version-1 metadata.
+        EXPECT_EQ(0, response.vacuumed_files());
         // The size of deleted metadata files is not counted in vacuumed_file_size.
         EXPECT_EQ(0, response.vacuumed_file_size());
 
@@ -6967,6 +6971,247 @@ TEST_P(LakeVacuumTest, test_vacuum_min_retain_below_min_version) {
     }
     SyncPoint::GetInstance()->ClearCallBack("collect_files_to_vacuum:get_tablet_metadata");
     SyncPoint::GetInstance()->DisableProcessing();
+}
+
+// The grace period stops a round from deleting anything, but a walk that ran off the bottom of the
+// prev_garbage_version chain still proved where that bottom is. That floor must be handed back to the
+// FE, otherwise every following round re-walks the same versions and re-pays the same NotFound read.
+TEST_P(LakeVacuumTest, test_vacuum_grace_blocked_records_chain_bottom) {
+    // Tablet 5300's only surviving metadata is version 10; its prev_garbage_version points at version 6,
+    // which an earlier vacuum already removed. commit_time 2000 is at/after the grace timestamp used
+    // below, so the grace period blocks every deletion this round.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 5300,
+            "version": 10,
+            "prev_garbage_version": 6,
+            "commit_time": 2000
+        }
+        )DEL")));
+
+    int64_t total_reads = 0;
+    int64_t not_found_reads = 0;
+    SyncPoint::GetInstance()->SetCallBack("collect_files_to_vacuum:get_tablet_metadata", [&](void* arg) {
+        auto* res = reinterpret_cast<StatusOr<TabletMetadataPtr>*>(arg);
+        ++total_reads;
+        if (res->status().is_not_found()) {
+            ++not_found_reads;
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("collect_files_to_vacuum:get_tablet_metadata");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    int64_t next_min_version = 0;
+    // Round 1: read version 10, follow its prev_garbage_version to the missing version 6, stop there.
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(5300);
+        info->set_min_version(1);
+        request.set_min_retain_version(10);
+        request.set_grace_timestamp(1000);
+        request.set_min_active_txn_id(99999);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(2, total_reads);
+        EXPECT_EQ(1, not_found_reads);
+        // Inside the grace window nothing may be deleted, and version 10 stays retained.
+        EXPECT_EQ(0, response.vacuumed_files());
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5300, 10)));
+        EXPECT_EQ(9, response.vacuumed_version());
+        // The only bound the walk established: nothing exists at or below version 6. NOT
+        // final_retain_version (10) -- version 10 was not deleted and its garbage is still to collect.
+        ASSERT_EQ(1, response.tablet_infos_size());
+        EXPECT_EQ(7, response.tablet_infos(0).min_version());
+        next_min_version = response.tablet_infos(0).min_version();
+    }
+
+    // Round 2: the FE replays the floor the BE reported. The walk stops at it instead of re-reading --
+    // and re-paying the NotFound on -- version 6. Before the fix this round repeated both reads.
+    total_reads = 0;
+    not_found_reads = 0;
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(5300);
+        info->set_min_version(next_min_version);
+        request.set_min_retain_version(10);
+        request.set_grace_timestamp(1000);
+        request.set_min_active_txn_id(99999);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(1, total_reads);
+        EXPECT_EQ(0, not_found_reads);
+        EXPECT_EQ(0, response.vacuumed_files());
+        // Nothing new was proved, so the floor is echoed back unchanged -- never lowered either.
+        ASSERT_EQ(1, response.tablet_infos_size());
+        EXPECT_EQ(7, response.tablet_infos(0).min_version());
+    }
+}
+
+// The counterpart of the test above: a NotFound on the very FIRST read is not proof of a chain bottom.
+// min_retain_version can be lowered to a bookmark fence version that this tablet never materialized
+// (batch publish folds a run of txns into a single snapshot at the batch's final version), so treating
+// that hole as the bottom would strand every version below it. The floor must stay put.
+TEST_P(LakeVacuumTest, test_vacuum_grace_blocked_keeps_floor_on_unanchored_miss) {
+    // Version 8 is a hole for this tablet; versions 5 and 12 are materialized. Both are inside the
+    // grace window.
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 5301,
+            "version": 5,
+            "commit_time": 2000
+        }
+        )DEL")));
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+            "id": 5301,
+            "version": 12,
+            "prev_garbage_version": 5,
+            "commit_time": 2000
+        }
+        )DEL")));
+
+    int64_t total_reads = 0;
+    int64_t not_found_reads = 0;
+    SyncPoint::GetInstance()->SetCallBack("collect_files_to_vacuum:get_tablet_metadata", [&](void* arg) {
+        auto* res = reinterpret_cast<StatusOr<TabletMetadataPtr>*>(arg);
+        ++total_reads;
+        if (res->status().is_not_found()) {
+            ++not_found_reads;
+        }
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("collect_files_to_vacuum:get_tablet_metadata");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // Round 1: the retain boundary is the hole at version 8, so the very first read misses.
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(5301);
+        info->set_min_version(1);
+        request.set_min_retain_version(8);
+        request.set_grace_timestamp(1000);
+        request.set_min_active_txn_id(99999);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(1, total_reads);
+        EXPECT_EQ(1, not_found_reads);
+        ASSERT_EQ(1, response.tablet_infos_size());
+        // The floor must NOT advance to 9: version 5 is still down there and still has to be walked.
+        EXPECT_EQ(1, response.tablet_infos(0).min_version());
+    }
+
+    // Round 2: the retain boundary lands on a materialized version again. Version 5 is still reachable,
+    // which it would not be had round 1 pushed the floor above it.
+    total_reads = 0;
+    not_found_reads = 0;
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        request.set_delete_txn_log(false);
+        auto* info = request.add_tablet_infos();
+        info->set_tablet_id(5301);
+        info->set_min_version(1);
+        request.set_min_retain_version(5);
+        request.set_grace_timestamp(1000);
+        request.set_min_active_txn_id(99999);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(1, total_reads);
+        EXPECT_EQ(0, not_found_reads);
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(5301, 5)));
+    }
+}
+
+// With file bundling on, vacuum also deletes each tablet's own version-1 metadata -- the initial file
+// create_tablet writes under the tablet id rather than into a bundle. That delete is only legal when
+// version 1 falls inside the partition-level deletable range; an empty range means nothing at all may
+// be deleted this round.
+TEST_P(LakeVacuumTest, test_vacuum_bundle_keeps_v1_metadata_when_range_empty) {
+    for (int64_t tablet_id : {700, 701}) {
+        auto v1 = json_to_pb<TabletMetadataPB>(R"DEL(
+            {
+                "version": 1,
+                "commit_time": 2000
+            }
+            )DEL");
+        v1->set_id(tablet_id);
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(v1));
+        auto v2 = json_to_pb<TabletMetadataPB>(R"DEL(
+            {
+                "version": 2,
+                "prev_garbage_version": 1,
+                "commit_time": 2000
+            }
+            )DEL");
+        v2->set_id(tablet_id);
+        ASSERT_OK(_tablet_mgr->put_tablet_metadata(v2));
+    }
+    ASSERT_TRUE(file_exist(tablet_metadata_filename(700, 1)));
+    ASSERT_TRUE(file_exist(tablet_metadata_filename(701, 1)));
+
+    auto make_request = [](VacuumRequest* request, int64_t grace_timestamp) {
+        request->set_delete_txn_log(false);
+        for (int64_t tablet_id : {700, 701}) {
+            auto* info = request->add_tablet_infos();
+            info->set_tablet_id(tablet_id);
+            info->set_min_version(1);
+        }
+        request->set_min_retain_version(2);
+        request->set_grace_timestamp(grace_timestamp);
+        request->set_min_active_txn_id(99999);
+        request->set_enable_file_bundling(true);
+        request->set_enable_shared_file_cleanup(true);
+    };
+
+    // Both versions were committed inside the grace window, so no tablet contributes a deletable range
+    // and the partition range stays empty. Before the fix the empty range still satisfied
+    // `min_version <= 1` and vacuum deleted both tablets' version-1 metadata, reporting 2 vacuumed files.
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        make_request(&request, 1000);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        EXPECT_EQ(0, response.vacuumed_files());
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(700, 1)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(701, 1)));
+    }
+
+    // Once the grace timestamp moves past the commit time the range becomes [1, 2), which does contain
+    // version 1: the special case still applies and both files go away.
+    {
+        VacuumRequest request;
+        VacuumResponse response;
+        make_request(&request, 3000);
+        vacuum(_tablet_mgr.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        // Two per-tablet version-1 files plus the (absent) bundle file for version 1.
+        EXPECT_EQ(3, response.vacuumed_files());
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(700, 1)));
+        EXPECT_FALSE(file_exist(tablet_metadata_filename(701, 1)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(700, 2)));
+        EXPECT_TRUE(file_exist(tablet_metadata_filename(701, 2)));
+    }
 }
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -65,6 +65,20 @@ public class LakeTablet extends Tablet {
     @SerializedName(value = "vibv")
     private volatile long vectorIndexBuiltVersion = 0L;
 
+    // The vacuum metadata floor the BE last proved for this tablet: no tablet metadata exists at or
+    // below this version, so the next vacuum round starts its prev_garbage_version walk here instead
+    // of descending into versions an earlier round already deleted. Sent to the BE as
+    // TabletInfoPB.min_version and adopted back from the vacuum response (AutovacuumDaemon); also the
+    // lower bound of a repair metadata scan (TabletRepairHelper).
+    //
+    // Known issue, working as designed for now: no @SerializedName, so it is neither persisted in the
+    // image nor journal-replicated, and every FE restart or leader failover resets it to 0 for every
+    // tablet. Acceptable because it is a hint, never a correctness input -- the BE clamps it with
+    // max(1, min_version), treats a NotFound during the walk as the chain bottom rather than an error,
+    // and re-reports a fresh floor on every round that proves one, so a stale-low value costs only
+    // extra metadata reads (one NotFound per tablet per round) until a later round restores it.
+    // Persisting it would be an image/journal format change. Do not start relying on this value for
+    // anything that must survive a restart.
     private volatile long minVersion = 0L;
 
     // Written by the ALTER ... DROP PERSISTENT INDEX path and read lock-free by the lake publish


### PR DESCRIPTION
Two defects share one trigger: the vacuum round in which every metadata the walk touched is newer than grace_timestamp, so nothing may be deleted. That is the normal state of a partition being written inside the default 30-minute grace window, not an edge case.

* First, the metadata floor the walk discovers is thrown away.
* Second, version-1 metadata is deleted while nothing is deletable.

Add VacuumTabletMetaVerionRange::empty() -- min_version >= max_version, which also catches a degenerate merged range and not just the {0, 0} default -- and require a non-empty range before the delete. A merged range always has min_version >= 1 (it is a `version + 1`), so a non-empty range with min_version <= 1 is exactly one that contains version 1. commit_metadata_range() already guards the mirrored special case through its to_delete_low >= to_delete_high early return.

Also document on LakeTablet.minVersion that its absence from the image and the journal is known and accepted for now: it is a hint the BE clamps and re-proves every round, never a correctness input.

Refs RB-249

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5