### PR TITLE
[Enhancement] Upgrade libdeflate to 1.26

### DIFF
--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -194,10 +194,10 @@ let
       md5 = "298b5bddf12c675d6345784261302252";
       sha256 = "0r36bcrj6b2afsp4aw1gjai3jbs1c7734pxpc1jz7hh9nasyiazm";
     };
-    "libdeflate-1.18.zip" = {
-      url = "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.18.zip";
-      md5 = "1ec42dfe7d777929ade295281560d750";
-      sha256 = "0y1vcvv5s3iwip1xskhggxsgyc6ivb2ajdddahzfif5gh4c5ijqr";
+    "libdeflate-1.26.zip" = {
+      url = "https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.26.zip";
+      md5 = "15fde5dcbc584d1adee99c0ed13212db";
+      sha256 = "0kqlm3j0iqh92apng41wqk2dsqd01adxv8v074nyszlcgqbvjr6c";
     };
     "libdivide-v5.2.0.tar.gz" = {
       url = "https://github.com/ridiculousfish/libdivide/archive/refs/tags/v5.2.0.tar.gz";
@@ -508,7 +508,7 @@ let
       "lzo-2.10.tar.gz"
       "datasketches-cpp-4.0.0.tar.gz"
       "libfiu-1.1.tar.gz"
-      "libdeflate-1.18.zip"
+      "libdeflate-1.26.zip"
       "llvm-project-18.1.8.src.tar.xz"
       "abseil-cpp-20220623.0.tar.gz"
       "cares-1_19_1.tar.gz"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -401,10 +401,10 @@ FIU_SOURCE="libfiu-1.1"
 FIU_MD5SUM="51092dcb7801efb511b7b962388d9ff4"
 
 # libdeflate
-LIBDEFLATE_DOWNLOAD="https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.18.zip"
-LIBDEFLATE_NAME="libdeflate-1.18.zip"
-LIBDEFLATE_SOURCE="libdeflate-1.18"
-LIBDEFLATE_MD5SUM="1ec42dfe7d777929ade295281560d750"
+LIBDEFLATE_DOWNLOAD="https://github.com/ebiggers/libdeflate/archive/refs/tags/v1.26.zip"
+LIBDEFLATE_NAME="libdeflate-1.26.zip"
+LIBDEFLATE_SOURCE="libdeflate-1.26"
+LIBDEFLATE_MD5SUM="15fde5dcbc584d1adee99c0ed13212db"
 
 # llvm
 LLVM_DOWNLOAD="https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/llvm-project-18.1.8.src.tar.xz"


### PR DESCRIPTION
## Why I'm doing:
Following up on #78457 (which enabled `libdeflate` on ARM64), this PR upgrades the bundled `libdeflate` dependency from **1.18** to **1.26**.

Upgrading to 1.26 brings significant performance vectorisation enhancements and correctness/compatibility fixes to StarRocks' block compression (`GzipBlockCompressionV2`) and ORC format reader (`LibDeflateDecompressionStream`).

### Key Performance Improvements (1.18 → 1.26)
* **x86_64 Vector Checksums**: Added `VPCLMULQDQ`-accelerated CRC-32 and `VNNI`-accelerated Adler-32 implementations using 256-bit and 512-bit (AVX-512) vectors, dramatically reducing checksum overhead on modern x86 CPUs (v1.20).
* **ARM64 Neoverse Optimisations**: Improved CRC-32 performance specifically on ARM Neoverse V-series cores by optimising instruction scheduling and implementation selection (v1.26).
* **Compression & Small Inputs**: Improved compression ratios and speed on short inputs, and reduced compression overhead across levels 1–9 (v1.19).
* **Buffer Fitting**: Enabled compressing directly up to the exact size of the output buffer without artificial headroom constraints (v1.19).

### Key Correctness & Compatibility Fixes (1.18 → 1.26)
* **AVX-512 Checksum Fixes**: Resolved an edge-case bug where incorrect checksums could be computed on AVX-512 capable machines under certain clang optimisation levels and kernel register context handling (v1.23).
* **Modern Compiler & Toolchain Support**: Fixed build issues with GCC 14/15/16, Clang 18+, glibc 2.43+, and older binutils on RHEL 9 / GCC 11 (v1.21, v1.23, v1.25, v1.26).
* **RFC/ZIP Compatibility**: Ensured Huffman codes always generate at least 2 codewords, improving decompression compatibility for edge-case streams (v1.19).

## What I'm doing:
1. Updated `thirdparty/vars.sh` to download `libdeflate-1.26.zip` (MD5: `15fde5dcbc584d1adee99c0ed13212db`).
2. Updated `nix/thirdparty-archives.nix` with the new version and sha256 base32 hash (`0kqlm3j0iqh92apng41wqk2dsqd01adxv8v074nyszlcgqbvjr6c`).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5