### PR TITLE
[BugFix] Compare list-partition drift against the live table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
@@ -128,9 +128,8 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
                 // if the partition names are not equal, it means the partition has changed.
                 return !snapShotOlapTable.getVisiblePartitionNames().equals(partitionNames);
             } else if (snapshotPartitionInfo.isListPartition()) {
-                OlapTable snapshotOlapTable = (OlapTable) baseTable;
-                PCellSortedSet snapshotPartitionMap = snapshotOlapTable.getListPartitionItems();
-                PCellSortedSet currentPartitionMap = snapshotOlapTable.getListPartitionItems();
+                PCellSortedSet snapshotPartitionMap = snapShotOlapTable.getListPartitionItems();
+                PCellSortedSet currentPartitionMap = ((OlapTable) table).getListPartitionItems();
                 return ListPartitionDiffer.hasListPartitionChanged(snapshotPartitionMap, currentPartitionMap);
             } else {
                 PCellSortedSet snapshotPartitionMap = snapShotOlapTable.getRangePartitionMap();

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
@@ -18,8 +18,16 @@ import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Table;
 import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
+import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PCellWithName;
+import com.starrocks.sql.common.PListCell;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -97,5 +106,54 @@ class PCTTableSnapshotInfoTest {
         Assertions.assertEquals(1L, mvPartitionInfo.getId());
         Assertions.assertEquals(30L, mvPartitionInfo.getVersion());
         Assertions.assertEquals(3000L, mvPartitionInfo.getLastRefreshTime());
+    }
+
+    private static PCellSortedSet listCells(String... values) {
+        return PCellSortedSet.of(Arrays.stream(values)
+                .map(v -> PCellWithName.of("p" + v, new PListCell(v)))
+                .toList());
+    }
+
+    private static OlapTable listPartitionedTable(PCellSortedSet cells) {
+        OlapTable table = mock(OlapTable.class);
+        PartitionInfo partitionInfo = mock(PartitionInfo.class);
+        when(partitionInfo.isUnPartitioned()).thenReturn(false);
+        when(partitionInfo.isListPartition()).thenReturn(true);
+        when(table.isOlapOrCloudNativeTable()).thenReturn(true);
+        when(table.getPartitionInfo()).thenReturn(partitionInfo);
+        when(table.getListPartitionItems()).thenReturn(cells);
+        return table;
+    }
+
+    /**
+     * The drift check must compare the snapshot copy against the live table. Comparing the snapshot
+     * with itself always reports "unchanged", which silently disables the retry loop that guards MV
+     * refresh against base-table partitions changing mid-refresh.
+     */
+    @Test
+    void testListPartitionDriftIsDetectedAgainstLiveTable() {
+        BaseTableInfo baseTableInfo = mock(BaseTableInfo.class);
+        MaterializedView mv = mock(MaterializedView.class);
+        OlapTable snapshot = listPartitionedTable(listCells("2026-01-01", "2026-01-02"));
+
+        OlapTable live = listPartitionedTable(listCells("2026-01-01", "2026-01-02", "2026-01-03"));
+        mockLiveTable(live);
+        Assertions.assertTrue(new PCTTableSnapshotInfo(baseTableInfo, snapshot).hasBaseTableChanged(mv),
+                "a partition added to the live table after the snapshot must be reported as changed");
+
+        // Control: an unchanged live table must still report false, so the assertion above cannot pass
+        // merely because hasBaseTableChanged swallows an exception and defaults to true.
+        mockLiveTable(listPartitionedTable(listCells("2026-01-01", "2026-01-02")));
+        Assertions.assertFalse(new PCTTableSnapshotInfo(baseTableInfo, snapshot).hasBaseTableChanged(mv),
+                "an unchanged live table must not be reported as changed");
+    }
+
+    private static void mockLiveTable(OlapTable live) {
+        new MockUp<MvUtils>() {
+            @Mock
+            public Optional<Table> getTableWithIdentifier(BaseTableInfo baseTableInfo) {
+                return Optional.of(live);
+            }
+        };
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`PCTTableSnapshotInfo.checkBaseTableChanged` read `getListPartitionItems()` from the snapshot copy on **both** sides of the comparison:

```java
} else if (snapshotPartitionInfo.isListPartition()) {
 OlapTable snapshotOlapTable = (OlapTable) baseTable;
 PCellSortedSet snapshotPartitionMap = snapshotOlapTable.getListPartitionItems();
 PCellSortedSet currentPartitionMap = snapshotOlapTable.getListPartitionItems();
 return ListPartitionDiffer.hasListPartitionChanged(snapshotPartitionMap, currentPartitionMap);
}
```

`ListPartitionDiffer.hasListPartitionChanged` is a symmetric cell-by-cell comparison, so passing the same set twice always returns `false`. For a list-partitioned internal base table — including expression / automatic partitioning such as `PARTITION BY (dt)` — the drift check is therefore a permanent no-op, and the retry loop in `MVPCTRefreshSynchronizer.syncAndCheckPCTPartitions` exits on the first iteration regardless of what happened to the base table's partitions while the refresh was preparing.

The adjacent range-partition branch already compares against the live table resolved a few lines above via `MvUtils.getTableWithIdentifier`, which is what this branch was meant to do.

Impact is not limited to IVM — this is the generic PCT path, so every PCT refresh over a list-partitioned internal base table loses that guard. It matters most during the IVM bootstrap refresh, where the refresh scope and its partition predicate are built from the (possibly stale) topology while the scan reads a frozen bookmark: a partition created in between is captured by the bookmark but never materialized, and the baseline advances past it.

## What I'm doing:

Compare the snapshot copy against the live table, mirroring the range-partition branch. The redundant `snapshotOlapTable` local is dropped — it duplicated `snapShotOlapTable` from the enclosing scope.

Added `PCTTableSnapshotInfoTest#testListPartitionDriftIsDetectedAgainstLiveTable`, which adds a partition to the live table after the snapshot is taken and asserts the drift is reported. It also asserts the unchanged case still returns `false`, so the positive assertion cannot pass merely because `hasBaseTableChanged` swallows an exception and defaults to `true`.

Verification:

- before the fix: `a partition added to the live table after the snapshot must be reported as changed ==> expected: <true> but was: <false>`
- after the fix: `Tests run: 3, Failures: 0, Errors: 0` for the whole `PCTTableSnapshotInfoTest` class, checkstyle clean

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: a refresh over a list-partitioned internal base table can now retry (and, past `max_mv_check_base_table_change_retry_times`, fail) when the base table's partitions change mid-refresh, where it previously always proceeded on the first iteration.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5