### PR TITLE
[BugFix] Pass catalogId in Glue column statistics requests

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastore.java
@@ -482,6 +482,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
         List<CompletableFuture<GetColumnStatisticsForTableResponse>> futures = columnChunks.stream().
                 map(columnChunk -> supplyAsync(() -> {
                     GetColumnStatisticsForTableRequest.Builder request = GetColumnStatisticsForTableRequest.builder()
+                            .catalogId(catalogId)
                             .databaseName(dbName)
                             .tableName(tableName)
                             .columnNames(columnChunk);
@@ -521,6 +522,7 @@ public class DefaultAWSGlueMetastore implements AWSGlueMetastore {
             futureForPartition.put(partitionName, columnChunks.stream().map(columnChunk -> supplyAsync(() -> {
                 GetColumnStatisticsForPartitionRequest.Builder request =
                         GetColumnStatisticsForPartitionRequest.builder()
+                                .catalogId(catalogId)
                                 .databaseName(dbName)
                                 .tableName(tableName)
                                 .columnNames(columnChunk)

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/glue/metastore/DefaultAWSGlueMetastoreTest.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.hive.glue.metastore;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.GetColumnStatisticsForPartitionRequest;
+import software.amazon.awssdk.services.glue.model.GetColumnStatisticsForPartitionResponse;
+import software.amazon.awssdk.services.glue.model.GetColumnStatisticsForTableRequest;
+import software.amazon.awssdk.services.glue.model.GetColumnStatisticsForTableResponse;
+
+public class DefaultAWSGlueMetastoreTest {
+    private static final String CATALOG_ID = "123456789012";
+
+    private HiveConf confWithCatalogId() {
+        HiveConf conf = new HiveConf();
+        conf.set("aws.glue.catalog_id", CATALOG_ID);
+        return conf;
+    }
+
+    @Test
+    public void testGetTableColumnStatisticsCarriesCatalogId() {
+        GlueClient glueClient = Mockito.mock(GlueClient.class);
+        Mockito.when(glueClient.getColumnStatisticsForTable(Mockito.any(GetColumnStatisticsForTableRequest.class)))
+                .thenReturn(GetColumnStatisticsForTableResponse.builder().build());
+
+        DefaultAWSGlueMetastore metastore = new DefaultAWSGlueMetastore(confWithCatalogId(), glueClient);
+        metastore.getTableColumnStatistics("db", "tbl", ImmutableList.of("c1"));
+
+        ArgumentCaptor<GetColumnStatisticsForTableRequest> captor =
+                ArgumentCaptor.forClass(GetColumnStatisticsForTableRequest.class);
+        Mockito.verify(glueClient).getColumnStatisticsForTable(captor.capture());
+        Assertions.assertEquals(CATALOG_ID, captor.getValue().catalogId());
+    }
+
+    @Test
+    public void testGetPartitionColumnStatisticsCarriesCatalogId() {
+        GlueClient glueClient = Mockito.mock(GlueClient.class);
+        Mockito.when(glueClient
+                        .getColumnStatisticsForPartition(Mockito.any(GetColumnStatisticsForPartitionRequest.class)))
+                .thenReturn(GetColumnStatisticsForPartitionResponse.builder().build());
+
+        DefaultAWSGlueMetastore metastore = new DefaultAWSGlueMetastore(confWithCatalogId(), glueClient);
+        metastore.getPartitionColumnStatistics("db", "tbl", ImmutableList.of("p=1"), ImmutableList.of("c1"));
+
+        ArgumentCaptor<GetColumnStatisticsForPartitionRequest> captor =
+                ArgumentCaptor.forClass(GetColumnStatisticsForPartitionRequest.class);
+        Mockito.verify(glueClient).getColumnStatisticsForPartition(captor.capture());
+        Assertions.assertEquals(CATALOG_ID, captor.getValue().catalogId());
+    }
+
+    @Test
+    public void testCatalogIdIsNullWhenNotConfigured() {
+        GlueClient glueClient = Mockito.mock(GlueClient.class);
+        Mockito.when(glueClient.getColumnStatisticsForTable(Mockito.any(GetColumnStatisticsForTableRequest.class)))
+                .thenReturn(GetColumnStatisticsForTableResponse.builder().build());
+
+        DefaultAWSGlueMetastore metastore = new DefaultAWSGlueMetastore(new HiveConf(), glueClient);
+        metastore.getTableColumnStatistics("db", "tbl", ImmutableList.of("c1"));
+
+        ArgumentCaptor<GetColumnStatisticsForTableRequest> captor =
+                ArgumentCaptor.forClass(GetColumnStatisticsForTableRequest.class);
+        Mockito.verify(glueClient).getColumnStatisticsForTable(captor.capture());
+        Assertions.assertNull(captor.getValue().catalogId());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`DefaultAWSGlueMetastore` sends `catalogId` on every AWS Glue request except the two column-statistics ones (`GetColumnStatisticsForTable` and `GetColumnStatisticsForPartition`). Both APIs accept `CatalogId`, and when it is omitted Glue falls back to the caller's own account.

So for any cross-account deployment that explicitly sets `aws.glue.catalog_id` (or `hive.metastore.glue.catalogid`), metadata and statistics resolve against two different catalogs:

```
 +-----------------------------+
 getTable / getPartitions | configured catalog | <-- table lives here
 (catalogId = 123456789012)| (account 123456789012) |
 +-----------------------------+

 +-----------------------------+
 getColumnStatistics* | caller's own catalog | <-- table not here
 (catalogId = null) | (default account) |
 +-----------------------------+
```

The result is column statistics that are silently always empty, or an EntityNotFound error for a table that clearly exists — leading to bad cardinality estimates and poor plans on Glue external tables. Deployments that do not set the property are unaffected, since `catalogId` is `null` there and Glue already defaults to the caller's account.

## What I'm doing:

- Add the missing `.catalogId(catalogId)` to the `GetColumnStatisticsForTable` and `GetColumnStatisticsForPartition` requests, so all Glue calls issued by `DefaultAWSGlueMetastore` target the same catalog. Passing `null` when the property is unset keeps the existing default behavior unchanged.
- Add `DefaultAWSGlueMetastoreTest`, which mocks `GlueClient` and asserts the captured requests carry the configured catalog id, and that it stays `null` when nothing is configured. Verified that the two new assertions fail without the fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5