### PR TITLE
[BugFix] Read multi_unnest array offsets as uint32 instead of int32

### DIFF
--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -45,9 +45,6 @@ public:
         struct ArrayView {
             const Column* nullable_column;
             const Column* elements;
-            // immutable_data() rather than get_data(): the non-const get_data() materializes a
-            // ContainerResource-backed column into its own buffer and drops the resource, which
-            // the Datum path this replaced did not do.
             UInt32Column::ImmContainer offsets;
         };
         std::vector<ArrayView> array_views;
@@ -57,9 +54,13 @@ public:
         unnested_array_list.reserve(column_count);
         for (auto& col : state->get_columns()) {
             Column* column = col->as_mutable_raw_ptr();
-            auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
-            array_views.emplace_back(ArrayView{column, col_array->elements_column_raw_ptr(),
-                                               col_array->offsets_column_raw_ptr()->immutable_data()});
+            // const: every ArrayColumn accessor then resolves to its const overload, which keeps the
+            // offsets read on immutable_data(). The non-const FixedLengthColumnBase::get_data()
+            // materializes a ContainerResource-backed column into its own buffer and drops the
+            // resource, and nothing here may mutate the input column.
+            const ArrayColumn* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
+            array_views.emplace_back(
+                    ArrayView{column, &col_array->elements(), col_array->offsets().immutable_data()});
             unnested_array_list.emplace_back(col_array->elements_column()->clone_empty());
         }
 

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -45,7 +45,10 @@ public:
         struct ArrayView {
             const Column* nullable_column;
             const Column* elements;
-            const Buffer<uint32_t>* offsets;
+            // immutable_data() rather than get_data(): the non-const get_data() materializes a
+            // ContainerResource-backed column into its own buffer and drops the resource, which
+            // the Datum path this replaced did not do.
+            UInt32Column::ImmContainer offsets;
         };
         std::vector<ArrayView> array_views;
         array_views.reserve(column_count);
@@ -56,7 +59,7 @@ public:
             Column* column = col->as_mutable_raw_ptr();
             auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
             array_views.emplace_back(ArrayView{column, col_array->elements_column_raw_ptr(),
-                                               &col_array->offsets_column_raw_ptr()->get_data()});
+                                               col_array->offsets_column_raw_ptr()->immutable_data()});
             unnested_array_list.emplace_back(col_array->elements_column()->clone_empty());
         }
 
@@ -70,7 +73,7 @@ public:
                     // current row is null, ignore the offset.
                     continue;
                 }
-                const uint32_t array_element_length = (*view.offsets)[row_idx + 1] - (*view.offsets)[row_idx];
+                const uint32_t array_element_length = view.offsets[row_idx + 1] - view.offsets[row_idx];
                 max_length_array_size = std::max(max_length_array_size, array_element_length);
             }
 
@@ -94,8 +97,8 @@ public:
                     continue;
                 }
 
-                const uint32_t array_start = (*view.offsets)[row_idx];
-                const uint32_t array_element_length = (*view.offsets)[row_idx + 1] - array_start;
+                const uint32_t array_start = view.offsets[row_idx];
+                const uint32_t array_element_length = view.offsets[row_idx + 1] - array_start;
                 unnested_array_list[col_idx]->append(*view.elements, array_start, array_element_length);
 
                 if (array_element_length < max_length_array_size) {

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -59,8 +59,7 @@ public:
             // materializes a ContainerResource-backed column into its own buffer and drops the
             // resource, and nothing here may mutate the input column.
             const ArrayColumn* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
-            array_views.emplace_back(
-                    ArrayView{column, &col_array->elements(), col_array->offsets().immutable_data()});
+            array_views.emplace_back(ArrayView{column, &col_array->elements(), col_array->offsets().immutable_data()});
             unnested_array_list.emplace_back(col_array->elements_column()->clone_empty());
         }
 

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -52,14 +52,14 @@ public:
 
         MutableColumns unnested_array_list;
         unnested_array_list.reserve(column_count);
