### PR TITLE
[BugFix] Avoid redundant lake metadata 404 probes

### DIFF
--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -218,7 +218,7 @@ std::shared_ptr<const DelVector> Metacache::lookup_delvec(std::string_view key) 
     }
 }
 
-bool Metacache::lookup_aggregation_partition(std::string_view key) {
+bool Metacache::lookup_bundled_metadata_marker(std::string_view key) {
     auto handle = _cache->lookup(CacheKey(key));
     if (handle == nullptr) {
         g_aggregate_partition_cache_miss << 1;
@@ -228,9 +228,9 @@ bool Metacache::lookup_aggregation_partition(std::string_view key) {
 
     try {
         auto value = static_cast<CacheValue*>(_cache->value(handle));
-        auto is_aggregation = std::get<bool>(*value);
+        auto is_bundled_metadata = std::get<bool>(*value);
         g_aggregate_partition_cache_hit << 1;
-        return is_aggregation;
+        return is_bundled_metadata;
     } catch (const std::bad_variant_access& e) {
         return false;
     }
@@ -301,8 +301,8 @@ void Metacache::cache_tablet_schema(std::string_view key, std::shared_ptr<const 
     insert(key, cache_value.release(), size);
 }
 
-void Metacache::cache_aggregation_partition(std::string_view key, bool is_aggregation) {
-    auto cache_value = std::make_unique<CacheValue>(is_aggregation);
+void Metacache::cache_bundled_metadata_marker(std::string_view key) {
+    auto cache_value = std::make_unique<CacheValue>(true);
     insert(key, cache_value.release(), sizeof(bool));
 }
 

--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -57,7 +57,7 @@ public:
 
     std::shared_ptr<const DelVector> lookup_delvec(std::string_view key);
 
-    bool lookup_aggregation_partition(std::string_view key);
+    bool lookup_bundled_metadata_marker(std::string_view key);
 
     void cache_tablet_metadata(std::string_view key, std::shared_ptr<const TabletMetadataPB> metadata);
 
@@ -79,7 +79,7 @@ public:
 
     void cache_delvec(std::string_view key, std::shared_ptr<const DelVector> delvec);
 
-    void cache_aggregation_partition(std::string_view key, bool is_aggregation);
+    void cache_bundled_metadata_marker(std::string_view key);
 
     void erase(std::string_view key);
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -151,6 +151,18 @@ std::string TabletManager::tablet_metadata_root_location(int64_t tablet_id) cons
     return _location_provider->metadata_root_location(tablet_id);
 }
 
+void TabletManager::cache_bundled_metadata_partition_marker(int64_t tablet_id) {
+    auto cache_key = _location_provider->real_location(tablet_metadata_root_location(tablet_id));
+    if (cache_key.ok()) {
+        _metacache->cache_bundled_metadata_marker(*cache_key);
+    }
+}
+
+bool TabletManager::lookup_cached_bundled_metadata_partition_marker(int64_t tablet_id) {
+    auto cache_key = _location_provider->real_location(tablet_metadata_root_location(tablet_id));
+    return cache_key.ok() && _metacache->lookup_bundled_metadata_marker(*cache_key);
+}
+
 std::string TabletManager::tablet_metadata_location(int64_t tablet_id, int64_t version) const {
     return _location_provider->tablet_metadata_location(tablet_id, version);
 }
@@ -702,7 +714,7 @@ Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadat
     put_fixed64_le(&fixed_buf, size_field_value);
     RETURN_IF_ERROR(meta_file->append(Slice(fixed_buf)));
     RETURN_IF_ERROR(meta_file->close());
-    _metacache->cache_aggregation_partition(partition_location, true);
+    _metacache->cache_bundled_metadata_marker(partition_location);
     return Status::OK();
 }
 
@@ -778,24 +790,18 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
                                                                const CacheOptions& cache_opts, int64_t expected_gtid,
                                                                const std::shared_ptr<FileSystem>& fs) {
     TEST_ERROR_POINT("TabletManager::get_tablet_metadata");
-    StatusOr<TabletMetadataPtr> tablet_metadata_or;
-    auto cache_key = _location_provider->real_location(tablet_metadata_root_location(tablet_id));
-    if (cache_key.ok() && _metacache->lookup_aggregation_partition(*cache_key)) {
-        tablet_metadata_or = get_single_tablet_metadata(tablet_id, version, cache_opts, expected_gtid, fs);
-        if (tablet_metadata_or.status().is_not_found()) {
-            tablet_metadata_or =
-                    get_tablet_metadata(tablet_metadata_location(tablet_id, version), cache_opts, expected_gtid, fs);
-        }
-    } else {
-        tablet_metadata_or =
-                get_tablet_metadata(tablet_metadata_location(tablet_id, version), cache_opts, expected_gtid, fs);
-    }
+    auto tablet_metadata_or =
+            get_tablet_metadata(tablet_metadata_location(tablet_id, version), cache_opts, expected_gtid, fs);
 
     if (!tablet_metadata_or.ok()) {
         return tablet_metadata_or.status();
     }
 
-    // Skip the deep copy when the cached PB already has the right id; set_id below would be a no-op.
+    // The path-based lookup may resolve this request through a partition-shared metadata object,
+    // especially the shared version-1 object. The serialized PB in that object can carry the id of
+    // the tablet that originally wrote it rather than |tablet_id|, but this tablet-id overload must
+    // always return metadata whose id identifies the requested tablet. Do not normalize the returned
+    // PB in place because it may be shared through the metacache; copy only when the id differs.
     if (tablet_metadata_or.value()->id() == tablet_id) {
         return std::move(tablet_metadata_or).value();
     }
@@ -822,8 +828,9 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
     }
     StatusOr<TabletMetadataPtr> metadata_or;
     auto [tablet_id, version] = parse_tablet_metadata_filename(basename(path));
-    auto cache_key = _location_provider->real_location(tablet_metadata_root_location(tablet_id));
-    if (cache_key.ok() && _metacache->lookup_aggregation_partition(*cache_key)) {
+    // The bundle is addressed from |tablet_id| through this process's LocationProvider, not from
+    // |path|; see the precondition on the declaration of this overload.
+    if (lookup_cached_bundled_metadata_partition_marker(tablet_id)) {
         metadata_or = get_single_tablet_metadata(tablet_id, version, cache_opts, expected_gtid, fs);
         if (metadata_or.status().is_not_found()) {
             metadata_or = load_tablet_metadata(path, cache_opts.fill_data_cache, expected_gtid, fs);
@@ -832,8 +839,8 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
         metadata_or = load_tablet_metadata(path, cache_opts.fill_data_cache, expected_gtid, fs);
         if (metadata_or.status().is_not_found()) {
             metadata_or = get_single_tablet_metadata(tablet_id, version, cache_opts, expected_gtid, fs);
-            if (metadata_or.ok() && cache_key.ok()) {
-                _metacache->cache_aggregation_partition(*cache_key, true);
+            if (metadata_or.ok()) {
+                cache_bundled_metadata_partition_marker(tablet_id);
             }
         }
     }
@@ -859,6 +866,9 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
     // coincidentally matches a local tablet_id would cause us to fetch the wrong metadata
     // from the local FE. Other local callers that pass non-null fs (e.g. LakeDelvecLoader)
     // do not request version 1 in practice, since version 1 has no rowsets or delvecs.
+    //
+    // TODO: splitting this overload into a local id-addressed reader and one that takes its root
+    // explicitly would make that exclusion structural instead of inferred from |fs|.
     if (metadata_or.status().is_not_found() && tablet_id != 0 && version == kInitialVersion && fs == nullptr) {
         metadata_or = construct_initial_metadata(tablet_id);
     }
@@ -1001,6 +1011,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
         return Status::NotFound("Not found expected tablet metadata");
     }
     auto path = bundle_tablet_metadata_location(tablet_id, version);
+    TEST_SYNC_POINT_CALLBACK("TabletManager::get_single_tablet_metadata", &path);
     ASSIGN_OR_RETURN(auto real_path, _location_provider->real_location(path));
     std::shared_ptr<FileSystem> file_system;
     if (!fs) {

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -91,6 +91,38 @@ public:
     // Compact with pre-selected rowsets (for parallel compaction)
     StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context, std::vector<RowsetPtr> input_rowsets);
 
+    // Durable tablet-metadata layout contract:
+    //
+    // When file_bundling is disabled:
+    // - Version 1 is normally a standard lake protobuf file named with the tablet id and contains
+    //   one complete TabletMetadataPB for that tablet. For example, tablet 42 uses
+    //   `000000000000002A_0000000000000001.meta` with this content:
+    //       [optional protobuf checksum header][serialized TabletMetadataPB(42, version 1)]
+    // - Version 2 and later use the same per-tablet filename and standard TabletMetadataPB format.
+    //   For example, tablet 42 at version 7 uses
+    //   `000000000000002A_0000000000000007.meta` with this content:
+    //       [optional protobuf checksum header][serialized TabletMetadataPB(42, version 7)]
+    //
+    // When file_bundling is enabled for normal table creation and publish:
+    // - Version 1 is a single shared initial-metadata file for the physical partition. Its filename
+    //   uses tablet id 0, but its payload is still one complete, standard TabletMetadataPB, not a
+    //   BundleTabletMetadataPB. The embedded id can identify the tablet that wrote the shared file,
+    //   so an id-based read normalizes it to the requested tablet id. The filename and content are:
+    //       `0000000000000000_0000000000000001.meta`
+    //       [optional protobuf checksum header][serialized writer TabletMetadataPB(version 1)]
+    // - Version 2 and later use one bundle file per physical partition and version, also named with
+    //   tablet id 0. The file contains serialized per-tablet metadata pages followed by a
+    //   BundleTabletMetadataPB footer with page pointers, deduplicated schemas, and checksums. Each
+    //   read extracts and returns one tablet's TabletMetadataPB from that bundle. For version 7:
+    //       `0000000000000000_0000000000000007.meta`
+    //       [TabletMetadataPB(42) page][TabletMetadataPB(43) page]...[BundleTabletMetadataPB]
+    //       [optional bundle footer checksum][uint64 bundle footer size and flags]
+    //
+    // The actual version-1 write switch is TCreateTabletReq::enable_tablet_creation_optimization.
+    // For normal table creation FE enables it for a file-bundling table, but a standalone config,
+    // legacy data, or a specialized creation path can make the version-1 layout differ from the
+    // table's current file_bundling property. Readers must therefore retain both version-1
+    // fallbacks. The version-2+ bundled-metadata marker does not change the version-1 file encoding.
     Status put_tablet_metadata(const TabletMetadata& metadata);
 
     Status put_tablet_metadata(const TabletMetadataPtr& metadata);
@@ -133,7 +165,19 @@ public:
                                                     int64_t expected_gtid = 0,
                                                     const std::shared_ptr<FileSystem>& fs = nullptr);
 
-    // Do not use this function except in a list dir
+    // Reads the tablet metadata named by |path|, but resolves it through this TabletManager's own
+    // LocationProvider: the tablet id comes from the filename, and a bundled partition is then read via
+    // bundle_tablet_metadata_location(tablet_id, version). The bundle path, the
+    // _bundle_tablet_metadata_group singleflight key, the metacache key, and the cn-free version-1
+    // fallback therefore all derive from the local provider, not from |path|.
+    //
+    // Precondition: |path| must resolve into the same physical partition as that tablet id's metadata
+    // root. Paths obtained by listing a metadata root satisfy this, including sibling tablets' files:
+    // their virtual roots differ (staros://<shard>/meta) but real_location() maps them to one physical
+    // partition. A path under a different physical partition does not qualify -- it would be served the
+    // local partition's bundle on a tablet-id collision. Reads against storage this provider does not
+    // describe belong in a reader that takes its root explicitly; see build_source_tablet_meta() in
+    // lake_replication_txn_manager.cpp.
     StatusOr<TabletMetadataPtr> get_tablet_metadata(const std::string& path, bool fill_cache = true,
                                                     int64_t expected_gtid = 0,
                                                     const std::shared_ptr<FileSystem>& fs = nullptr);
@@ -235,6 +279,15 @@ public:
     std::string real_tablet_root_location(int64_t tablet_id) const;
 
     std::string tablet_metadata_root_location(int64_t tablet_id) const;
+
+    // Cache a process-local marker indicating that the tablet's physical partition uses bundled
+    // metadata. The marker key uses the resolved storage path so every tablet in the partition
+    // consults the same cache entry.
+    void cache_bundled_metadata_partition_marker(int64_t tablet_id);
+
+    // Check only the process-local metacache for the bundled-metadata marker. This does not inspect
+    // the local data cache or remote storage.
+    bool lookup_cached_bundled_metadata_partition_marker(int64_t tablet_id);
 
     std::string tablet_metadata_location(int64_t tablet_id, int64_t version) const;
 

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -600,8 +600,7 @@ Status publish_resharding_tablet(TabletManager* tablet_manager, const Resharding
                 g_tablet_reshard_failed << 1;
                 return st;
             }
-            tablet_manager->metacache()->cache_aggregation_partition(
-                    tablet_manager->tablet_metadata_root_location(tablet_id), true);
+            tablet_manager->cache_bundled_metadata_partition_marker(tablet_id);
         }
         // Deliberately at the END of the body: one tablet is now switched to the new version and the
         // rest are not, which is the partial-switch state a reshard has to recover from. At the top of

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -289,8 +289,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
             RETURN_IF_ERROR(tablet_mgr->put_tablet_metadata(new_metadata));
         } else {
             RETURN_IF_ERROR(tablet_mgr->cache_tablet_metadata(new_metadata));
-            tablet_mgr->metacache()->cache_aggregation_partition(
-                    tablet_mgr->tablet_metadata_root_location(tablet_info.get_tablet_id_in_metadata()), true);
+            tablet_mgr->cache_bundled_metadata_partition_marker(tablet_info.get_tablet_id_in_metadata());
         }
         return new_metadata;
     }
