### PR TITLE
[BugFix] Make SQL blacklist verification lock-free

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.meta;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.staros.util.LockCloseable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
@@ -42,12 +44,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.stream.Collectors;
 
 // Used by sql's blacklist
 public class SqlBlackList {
@@ -56,19 +56,17 @@ public class SqlBlackList {
 
     public void verifying(String sql) throws AnalysisException {
         String formatSql = sql.replace("\r", " ").replace("\n", " ").replaceAll("\\s+", " ");
-        try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
-            for (BlackListSql patternAndId : sqlBlackListMap.values()) {
-                Matcher m = patternAndId.pattern.matcher(formatSql);
-                if (m.find()) {
-                    MetricRepo.COUNTER_SQL_BLOCK_HIT_COUNT.increase(1L);
-                    ErrorReport.reportSqlBlackListException(ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR, patternAndId.id);
-                }
+        for (BlackListSql patternAndId : ruleSnapshot) {
+            Matcher m = patternAndId.pattern.matcher(formatSql);
+            if (m.find()) {
+                MetricRepo.COUNTER_SQL_BLOCK_HIT_COUNT.increase(1L);
+                ErrorReport.reportSqlBlackListException(ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR, patternAndId.id);
             }
         }
     }
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
-        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+        try (LockCloseable ignored = new LockCloseable(updateLock)) {
             int cnt = reader.readInt();
             for (int i = 0; i < cnt; i++) {
                 SqlBlackListPersistInfo sqlBlackListPersistInfo = reader.readJson(SqlBlackListPersistInfo.class);
@@ -80,13 +78,16 @@ public class SqlBlackList {
 
     // we use string of sql as key, and (pattern, id) as value.
     public long put(Pattern pattern) {
-        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+        try (LockCloseable ignored = new LockCloseable(updateLock)) {
             BlackListSql blackListSql = sqlBlackListMap.get(pattern.toString());
             if (blackListSql == null) {
                 long id = ids.getAndIncrement();
                 GlobalStateMgr.getCurrentState().getEditLog().logAddSQLBlackList(
                         new SqlBlackListPersistInfo(id, pattern.pattern()),
-                        wal -> sqlBlackListMap.put(pattern.toString(), new BlackListSql(pattern, id)));
+                        wal -> {
+                            sqlBlackListMap.put(pattern.toString(), new BlackListSql(pattern, id));
+                            refreshSnapshot();
+                        });
                 return id;
             } else {
                 return blackListSql.id;
@@ -95,11 +96,12 @@ public class SqlBlackList {
     }
 
     public void put(long id, Pattern pattern) {
-        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+        try (LockCloseable ignored = new LockCloseable(updateLock)) {
             BlackListSql blackListSql = sqlBlackListMap.get(pattern.toString());
             if (blackListSql == null) {
                 ids.set(Math.max(ids.get(), id + 1));
                 sqlBlackListMap.put(pattern.toString(), new BlackListSql(pattern, id));
+                refreshSnapshot();
             }
         }
     }
@@ -139,10 +141,11 @@ public class SqlBlackList {
 
     // we delete sql's regular expression use id, so we iterate this map.
     public void delete(long id) {
-        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+        try (LockCloseable ignored = new LockCloseable(updateLock)) {
             for (Map.Entry<String, BlackListSql> entry : sqlBlackListMap.entrySet()) {
                 if (entry.getValue().id == id) {
                     sqlBlackListMap.remove(entry.getKey());
+                    refreshSnapshot();
                     return;
                 }
             }
@@ -156,7 +159,7 @@ public class SqlBlackList {
     }
 
     public void save(ImageWriter imageWriter) throws IOException, SRMetaBlockException {
-        try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
+        try (LockCloseable ignored = new LockCloseable(updateLock)) {
             // one for self and N for patterns
             final int cnt = 1 + sqlBlackListMap.size();
             SRMetaBlockWriter writer = imageWriter.getBlockWriter(SRMetaBlockID.BLACKLIST_MGR, cnt);
@@ -171,12 +174,22 @@ public class SqlBlackList {
     }
 
     public List<BlackListSql> getBlackLists() {
-        try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
-            return this.sqlBlackListMap.values().stream().sorted(Comparator.comparing(x -> x.id)).collect(Collectors.toList());
-        }
+        return ruleSnapshot;
     }
 
-    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+    private void refreshSnapshot() {
+        ruleSnapshot = this.sqlBlackListMap.values().stream().sorted(Comparator.comparing(x -> x.id))
+                .collect(ImmutableList.toImmutableList());
+    }
+
+    @VisibleForTesting
+    ReentrantLock getUpdateLock() {
+        return updateLock;
+    }
+
+    private final ReentrantLock updateLock = new ReentrantLock();
+
+    private volatile List<BlackListSql> ruleSnapshot = ImmutableList.of();
 
     // sqlBlackListMap: key is String(sql), value is BlackListSql.
     // BlackListSql is (Pattern, id). Pattern is the regular expression, id marks this sql, and is show with "show sqlblacklist";
@@ -186,9 +199,10 @@ public class SqlBlackList {
     private final AtomicLong ids = new AtomicLong();
 
     protected void cleanup() {
-        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+        try (LockCloseable ignored = new LockCloseable(updateLock)) {
             sqlBlackListMap.clear();
             ids.set(0);
+            refreshSnapshot();
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistLockFreeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistLockFreeTest.java
@@ -1,0 +1,242 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.meta;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+public class SqlBlacklistLockFreeTest {
+    private static final long RESPONSIVE_MS = 5000;
+
+    private SqlBlackList sqlBlackList;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        AnalyzeTestUtil.init();
+    }
+
+    @BeforeEach
+    public void beforeEach() {
+        sqlBlackList = GlobalStateMgr.getCurrentState().getSqlBlackList();
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ctx.setQueryId(UUIDUtil.genUUID());
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+        sqlBlackList.cleanup();
+    }
+
+    @Test
+    public void testSnapshotReflectsAddAndDelete() {
+        Assertions.assertTrue(sqlBlackList.getBlackLists().isEmpty());
+
+        long first = sqlBlackList.put(Pattern.compile("select .* from t1"));
+        Assertions.assertEquals(1, sqlBlackList.getBlackLists().size());
+
+        long second = sqlBlackList.put(Pattern.compile("select .* from t2"));
+        Assertions.assertEquals(2, sqlBlackList.getBlackLists().size());
+
+        sqlBlackList.delete(first);
+        List<BlackListSql> remaining = sqlBlackList.getBlackLists();
+        Assertions.assertEquals(1, remaining.size());
+        Assertions.assertEquals(second, remaining.get(0).id);
+    }
+
+    @Test
+    public void testSnapshotReflectsReplay() {
+        sqlBlackList.put(7L, Pattern.compile("replayed_rule_b"));
+        sqlBlackList.put(3L, Pattern.compile("replayed_rule_a"));
+
+        List<BlackListSql> rules = sqlBlackList.getBlackLists();
+        Assertions.assertEquals(2, rules.size());
+        Assertions.assertEquals(3L, rules.get(0).id);
+        Assertions.assertEquals(7L, rules.get(1).id);
+
+        long next = sqlBlackList.put(Pattern.compile("locally_added_rule"));
+        Assertions.assertTrue(next > 7L, "expected an id above the replayed ones, got " + next);
+    }
+
+    @Test
+    public void testSnapshotIsRebuiltAfterImageRoundTrip() throws Exception {
+        SqlBlackList original = new SqlBlackList();
+        long first = original.put(Pattern.compile("rule_from_image_a"));
+        long second = original.put(Pattern.compile("rule_from_image_b"));
+
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        original.save(image.getImageWriter());
+
+        SqlBlackList recovered = new SqlBlackList();
+        Assertions.assertTrue(recovered.getBlackLists().isEmpty());
+        recovered.load(image.getMetaBlockReader());
+
+        List<BlackListSql> rules = recovered.getBlackLists();
+        Assertions.assertEquals(2, rules.size());
+        Assertions.assertEquals(first, rules.get(0).id);
+        Assertions.assertEquals(second, rules.get(1).id);
+        Assertions.assertEquals("rule_from_image_a", rules.get(0).pattern.pattern());
+        Assertions.assertEquals("rule_from_image_b", rules.get(1).pattern.pattern());
+
+        AnalysisException hit = Assertions.assertThrows(AnalysisException.class,
+                () -> recovered.verifying("select rule_from_image_b from t"));
+        Assertions.assertTrue(hit.getMessage().contains(String.valueOf(second)), hit.getMessage());
+        recovered.verifying("select nothing_matches_here from t");
+
+        long third = recovered.put(Pattern.compile("rule_added_after_load"));
+        Assertions.assertTrue(third > second, "expected an id above the loaded ones, got " + third);
+        Assertions.assertEquals(3, recovered.getBlackLists().size());
+    }
+
+    @Test
+    public void testLowestMatchingIdIsReported() {
+        long low = sqlBlackList.put(Pattern.compile("from orders"));
+        long high = sqlBlackList.put(Pattern.compile("select"));
+        Assertions.assertTrue(low < high);
+
+        for (int i = 0; i < 20; i++) {
+            AnalysisException e = Assertions.assertThrows(AnalysisException.class,
+                    () -> sqlBlackList.verifying("select id from orders"));
+            Assertions.assertTrue(e.getMessage().contains(String.valueOf(low)),
+                    "expected the lowest matching rule id " + low + " in: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testVerifyingIsNotBlockedByAnInProgressMutation() throws Exception {
+        sqlBlackList.put(Pattern.compile("this_rule_never_matches"));
+
+        assertCompletesWhileUpdateLockIsHeld(() -> {
+            try {
+                sqlBlackList.verifying("select 1");
+            } catch (AnalysisException e) {
+                throw new IllegalStateException("unexpected blacklist hit", e);
+            }
+        });
+    }
+
+    @Test
+    public void testShowIsNotBlockedByAnInProgressMutation() throws Exception {
+        sqlBlackList.put(Pattern.compile("some_rule"));
+
+        assertCompletesWhileUpdateLockIsHeld(() -> Assertions.assertEquals(1, sqlBlackList.getBlackLists().size()));
+    }
+
+    @Test
+    public void testConcurrentVerifyAndMutateDoNotFail() throws Exception {
+        final int readers = 8;
+        final int rounds = 200;
+        AtomicBoolean stop = new AtomicBoolean(false);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        CountDownLatch started = new CountDownLatch(readers);
+        List<Thread> threads = new ArrayList<>();
+
+        for (int i = 0; i < readers; i++) {
+            Thread t = new Thread(() -> {
+                started.countDown();
+                try {
+                    while (!stop.get()) {
+                        for (BlackListSql rule : sqlBlackList.getBlackLists()) {
+                            Assertions.assertNotNull(rule.pattern);
+                        }
+                        sqlBlackList.verifying("select id from a_table_no_rule_matches");
+                    }
+                } catch (Throwable e) {
+                    failure.compareAndSet(null, e);
+                }
+            });
+            t.setDaemon(true);
+            threads.add(t);
+            t.start();
+        }
+        Assertions.assertTrue(started.await(RESPONSIVE_MS, TimeUnit.MILLISECONDS));
+
+        for (int i = 0; i < rounds; i++) {
+            long id = sqlBlackList.put(Pattern.compile("churn_rule_" + i));
+            sqlBlackList.delete(id);
+        }
+        stop.set(true);
+        for (Thread t : threads) {
+            t.join(RESPONSIVE_MS);
+        }
+        if (failure.get() != null) {
+            throw new AssertionError("a concurrent reader failed", failure.get());
+        }
+        Assertions.assertTrue(sqlBlackList.getBlackLists().isEmpty());
+    }
+
+    private void assertCompletesWhileUpdateLockIsHeld(Runnable queryPathAction) throws Exception {
+        CountDownLatch locked = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Thread holder = new Thread(() -> {
+            sqlBlackList.getUpdateLock().lock();
+            try {
+                locked.countDown();
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                sqlBlackList.getUpdateLock().unlock();
+            }
+        });
+        holder.setDaemon(true);
+        holder.start();
+        try {
+            Assertions.assertTrue(locked.await(RESPONSIVE_MS, TimeUnit.MILLISECONDS),
+                    "could not acquire the update lock");
+
+            CountDownLatch done = new CountDownLatch(1);
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+            Thread reader = new Thread(() -> {
+                try {
+                    queryPathAction.run();
+                } catch (Throwable e) {
+                    failure.compareAndSet(null, e);
+                } finally {
+                    done.countDown();
+                }
+            });
+            reader.setDaemon(true);
+            reader.start();
+
+            Assertions.assertTrue(done.await(RESPONSIVE_MS, TimeUnit.MILLISECONDS),
+                    "the query path blocked while a mutation held the update lock");
+            if (failure.get() != null) {
+                throw new AssertionError("the query path failed", failure.get());
+            }
+        } finally {
+            release.countDown();
+            holder.join(RESPONSIVE_MS);
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

SqlBlackList.verifying() runs Matcher.find() while holding a global read lock. An expensive pattern keeps that read lock for a long time, and once an ADD/DELETE SQLBLACKLIST is waiting for the write lock, the non-fair ReentrantReadWriteLock blocks every subsequent reader as well, so all queries stall at the SQL entry point. SHOW SQLBLACKLIST shares the same read lock, so the rules cannot even be inspected, and the FE has to be restarted.

## What I'm doing:

Publish the rules as an immutable list through a volatile reference. Query verification and show read that reference and take no lock at all; only rule mutations (add / delete / edit log replay / image load / cleanup) are serialized by updateLock, which the query path never touches.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