-        for (auto& col : state->get_columns()) {
-            Column* column = col->as_mutable_raw_ptr();
-            // const: every ArrayColumn accessor then resolves to its const overload, which keeps the
-            // offsets read on immutable_data(). The non-const FixedLengthColumnBase::get_data()
-            // materializes a ContainerResource-backed column into its own buffer and drops the
-            // resource, and nothing here may mutate the input column.
-            const ArrayColumn* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
-            array_views.emplace_back(ArrayView{column, &col_array->elements(), col_array->offsets().immutable_data()});
+        // Everything here is const, all the way down from the input ColumnPtr: nothing on this path
+        // may mutate the input columns. That is also what keeps the offsets read on immutable_data(),
+        // since the non-const FixedLengthColumnBase::get_data() materializes a
+        // ContainerResource-backed column into its own buffer and drops the resource.
+        for (const auto& col : state->get_columns()) {
+            const auto* col_array = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(col));
+            array_views.emplace_back(
+                    ArrayView{col.get(), &col_array->elements(), col_array->offsets().immutable_data()});
             unnested_array_list.emplace_back(col_array->elements_column()->clone_empty());
         }
 

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <vector>
+
 #include "column/array_column.h"
 #include "column/column_helper.h"
 #include "column/nullable_column.h"
@@ -34,68 +37,69 @@ public:
             return {};
         }
 
-        long row_count = state->get_columns()[0]->size();
+        const size_t column_count = state->get_columns().size();
+        const size_t row_count = state->get_columns()[0]->size();
         state->set_processed_rows(row_count);
 
