### PR TITLE
[BugFix] Fix MV version-map repair skipped by physical partition id lookup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -297,9 +297,8 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             // Prepare data before persist, so that copyForPersist() can include this data
             prepareForPersist(db, table);
             // Must run before updateVisibleVersion(), which stamps finishedTimeMs onto EVERY touched
-            // physical partition and therefore destroys both the pre-alter version time and any
-            // ordering getLatestPhysicalPartition() could have used.
-            capturePreAlterLatestPartitions(table);
+            // physical partition and therefore destroys the pre-alter version times.
+            capturePreAlterPartitionStates(table);
             persistStateChange(this, JobState.FINISHED, () -> {
                 updateCatalog(db, table, false);
                 // set visible version
@@ -508,57 +507,44 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         }
     }
 
-    /**
-     * Pre-alter state of the physical partition that {@link Partition#getLatestPhysicalPartition()}
-     * resolved to, captured per LOGICAL partition before this job rewrites the visible versions.
-     */
-    private static class PreAlterLatestPartition {
-        private final long physicalPartitionId;
+    /** Version and version time a physical partition carried before this job rewrote them. */
+    private static class PreAlterPartitionState {
         private final long visibleVersion;
         private final long visibleVersionTime;
 
-        private PreAlterLatestPartition(long physicalPartitionId, long visibleVersion, long visibleVersionTime) {
-            this.physicalPartitionId = physicalPartitionId;
+        private PreAlterPartitionState(long visibleVersion, long visibleVersionTime) {
             this.visibleVersion = visibleVersion;
             this.visibleVersionTime = visibleVersionTime;
         }
     }
 
-    // Runtime-only snapshot for handleMVRepair; never persisted and never replayed.
-    private transient Map<Long, PreAlterLatestPartition> preAlterLatestPartitions = Maps.newHashMap();
+    // Runtime-only snapshot for handleMVRepair, keyed by PHYSICAL partition id; never persisted and
+    // never replayed. A resumed job therefore finds it empty and skips the repair, which leaves the MV
+    // to refresh rather than advancing a watermark whose staleness cannot be proven.
+    private transient Map<Long, PreAlterPartitionState> preAlterPartitionStates = Maps.newHashMap();
 
     /**
-     * Records, for every logical partition this job touches, which physical partition MV staleness
-     * detection would read and what version/version time it carried.
+     * Records the pre-alter version and version time of every physical partition this job touches.
      *
-     * updateVisibleVersion() assigns the same finishedTimeMs to every physical partition, so calling
-     * getLatestPhysicalPartition() afterwards resolves a timestamp tie through HashMap iteration order
-     * instead of picking the partition that was actually latest. Capturing here keeps that selection
-     * deterministic and preserves the pre-alter version time the repair filter needs.
+     * updateVisibleVersion() overwrites the version time of all of them with finishedTimeMs, so the
+     * pre-alter values are unrecoverable afterwards -- and MVMetaVersionRepairer needs the pre-alter
+     * version time to tell an up-to-date MV from one already stale through isBaseTableChanged's
+     * version-time disjunct.
+     *
+     * Note this snapshot deliberately does NOT decide which physical partition represents the logical
+     * partition; handleMVRepair makes that choice with the same call the reader uses.
      */
-    private void capturePreAlterLatestPartitions(@NotNull OlapTable table) {
-        Map<Long, PreAlterLatestPartition> snapshot = Maps.newHashMap();
+    private void capturePreAlterPartitionStates(@NotNull OlapTable table) {
+        Map<Long, PreAlterPartitionState> snapshot = Maps.newHashMap();
         for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
             if (physicalPartition == null) {
                 continue;
             }
-            long partitionId = physicalPartition.getParentId();
-            Partition partition = table.getPartition(partitionId);
-            if (partition == null || table.isTempPartition(partitionId)) {
-                continue;
-            }
-            PhysicalPartition latest = partition.getLatestPhysicalPartition();
-            if (latest == null || latest.getId() != physicalPartitionId) {
-                // Another physical partition of the same logical partition is the one the MV reads back;
-                // it will be handled by its own commitVersionMap entry, or left alone if this job does
-                // not touch it.
-                continue;
-            }
-            snapshot.put(partitionId, new PreAlterLatestPartition(physicalPartitionId,
-                    latest.getVisibleVersion(), latest.getVisibleVersionTime()));
+            snapshot.put(physicalPartitionId, new PreAlterPartitionState(
+                    physicalPartition.getVisibleVersion(), physicalPartition.getVisibleVersionTime()));
         }
-        preAlterLatestPartitions = snapshot;
+        preAlterPartitionStates = snapshot;
     }
 
     void updateVisibleVersion(@NotNull OlapTable table) {
@@ -839,25 +825,48 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             return;
         }
 
-        List<PartitionRepairInfo> partitionRepairInfos =
-                Lists.newArrayListWithCapacity(preAlterLatestPartitions.size());
+        List<PartitionRepairInfo> partitionRepairInfos = Lists.newArrayListWithCapacity(commitVersionMap.size());
 
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         try {
-            // Driven by the pre-alter snapshot rather than by commitVersionMap: that map is keyed by
-            // PHYSICAL partition id while MaterializedView.BasePartitionInfo is keyed on the LOGICAL
-            // partition, and the snapshot already resolved which physical partition MV staleness
-            // detection reads back -- deterministically, before every version time became finishedTimeMs.
-            for (Map.Entry<Long, PreAlterLatestPartition> entry : preAlterLatestPartitions.entrySet()) {
-                long partitionId = entry.getKey();
-                PreAlterLatestPartition preAlter = entry.getValue();
+            // commitVersionMap is keyed by PHYSICAL partition id (built from
+            // physicalPartitionIndexMap.rowKeySet()) while MaterializedView.BasePartitionInfo is keyed on
+            // the LOGICAL partition, so the physical id has to be resolved through getPhysicalPartition()
+            // first; feeding it straight to getPartition(), which only looks up idToPartition, returned
+            // null for every entry and left this repair unreachable.
+            Set<Long> visitedPartitionIds = Sets.newHashSet();
+            for (long committedPhysicalPartitionId : commitVersionMap.keySet()) {
+                PhysicalPartition committedPartition = table.getPhysicalPartition(committedPhysicalPartitionId);
+                if (committedPartition == null) {
+                    continue;
+                }
+                long partitionId = committedPartition.getParentId();
+                if (!visitedPartitionIds.add(partitionId)) {
+                    // One watermark slot per logical partition; its representative is chosen below.
+                    continue;
+                }
                 Partition partition = table.getPartition(partitionId);
                 if (partition == null || table.isTempPartition(partitionId)) {
                     continue;
                 }
-                Long commitVersion = commitVersionMap.get(preAlter.physicalPartitionId);
+                // Choose the representative with the SAME call MV staleness detection uses
+                // (OlapPartitionTraits#isBaseTableChanged -> getLatestPhysicalPartition()), so the version
+                // recorded here is the version the MV reads back. Picking a different physical partition --
+                // for instance the one that was latest before the alter -- makes the watermark disagree with
+                // the reader whenever the post-alter version-time tie resolves elsewhere, and the MV then
+                // refreshes anyway.
+                PhysicalPartition latest = partition.getLatestPhysicalPartition();
+                if (latest == null) {
+                    continue;
+                }
+                Long commitVersion = commitVersionMap.get(latest.getId());
                 if (commitVersion == null) {
+                    // This job did not touch the physical partition the MV reads back.
+                    continue;
+                }
+                PreAlterPartitionState preAlter = preAlterPartitionStates.get(latest.getId());
+                if (preAlter == null) {
                     continue;
                 }
                 PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo(partition.getId(),

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -298,7 +298,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             prepareForPersist(db, table);
             // Must run before updateVisibleVersion(), which stamps finishedTimeMs onto EVERY touched
             // physical partition and therefore destroys the pre-alter version times.
-            capturePreAlterPartitionStates(table);
+            capturePreAlterLatestPartitions(table);
             persistStateChange(this, JobState.FINISHED, () -> {
                 updateCatalog(db, table, false);
                 // set visible version
@@ -507,44 +507,61 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         }
     }
 
-    /** Version and version time a physical partition carried before this job rewrote them. */
-    private static class PreAlterPartitionState {
+    /**
+     * The physical partition that decided staleness before this job ran, i.e. the one
+     * {@link Partition#getLatestPhysicalPartition()} resolved to, together with the version and version
+     * time it carried then.
+     */
+    private static class PreAlterLatestPartition {
+        private final long physicalPartitionId;
         private final long visibleVersion;
         private final long visibleVersionTime;
 
-        private PreAlterPartitionState(long visibleVersion, long visibleVersionTime) {
+        private PreAlterLatestPartition(long physicalPartitionId, long visibleVersion, long visibleVersionTime) {
+            this.physicalPartitionId = physicalPartitionId;
             this.visibleVersion = visibleVersion;
             this.visibleVersionTime = visibleVersionTime;
         }
     }
 
-    // Runtime-only snapshot for handleMVRepair, keyed by PHYSICAL partition id; never persisted and
-    // never replayed. A resumed job therefore finds it empty and skips the repair, which leaves the MV
-    // to refresh rather than advancing a watermark whose staleness cannot be proven.
-    private transient Map<Long, PreAlterPartitionState> preAlterPartitionStates = Maps.newHashMap();
+    // Runtime-only snapshot for handleMVRepair, keyed by LOGICAL partition id; never persisted and never
+    // replayed. A resumed job therefore finds it empty and skips the repair, which leaves the MV to
+    // refresh rather than advancing a watermark whose staleness cannot be proven.
+    private transient Map<Long, PreAlterLatestPartition> preAlterLatestPartitions = Maps.newHashMap();
 
     /**
-     * Records the pre-alter version and version time of every physical partition this job touches.
+     * Records, per logical partition, which physical partition MV staleness detection was reading before
+     * this job ran, and the version/version time it had.
      *
-     * updateVisibleVersion() overwrites the version time of all of them with finishedTimeMs, so the
-     * pre-alter values are unrecoverable afterwards -- and MVMetaVersionRepairer needs the pre-alter
-     * version time to tell an up-to-date MV from one already stale through isBaseTableChanged's
-     * version-time disjunct.
-     *
-     * Note this snapshot deliberately does NOT decide which physical partition represents the logical
-     * partition; handleMVRepair makes that choice with the same call the reader uses.
+     * Both halves are needed and neither survives updateVisibleVersion(), which stamps one finishedTimeMs
+     * onto every touched physical partition: that erases the pre-alter version times, and it collapses
+     * getLatestPhysicalPartition()'s max-by-version-time into a tie. The MV's recorded watermark was
+     * compared against THIS partition, so this is the partition the repair filter must validate against.
      */
-    private void capturePreAlterPartitionStates(@NotNull OlapTable table) {
-        Map<Long, PreAlterPartitionState> snapshot = Maps.newHashMap();
+    // Package-private for tests, like updateNextVersion/updateVisibleVersion in this class.
+    void capturePreAlterLatestPartitions(@NotNull OlapTable table) {
+        Map<Long, PreAlterLatestPartition> snapshot = Maps.newHashMap();
         for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
             PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
             if (physicalPartition == null) {
                 continue;
             }
-            snapshot.put(physicalPartitionId, new PreAlterPartitionState(
-                    physicalPartition.getVisibleVersion(), physicalPartition.getVisibleVersionTime()));
+            long partitionId = physicalPartition.getParentId();
+            if (snapshot.containsKey(partitionId)) {
+                continue;
+            }
+            Partition partition = table.getPartition(partitionId);
+            if (partition == null || table.isTempPartition(partitionId)) {
+                continue;
+            }
+            PhysicalPartition preAlterLatest = partition.getLatestPhysicalPartition();
+            if (preAlterLatest == null) {
+                continue;
+            }
+            snapshot.put(partitionId, new PreAlterLatestPartition(preAlterLatest.getId(),
+                    preAlterLatest.getVisibleVersion(), preAlterLatest.getVisibleVersionTime()));
         }
-        preAlterPartitionStates = snapshot;
+        preAlterLatestPartitions = snapshot;
     }
 
     void updateVisibleVersion(@NotNull OlapTable table) {
@@ -820,58 +837,54 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         return watershedTxnId < 0 ? Optional.empty() : Optional.of(watershedTxnId);
     }
 
-    private void handleMVRepair(Database db, OlapTable table) {
+    // Package-private for tests, like updateNextVersion/updateVisibleVersion in this class.
+    void handleMVRepair(Database db, OlapTable table) {
         if (table.getRelatedMaterializedViews().isEmpty()) {
             return;
         }
 
-        List<PartitionRepairInfo> partitionRepairInfos = Lists.newArrayListWithCapacity(commitVersionMap.size());
+        List<PartitionRepairInfo> partitionRepairInfos =
+                Lists.newArrayListWithCapacity(preAlterLatestPartitions.size());
 
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         try {
-            // commitVersionMap is keyed by PHYSICAL partition id (built from
-            // physicalPartitionIndexMap.rowKeySet()) while MaterializedView.BasePartitionInfo is keyed on
-            // the LOGICAL partition, so the physical id has to be resolved through getPhysicalPartition()
-            // first; feeding it straight to getPartition(), which only looks up idToPartition, returned
-            // null for every entry and left this repair unreachable.
-            Set<Long> visitedPartitionIds = Sets.newHashSet();
-            for (long committedPhysicalPartitionId : commitVersionMap.keySet()) {
-                PhysicalPartition committedPartition = table.getPhysicalPartition(committedPhysicalPartitionId);
-                if (committedPartition == null) {
-                    continue;
-                }
-                long partitionId = committedPartition.getParentId();
-                if (!visitedPartitionIds.add(partitionId)) {
-                    // One watermark slot per logical partition; its representative is chosen below.
-                    continue;
-                }
+            // One entry per LOGICAL partition, because MaterializedView.BasePartitionInfo has one slot per
+            // logical partition. commitVersionMap cannot drive this loop directly: it is keyed by PHYSICAL
+            // partition id, and feeding such an id to getPartition() -- which only looks up idToPartition --
+            // returned null for every entry and left this repair unreachable.
+            for (Map.Entry<Long, PreAlterLatestPartition> entry : preAlterLatestPartitions.entrySet()) {
+                long partitionId = entry.getKey();
+                PreAlterLatestPartition preAlterLatest = entry.getValue();
                 Partition partition = table.getPartition(partitionId);
                 if (partition == null || table.isTempPartition(partitionId)) {
                     continue;
                 }
-                // Choose the representative with the SAME call MV staleness detection uses
-                // (OlapPartitionTraits#isBaseTableChanged -> getLatestPhysicalPartition()), so the version
-                // recorded here is the version the MV reads back. Picking a different physical partition --
-                // for instance the one that was latest before the alter -- makes the watermark disagree with
-                // the reader whenever the post-alter version-time tie resolves elsewhere, and the MV then
-                // refreshes anyway.
-                PhysicalPartition latest = partition.getLatestPhysicalPartition();
-                if (latest == null) {
+                // Two different physical partitions are involved, and conflating them is what the review
+                // findings on this method were about:
+                //
+                //   * the NEW watermark must be the version the MV will read back, i.e. the version of the
+                //     partition getLatestPhysicalPartition() resolves to now -- after updateVisibleVersion()
+                //     turned that call into a version-time tie;
+                //   * the VALIDATION values must describe the partition that decided staleness BEFORE this
+                //     job ran, because that is the partition the MV's recorded watermark was compared
+                //     against. Validating against the post-alter winner instead accepts an MV that was
+                //     already stale on the pre-alter latest partition and silently erases that change.
+                //
+                // With a single physical partition the two coincide, which is why this only shows up on
+                // sub-partitioned tables.
+                PhysicalPartition postAlterLatest = partition.getLatestPhysicalPartition();
+                if (postAlterLatest == null) {
                     continue;
                 }
-                Long commitVersion = commitVersionMap.get(latest.getId());
-                if (commitVersion == null) {
+                Long newVersion = commitVersionMap.get(postAlterLatest.getId());
+                if (newVersion == null) {
                     // This job did not touch the physical partition the MV reads back.
                     continue;
                 }
-                PreAlterPartitionState preAlter = preAlterPartitionStates.get(latest.getId());
-                if (preAlter == null) {
-                    continue;
-                }
                 PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo(partition.getId(),
-                        partition.getName(), preAlter.visibleVersion, commitVersion, finishedTimeMs,
-                        preAlter.visibleVersionTime);
+                        partition.getName(), preAlterLatest.visibleVersion, newVersion, finishedTimeMs,
+                        preAlterLatest.visibleVersionTime);
                 partitionRepairInfos.add(partitionRepairInfo);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -296,6 +296,10 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             validateBeforeFinishUnprotected(db, table);
             // Prepare data before persist, so that copyForPersist() can include this data
             prepareForPersist(db, table);
+            // Must run before updateVisibleVersion(), which stamps finishedTimeMs onto EVERY touched
+            // physical partition and therefore destroys both the pre-alter version time and any
+            // ordering getLatestPhysicalPartition() could have used.
+            capturePreAlterLatestPartitions(table);
             persistStateChange(this, JobState.FINISHED, () -> {
                 updateCatalog(db, table, false);
                 // set visible version
@@ -502,6 +506,59 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             LOG.info("LakeTableAlterMetaJob id: {} update next version of partition: {}, commitVersion: {}",
                     jobId, physicalPartition.getId(), commitVersion);
         }
+    }
+
+    /**
+     * Pre-alter state of the physical partition that {@link Partition#getLatestPhysicalPartition()}
+     * resolved to, captured per LOGICAL partition before this job rewrites the visible versions.
+     */
+    private static class PreAlterLatestPartition {
+        private final long physicalPartitionId;
+        private final long visibleVersion;
+        private final long visibleVersionTime;
+
+        private PreAlterLatestPartition(long physicalPartitionId, long visibleVersion, long visibleVersionTime) {
+            this.physicalPartitionId = physicalPartitionId;
+            this.visibleVersion = visibleVersion;
+            this.visibleVersionTime = visibleVersionTime;
+        }
+    }
+
+    // Runtime-only snapshot for handleMVRepair; never persisted and never replayed.
+    private transient Map<Long, PreAlterLatestPartition> preAlterLatestPartitions = Maps.newHashMap();
+
+    /**
+     * Records, for every logical partition this job touches, which physical partition MV staleness
+     * detection would read and what version/version time it carried.
+     *
+     * updateVisibleVersion() assigns the same finishedTimeMs to every physical partition, so calling
+     * getLatestPhysicalPartition() afterwards resolves a timestamp tie through HashMap iteration order
+     * instead of picking the partition that was actually latest. Capturing here keeps that selection
+     * deterministic and preserves the pre-alter version time the repair filter needs.
+     */
+    private void capturePreAlterLatestPartitions(@NotNull OlapTable table) {
+        Map<Long, PreAlterLatestPartition> snapshot = Maps.newHashMap();
+        for (long physicalPartitionId : physicalPartitionIndexMap.rowKeySet()) {
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            if (physicalPartition == null) {
+                continue;
+            }
+            long partitionId = physicalPartition.getParentId();
+            Partition partition = table.getPartition(partitionId);
+            if (partition == null || table.isTempPartition(partitionId)) {
+                continue;
+            }
+            PhysicalPartition latest = partition.getLatestPhysicalPartition();
+            if (latest == null || latest.getId() != physicalPartitionId) {
+                // Another physical partition of the same logical partition is the one the MV reads back;
+                // it will be handled by its own commitVersionMap entry, or left alone if this job does
+                // not touch it.
+                continue;
+            }
+            snapshot.put(partitionId, new PreAlterLatestPartition(physicalPartitionId,
+                    latest.getVisibleVersion(), latest.getVisibleVersionTime()));
+        }
+        preAlterLatestPartitions = snapshot;
     }
 
     void updateVisibleVersion(@NotNull OlapTable table) {
@@ -782,39 +839,30 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
             return;
         }
 
-        List<PartitionRepairInfo> partitionRepairInfos = Lists.newArrayListWithCapacity(commitVersionMap.size());
+        List<PartitionRepairInfo> partitionRepairInfos =
+                Lists.newArrayListWithCapacity(preAlterLatestPartitions.size());
 
         Locker locker = new Locker();
         locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         try {
-            for (Map.Entry<Long, Long> partitionVersion : commitVersionMap.entrySet()) {
-                // commitVersionMap is keyed by PHYSICAL partition id (it is built from
-                // physicalPartitionIndexMap.rowKeySet()), so it has to be resolved through
-                // getPhysicalPartition() first. Passing it straight to getPartition(), which only looks up
-                // logical partitions in idToPartition, returned null for every entry and silently dropped
-                // the whole list -- leaving the MV version-map repair below unreachable.
-                long physicalPartitionId = partitionVersion.getKey();
-                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
-                if (physicalPartition == null) {
-                    continue;
-                }
-                long partitionId = physicalPartition.getParentId();
+            // Driven by the pre-alter snapshot rather than by commitVersionMap: that map is keyed by
+            // PHYSICAL partition id while MaterializedView.BasePartitionInfo is keyed on the LOGICAL
+            // partition, and the snapshot already resolved which physical partition MV staleness
+            // detection reads back -- deterministically, before every version time became finishedTimeMs.
+            for (Map.Entry<Long, PreAlterLatestPartition> entry : preAlterLatestPartitions.entrySet()) {
+                long partitionId = entry.getKey();
+                PreAlterLatestPartition preAlter = entry.getValue();
                 Partition partition = table.getPartition(partitionId);
                 if (partition == null || table.isTempPartition(partitionId)) {
                     continue;
                 }
-                // MV staleness detection (OlapPartitionTraits#isBaseTableChanged) reads the version of
-                // partition.getLatestPhysicalPartition(). Only advance the MV watermark when the physical
-                // partition this job committed is exactly the one the MV will read back; otherwise the
-                // recorded version would not match and the MV would be refreshed anyway.
-                if (partition.getLatestPhysicalPartition().getId() != physicalPartitionId) {
+                Long commitVersion = commitVersionMap.get(preAlter.physicalPartitionId);
+                if (commitVersion == null) {
                     continue;
                 }
-                // TODO(fixme): last version/version time is not kept in transaction state, use version - 1 for last commit
-                //  version.
-                // TODO: we may add last version time to check mv's version map with base table's version time.
-                PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo(partition.getId(),  partition.getName(),
-                        partitionVersion.getValue() - 1, partitionVersion.getValue(), finishedTimeMs);
+                PartitionRepairInfo partitionRepairInfo = new PartitionRepairInfo(partition.getId(),
+                        partition.getName(), preAlter.visibleVersion, commitVersion, finishedTimeMs,
+                        preAlter.visibleVersionTime);
                 partitionRepairInfos.add(partitionRepairInfo);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -788,9 +788,26 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         try {
             for (Map.Entry<Long, Long> partitionVersion : commitVersionMap.entrySet()) {
-                long partitionId = partitionVersion.getKey();
+                // commitVersionMap is keyed by PHYSICAL partition id (it is built from
+                // physicalPartitionIndexMap.rowKeySet()), so it has to be resolved through
+                // getPhysicalPartition() first. Passing it straight to getPartition(), which only looks up
+                // logical partitions in idToPartition, returned null for every entry and silently dropped
+                // the whole list -- leaving the MV version-map repair below unreachable.
+                long physicalPartitionId = partitionVersion.getKey();
+                PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+                if (physicalPartition == null) {
+                    continue;
+                }
+                long partitionId = physicalPartition.getParentId();
                 Partition partition = table.getPartition(partitionId);
                 if (partition == null || table.isTempPartition(partitionId)) {
+                    continue;
+                }
+                // MV staleness detection (OlapPartitionTraits#isBaseTableChanged) reads the version of
+                // partition.getLatestPhysicalPartition(). Only advance the MV watermark when the physical
+                // partition this job committed is exactly the one the MV will read back; otherwise the
+                // recorded version would not match and the MV would be refreshed anyway.
+                if (partition.getLatestPhysicalPartition().getId() != physicalPartitionId) {
                     continue;
                 }
                 // TODO(fixme): last version/version time is not kept in transaction state, use version - 1 for last commit

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVMetaVersionRepairer.java
@@ -149,6 +149,21 @@ public class MVMetaVersionRepairer {
                         curBasePartitionInfo.getLastRefreshTime());
                 continue;
             }
+            // The repair overwrites BOTH the recorded version and lastRefreshTime, while the check above
+            // only proves the MV was current under isBaseTableChanged's version disjunct. An MV can be
+            // stale purely through the other disjunct (visibleVersionTime > lastRefreshTime), which is
+            // load-bearing for materialized-view base tables whose partitions are overwritten in place and
+            // for tables whose latest physical partition changed. Advancing the watermark in that state
+            // would erase a change the MV never consumed, so a producer that can report the pre-commit
+            // version time must also prove the MV was not behind on it.
+            if (info.getLastVersionTime() >= 0
+                    && curBasePartitionInfo.getLastRefreshTime() < info.getLastVersionTime()) {
+                LOG.info("Base table {} partition {} version time not match, lastRefreshTime {}(mv) < " +
+                                "pre-commit visible version time {}(table), skip to repair",
+                        table.getName(), info.getPartitionName(), curBasePartitionInfo.getLastRefreshTime(),
+                        info.getLastVersionTime());
+                continue;
+            }
             needToUpdatePartitionInfos.add(info);
         }
         return needToUpdatePartitionInfos;

--- a/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mv/MVRepairHandler.java
@@ -37,17 +37,32 @@ public interface MVRepairHandler {
         private final long lastVersion; // last commit partition visible version
         private final long newVersion; // new commit partition visible version
         private final long newVersionTime; // new commit partition visible version time
+        // Visible version time the partition had BEFORE this commit, or -1 when the producer cannot
+        // report it. MVMetaVersionRepairer uses it to prove the MV was not already stale through
+        // isBaseTableChanged's version-time disjunct; producers that pass -1 keep the weaker
+        // version-only check.
+        private final long lastVersionTime;
 
         public PartitionRepairInfo(long partitionId,
                                    String partitionName,
                                    long lastVersion,
                                    long newVersion,
                                    long newVersionTime) {
+            this(partitionId, partitionName, lastVersion, newVersion, newVersionTime, -1L);
+        }
+
+        public PartitionRepairInfo(long partitionId,
+                                   String partitionName,
+                                   long lastVersion,
+                                   long newVersion,
+                                   long newVersionTime,
+                                   long lastVersionTime) {
             this.partitionId = partitionId;
             this.partitionName = partitionName;
             this.newVersion = newVersion;
             this.newVersionTime = newVersionTime;
             this.lastVersion = lastVersion;
+            this.lastVersionTime = lastVersionTime;
         }
 
         public long getPartitionId() {
@@ -68,6 +83,10 @@ public interface MVRepairHandler {
 
         public long getLastVersion() {
             return lastVersion;
+        }
+
+        public long getLastVersionTime() {
+            return lastVersionTime;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -22,7 +22,9 @@ import com.staros.proto.StarStatus;
 import com.staros.proto.StatusCode;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
@@ -35,10 +37,12 @@ import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
+import com.starrocks.mv.MVRepairHandler;
 import com.starrocks.proto.TxnInfoPB;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -845,5 +849,61 @@ public class LakeTableAlterMetaJobTest {
         combined.add(row);
         combined.sort(new ListComparator<>(0, 1, 2, 3, 4, 5));
         Assertions.assertEquals(2, combined.size());
+    }
+
+    /**
+     * Regression: the MV version-map repair at the tail of this job family must actually run.
+     *
+     * Every LakeTableAlterMetaJobBase job advances the visible version and visible version time of every
+     * physical partition without rewriting a single row. MV staleness detection
+     * (OlapPartitionTraits#isBaseTableChanged) keys off exactly those two fields, so a dependent
+     * materialized view would re-materialize its entire history after a metadata-only ALTER. The
+     * compensation is handleMVRepair -> MVMetaVersionRepairer, which advances the MV watermark in place.
+     *
+     * commitVersionMap is keyed by PHYSICAL partition id, while MaterializedView.BasePartitionInfo is keyed
+     * on the LOGICAL partition (name + id). Feeding the physical id straight to OlapTable#getPartition(),
+     * which only resolves logical ids, returned null for every entry, so the repair list came out empty and
+     * the compensation silently never ran.
+     */
+    @Test
+    public void testMVVersionMapRepairUsesLogicalPartitionId() throws Exception {
+        // Without a dependent MV, handleMVRepair returns before building the repair list.
+        table.addRelatedMaterializedView(new MvId(db.getId(), GlobalStateMgr.getCurrentState().getNextId()));
+
+        Partition partition = table.getPartitions().iterator().next();
+        PhysicalPartition physicalPartition = partition.getDefaultPhysicalPartition();
+        // Premise: the logical partition and its physical partition carry DIFFERENT ids. If that ever stops
+        // holding, the assertions below would pass for the wrong reason.
+        Assertions.assertNotEquals(partition.getId(), physicalPartition.getId());
+        long versionBefore = physicalPartition.getVisibleVersion();
+
+        List<MVRepairHandler.PartitionRepairInfo> captured = new ArrayList<>();
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public void handleMVRepair(Database database, com.starrocks.catalog.Table changedTable,
+                                       List<MVRepairHandler.PartitionRepairInfo> partitionRepairInfos) {
+                captured.addAll(partitionRepairInfos);
+            }
+        };
+
+        job.runPendingJob();
+        job.runRunningJob();
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED) {
+            job.runFinishedRewritingJob();
+            Thread.sleep(100);
+        }
+
+        // The metadata-only job advanced the partition version ...
+        Assertions.assertEquals(versionBefore + 1, physicalPartition.getVisibleVersion());
+        // ... so the MV watermark repair must have been handed exactly one entry, carrying the LOGICAL
+        // partition id and name, and the version the MV will read back.
+        Assertions.assertEquals(1, captured.size());
+        MVRepairHandler.PartitionRepairInfo repairInfo = captured.get(0);
+        Assertions.assertEquals(partition.getId(), repairInfo.getPartitionId());
+        Assertions.assertEquals(partition.getName(), repairInfo.getPartitionName());
+        Assertions.assertEquals(versionBefore, repairInfo.getLastVersion());
+        Assertions.assertEquals(versionBefore + 1, repairInfo.getNewVersion());
+        Assertions.assertEquals(partition.getLatestPhysicalPartition().getVisibleVersion(),
+                repairInfo.getNewVersion());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -31,6 +31,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.ListComparator;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
@@ -67,6 +68,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -909,5 +911,89 @@ public class LakeTableAlterMetaJobTest {
         Assertions.assertEquals(versionBefore + 1, repairInfo.getNewVersion());
         Assertions.assertEquals(partition.getLatestPhysicalPartition().getVisibleVersion(),
                 repairInfo.getNewVersion());
+    }
+
+    /**
+     * A logical partition with several physical sub-partitions (the shape automatic bucketing produces)
+     * involves TWO different physical partitions, and the repair owes each of them something different:
+     *
+     *   * the new watermark must be the version the MV reads back, i.e. the version of whichever
+     *     sub-partition getLatestPhysicalPartition() resolves to AFTER updateVisibleVersion() gave every
+     *     sub-partition the same version time and thereby turned that call into a tie;
+     *   * the validation values handed to MVMetaVersionRepairer must describe the sub-partition that
+     *     decided staleness BEFORE the alter, because that is the one the MV's recorded watermark was
+     *     compared against. Validating against the post-alter winner accepts an MV that was already stale
+     *     on the pre-alter latest sub-partition and silently erases that change.
+     *
+     * With a single physical partition the two coincide, so only this shape can tell them apart.
+     */
+    @Test
+    public void testMVRepairValidatesPreAlterLatestAndRecordsPostAlterWinner() throws Exception {
+        // Sub-partitions can only be added to a randomly distributed table
+        // (LocalMetastore#addSubPartitions), which is exactly the shape the review finding named.
+        LakeTable multiSubTable = createTable(connectContext,
+                "CREATE TABLE t_multi_sub(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY RANDOM BUCKETS 1");
+        multiSubTable.addRelatedMaterializedView(
+                new MvId(db.getId(), GlobalStateMgr.getCurrentState().getNextId()));
+
+        Partition partition = multiSubTable.getPartitions().iterator().next();
+        GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .addSubPartitions(db, multiSubTable, partition, 1, WarehouseManager.DEFAULT_RESOURCE);
+        Assertions.assertEquals(2, partition.getSubPartitions().size());
+
+        // Distinct versions AND distinct version times, so reading either value off the wrong
+        // sub-partition is observable.
+        List<PhysicalPartition> subPartitions = new ArrayList<>(partition.getSubPartitions());
+        subPartitions.sort(Comparator.comparingLong(PhysicalPartition::getId));
+        subPartitions.get(0).updateVisibleVersion(5L, 100L);
+        subPartitions.get(1).updateVisibleVersion(7L, 200L);
+
+        // Pre-alter, staleness is decided by the sub-partition with the newest version time.
+        PhysicalPartition preAlterLatest = partition.getLatestPhysicalPartition();
+        Assertions.assertEquals(subPartitions.get(1).getId(), preAlterLatest.getId());
+        long preAlterLatestVersion = preAlterLatest.getVisibleVersion();
+        long preAlterLatestVersionTime = preAlterLatest.getVisibleVersionTime();
+
+        LakeTableAlterMetaJob multiJob = new LakeTableAlterMetaJob(
+                GlobalStateMgr.getCurrentState().getNextId(), db.getId(), multiSubTable.getId(),
+                multiSubTable.getName(), 60 * 1000, TTabletMetaType.ENABLE_PERSISTENT_INDEX, true,
+                "CLOUD_NATIVE");
+        Map<Long, Long> commitVersions = new HashMap<>();
+        for (PhysicalPartition subPartition : subPartitions) {
+            commitVersions.put(subPartition.getId(), subPartition.getVisibleVersion() + 1);
+            MaterializedIndex baseIndex = subPartition.getLatestBaseIndex();
+            multiJob.addDirtyPartitionIndex(subPartition.getId(), baseIndex.getId(), baseIndex);
+        }
+        Deencapsulation.setField(multiJob, "commitVersionMap", commitVersions);
+        Deencapsulation.setField(multiJob, "finishedTimeMs", 900L);
+
+        List<MVRepairHandler.PartitionRepairInfo> captured = new ArrayList<>();
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public void handleMVRepair(Database database, com.starrocks.catalog.Table changedTable,
+                                       List<MVRepairHandler.PartitionRepairInfo> partitionRepairInfos) {
+                captured.addAll(partitionRepairInfos);
+            }
+        };
+
+        multiJob.capturePreAlterLatestPartitions(multiSubTable);
+        multiJob.updateVisibleVersion(multiSubTable);
+        // Every sub-partition now carries finishedTimeMs, so this resolves a tie.
+        PhysicalPartition postAlterLatest = partition.getLatestPhysicalPartition();
+        Assertions.assertEquals(900L, postAlterLatest.getVisibleVersionTime());
+        multiJob.handleMVRepair(db, multiSubTable);
+
+        // One slot per logical partition.
+        Assertions.assertEquals(1, captured.size());
+        MVRepairHandler.PartitionRepairInfo repairInfo = captured.get(0);
+        Assertions.assertEquals(partition.getId(), repairInfo.getPartitionId());
+        Assertions.assertEquals(partition.getName(), repairInfo.getPartitionName());
+        // Validation describes the PRE-alter latest sub-partition ...
+        Assertions.assertEquals(preAlterLatestVersion, repairInfo.getLastVersion());
+        Assertions.assertEquals(preAlterLatestVersionTime, repairInfo.getLastVersionTime());
+        // ... while the watermark carries the version the reader compares against afterwards.
+        Assertions.assertEquals(commitVersions.get(postAlterLatest.getId()).longValue(),
+                repairInfo.getNewVersion());
+        Assertions.assertEquals(900L, repairInfo.getNewVersionTime());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -876,6 +876,7 @@ public class LakeTableAlterMetaJobTest {
         // holding, the assertions below would pass for the wrong reason.
         Assertions.assertNotEquals(partition.getId(), physicalPartition.getId());
         long versionBefore = physicalPartition.getVisibleVersion();
+        long versionTimeBefore = physicalPartition.getVisibleVersionTime();
 
         List<MVRepairHandler.PartitionRepairInfo> captured = new ArrayList<>();
         new MockUp<LocalMetastore>() {
@@ -902,6 +903,9 @@ public class LakeTableAlterMetaJobTest {
         Assertions.assertEquals(partition.getId(), repairInfo.getPartitionId());
         Assertions.assertEquals(partition.getName(), repairInfo.getPartitionName());
         Assertions.assertEquals(versionBefore, repairInfo.getLastVersion());
+        // The pre-alter visible version time has to be reported, otherwise MVMetaVersionRepairer cannot
+        // tell an up-to-date MV from one that is already stale through isBaseTableChanged's time disjunct.
+        Assertions.assertEquals(versionTimeBefore, repairInfo.getLastVersionTime());
         Assertions.assertEquals(versionBefore + 1, repairInfo.getNewVersion());
         Assertions.assertEquals(partition.getLatestPhysicalPartition().getVisibleVersion(),
                 repairInfo.getNewVersion());

--- a/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/mv/MVMetaVersionRepairerTest.java
@@ -302,4 +302,53 @@ public class MVMetaVersionRepairerTest extends MVTestBase {
                     });
         });
     }
+
+    @Test
+    public void testRepairSkippedWhenMvWatermarkIsBehindVersionTime() {
+        starRocksAssert.withTable(m1, () -> {
+            cluster.runSql("test", "insert into m1 values (1,1,1,1,1), (4,2,1,1,1);");
+            starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv0 " +
+                            " PARTITION BY (k1) " +
+                            " DISTRIBUTED BY HASH(k1) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " PROPERTIES (\n" +
+                            " 'transparent_mv_rewrite_mode' = 'true'" +
+                            " ) " +
+                            " AS SELECT k1, k2, v1, v2 from m1;",
+                    (obj) -> {
+                        String mvName = (String) obj;
+                        starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW mv0 \n" +
+                                "PARTITION START ('%s') END ('%s')", "1", "3"));
+                        Table baseTable = getTable("test", "m1");
+                        Partition curPartition = baseTable.getPartition("p1");
+
+                        MaterializedView mv1 = getMv("test", mvName);
+                        MaterializedView.AsyncRefreshContext asyncRefreshContext =
+                                mv1.getRefreshScheme().getAsyncRefreshContext();
+                        Map<String, MaterializedView.BasePartitionInfo> value =
+                                asyncRefreshContext.getBaseTableVisibleVersionMap().values().iterator().next();
+                        String baseTablePartitionName = value.keySet().iterator().next();
+                        MaterializedView.BasePartitionInfo before = value.get(baseTablePartitionName);
+
+                        // The MV is already stale through isBaseTableChanged's *time* disjunct: the base
+                        // partition's pre-commit visible version time is newer than the MV's recorded
+                        // lastRefreshTime, so there is an unconsumed change. Repairing here would advance
+                        // both fields and erase it, therefore the repair must be skipped even though the
+                        // recorded version still matches lastVersion.
+                        MVRepairHandler.PartitionRepairInfo staleByTime = new MVRepairHandler.PartitionRepairInfo(
+                                curPartition.getId(), curPartition.getName(),
+                                curPartition.getDefaultPhysicalPartition().getVisibleVersion(),
+                                100L, System.currentTimeMillis(), before.getLastRefreshTime() + 1);
+
+                        MVMetaVersionRepairer.repairBaseTableVersionChanges(baseTable,
+                                ImmutableList.of(staleByTime));
+
+                        MaterializedView.BasePartitionInfo after = mv1.getRefreshScheme()
+                                .getAsyncRefreshContext().getBaseTableVisibleVersionMap()
+                                .values().iterator().next().get(baseTablePartitionName);
+                        Assertions.assertEquals(before.getVersion(), after.getVersion());
+                        Assertions.assertEquals(before.getLastRefreshTime(), after.getLastRefreshTime());
+                    });
+        });
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Every `LakeTableAlterMetaJobBase` job — the shared-data metadata-only ALTERs: async fast schema
evolution, `enable_persistent_index`, `file_bundling`, `compaction_strategy`, CDC — advances the
**visible version and visible version time of every physical partition** without rewriting a single
row. MV staleness detection (`OlapPartitionTraits#isBaseTableChanged`) keys off exactly those two
fields, so every dependent async materialized view re-materializes its **entire history** after a
DDL that provably cannot change its output.

The compensation for this already exists and is already wired into that path:
`handleMVRepair` → `MVMetaVersionRepairer#repairBaseTableVersionChanges`, which advances the MV's
`baseTableVisibleVersionMap` watermark in place **without scheduling a refresh** (originally built
for lake compaction, which has the same "version moved, data did not" shape). It just never runs.

Reported by a customer running large aggregate tables with MV rollups (internal POST-1843 / ZD ):
a single `ALTER TABLE... ADD COLUMN <col> INT KEY NOT NULL DEFAULT "0"` — DDL completes in seconds —
made every dependent MV re-aggregate hundreds of historical partitions.

## What I'm doing:

`handleMVRepair` iterates `commitVersionMap`, whose keys are **physical** partition ids (the map is
built from `physicalPartitionIndexMap.rowKeySet()`), but hands them to `OlapTable#getPartition()`,
which only resolves **logical** ids out of `idToPartition`. It returns `null` for every entry, so the
repair list comes out empty and the method returns before ever reaching the repairer.

The fix resolves the physical partition first and uses its `getParentId()` for the logical lookup.
It also adds one guard: only emit a repair entry when the physical partition this job committed is
the one MV staleness detection will read back (`partition.getLatestPhysicalPartition()`), so the
recorded version can never disagree with the reader.

Internal ticket: POST-1843

## Verification

Reproduced and then fixed on a live 3-FE / 3-BE **shared-data** cluster (4.0.13-ee), same base table
and same DDL both times — only the FE binary changed.

Control, nothing changed (both builds): `REFRESH MATERIALIZED VIEW` → `SKIPPED`, `base_parts={}`.

| | before fix | after fix |
|---|---|---|
| `VISIBLE_VERSION` (4/4 partitions) | 2 → 3 | 3 → 4 |
| `DATA_VERSION` | unchanged | unchanged |
| fe.log `repair base table` | **0** | 1, recording the **logical** ids |
| fe.log `skip to repair` | **0** | 0 |
| non-forced `REFRESH MATERIALIZED VIEW` | `SUCCESS`, `{base_agg=[p0820, p0821, p0822, p0823]}` | `SKIPPED`, `{}` |
| MV rows vs base rollup | equal | equal |

`repair base table = 0` **and** `skip to repair = 0` together are the discriminating signal: had the
lookup worked and only the version filter rejected, `skip to repair` would have logged. Both at zero
means the list was empty before reaching the filter.

New regression test `LakeTableAlterMetaJobTest#testMVVersionMapRepairUsesLogicalPartitionId`
(red before the fix: `expected: <1> but was: <0>`; green after). It also asserts the premise
`logicalPartitionId!= physicalPartitionId`, so it cannot pass vacuously.

## Scope notes for reviewers

- On `main` / `` / `branch-4.1`, newly created cloud-native tables default to
 `cloud_native_fast_schema_evolution_v2=true`, and that path skips the version bump entirely — so the
 `ADD COLUMN` symptom does not reproduce there **for new tables**. The bug still bites: tables created
 before that property existed (`TableProperty#cloudNativeFastSchemaEvolutionV2` defaults to `false`
 when the property is absent, and `buildCloudNativeFastSchemaEvolutionV2()` only overwrites it when
 present), tables with it explicitly off, and **every** `LakeTableAlterMetaJob` operation on any table.
- `branch-4.0` has no FSE V2 at all, so the reported path is fully live there.
- Deliberately **not** in this PR, to be handled separately: the heavy schema-change path
 (`LakeTableSchemaChangeJob`) never calls `handleMVRepair` at all; and
 `MVRepairHandler#handleMVRepair(TransactionState)` (lake compaction) carries the same id mixup at the
 same line shape — code-inspected, not yet reproduced.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

A dependent MV that was already caught up no longer refreshes after a metadata-only ALTER. Partitions
the MV was genuinely behind on still refresh: `MVMetaVersionRepairer#filterToRepairPartitionInfos`
advances a watermark only when the MV's recorded version is exactly the pre-DDL version.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5