@@ -666,6 +665,9 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const Pub
     {
         TRACE_COUNTER_SCOPE_LATENCY_US("apply_finish_latency_us");
         RETURN_IF_ERROR(log_applier->finish());
+    }
+    if (skip_write_tablet_metadata) {
+        tablet_mgr->cache_bundled_metadata_partition_marker(tablet_info.get_tablet_id_in_metadata());
     }
 
     delete_files_async(std::move(files_to_delete));

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -83,6 +83,19 @@ public:
     std::unique_ptr<lake::UpdateManager> _update_manager;
 };
 
+namespace {
+
+class MappedCacheKeyLocationProvider final : public lake::LocationProvider {
+public:
+    std::string root_location(int64_t tablet_id) const override { return fmt::format("virtual://{}", tablet_id); }
+
+    StatusOr<std::string> real_location(const std::string& virtual_path) const override {
+        return fmt::format("physical/{}", virtual_path);
+    }
+};
+
+} // namespace
+
 // NOLINTNEXTLINE
 TEST_F(LakeTabletManagerTest, tablet_meta_write_and_read) {
     starrocks::TabletMetadata metadata;
@@ -1112,6 +1125,42 @@ TEST_F(LakeTabletManagerTest, cache_tablet_metadata) {
     auto path = _tablet_manager->tablet_metadata_location(tablet_id, 2);
     ASSERT_TRUE(_tablet_manager->metacache()->lookup_tablet_metadata(path) != nullptr);
     ASSERT_TRUE(_tablet_manager->get_latest_cached_tablet_metadata(tablet_id) != nullptr);
+}
+
+TEST_F(LakeTabletManagerTest, bundled_metadata_partition_marker_uses_real_location) {
+    auto location_provider = std::make_shared<MappedCacheKeyLocationProvider>();
+    auto old_location_provider = _tablet_manager->TEST_set_location_provider(location_provider);
+    DeferOp restore_location_provider(
+            [&]() { _tablet_manager->TEST_set_location_provider(std::move(old_location_provider)); });
+
+    auto tablet_id = next_id();
+    auto virtual_key = location_provider->metadata_root_location(tablet_id);
+    ASSIGN_OR_ABORT(auto real_key, location_provider->real_location(virtual_key));
+
+    _tablet_manager->cache_bundled_metadata_partition_marker(tablet_id);
+
+    EXPECT_TRUE(_tablet_manager->lookup_cached_bundled_metadata_partition_marker(tablet_id));
+    EXPECT_TRUE(_tablet_manager->metacache()->lookup_bundled_metadata_marker(real_key));
+    EXPECT_FALSE(_tablet_manager->metacache()->lookup_bundled_metadata_marker(virtual_key));
+}
+
+TEST_F(LakeTabletManagerTest, bundled_metadata_not_found_reads_bundle_once) {
+    auto tablet_id = next_id();
+    _tablet_manager->cache_bundled_metadata_partition_marker(tablet_id);
+
+    int bundle_read_attempts = 0;
+    SyncPoint::GetInstance()->SetCallBack("TabletManager::get_single_tablet_metadata",
+                                          [&](void*) { ++bundle_read_attempts; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp cleanup_sync_point([]() {
+        SyncPoint::GetInstance()->ClearCallBack("TabletManager::get_single_tablet_metadata");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    auto metadata = _tablet_manager->get_tablet_metadata(tablet_id, 2, false);
+
+    EXPECT_TRUE(metadata.status().is_not_found()) << metadata.status();
+    EXPECT_EQ(1, bundle_read_attempts);
 }
 
 TEST_F(LakeTabletManagerTest, get_tablet_metadata_cache_options) {

--- a/be/test/storage/lake/transactions_test.cpp
+++ b/be/test/storage/lake/transactions_test.cpp
@@ -327,6 +327,24 @@ TEST_F(NoOpPublishTest, no_op_publish_advances_version_without_txnlog) {
     ASSERT_EQ(_tablet_metadata->rowsets_size(), new_metadata->rowsets_size());
 }
 
+TEST_F(NoOpPublishTest, aggregate_publish_caches_bundled_metadata_marker) {
+    const int64_t tablet_id = _tablet_metadata->id();
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(next_id());
+    txn_info.set_txn_type(TXN_NORMAL);
+    txn_info.set_combined_txn_log(false);
+    txn_info.set_commit_time(time(nullptr));
+    txn_info.set_no_op_publish(true);
+
+    std::vector<TxnInfoPB> txns{txn_info};
+    auto result = publish_version(_tablet_mgr.get(), PublishTabletInfo(tablet_id), 1, 2, txns,
+                                  /*skip_write_tablet_metadata=*/true);
+    ASSERT_OK(result.status());
+
+    EXPECT_TRUE(_tablet_mgr->lookup_cached_bundled_metadata_partition_marker(tablet_id));
+}
+
 // Verifies that has_no_op_publish_in_batch causes the metacache early-return
 // to be bypassed. We pre-populate the metacache with a deliberately-different
 // metadata at the target version (commit_time=999999) to simulate a stale
@@ -640,16 +658,16 @@ TEST_F(CalNewBaseVersionTest, cache_only_version_not_adopted) {
     ASSERT_EQ(0, _update_mgr->get_primary_index_data_version(tablet_id));
 }
 
-// Same as above but with the partition marked as an aggregation (file
-// bundling) partition, so the read goes through get_single_tablet_metadata
-// first — the exact metacache lookup the original bug hit.
-TEST_F(CalNewBaseVersionTest, cache_only_version_not_adopted_on_aggregation_partition) {
+// Same as above but with the partition marked as using bundled metadata, so
+// the read goes through get_single_tablet_metadata
+// first -- the exact metacache lookup the original bug hit.
+TEST_F(CalNewBaseVersionTest, cache_only_version_not_adopted_on_bundled_metadata_partition) {
     const int64_t tablet_id = _tablet_metadata->id();
 
     auto meta_v2 = std::make_shared<TabletMetadataPB>(*_tablet_metadata);
     meta_v2->set_version(2);
     _tablet_mgr->metacache()->cache_tablet_metadata(_tablet_mgr->tablet_metadata_location(tablet_id, 2), meta_v2);
-    _tablet_mgr->metacache()->cache_aggregation_partition(_tablet_mgr->tablet_metadata_root_location(tablet_id), true);
+    _tablet_mgr->cache_bundled_metadata_partition_marker(tablet_id);
     set_primary_index_data_version(tablet_id, 2);
 
     auto txns = make_txns();
@@ -686,7 +704,7 @@ TEST_F(CalNewBaseVersionTest, durable_bundle_version_adopted) {
     tablet_metas.emplace(tablet_id, meta_v2);
     CHECK_OK(_tablet_mgr->put_bundle_tablet_metadata(tablet_metas));
     _tablet_mgr->metacache()->prune();
-    _tablet_mgr->metacache()->cache_aggregation_partition(_tablet_mgr->tablet_metadata_root_location(tablet_id), true);
+    _tablet_mgr->cache_bundled_metadata_partition_marker(tablet_id);
     set_primary_index_data_version(tablet_id, 2);
 
     auto txns = make_txns();


### PR DESCRIPTION
Bundled tablet metadata uses a process-local partition marker to choose the bundle-first read path. Producers keyed that marker by the virtual metadata root while readers looked it up by the resolved root, so the two never agreed, and the regular aggregate-publish path installed no marker at all. Readers therefore probed a per-tablet object that does not exist in a bundled partition and paid an avoidable HTTP 404 before falling back to the bundle.

- Marker keys are canonicalized on both sides, so a marker a producer writes is now visible to readers
- The aggregate-publish and reshard paths install the marker they were missing
- A missing bundle is attempted once rather than twice, since bundle dispatch and fallback now sit behind a single entry point
- Version-1 shared-metadata reads are unchanged: the returned metadata is copied only when its tablet id needs normalizing

The marker APIs are renamed to state their bundled-metadata and cache-only semantics, and the durable metadata layout for file bundling is documented.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5