### PR TITLE
[BugFix] Log MV lastRefreshTime instead of recomputing it on replay

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -552,19 +552,36 @@ public class AlterJobMgr {
             newMvRefreshScheme.setAsyncRefreshContext(asyncRefreshContext);
             newMvRefreshScheme.setMoment(moment);
 
+<<<<<<< HEAD
             long maxChangedTableRefreshTime =
                     MvUtils.getMaxTablePartitionInfoRefreshTime(
                             log.getAsyncRefreshContext().getBaseTableVisibleVersionMap().values());
             newMvRefreshScheme.setLastRefreshTime(maxChangedTableRefreshTime);
+=======
+            if (log.getLastRefreshTime() != null) {
+                newMvRefreshScheme.setLastRefreshTime(log.getLastRefreshTime());
+            } else {
+                // Both maps, the way the leader maxes over every refreshed base table. Max with the current
+                // value too: the maps get cleared and pruned, so a derivation alone can regress.
+                long derived = Math.max(
+                        MvUtils.getMaxTablePartitionInfoRefreshTime(
+                                asyncRefreshContext.getBaseTableVisibleVersionMap().values()),
+                        MvUtils.getMaxTablePartitionInfoRefreshTime(
+                                asyncRefreshContext.getBaseTableInfoVisibleVersionMap().values()));
+                newMvRefreshScheme.setLastRefreshTime(
+                        Math.max(oldRefreshScheme.getLastRefreshTime(), derived));
+            }
+>>>>>>> 11750b79fe7 ([BugFix] Log MV lastRefreshTime instead of recomputing it on replay (#61299))
             newMvRefreshScheme.setLastFreshnessConfirmedAt(log.getLastFreshnessConfirmedAt());
 
             oldMaterializedView.setRefreshScheme(newMvRefreshScheme);
             LOG.info(
                     "Replay materialized view [{}]'s refresh type to {}, start time to {}, " +
-                            "interval step to {}, timeunit to {}, id: {}, maxChangedTableRefreshTime:{}",
+                            "interval step to {}, timeunit to {}, id: {}, lastRefreshTime:{}",
                     oldMaterializedView.getName(), refreshType.name(), asyncRefreshContext.getStartTime(),
                     asyncRefreshContext.getStep(),
-                    asyncRefreshContext.getTimeUnit(), oldMaterializedView.getId(), maxChangedTableRefreshTime);
+                    asyncRefreshContext.getTimeUnit(), oldMaterializedView.getId(),
+                    newMvRefreshScheme.getLastRefreshTime());
 
             // trigger timeless info event since mv refresh scheme has changed
             GlobalStateMgr.getCurrentState().getMaterializedViewMgr()

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLog.java
@@ -42,6 +42,10 @@ public class ChangeMaterializedViewRefreshSchemeLog implements Writable {
     @SerializedName(value = "lastFreshnessConfirmedAt")
     private long lastFreshnessConfirmedAt;
 
+    // Boxed: null = the log predates this field (replay keeps the in-memory value); 0 = a real leader value.
+    @SerializedName(value = "lastRefreshTime")
+    private Long lastRefreshTime;
+
     public ChangeMaterializedViewRefreshSchemeLog(MaterializedView materializedView) {
         this(materializedView, materializedView.getRefreshScheme());
     }
@@ -53,6 +57,7 @@ public class ChangeMaterializedViewRefreshSchemeLog implements Writable {
         this.refreshType = refreshScheme.getType();
         this.asyncRefreshContext = refreshScheme.getAsyncRefreshContext().copy();
         this.lastFreshnessConfirmedAt = refreshScheme.getLastFreshnessConfirmedAt();
+        this.lastRefreshTime = refreshScheme.getLastRefreshTime();
     }
 
     public ChangeMaterializedViewRefreshSchemeLog() {
@@ -76,6 +81,10 @@ public class ChangeMaterializedViewRefreshSchemeLog implements Writable {
 
     public long getLastFreshnessConfirmedAt() {
         return lastFreshnessConfirmedAt;
+    }
+
+    public Long getLastRefreshTime() {
+        return lastRefreshTime;
     }
 
     public static ChangeMaterializedViewRefreshSchemeLog read(DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -115,7 +115,11 @@ public class MVVersionManager {
                 }
             }
         }
-        copiedScheme.setLastRefreshTime(maxChangedTableRefreshTime);
+        // A run that touches a base table without refreshing any of its partitions yields 0 here; keep the
+        // previous data timestamp rather than reporting the MV as never refreshed.
+        if (maxChangedTableRefreshTime > 0) {
+            copiedScheme.setLastRefreshTime(maxChangedTableRefreshTime);
+        }
         // Freshness is confirmed as of the batch's first-run start (the pinned-snapshot moment), and only once
         // the batch's final run completes. Monotonic (>) so it can never move backwards.
         long freshnessBaseline = freshnessBaselineTime();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1219,20 +1219,19 @@ public class MvUtils {
     }
 
     /**
-     * Returns the maximum refresh timestamp among all partition infos.
-     * If no valid refresh time is found, returns the current system time.
+     * Returns the maximum refresh timestamp among all partition infos, or 0 when there is none -- not the
+     * wall clock: this is persisted as a base-table data timestamp, and <= 0 already means "unknown".
      */
     public static long getMaxTablePartitionInfoRefreshTime(
             Collection<Map<String, MaterializedView.BasePartitionInfo>> partitionInfos) {
         return partitionInfos.stream()
                 .map(MvUtils::getMaxTablePartitionInfoRefreshTime)
                 .max(Long::compareTo)
-                .orElseGet(System::currentTimeMillis);
+                .orElse(0L);
     }
 
     /**
-     * Returns the maximum refresh timestamp from a single partition info map.
-     * If no valid refresh time is found, returns the current system time.
+     * Returns the maximum refresh timestamp from a single partition info map, or 0 when it is empty.
      */
     public static long getMaxTablePartitionInfoRefreshTime(
             Map<String, MaterializedView.BasePartitionInfo> partitionInfos) {
@@ -1240,7 +1239,7 @@ public class MvUtils {
                 .map(MaterializedView.BasePartitionInfo::getLastRefreshTime)
                 .filter(Objects::nonNull)
                 .max(Long::compareTo)
-                .orElseGet(System::currentTimeMillis);
+                .orElse(0L);
     }
 
     public static List<ScalarOperator> collectOnPredicate(OptExpression optExpression) {

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLogTest.java
@@ -15,10 +15,13 @@
 
 package com.starrocks.persist;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.alter.MaterializedViewHandler;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.alter.SystemHandler;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
@@ -47,8 +50,10 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 public class ChangeMaterializedViewRefreshSchemeLogTest {
 
@@ -194,4 +199,218 @@ public class ChangeMaterializedViewRefreshSchemeLogTest {
         Assertions.assertEquals(freshnessTime, materializedView.getRefreshScheme().getLastFreshnessConfirmedAt());
     }
 
+
+
+    private static MaterializedView buildMv(MaterializedView.MvRefreshScheme refreshScheme) {
+        List<Column> columns = new LinkedList<>();
+        columns.add(new Column("k1", IntegerType.TINYINT, true, null, "", ""));
+        RandomDistributionInfo distributionInfo = new RandomDistributionInfo(10);
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(1, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(1, (short) 3);
+        return new MaterializedView(1000, 100, "mv_name", columns, KeysType.AGG_KEYS,
+                partitionInfo, distributionInfo, refreshScheme);
+    }
+
+    private static Map<String, MaterializedView.BasePartitionInfo> partitionInfo(String name, long refreshTime) {
+        Map<String, MaterializedView.BasePartitionInfo> infos = new HashMap<>();
+        infos.put(name, new MaterializedView.BasePartitionInfo(1, 2, refreshTime));
+        return infos;
+    }
+
+    private static ChangeMaterializedViewRefreshSchemeLog writeAndRead(MaterializedView mv, boolean asPreUpgradeLog)
+            throws IOException {
+        String json = GsonUtils.GSON.toJson(new ChangeMaterializedViewRefreshSchemeLog(mv),
+                ChangeMaterializedViewRefreshSchemeLog.class);
+        if (asPreUpgradeLog) {
+            JsonObject object = JsonParser.parseString(json).getAsJsonObject();
+            object.remove("lastRefreshTime");
+            json = object.toString();
+        }
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(buffer);
+        Text.writeString(out, json);
+        out.flush();
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {
+            return ChangeMaterializedViewRefreshSchemeLog.read(in);
+        }
+    }
+
+    private static void replay(ChangeMaterializedViewRefreshSchemeLog log, MaterializedView mv,
+                               GlobalStateMgr globalStateMgr, Database db) {
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getLocalMetastore().getDb(anyLong);
+                result = db;
+
+                globalStateMgr.getCurrentState().getLocalMetastore().getTable(anyLong, anyLong);
+                result = mv;
+
+                db.getId();
+                result = anyLong;
+
+                mv.getId();
+                result = anyLong;
+            }
+        };
+        new AlterJobMgr(null, null, null).replayChangeMaterializedViewRefreshScheme(log);
+    }
+
+    // An external-table-only MV leaves the OLAP version map empty; replay must not read that as "now".
+    @Test
+    public void testLastRefreshTimeSurvivesReplayWhenOlapVersionMapIsEmpty(@Mocked GlobalStateMgr globalStateMgr,
+                                                                          @Injectable Database db) throws IOException {
+        long historicalRefreshTime = 1735689600000L; // 2025-01-01T00:00:00Z
+        long beforeReplay = System.currentTimeMillis();
+
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(historicalRefreshTime);
+        Assertions.assertTrue(refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap().isEmpty());
+        MaterializedView materializedView = buildMv(refreshScheme);
+
+        ChangeMaterializedViewRefreshSchemeLog readChangeLog = writeAndRead(materializedView, false);
+        Assertions.assertTrue(readChangeLog.getAsyncRefreshContext().getBaseTableVisibleVersionMap().isEmpty());
+        replay(readChangeLog, materializedView, globalStateMgr, db);
+
+        long replayed = materializedView.getRefreshScheme().getLastRefreshTime();
+        long afterReplay = System.currentTimeMillis();
+        System.out.printf("[repro] expected lastRefreshTime=%d, observed=%d, replay window=[%d, %d], "
+                        + "observedIsWallClockNow=%b%n",
+                historicalRefreshTime, replayed, beforeReplay, afterReplay,
+                replayed >= beforeReplay && replayed <= afterReplay);
+        Assertions.assertEquals(historicalRefreshTime, replayed,
+                "replay must not recompute lastRefreshTime as wall-clock now when the OLAP version map is empty");
+    }
+
+    // The version map accumulates every partition ever refreshed, so its max can be newer than this run's.
+    @Test
+    public void testLastRefreshTimeSurvivesReplayWhenOlapVersionMapHasNewerPartition(
+            @Mocked GlobalStateMgr globalStateMgr, @Injectable Database db) throws IOException {
+        long refreshedPartitionTime = 1735689600000L;  // what this run refreshed: 2025-01-01T00:00:00Z
+        long newerPartitionTime = 1767225600000L;      // already in the accumulated map: 2026-01-01T00:00:00Z
+
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(refreshedPartitionTime);
+        Map<String, MaterializedView.BasePartitionInfo> accumulated = partitionInfo("p1", refreshedPartitionTime);
+        accumulated.put("p3", new MaterializedView.BasePartitionInfo(3, 2, newerPartitionTime));
+        refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap().put(1000L, accumulated);
+        MaterializedView materializedView = buildMv(refreshScheme);
+
+        replay(writeAndRead(materializedView, false), materializedView, globalStateMgr, db);
+
+        long replayed = materializedView.getRefreshScheme().getLastRefreshTime();
+        System.out.printf("[repro-olap] expected lastRefreshTime=%d, observed=%d, "
+                        + "observedIsAccumulatedMax=%b%n",
+                refreshedPartitionTime, replayed, replayed == newerPartitionTime);
+        Assertions.assertEquals(refreshedPartitionTime, replayed,
+                "replay must not recompute lastRefreshTime from the accumulated version map");
+    }
+
+    // An external-table-only MV records its versions in the external map, the one the old derivation
+    // never looked at.
+    @Test
+    public void testPreUpgradeLogDerivesFromExternalVersionMap(@Mocked GlobalStateMgr globalStateMgr,
+                                                               @Injectable Database db) throws IOException {
+        long externalRefreshTime = 1782405968232000L; // iceberg micros
+        long beforeReplay = System.currentTimeMillis();
+
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(0L);
+        refreshScheme.getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap()
+                .put(new BaseTableInfo("iceberg_catalog", "db", "tbl", "tbl:1"),
+                        partitionInfo("p1", externalRefreshTime));
+        MaterializedView materializedView = buildMv(refreshScheme);
+
+        ChangeMaterializedViewRefreshSchemeLog readChangeLog = writeAndRead(materializedView, true);
+        Assertions.assertNull(readChangeLog.getLastRefreshTime());
+        Assertions.assertTrue(readChangeLog.getAsyncRefreshContext().getBaseTableVisibleVersionMap().isEmpty());
+        replay(readChangeLog, materializedView, globalStateMgr, db);
+
+        long replayed = materializedView.getRefreshScheme().getLastRefreshTime();
+        long afterReplay = System.currentTimeMillis();
+        System.out.printf("[legacy-external] expected lastRefreshTime=%d, observed=%d, "
+                        + "observedIsWallClockNow=%b%n",
+                externalRefreshTime, replayed, replayed >= beforeReplay && replayed <= afterReplay);
+        Assertions.assertEquals(externalRefreshTime, replayed,
+                "replay of a pre-upgrade log must derive from the external version map, not the wall clock");
+    }
+
+    // The maps get cleared and pruned, so a derivation alone can come out lower than what the MV absorbed.
+    @Test
+    public void testPreUpgradeLogNeverMovesLastRefreshTimeBackwards(@Mocked GlobalStateMgr globalStateMgr,
+                                                                    @Injectable Database db) throws IOException {
+        long absorbedRefreshTime = 1767225600000L;  // already in memory: 2026-01-01T00:00:00Z
+        long prunedMapRefreshTime = 1735689600000L; // all the pruned map still proves: 2025-01-01T00:00:00Z
+
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(absorbedRefreshTime);
+        refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap()
+                .put(1000L, partitionInfo("p1", prunedMapRefreshTime));
+        MaterializedView materializedView = buildMv(refreshScheme);
+
+        ChangeMaterializedViewRefreshSchemeLog readChangeLog = writeAndRead(materializedView, true);
+        Assertions.assertNull(readChangeLog.getLastRefreshTime());
+        replay(readChangeLog, materializedView, globalStateMgr, db);
+
+        long replayed = materializedView.getRefreshScheme().getLastRefreshTime();
+        System.out.printf("[legacy-monotonic] expected lastRefreshTime=%d, observed=%d, observedIsDerived=%b%n",
+                absorbedRefreshTime, replayed, replayed == prunedMapRefreshTime);
+        Assertions.assertEquals(absorbedRefreshTime, replayed,
+                "replay of a pre-upgrade log must not regress below the value the MV already absorbed");
+    }
+
+    // A mixed MV (internal join external) is the only shape that needs BOTH maps read: dropping either
+    // one silently loses half the base tables. Iceberg micros dominate OLAP millis, as they do for the leader.
+    @Test
+    public void testPreUpgradeLogDerivesFromBothVersionMaps(@Mocked GlobalStateMgr globalStateMgr,
+                                                            @Injectable Database db) throws IOException {
+        long olapRefreshTime = 1735689600000L;        // millis
+        long externalRefreshTime = 1782405968232000L; // iceberg micros, numerically larger
+
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(0L);
+        refreshScheme.getAsyncRefreshContext().getBaseTableVisibleVersionMap()
+                .put(1000L, partitionInfo("p1", olapRefreshTime));
+        refreshScheme.getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap()
+                .put(new BaseTableInfo("iceberg_catalog", "db", "tbl", "tbl:1"),
+                        partitionInfo("p1", externalRefreshTime));
+        MaterializedView materializedView = buildMv(refreshScheme);
+
+        ChangeMaterializedViewRefreshSchemeLog readChangeLog = writeAndRead(materializedView, true);
+        Assertions.assertNull(readChangeLog.getLastRefreshTime());
+        Assertions.assertFalse(readChangeLog.getAsyncRefreshContext().getBaseTableVisibleVersionMap().isEmpty());
+        Assertions.assertFalse(readChangeLog.getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap().isEmpty());
+        replay(readChangeLog, materializedView, globalStateMgr, db);
+
+        long replayed = materializedView.getRefreshScheme().getLastRefreshTime();
+        System.out.printf("[legacy-both] olap=%d external=%d observed=%d observedIsOlapOnly=%b%n",
+                olapRefreshTime, externalRefreshTime, replayed, replayed == olapRefreshTime);
+        Assertions.assertEquals(externalRefreshTime, replayed,
+                "replay of a pre-upgrade log must max over both version maps, not just one");
+    }
+
+    // Nothing to derive from at all: the value in memory is the only thing left that is not a guess.
+    @Test
+    public void testPreUpgradeLogKeepsMemoryValueWhenBothMapsAreEmpty(@Mocked GlobalStateMgr globalStateMgr,
+                                                                      @Injectable Database db) throws IOException {
+        long absorbedRefreshTime = 1767225600000L;
+        long beforeReplay = System.currentTimeMillis();
+
+        MaterializedView.MvRefreshScheme refreshScheme = new MaterializedView.MvRefreshScheme();
+        refreshScheme.setLastRefreshTime(absorbedRefreshTime);
+        MaterializedView materializedView = buildMv(refreshScheme);
+
+        ChangeMaterializedViewRefreshSchemeLog readChangeLog = writeAndRead(materializedView, true);
+        Assertions.assertNull(readChangeLog.getLastRefreshTime());
+        Assertions.assertTrue(readChangeLog.getAsyncRefreshContext().getBaseTableVisibleVersionMap().isEmpty());
+        Assertions.assertTrue(readChangeLog.getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap().isEmpty());
+        replay(readChangeLog, materializedView, globalStateMgr, db);
+
+        long replayed = materializedView.getRefreshScheme().getLastRefreshTime();
+        long afterReplay = System.currentTimeMillis();
+        System.out.printf("[legacy-empty] expected=%d observed=%d observedIsWallClockNow=%b observedIsZero=%b%n",
+                absorbedRefreshTime, replayed, replayed >= beforeReplay && replayed <= afterReplay, replayed == 0L);
+        Assertions.assertEquals(absorbedRefreshTime, replayed,
+                "replay of a pre-upgrade log with nothing to derive from must keep the in-memory value");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVVersionManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVVersionManagerTest.java
@@ -14,9 +14,11 @@
 
 package com.starrocks.scheduler.mv;
 
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
@@ -28,9 +30,11 @@ import com.starrocks.persist.WALApplier;
 import com.starrocks.scheduler.MvTaskRunContext;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.type.IntegerType;
 import mockit.Mock;
 import mockit.MockUp;
@@ -42,8 +46,12 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class MVVersionManagerTest {
 
@@ -74,6 +82,16 @@ public class MVVersionManagerTest {
             @Mock
             public EditLog getEditLog() {
                 return new EditLog(null);
+            }
+
+            @Mock
+            public MaterializedViewMgr getMaterializedViewMgr() {
+                return new MaterializedViewMgr();
+            }
+        };
+        new MockUp<MaterializedViewMgr>() {
+            @Mock
+            public void triggerTimelessInfoEvent(MaterializedView mv, MVTimelinessMgr.MVChangeEvent event) {
             }
         };
     }
@@ -192,5 +210,29 @@ public class MVVersionManagerTest {
 
         Assertions.assertEquals(1000L, mv.getRefreshScheme().getLastFreshnessConfirmedAt());
         Assertions.assertEquals(0, editLogCount.get());
+    }
+
+    // A base table can be processed by a run without any of its partitions being refreshed: the run is not
+    // skipped (isOlapTableRefreshed is set unconditionally), but the derived max is 0.
+    @Test
+    public void updateMVVersionInfoKeepsLastRefreshTimeWhenNoPartitionWasRefreshed() {
+        long absorbedRefreshTime = 1767225600000L;
+        MaterializedView mv = buildMv(1000L);
+        mv.getRefreshScheme().setLastRefreshTime(absorbedRefreshTime);
+
+        OlapTable baseTable = mock(OlapTable.class);
+        when(baseTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        when(baseTable.isOlapOrCloudNativeTable()).thenReturn(true);
+        when(baseTable.getId()).thenReturn(2000L);
+        when(baseTable.getVisiblePartitionNames()).thenReturn(Set.of());
+        PCTTableSnapshotInfo snapshot = new PCTTableSnapshotInfo(mock(BaseTableInfo.class), baseTable);
+        Assertions.assertTrue(snapshot.getRefreshedPartitionInfos().isEmpty());
+
+        MVVersionManager manager = new MVVersionManager(mv, buildContext(null, statusWithProcessStartTime(2000L)));
+        manager.updateMVVersionInfo(Map.of(2000L, snapshot), PCellSortedSet.of(), Set.of(2000L),
+                Map.of(), null, true);
+
+        Assertions.assertEquals(absorbedRefreshTime, mv.getRefreshScheme().getLastRefreshTime(),
+                "a run that refreshed no partition must not report the MV as never refreshed");
     }
 }


### PR DESCRIPTION
## Conflict Info:  
UU fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
## Why I'm doing:

`MvRefreshScheme.lastRefreshTime` is persisted state, but it is not carried in
`ChangeMaterializedViewRefreshSchemeLog`. Replay re-derives it instead, and the
derivation input differs from what the leader used, in two ways:

- An external-table-only MV records base-table versions in
 `baseTableInfoVisibleVersionMap`, leaving the OLAP `baseTableVisibleVersionMap`
 empty. `MvUtils.getMaxTablePartitionInfoRefreshTime` falls back to
 `System.currentTimeMillis()` on an empty collection, so the value becomes
 "when this FE happened to replay the entry" -- different per FE and per
 restart. The checkpoint worker replays through the same path, so it persists
 the wall clock into the image rather than masking the problem.
- The leader takes the max over the partitions refreshed by the current run,
 while the version map accumulates every partition ever refreshed, so replay
 can pick a newer partition than the leader chose.

Observed on a shared-data dev cluster, single FE, before this change. Two MVs
over the same FE, values read from `information_schema.materialized_views`:

| MV | base tables | before restart | after restart |
|---|---|---|---|
| `mv_ext` | one Iceberg table | leader wrote `1782405968232000` | `2026-08-26 17:28:34` = FE `StartTime` |
| `mv_olap` | one OLAP table, 3 partitions | `17:31:35` = p1, the partition the last batch refreshed | `17:31:42` = p3, the accumulated map max |

FE log for the same window, `maxChangedTableRefreshTime` equals the replay
instant every time, and the checkpoint worker persists it:

```
17:28:32.250 (state-change-executor|83) mv_ext maxChangedTableRefreshTime:1787736512250 = 17:28:32.250
17:28:34.444 (state-change-executor|83) mv_ext maxChangedTableRefreshTime:1787736514444 = 17:28:34.444
17:28:46.621 (global-state-checkpoint-worker) mv_ext maxChangedTableRefreshTime:1787736526621 = 17:28:46.621
```

`lastFreshnessConfirmedAt` and the base-table version maps round-trip correctly
across the same restarts; only the recomputed field is lost.

Consumers affected: `SHOW MATERIALIZED VIEWS` / `information_schema` expose
`LAST_REFRESH_TIME` per FE, and `MaterializedView.isStalenessSatisfied()` uses
`lastRefreshTime` as a base-table-regression guard -- a wall clock is larger than
any real base-table timestamp, so the guard fires and `mv_rewrite_staleness_second`
rewrite stops working on that FE.

## What I'm doing:

Carrying `lastRefreshTime` in the edit log, the way `lastFreshnessConfirmedAt`
already is, and dropping the recomputation on replay. The field is boxed
(`Long`) so a log written before it existed stays distinguishable from one that
carries a value.

Also dropping the wall-clock fallback in `MvUtils`, and handling the two places
`0` then reaches.

**Leader.** `MVVersionManager` overwrites `lastRefreshTime` unconditionally, and
the derived max is `0` when a base table is processed without any of its
partitions being refreshed. The early return at the top of `updateMVVersionInfo`
does not prevent this -- `isOlapTableRefreshed` is set once a base table is
processed, whether or not it contributed a partition. `ShowMaterializedViewStatus`
reports the column only when the value is `> 0`, so such a run would blank
`LAST_REFRESH_TIME` on an MV that had been refreshing fine. The leader now keeps
the previous value when a run derives `0`.

`MVMetaVersionRepairer`, the third caller, is unaffected: it returns early when
there is nothing to repair, so its map is never empty and the fallback is
unreachable. That early return tests the content; the one in `updateMVVersionInfo`
tests only whether a table was processed, which is why the same `orElse(0L)` is
harmless in one and not the other.

**Replay of a pre-upgrade log** (`null`) derives from BOTH version maps -- OLAP
`baseTableVisibleVersionMap` and external `baseTableInfoVisibleVersionMap` -- and
maxes that against the value already in memory. Both maps hold the same
`Map<String, BasePartitionInfo>`, and the leader maxes over every refreshed base
table without distinguishing them, so the derivation matches what the leader
would have written. The max against the in-memory value is required because both
maps get cleared and pruned (`clearVisibleVersionMap`,
`clearVisibleVersionMapByMVPartitions`), so a derivation alone can regress.

Before:

```
leader MVVersionManager.updateMVVersionInfo (MVVersionManager.java:107-118) — max over the partitions refreshed by THIS run
 └─ ChangeMaterializedViewRefreshSchemeLog (ctor ·:49-57) — logs refreshType + asyncRefreshContext + lastFreshnessConfirmedAt
 ← BUG: lastRefreshTime is persisted state but never logged
replay AlterJobMgr.replayChangeMaterializedViewRefreshScheme (AlterJobMgr.java:547) — assigns the in-memory value
 └─ MvUtils.getMaxTablePartitionInfoRefreshTime (MvUtils.java:1225) — re-derives from baseTableVisibleVersionMap only
 └─.orElseGet(System::currentTimeMillis) (MvUtils.java:1231) ← BUG: empty collection becomes the wall clock
 └─ AlterJobMgr.java:558 setLastRefreshTime(recomputed) — overwrites the assignment at:547
```

After:

```
leader MVVersionManager.updateMVVersionInfo — keeps the previous value when the run derives 0
 └─ ChangeMaterializedViewRefreshSchemeLog (ctor) — now also carries Long lastRefreshTime
replay AlterJobMgr.replayChangeMaterializedViewRefreshScheme — assigns the in-memory value
 ├─ log.getLastRefreshTime()!= null → copied verbatim, never re-derived
 └─ null (pre-upgrade log) → max(in-memory, OLAP map, external map)
MvUtils.getMaxTablePartitionInfoRefreshTime (both overloads) —.orElse(0L), no wall-clock fallback
```

Re-verified end to end on a fresh single-FE shared-data cluster, upgrading the FE
in place from a build without this change (`main-b0c4dd0`) to one with it
(`main-558ebdd`), same metadata throughout. Values read from
`information_schema.materialized_views`; each row is the same MV before and after
an FE restart, so any difference is replay:

| MV | mode | base table | restart on old FE | restart on new FE |
|---|---|---|---|---|
| `mv_olap` | PCT | internal, 3 partitions | `11:06:05` -> **`11:06:51`** | `11:06:05` -> `11:06:05` |
| `mv_ext` | PCT | Hive | `1970-01-21 20:17:52` -> **`11:15:58`** | `1970-01-21 20:17:52` -> unchanged |
| `mv_ice_ivm` | INCREMENTAL | Iceberg | `NULL` -> **`11:33:29`** | `11:34:31` -> unchanged |
| `mv_ivm`, `mv_ivm2` | INCREMENTAL | internal | unchanged | unchanged |

The two drift shapes, both reproduced on the old build:

- `mv_olap` was FORCE-refreshed on its OLDEST partition only, so the leader
 recorded p1's `11:06:05` while the accumulated map still held p3's `11:06:51`.
 Replay picked the accumulated max. On the new FE the gap was widened to about
 an hour and the value still held.
- `mv_ext` and `mv_ice_ivm` have an empty OLAP version map, so replay hit the
 wall-clock fallback: `mv_ext` moved to `11:15:58` against an FE `StartTime` of
 `11:15:59`, and `mv_ice_ivm` from `NULL` to `11:33:29` against `11:33:31`. Both
 land within seconds of the restart instant, which is the fingerprint.

`mv_ivm` / `mv_ivm2` are the negative control and never moved on either build.
Internal-table INCREMENTAL MVs cannot show the partial-refresh gap at all:
partition refresh is rejected for `refresh_mode=INCREMENTAL`, so the leader's max
and the accumulated map always cover the same partitions. Iceberg is the
INCREMENTAL shape that IS affected -- `IVMAnalyzer.SUPPORTED_TABLE_TYPES` is
`{ICEBERG, CLOUD_NATIVE}`, and only the Iceberg side leaves the OLAP map empty.

One caveat on the baseline: the "old FE" build also carries an unmerged PR (tablet
split/merge bookmark CDC), because the plain `main` build was failing to compile
in BE at the time. None of its files touch this path, and the FE-only artifact for
this PR was built from the branch head itself (`StarRocks-558ebdd.tar.gz`).

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

`LAST_REFRESH_TIME` stops changing after a replay, so an FE that used to show a
restart timestamp for an external-table-only MV now shows what the leader
recorded. A refresh that touches a base table without refreshing any partition no
longer blanks the column; it used to be filled with the wall clock, which hid
that the run had nothing to report. Compatibility: a new FE reading a pre-upgrade
log derives from both version maps instead of trusting the wall clock, and never
below what the MV already absorbed; an old FE reading a new log ignores the
unknown field and recomputes as before.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Seven new cases. Each was verified against the specific mutation it guards, not
against one blanket revert -- a blanket revert scores two of them as toothless,
because "never regress" and "keep the memory value" are both trivially satisfied
by doing nothing:

| case | mutation | observed under mutation |
|---|---|---|
| `...WhenOlapVersionMapIsEmpty` | revert the whole change | wall clock, inside the replay window |
| `...WhenOlapVersionMapHasNewerPartition` | revert the whole change | `1767225600000` = accumulated max |
| `...DerivesFromExternalVersionMap` | drop the pre-upgrade branch | `0` |
| `...DerivesFromBothVersionMaps` | read only the OLAP map | `1735689600000` = the OLAP value |
| `...NeverMovesLastRefreshTimeBackwards` | drop the max, use the derivation | `1735689600000` = the derivation |
| `...KeepsMemoryValueWhenBothMapsAreEmpty` | drop the max, use the derivation | `0` |
| `updateMVVersionInfoKeepsLastRefreshTimeWhenNoPartitionWasRefreshed` | drop the `> 0` guard | `0` |

`...DerivesFromBothVersionMaps` is the one that matters for the two-map read: it
is the only shape (internal join external) where dropping either map loses half
the base tables, and the external-only case cannot catch it because its OLAP
derivation is `0` either way.

`updateMVVersionInfoKeepsLastRefreshTimeWhenNoPartitionWasRefreshed` also
establishes that the leader-side path is reachable: it builds a run where a base
table is processed with no refreshed partitions, and without the guard
`LAST_REFRESH_TIME` goes to `0`.

Whole change in place -- `RefreshMaterializedViewTest`, `MaterializedViewTest`
(catalog + planner), `MVMetaVersionRepairerTest`, `MVVersionManagerTest`,
`ChangeMaterializedViewRefreshSchemeLogTest`: `Tests run: 319, Failures: 0,
Errors: 0, Skipped: 12`.

No SQL-Tester case: the bug needs an FE restart so the entry is replayed, and the
framework does not restart the FE. The cluster runs below stand in for it.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5