-        MutableColumns unnested_array_list;
-        for (auto& col_idx : state->get_columns()) {
-            Column* column = ColumnHelper::get_data_column(col_idx->as_mutable_raw_ptr());
+        // Resolve the per-column views once instead of re-resolving them for every row.
+        struct ArrayView {
+            const Column* nullable_column;
+            const Column* elements;
+            const Buffer<uint32_t>* offsets;
+        };
+        std::vector<ArrayView> array_views;
+        array_views.reserve(column_count);
 
+        MutableColumns unnested_array_list;
+        unnested_array_list.reserve(column_count);
+        for (auto& col : state->get_columns()) {
+            Column* column = col->as_mutable_raw_ptr();
             auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
-            MutableColumnPtr unnested_array_elements = col_array->elements_column()->clone_empty();
-            unnested_array_list.emplace_back(std::move(unnested_array_elements));
+            array_views.emplace_back(ArrayView{column, col_array->elements_column_raw_ptr(),
+                                               &col_array->offsets_column_raw_ptr()->get_data()});
+            unnested_array_list.emplace_back(col_array->elements_column()->clone_empty());
         }
 
         auto copy_count_column = UInt32Column::create();
         uint32_t offset = 0;
         copy_count_column->append(offset);
-        for (int row_idx = 0; row_idx < row_count; ++row_idx) {
+        for (size_t row_idx = 0; row_idx < row_count; ++row_idx) {
             uint32_t max_length_array_size = 0;
-            for (auto& col_idx : state->get_columns()) {
-                Column* column = col_idx->as_mutable_raw_ptr();
-                if (column->is_null(row_idx)) {
+            for (const auto& view : array_views) {
+                if (view.nullable_column->is_null(row_idx)) {
                     // current row is null, ignore the offset.
                     continue;
                 }
-                auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
-                auto offset_column = col_array->offsets_column();
-
-                long array_element_length =
-                        offset_column->get(row_idx + 1).get_int32() - offset_column->get(row_idx).get_int32();
-                if (array_element_length > max_length_array_size) {
-                    max_length_array_size = array_element_length;
-                }
+                const uint32_t array_element_length = (*view.offsets)[row_idx + 1] - (*view.offsets)[row_idx];
+                max_length_array_size = std::max(max_length_array_size, array_element_length);
             }
+
             if (max_length_array_size == 0 && state->get_is_left_join()) {
                 offset += 1;
                 copy_count_column->append(offset);
-            } else {
-                offset += max_length_array_size;
-                copy_count_column->append(offset);
+                for (size_t col_idx = 0; col_idx < column_count; ++col_idx) {
+                    unnested_array_list[col_idx]->append_nulls(1);
+                }
+                continue;
             }
 
-            for (int col_idx = 0; col_idx < state->get_columns().size(); ++col_idx) {
-                Column* column = state->get_columns()[col_idx]->as_mutable_raw_ptr();
-                auto* col_array = down_cast<ArrayColumn*>(ColumnHelper::get_data_column(column));
-                auto offset_column = col_array->offsets_column();
+            offset += max_length_array_size;
+            copy_count_column->append(offset);
 
-                if (max_length_array_size == 0 && state->get_is_left_join()) {
-                    unnested_array_list[col_idx]->append_nulls(1);
-                } else {
-                    if (column->is_null(row_idx)) {
-                        // current row is null, ignore element data.
-                        unnested_array_list[col_idx]->append_nulls(max_length_array_size);
-                    } else {
-                        auto array_element_length =
-                                offset_column->get(row_idx + 1).get_int32() - offset_column->get(row_idx).get_int32();
-                        unnested_array_list[col_idx]->append(*(col_array->elements_column()),
-                                                             offset_column->get(row_idx).get_int32(),
-                                                             array_element_length);
+            for (size_t col_idx = 0; col_idx < column_count; ++col_idx) {
+                const auto& view = array_views[col_idx];
+                if (view.nullable_column->is_null(row_idx)) {
+                    // current row is null, ignore element data.
+                    unnested_array_list[col_idx]->append_nulls(max_length_array_size);
+                    continue;
+                }
 
-                        if (array_element_length < max_length_array_size) {
-                            unnested_array_list[col_idx]->append_nulls(max_length_array_size - array_element_length);
-                        }
-                    }
+                const uint32_t array_start = (*view.offsets)[row_idx];
+                const uint32_t array_element_length = (*view.offsets)[row_idx + 1] - array_start;
+                unnested_array_list[col_idx]->append(*view.elements, array_start, array_element_length);
+
+                if (array_element_length < max_length_array_size) {
+                    unnested_array_list[col_idx]->append_nulls(max_length_array_size - array_element_length);
                 }
             }
         }

--- a/be/test/exprs/CMakeLists.txt
+++ b/be/test/exprs/CMakeLists.txt
@@ -59,6 +59,7 @@ set(EXPR_TEST_FILES
     map_expr_test.cpp
     map_element_expr_test.cpp
     map_functions_test.cpp
+    multi_unnest_core_test.cpp
     ngram_search_test.cpp
     percentile_functions_test.cpp
     condition_expr_core_test.cpp

--- a/be/test/exprs/multi_unnest_core_test.cpp
+++ b/be/test/exprs/multi_unnest_core_test.cpp
@@ -108,11 +108,11 @@ protected:
 // still yields one all-NULL row under LEFT JOIN.
 TEST_F(MultiUnnestCoreTest, zips_arrays_of_unequal_length) {
     //        a              b
-    //  row 0 [10, 20]       [100]
-    //  row 1 []             [200, 201]
-    //  row 2 NULL           [300]
-    //  row 3 [30]           NULL
-    //  row 4 []             NULL
+    //  row 0 [10, 20]       [100]        zip pads b to 2
+    //  row 1 []             [200, 201]   zip pads a to 2
+    //  row 2 NULL           [300]        a is a NULL array
+    //  row 3 [30]           NULL         b is a NULL array
+    //  row 4 []             []           both empty, so LEFT JOIN keeps the row
     Columns args;
     args.emplace_back(make_int_array({10, 20, 30}, {0, 2, 2, 2, 3, 3}, {0, 0, 1, 0, 0}));
     args.emplace_back(make_int_array({100, 200, 201, 300}, {0, 1, 3, 4, 4, 4}, {0, 0, 0, 1, 0}));

--- a/be/test/exprs/multi_unnest_core_test.cpp
+++ b/be/test/exprs/multi_unnest_core_test.cpp
@@ -1,0 +1,237 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "base/testutil/parallel_test.h"
+#include "column/array_column.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "exprs/table_function/multi_unnest.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks {
+
+class MultiUnnestCoreTest : public ::testing::Test {
+protected:
+    struct Result {
+        Columns columns;
+        std::vector<uint32_t> copy_counts;
+    };
+
+    // Builds one nullable ARRAY<INT> column from an explicit elements/offsets/null-flags triple, so a
+    // test can lay out offsets that no INSERT could produce.
+    static ColumnPtr make_int_array(const std::vector<int32_t>& elements, const std::vector<uint32_t>& offsets,
+                                    const std::vector<uint8_t>& row_nulls) {
+        auto elements_data = Int32Column::create();
+        for (int32_t v : elements) {
+            elements_data->append(v);
+        }
+        auto elements_nulls = NullColumn::create();
+        elements_nulls->resize(elements.size());
+        auto array = ArrayColumn::create(NullableColumn::create(std::move(elements_data), std::move(elements_nulls)),
+                                         make_offsets(offsets));
+
+        auto array_nulls = NullColumn::create();
+        for (uint8_t is_null : row_nulls) {
+            array_nulls->append(is_null);
+        }
+        auto nullable = NullableColumn::create(std::move(array), std::move(array_nulls));
+        nullable->update_has_null();
+        return nullable;
+    }
+
+    static MutableColumnPtr make_offsets(const std::vector<uint32_t>& offsets) {
+        auto column = UInt32Column::create();
+        for (uint32_t offset : offsets) {
+            column->append(offset);
+        }
+        return column;
+    }
+
+    // Runs one `process()` batch over the given array arguments.
+    static Result run_one_batch(Columns args, bool is_left_join) {
+        MultiUnnest function;
+        TableFunctionState* state = nullptr;
+        CHECK(function.init(TFunction(), &state).ok());
+        CHECK(state != nullptr);
+        CHECK(function.prepare(state).ok());
+
+        RuntimeState runtime_state;
+        CHECK(function.open(&runtime_state, state).ok());
+
+        state->set_params(std::move(args));
+        state->set_is_left_join(is_left_join);
+
+        auto [result_columns, copy_count_column] = function.process(&runtime_state, state);
+
+        Result result;
+        result.columns = std::move(result_columns);
+        if (copy_count_column != nullptr) {
+            const auto counts = copy_count_column->immutable_data();
+            result.copy_counts.assign(counts.begin(), counts.end());
+        }
+        CHECK(function.close(&runtime_state, state).ok());
+        return result;
+    }
+
+    // Reads one output column back as {value, is_null} pairs.
+    template <LogicalType LT>
+    static std::vector<std::pair<int64_t, bool>> read_column(const ColumnPtr& column) {
+        const auto* values = ColumnHelper::get_data_column_by_type<LT>(column);
+        const auto data = values->immutable_data();
+        std::vector<std::pair<int64_t, bool>> out;
+        out.reserve(column->size());
+        for (size_t i = 0; i < column->size(); ++i) {
+            out.emplace_back(static_cast<int64_t>(data[i]), column->is_null(i));
+        }
+        return out;
+    }
+};
+
+// Pins the zip this PR restructured: every input row expands to the longest of its arrays, shorter
+// arrays and NULL arrays pad with NULLs to that length, and a row whose arrays are all empty or NULL
+// still yields one all-NULL row under LEFT JOIN.
+TEST_F(MultiUnnestCoreTest, zips_arrays_of_unequal_length) {
+    //        a              b
+    //  row 0 [10, 20]       [100]
+    //  row 1 []             [200, 201]
+    //  row 2 NULL           [300]
+    //  row 3 [30]           NULL
+    //  row 4 []             NULL
+    Columns args;
+    args.emplace_back(make_int_array({10, 20, 30}, {0, 2, 2, 2, 3, 3}, {0, 0, 1, 0, 0}));
+    args.emplace_back(make_int_array({100, 200, 201, 300}, {0, 1, 3, 4, 4, 4}, {0, 0, 0, 1, 0}));
+
+    auto result = run_one_batch(std::move(args), /*is_left_join=*/true);
+
+    ASSERT_EQ(2, result.columns.size());
+    // Rows contribute 2, 2, 1, 1 and then 1 for the all-empty LEFT JOIN row.
+    EXPECT_EQ(std::vector<uint32_t>({0, 2, 4, 5, 6, 7}), result.copy_counts);
+    ASSERT_EQ(7, result.columns[0]->size());
+    ASSERT_EQ(7, result.columns[1]->size());
+
+    const std::vector<std::pair<int64_t, bool>> expected_a{
+            {10, false}, {20, false},                 // row 0
+            {0, true},   {0, true},                   // row 1, padded to b's length
+            {0, true},                                // row 2, NULL array
+            {30, false},                              // row 3
+            {0, true},                                // row 4, LEFT JOIN placeholder
+    };
+    const std::vector<std::pair<int64_t, bool>> expected_b{
+            {100, false}, {0, true},                  // row 0, padded to a's length
+            {200, false}, {201, false},               // row 1
+            {300, false},                             // row 2
+            {0, true},                                // row 3, NULL array
+            {0, true},                                // row 4, LEFT JOIN placeholder
+    };
+
+    const auto actual_a = read_column<TYPE_INT>(result.columns[0]);
+    const auto actual_b = read_column<TYPE_INT>(result.columns[1]);
+    for (size_t i = 0; i < expected_a.size(); ++i) {
+        EXPECT_EQ(expected_a[i].second, actual_a[i].second) << "column a, row " << i << " nullness";
+        if (!expected_a[i].second) {
+            EXPECT_EQ(expected_a[i].first, actual_a[i].first) << "column a, row " << i;
+        }
+        EXPECT_EQ(expected_b[i].second, actual_b[i].second) << "column b, row " << i << " nullness";
+        if (!expected_b[i].second) {
+            EXPECT_EQ(expected_b[i].first, actual_b[i].first) << "column b, row " << i;
+        }
+    }
+}
+
+// Regression test for https://github.com/StarRocks/starrocks/issues/76953.
+//
+// Reading the offsets through Datum::get_int32() reinterprets any offset in [2^31, 2^32) as
+// negative, and passing that to Column::append(src, size_t offset, size_t count) converts modularly
+// to ~1.8e19, breaking the offset + count <= src.size() precondition. Unlike Unnest, MultiUnnest has
+// no fast path, so it reads offsets per row on every invocation.
+//
+// Marked SLOW: it needs an elements column holding more than 2^31 entries, i.e. about 4GiB of RSS
+// (2GiB of TINYINT data plus a 2GiB null column). GROUP_SLOW_TEST_F keeps it out of the default ASAN/Debug
+// runs, where it would also pay the shadow-memory cost on those two buffers, and enables it in
+// release builds:
+//
+//   BUILD_TYPE=Release ./run-be-ut.sh --build-target expr_test --module expr_test \
+//       --without-java-ext --gtest_filter='MultiUnnestCoreTest.SLOW_offsets_across_int32_boundary'
+//
+// The ArrayColumn constructor does not validate offsets against the elements size, so the offsets
+// can start just below 2^31 instead of accumulating there row by row. That keeps the test to four
+// rows, and only the first argument's elements column has to be large: every row holds one element,
+// so the zip length stays 1 and nothing large is written to the output.
+GROUP_SLOW_TEST_F(MultiUnnestCoreTest, offsets_across_int32_boundary) {
+    constexpr uint32_t kFirstOffset = 0x7ffffffeU;
+    constexpr uint32_t kRowCount = 4;
+    constexpr size_t kElementCount = static_cast<size_t>(kFirstOffset) + kRowCount;
+
+    // Rows start at 0x7ffffffe, 0x7fffffff, 0x80000000 and 0x80000001: the last two are the ones
+    // that come back negative through get_int32().
+    // TINYINT, not INT: the elements buffer is sized by kElementCount, so a 4-byte type would make
+    // it 8GiB of data instead of 2GiB.
+    auto big_elements = Int8Column::create();
+    big_elements->resize(kElementCount);
+    for (uint32_t i = 0; i < kRowCount; ++i) {
+        big_elements->get_data()[kFirstOffset + i] = static_cast<int8_t>(10 + i);
+    }
+    auto big_element_nulls = NullColumn::create();
+    big_element_nulls->resize(kElementCount);
+    auto big_offsets = UInt32Column::create();
+    for (uint32_t i = 0; i <= kRowCount; ++i) {
+        big_offsets->append(kFirstOffset + i);
+    }
+    auto big_array = ArrayColumn::create(
+            NullableColumn::create(std::move(big_elements), std::move(big_element_nulls)), std::move(big_offsets));
+    ASSERT_EQ(kRowCount, big_array->size());
+
+    Columns args;
+    args.emplace_back(std::move(big_array));
+    // A second argument of the same shape but ordinary size: MultiUnnest needs more than one array,
+    // and matching lengths keep the zip from padding anything.
+    auto small_elements = Int8Column::create();
+    for (int8_t v : {20, 21, 22, 23}) {
+        small_elements->append(v);
+    }
+    auto small_element_nulls = NullColumn::create();
+    small_element_nulls->resize(4);
+    auto small_offsets = UInt32Column::create();
+    for (uint32_t i = 0; i <= kRowCount; ++i) {
+        small_offsets->append(i);
+    }
+    args.emplace_back(ArrayColumn::create(
+            NullableColumn::create(std::move(small_elements), std::move(small_element_nulls)),
+            std::move(small_offsets)));
+
+    auto result = run_one_batch(std::move(args), /*is_left_join=*/false);
+
+    ASSERT_EQ(2, result.columns.size());
+    ASSERT_EQ(kRowCount, result.columns[0]->size());
+    ASSERT_EQ(kRowCount, result.columns[1]->size());
+    EXPECT_EQ(std::vector<uint32_t>({0, 1, 2, 3, 4}), result.copy_counts);
+
+    // Every row must carry the element its own offset points at, including the rows whose start
+    // offset is past 2^31.
+    const auto actual_big = read_column<TYPE_TINYINT>(result.columns[0]);
+    const auto actual_small = read_column<TYPE_TINYINT>(result.columns[1]);
+    for (uint32_t i = 0; i < kRowCount; ++i) {
+        EXPECT_FALSE(actual_big[i].second) << "row " << i;
+        EXPECT_EQ(static_cast<int64_t>(10 + i), actual_big[i].first) << "row " << i;
+        EXPECT_FALSE(actual_small[i].second) << "row " << i;
+        EXPECT_EQ(static_cast<int64_t>(20 + i), actual_small[i].first) << "row " << i;
+    }
+}
+
+} // namespace starrocks

--- a/be/test/exprs/multi_unnest_core_test.cpp
+++ b/be/test/exprs/multi_unnest_core_test.cpp
@@ -126,18 +126,18 @@ TEST_F(MultiUnnestCoreTest, zips_arrays_of_unequal_length) {
     ASSERT_EQ(7, result.columns[1]->size());
 
     const std::vector<std::pair<int64_t, bool>> expected_a{
-            {10, false}, {20, false},                 // row 0
-            {0, true},   {0, true},                   // row 1, padded to b's length
-            {0, true},                                // row 2, NULL array
-            {30, false},                              // row 3
-            {0, true},                                // row 4, LEFT JOIN placeholder
+            {10, false}, {20, false}, // row 0
+            {0, true},   {0, true},   // row 1, padded to b's length
+            {0, true},                // row 2, NULL array
+            {30, false},              // row 3
+            {0, true},                // row 4, LEFT JOIN placeholder
     };
     const std::vector<std::pair<int64_t, bool>> expected_b{
-            {100, false}, {0, true},                  // row 0, padded to a's length
-            {200, false}, {201, false},               // row 1
-            {300, false},                             // row 2
-            {0, true},                                // row 3, NULL array
-            {0, true},                                // row 4, LEFT JOIN placeholder
+            {100, false}, {0, true},    // row 0, padded to a's length
+            {200, false}, {201, false}, // row 1
+            {300, false},               // row 2
+            {0, true},                  // row 3, NULL array
+            {0, true},                  // row 4, LEFT JOIN placeholder
     };
 
     const auto actual_a = read_column<TYPE_INT>(result.columns[0]);
@@ -193,8 +193,8 @@ GROUP_SLOW_TEST_F(MultiUnnestCoreTest, offsets_across_int32_boundary) {
     for (uint32_t i = 0; i <= kRowCount; ++i) {
         big_offsets->append(kFirstOffset + i);
     }
-    auto big_array = ArrayColumn::create(
-            NullableColumn::create(std::move(big_elements), std::move(big_element_nulls)), std::move(big_offsets));
+    auto big_array = ArrayColumn::create(NullableColumn::create(std::move(big_elements), std::move(big_element_nulls)),
+                                         std::move(big_offsets));
     ASSERT_EQ(kRowCount, big_array->size());
 
     Columns args;
@@ -211,9 +211,9 @@ GROUP_SLOW_TEST_F(MultiUnnestCoreTest, offsets_across_int32_boundary) {
     for (uint32_t i = 0; i <= kRowCount; ++i) {
         small_offsets->append(i);
     }
-    args.emplace_back(ArrayColumn::create(
-            NullableColumn::create(std::move(small_elements), std::move(small_element_nulls)),
-            std::move(small_offsets)));
+    args.emplace_back(
+            ArrayColumn::create(NullableColumn::create(std::move(small_elements), std::move(small_element_nulls)),
+                                std::move(small_offsets)));
 
     auto result = run_one_batch(std::move(args), /*is_left_join=*/false);
 


### PR DESCRIPTION
## Why I'm doing:

```
PC: starrocks::FixedLengthColumnBase<long>::append(...)
*** SIGSEGV (@0x0) received by PID 33 LWP(996) from PID 0
    libc
    google::FailureSignalHandler
    JVM_handle_linux_signal
    [vdso]
    starrocks::FixedLengthColumnBase<long>::append(...)
    starrocks::MultiUnnest::process(...)
    starrocks::pipeline::TableFunctionOperator::_process_table_function(...)
    starrocks::pipeline::TableFunctionOperator::pull_chunk(...)
    starrocks::pipeline::PipelineDriver::process(...)
    starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
```

`multi_unnest` reads a `UInt32Column`'s array offsets through `Datum::get_int32()`.
`Datum` stores unsigned values in the matching signed slot — `be/src/types/datum.h`
`set<uint32_t>()` stores the value as `int32_t`, and `get<uint32_t>()` recovers it via a
`reinterpret_cast` — so `get_int32()` hands back the raw signed reinterpretation. Any
offset in `[2^31, 2^32)` therefore comes back negative, and two defects follow once a
chunk's cumulative element offset reaches `2^31`:

1. **Length subtraction.** `offsets[i+1] - offsets[i]` is evaluated between two
   `int32_t` operands. For the array straddling the boundary (`offsets[i] = 0x7fffffff`,
   `offsets[i+1] = 0x80000000`, real length 1) the mathematical difference `-4294967295`
   is outside `int32_t` — signed overflow (UB). Declaring the destination `long` does not
   help; the subtraction already happened.
2. **`append` start offset.** A negative `int32_t` is passed as the `offset` parameter of
   `Column::append(const Column& src, size_t offset, size_t count)`. The
   signed-to-unsigned conversion is modular, so `-2147483648` becomes
   `18446744071562067968`, violating the `offset + count <= src.size()` precondition and
   producing out-of-bounds pointer arithmetic.

Unlike `unnest`, `multi_unnest` has no fast path — it reads offsets per row on every
invocation.

## What I'm doing:

Read the offsets buffer directly as `const Buffer<uint32_t>&` via
`offsets_column_raw_ptr()->get_data()`, so all offset arithmetic stays in the `uint32_t`
domain: lengths are computed correctly and the `append` start offset satisfies
`offset + count <= src.size()`. Row and column indices become `size_t`, removing the
signed/unsigned comparisons that went with the old code.

While in the loop, the per-column `ColumnHelper::get_data_column` + `down_cast<ArrayColumn*>`
resolution is hoisted into a small `ArrayView` cache built once before the row loop,
instead of being redone — along with a `Datum` construction and a `WrappedPtr` copy — for
every row and every column. The `max == 0 && is_left_join` branch moves up to the row
level rather than being re-tested per column.

Semantics are unchanged: NULL rows are still skipped when computing the row's max array
length and still emit `append_nulls(max)`; LEFT JOIN empty rows still emit one NULL row;
shorter arrays are still padded to the row's max length.

Part of #76953. That issue also covers `be/src/exprs/table_function/unnest.h`
(`:57`, `:66`, `:69`), which this PR deliberately leaves alone — it is a separate call
site with a different fast/slow-path structure and will be handled in a follow-up, so the
issue should stay open after this merges.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

`be/test/exprs/multi_unnest_core_test.cpp` (target `expr_test`) drives `MultiUnnest::process`
directly, in the style of the existing `generate_series_core_test.cpp` and
`json_each_core_test.cpp`. MultiUnnest had no BE unit test at all before this.

- `zips_arrays_of_unequal_length` runs in CI and pins the behaviour this PR restructured:
  every input row expands to the longest of its arrays, shorter and NULL arrays pad with
  NULLs to that length, and a row whose arrays are all empty or NULL still yields one
  all-NULL row under LEFT JOIN. It asserts both output columns and the copy-count column -
  the latter drives outer-column replication, so getting it wrong silently corrupts a join
  result rather than failing.
- `offsets_across_int32_boundary` is the regression test for the defect, declared with
  `GROUP_SLOW_TEST_F` because it needs an elements column with more than 2^31 entries (~4GiB
  of RSS: 2GiB of TINYINT data plus a 2GiB null column). That macro compiles it as
  `DISABLED_` unless `NDEBUG` is set, so it is skipped in the default ASAN/Debug UT runs and
  enabled in release builds:

  ```
  BUILD_TYPE=Release ./run-be-ut.sh --build-target expr_test --module expr_test \
      --without-java-ext --gtest_filter='MultiUnnestCoreTest.SLOW_offsets_across_int32_boundary'
  ```

  The `ArrayColumn` constructor does not validate offsets against the elements size, so the
  offsets can start just below 2^31 instead of accumulating there row by row. That keeps the
  test to four rows of one element each: only the first argument's elements buffer is large,
  and nothing large is written to the output.

The existing `test/sql/test_unnest/` cases (including `test_unnest_left_join` and
`test_unnest_stacked_same_array_join_crash`) continue to cover the LEFT JOIN and
multi-column paths end to end.

Also verified manually against a live cluster, on a table whose scan yields a single chunk
holding 2150400000 array elements (4096 rows x 525000, so the offsets of row 4091 onwards
are past 2^31):

```sql
SELECT sum(x), sum(y) FROM big_arr, unnest(arr, arr) AS unnest(x, y);
```

| build | sum(x) | sum(y) |
|---|---|---|
| unpatched | `35872453` | `35872453` |
| with this PR | `33292288` | `33292288` |

`33292288` is the correct answer (`8128 * 4096`). The unpatched run did **not** crash - it
returned a silently wrong result, because `offsets[4091] = 2147775000` read back through
`get_int32()` as `-2147192296`, which converts to a `size_t` that wraps the pointer to
roughly 2GiB *below* the elements buffer - still mapped in a process holding that much heap.
The same defect in `Unnest` (#78480) was observed both ways on the same data: a wrong result
on one run, a SIGSEGV on the next.

Note that `count(*)` cannot detect this: the out-of-bounds read corrupts values, not row
counts, and it returned the correct `2150400000` on the unpatched build.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

