### PR TITLE
[BugFix] Stop forcing external CTAS list partition columns to NOT NULL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CTASAnalyzer.java
@@ -149,7 +149,9 @@ public class CTASAnalyzer {
             }
             AnalyzerUtils.checkAutoPartitionTableLimit(functionCallExpr, currentGranularity);
             rangePartitionDesc.setAutoPartitionTable(true);
-        } else if (partitionDesc instanceof ListPartitionDesc) {
+        } else if (partitionDesc instanceof ListPartitionDesc && createTableStmt.isOlapEngine()) {
+            // Only OLAP needs a non-nullable list partition column. External engines keep the
+            // nullability the query derived: an Iceberg identity partition accepts NULL.
             for (ColumnDef columnDef : columnDefs) {
                 for (String partitionColName : ((ListPartitionDesc) partitionDesc).getPartitionColNames()) {
                     if (columnDef.getName().equalsIgnoreCase(partitionColName)) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerIcebergTest.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.ColumnDef;
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.util.List;
+
+import static com.starrocks.sql.plan.ConnectorPlanTestBase.newFolder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CTASAnalyzerIcebergTest {
+    private static ConnectContext connectContext;
+
+    @TempDir
+    public static File temp;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        new StarRocksAssert(connectContext);
+        ConnectorPlanTestBase.mockAllCatalogs(connectContext, newFolder(temp, "junit").toURI().toString());
+    }
+
+    private static List<ColumnDef> analyzeCtasColumnDefs(String sql) throws Exception {
+        CreateTableAsSelectStmt stmt =
+                (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        CreateTableStmt createTableStmt = stmt.getCreateTableStmt();
+        assertEquals("iceberg", createTableStmt.getEngineName());
+        return createTableStmt.getColumnDefs();
+    }
+
+    @Test
+    public void testIcebergCtasKeepsPartitionColumnNullable() throws Exception {
+        List<ColumnDef> columnDefs = analyzeCtasColumnDefs(
+                "create table iceberg0.partitioned_db.ctas_null_part (a, b, c) "
+                        + "partition by (c) as select 1, 2, null");
+
+        // Nullability must come from the source expression only. Iceberg allows NULL in an
+        // identity partition, so being the partition column must not tighten `c` to NOT NULL.
+        assertFalse(columnDefs.get(0).isAllowNull());
+        assertFalse(columnDefs.get(1).isAllowNull());
+        assertTrue(columnDefs.get(2).isAllowNull());
+    }
+
+    @Test
+    public void testIcebergCtasKeepsNonNullPartitionColumnNotNull() throws Exception {
+        List<ColumnDef> columnDefs = analyzeCtasColumnDefs(
+                "create table iceberg0.partitioned_db.ctas_notnull_part (a, b, c) "
+                        + "partition by (c) as select 1, null, 3");
+
+        assertFalse(columnDefs.get(0).isAllowNull());
+        assertTrue(columnDefs.get(1).isAllowNull());
+        assertFalse(columnDefs.get(2).isAllowNull());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CTASAnalyzerTest.java
@@ -576,4 +576,17 @@ public class CTASAnalyzerTest {
         CreateTableAsSelectStmt stmt = (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         Assertions.assertEquals("olap", stmt.getCreateTableStmt().getEngineName());
     }
+
+    @Test
+    public void testCTASOlapListPartitionColumnStaysNotNull() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String sql = "create table ctas_olap_list_part (a, c) partition by (c) "
+                + "distributed by hash(a) buckets 1 as select 1 as a, null as c;";
+
+        CreateTableAsSelectStmt stmt = (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        List<ColumnDef> columnDefs = stmt.getCreateTableStmt().getColumnDefs();
+        // An OLAP list partition column is forced NOT NULL even when the query derives it as
+        // nullable. Only external engines keep the derived nullability.
+        Assertions.assertFalse(columnDefs.get(1).isAllowNull());
+    }
 }

--- a/test/sql/test_iceberg/R/test_iceberg_null_partition
+++ b/test/sql/test_iceberg/R/test_iceberg_null_partition
@@ -40,6 +40,33 @@ select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} whe
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
 -- result:
 -- !result
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} (k1, k2) partition by (k2) as select 1, cast(null as string);
+-- result:
+-- !result
+desc iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0};
+-- result:
+k1	INT	No	false	None		None
+k2	VARCHAR(1073741824)	Yes	false	None	partition key	None
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} select 2, "null";
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} order by k1;
+-- result:
+1	None
+2	null
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} where k2 is null;
+-- result:
+1	None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} where k2 = "null";
+-- result:
+2	null
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} force;
+-- result:
+-- !result
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_null_partition
+++ b/test/sql/test_iceberg/T/test_iceberg_null_partition
@@ -22,6 +22,17 @@ select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} whe
 select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} where k2 = "null";
 
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+
+-- CTAS must derive the partition column's nullability from the query, like plain CREATE TABLE
+-- does. An Iceberg identity partition accepts NULL, so the column must stay nullable.
+create table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} (k1, k2) partition by (k2) as select 1, cast(null as string);
+desc iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0};
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} select 2, "null";
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} where k2 is null;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} where k2 = "null";
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.ice_ctas_${uuid0} force;
+
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 drop catalog iceberg_sql_test_${uuid0};
 


### PR DESCRIPTION
## Why I'm doing:

`CTASAnalyzer` applied an OLAP-only rule to every engine: every list partition column was
marked `NOT NULL`, with no engine check. For an Iceberg CTAS that turned the partition column
into an Iceberg **required** field, so a NULL partition value failed the write path:

```sql
CREATE TABLE t (a, b, c) PARTITION BY (c) AS SELECT 1, 2, NULL;
-- ERROR 5609 (22000): NULL value in non-nullable column 'c': BE:10001
```

Plain `CREATE TABLE` left the same column nullable and accepted the NULL, so the two paths
disagreed. Iceberg identity partitions do accept NULL, and Spark keeps such a column optional.

The FE side has been wrong since (2024-01), but it was invisible while the BE ignored
the flag. Enforcing Iceberg NOT NULL on the write path made it a hard failure.

## What I'm doing:

Gate the rule on `isOlapEngine()` so external engines keep the nullability the query derived.
The BE-side check is correct and is left alone: an explicitly `NOT NULL` column still rejects
NULL.

Verified on a cluster, before and after the fix:

| Check | Before | After |
|---|---|---|
| CTAS with NULL on the partition column | `5609... 'c'` | succeeds, row readable via `c IS NULL` |
| Partition column DDL from CTAS | `NOT NULL` | `DEFAULT NULL` |
| Plain CREATE TABLE + INSERT NULL partition | works | unchanged |
| CTAS with NULL on a non-partition column | works | unchanged |
| Explicit `NOT NULL` column + NULL | rejected | still rejected |

OLAP is unaffected by design, and a new unit test locks that.

Not fixed here: OLAP CTAS has the same CTAS-vs-CREATE-TABLE inconsistency (a NULL partition
value fails with `Insert has filtered data`). That needs a user-visible OLAP behavior change and
is tracked separately.

Fixes https://github.com/StarRocks/StarRocksTest/issues/11948

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5