### PR TITLE
[Enhancement] Implement statistics propagation for row_number operator(backport #77415)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -28,6 +28,7 @@ import com.starrocks.analysis.JoinOperator;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.MaxLiteral;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.KuduTable;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
@@ -1894,30 +1895,46 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     public Void visitLogicalAnalytic(LogicalWindowOperator node, ExpressionContext context) {
         PredicateColumnsMgr.getInstance().recordWindowPartitionBy(node.getPartitionExpressions(),
                 optimizerContext.getColumnRefFactory(), context.getOptExpression());
-        return computeAnalyticNode(context, node.getWindowCall());
+        return computeAnalyticNode(context, node.getPartitionExpressions(), node.getWindowCall());
     }
 
     @Override
     public Void visitPhysicalAnalytic(PhysicalWindowOperator node, ExpressionContext context) {
         PredicateColumnsMgr.getInstance().recordWindowPartitionBy(node.getPartitionExpressions(),
                 optimizerContext.getColumnRefFactory(), context.getOptExpression());
-        return computeAnalyticNode(context, node.getAnalyticCall());
+        return computeAnalyticNode(context, node.getPartitionExpressions(), node.getAnalyticCall());
     }
 
-    private Void computeAnalyticNode(ExpressionContext context, Map<ColumnRefOperator, CallOperator> analyticCall) {
+    private Void computeAnalyticNode(ExpressionContext context, List<ScalarOperator> partitionExpressions,
+                                     Map<ColumnRefOperator, CallOperator> analyticCall) {
         Preconditions.checkState(context.arity() == 1);
 
         Statistics.Builder builder = Statistics.builder();
         Statistics inputStatistics = context.getChildStatistics(0);
         builder.addColumnStatistics(inputStatistics.getColumnStatistics());
 
-        analyticCall.forEach((key, value) -> builder
-                .addColumnStatistic(key, ExpressionStatisticCalculator.calculate(value, inputStatistics)));
+        analyticCall.forEach((key, value) -> builder.addColumnStatistic(
+                key, estimateWindowCall(value, inputStatistics, partitionExpressions)));
 
         builder.setOutputRowCount(inputStatistics.getOutputRowCount());
 
         context.setStatistics(builder.build());
         return visitOperator(context.getOp(), context);
+    }
+
+    private static ColumnStatistic estimateWindowCall(CallOperator call, Statistics inputStatistics,
+                                                      List<ScalarOperator> partitionExpressions) {
+        if (!partitionExpressions.isEmpty() || !FunctionSet.ROW_NUMBER.equals(call.getFnName())) {
+            return ExpressionStatisticCalculator.calculate(call, inputStatistics);
+        }
+        double rowCount = inputStatistics.getOutputRowCount();
+        return ColumnStatistic.builder()
+                .setMinValue(1)
+                .setMaxValue(rowCount)
+                .setDistinctValuesCount(rowCount)
+                .setNullsFraction(0)
+                .setAverageRowSize(call.getType().getTypeSize())
+                .build();
     }
 
     public Statistics estimateStatistics(List<ScalarOperator> predicateList, Statistics statistics) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculatorTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.JoinOperator;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -45,6 +46,7 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -1117,6 +1119,61 @@ public class StatisticsCalculatorTest {
         // THEN — right side is nullable from left's perspective, and left key has 80% nulls
         // With unknown stats fallback, the right-side null fraction should reflect the left key's null fraction
         Assertions.assertTrue(rightValStat.getNullsFraction() >= leftKeyNullFraction - 0.05);
+    }
+
+    @Test
+    public void testUnpartitionedRowNumberStatistics() {
+        ColumnRefOperator pk = columnRefFactory.create("pk", Type.BIGINT, false);
+        ColumnRefOperator rn = columnRefFactory.create("rn", Type.BIGINT, false);
+        CallOperator rowNumber = new CallOperator(FunctionSet.ROW_NUMBER, Type.BIGINT, Lists.newArrayList());
+
+        Statistics.Builder childStats = Statistics.builder();
+        childStats.setOutputRowCount(1000);
+        childStats.addColumnStatistic(pk, ColumnStatistic.builder()
+                .setMinValue(1).setMaxValue(100).setDistinctValuesCount(100).setNullsFraction(0).build());
+        Group childGroup = new Group(0);
+        childGroup.setStatistics(childStats.build());
+
+        LogicalWindowOperator windowOperator = new LogicalWindowOperator.Builder()
+                .setWindowCall(ImmutableMap.of(rn, rowNumber))
+                .build();
+        GroupExpression groupExpression = new GroupExpression(windowOperator, Lists.newArrayList(childGroup));
+        groupExpression.setGroup(new Group(1));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+        new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext).estimatorStats();
+
+        ColumnStatistic rowNumberStatistic = expressionContext.getStatistics().getColumnStatistic(rn);
+        Assertions.assertFalse(rowNumberStatistic.isUnknown());
+        Assertions.assertEquals(1, rowNumberStatistic.getMinValue(), 0.001);
+        Assertions.assertEquals(1000, rowNumberStatistic.getMaxValue(), 0.001);
+        Assertions.assertEquals(1000, rowNumberStatistic.getDistinctValuesCount(), 0.001);
+        Assertions.assertEquals(0, rowNumberStatistic.getNullsFraction(), 0.001);
+    }
+
+    @Test
+    public void testPartitionedRowNumberKeepsLegacyStatistics() {
+        ColumnRefOperator pk = columnRefFactory.create("pk", Type.BIGINT, false);
+        ColumnRefOperator rn = columnRefFactory.create("rn", Type.BIGINT, false);
+        CallOperator rowNumber = new CallOperator(FunctionSet.ROW_NUMBER, Type.BIGINT, Lists.newArrayList());
+
+        Statistics.Builder childStats = Statistics.builder();
+        childStats.setOutputRowCount(1000);
+        childStats.addColumnStatistic(pk, ColumnStatistic.builder()
+                .setMinValue(1).setMaxValue(100).setDistinctValuesCount(100).setNullsFraction(0).build());
+        Group childGroup = new Group(0);
+        childGroup.setStatistics(childStats.build());
+
+        LogicalWindowOperator windowOperator = new LogicalWindowOperator.Builder()
+                .setWindowCall(ImmutableMap.of(rn, rowNumber))
+                .setPartitionExpressions(Lists.newArrayList(pk))
+                .build();
+        GroupExpression groupExpression = new GroupExpression(windowOperator, Lists.newArrayList(childGroup));
+        groupExpression.setGroup(new Group(1));
+        ExpressionContext expressionContext = new ExpressionContext(groupExpression);
+        new StatisticsCalculator(expressionContext, columnRefFactory, optimizerContext).estimatorStats();
+
+        ColumnStatistic rowNumberStatistic = expressionContext.getStatistics().getColumnStatistic(rn);
+        Assertions.assertTrue(rowNumberStatistic.isUnknown());
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {


### PR DESCRIPTION
Backport of #77415 to `branch-3.5-cc`.

Original commit: https://github.com/StarRocks/starrocks/commit/78d8cc3b95695e52ee424604b081f47cd5a74bc9
Original PR: #77415 

## Why I'm doing:
`ROW_NUMBER()` column statistics were not implemented in the optimiser.

## What I'm doing:

- Add a `ROW_NUMBER` case in `nullaryExpressionCalculate()`
- Move nullary function handling before the unknown-stats guard in `visitCall()`, so nullary functions are estimated from row count only and are not affected by missing column statistics.
- Add unit tests in `ExpressionStatisticsCalculatorTest`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [X] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
