### PR TITLE
[BugFix] Keep the inner cast when reducing a lossy float to integral cast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -159,6 +159,14 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
             return false;
         }
 
+        // A floating point -> integral/boolean cast discards the fractional part, so the middle cast
+        // carries a value change that the size check below cannot see: PrimitiveType.getTypeSize()
+        // reports 8 bytes for FLOAT, DOUBLE and BIGINT alike, so no narrowing is detected.
+        // e.g. cast(cast(100 / 3 as bigint) as varchar) must stay '33', not '33.333333333333336'
+        if (grandChild.isFloatingPointType() && !child.isFloatingPointType()) {
+            return false;
+        }
+
         // cascaded cast cannot be reduced if middle type's size is smaller than two sides
         // e.g. cast(cast(smallint as tinyint) as int)
         if (parentSlotSize > childSlotSize && childSlotSize < grandChildSlotSize) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -54,6 +54,10 @@ import java.util.Optional;
 //   a(String)
 //
 public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
+    // IEEE-754 significand widths: binary32 is exact up to 2^24, binary64 up to 2^53
+    private static final int FLOAT_MANTISSA_BITS = 24;
+    private static final int DOUBLE_MANTISSA_BITS = 53;
+
     @Override
     public ScalarOperator visitCastOperator(CastOperator operator, ScalarOperatorRewriteContext context) {
         if (SPMFunctions.isSPMFunctions(operator.getChild(0))) {
@@ -159,11 +163,8 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
             return false;
         }
 
-        // A floating point -> integral/boolean cast discards the fractional part, so the middle cast
-        // carries a value change that the size check below cannot see: PrimitiveType.getTypeSize()
-        // reports 8 bytes for FLOAT, DOUBLE and BIGINT alike, so no narrowing is detected.
-        // e.g. cast(cast(100 / 3 as bigint) as varchar) must stay '33', not '33.333333333333336'
-        if (grandChild.isFloatingPointType() && !child.isFloatingPointType()) {
+        // the size check below misses this: getTypeSize() reports 8 bytes for FLOAT, DOUBLE and BIGINT
+        if (isValueChangingCast(grandChild, child)) {
             return false;
         }
 
@@ -176,6 +177,32 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
         Type childCompatibleType = TypeManager.getAssignmentCompatibleType(grandChild, child, true);
         Type parentCompatibleType = TypeManager.getAssignmentCompatibleType(child, parent, true);
         return childCompatibleType != InvalidType.INVALID && parentCompatibleType != InvalidType.INVALID;
+    }
+
+    // float -> integral truncates; integral -> float and double -> float round.
+    // e.g. cast(cast(100 / 3 as bigint) as varchar) must stay '33', not '33.333333333333336'
+    private static boolean isValueChangingCast(Type from, Type to) {
+        if (from.isFloatingPointType()) {
+            return !to.isFloatingPointType() || mantissaBits(from) > mantissaBits(to);
+        }
+        if (to.isFloatingPointType()) {
+            return exactValueBits(from) > mantissaBits(to);
+        }
+        return false;
+    }
+
+    private static int mantissaBits(Type type) {
+        return type.isFloat() ? FLOAT_MANTISSA_BITS : DOUBLE_MANTISSA_BITS;
+    }
+
+    // value bits from the stored width, minus the sign bit: BIGINT is 8 bytes, so 63
+    private static int exactValueBits(Type type) {
+        int slotSize = type.getPrimitiveType().getSlotSize();
+        if (slotSize <= 0) {
+            // no width to compare, assume lossy
+            return Integer.MAX_VALUE;
+        }
+        return (slotSize << 3) - 1;
     }
 
     private ScalarOperator inheritVarcharLengthAfterReduceCast(CastOperator operator) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
+import com.google.common.collect.Lists;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -24,9 +25,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.CharType;
 import com.starrocks.type.DateType;
+import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
@@ -100,6 +103,101 @@ public class ReduceCastRuleTest {
         assertTrue(child instanceof CastOperator);
         ScalarOperator grandChild = child.getChild(0);
         assertEquals(OperatorType.CONSTANT, grandChild.getOpType());
+    }
+
+    @Test
+    public void testFloatToIntegralCastIsNotReduced() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+        ScalarOperator doubleColumn = new ColumnRefOperator(0, FloatType.DOUBLE, "id_double", false);
+        ScalarOperator floatColumn = new ColumnRefOperator(1, FloatType.FLOAT, "id_float", false);
+
+        // cast(cast(id_double as bigint) as varchar) keeps the truncating cast
+        {
+            ScalarOperator operator =
+                    new CastOperator(VarcharType.VARCHAR, new CastOperator(IntegerType.BIGINT, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isVarchar());
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBigint());
+            Assertions.assertSame(doubleColumn, result.getChild(0).getChild(0));
+        }
+        // cast(cast(id_double as bigint) as double) keeps the truncating cast
+        {
+            ScalarOperator operator =
+                    new CastOperator(FloatType.DOUBLE, new CastOperator(IntegerType.BIGINT, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isDouble());
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBigint());
+        }
+        // float is 8 bytes in PrimitiveType.getTypeSize() as well, so it needs the same guard
+        {
+            ScalarOperator operator =
+                    new CastOperator(VarcharType.VARCHAR, new CastOperator(IntegerType.BIGINT, floatColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBigint());
+        }
+        // float -> boolean changes the value the same way, and boolean is not caught by the size check
+        // when the outer type is 1 byte wide either
+        {
+            ScalarOperator operator =
+                    new CastOperator(IntegerType.TINYINT, new CastOperator(BooleanType.BOOLEAN, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBoolean());
+        }
+    }
+
+    @Test
+    public void testFloatToIntegralCastFoldsToTruncatedValue() {
+        // cast(cast(100 / 3 as bigint) as varchar) -> '33', not '33.333333333333336'
+        ScalarOperator operator = new CastOperator(VarcharType.VARCHAR,
+                new CastOperator(IntegerType.BIGINT, ConstantOperator.createDouble(100.0 / 3)));
+
+        ScalarOperator result = new ScalarOperatorRewriter().rewrite(operator,
+                Lists.newArrayList(new ReduceCastRule(), new FoldConstantsRule()));
+
+        assertTrue(result instanceof ConstantOperator);
+        assertEquals("33", ((ConstantOperator) result).getVarchar());
+    }
+
+    @Test
+    public void testIntegralCastIsStillReduced() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+
+        // cast(cast(id_int as bigint) as varchar) -> cast(id_int as varchar)
+        {
+            ScalarOperator intColumn = new ColumnRefOperator(0, IntegerType.INT, "id_int", false);
+            ScalarOperator operator =
+                    new CastOperator(VarcharType.VARCHAR, new CastOperator(IntegerType.BIGINT, intColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isVarchar());
+            assertTrue(result.getChild(0) instanceof ColumnRefOperator);
+            assertTrue(result.getChild(0).getType().isInt());
+        }
+        // the guard only covers a float grandchild: cast(cast(id_bigint as double) as varchar) still reduces
+        {
+            ScalarOperator bigintColumn = new ColumnRefOperator(0, IntegerType.BIGINT, "id_bigint", false);
+            ScalarOperator operator =
+                    new CastOperator(VarcharType.VARCHAR, new CastOperator(FloatType.DOUBLE, bigintColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isVarchar());
+            assertTrue(result.getChild(0) instanceof ColumnRefOperator);
+            assertTrue(result.getChild(0).getType().isBigint());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -134,7 +134,7 @@ public class ReduceCastRuleTest {
             assertTrue(result.getChild(0) instanceof CastOperator);
             assertTrue(result.getChild(0).getType().isBigint());
         }
-        // float is 8 bytes in PrimitiveType.getTypeSize() as well, so it needs the same guard
+        // float needs the same guard
         {
             ScalarOperator operator =
                     new CastOperator(VarcharType.VARCHAR, new CastOperator(IntegerType.BIGINT, floatColumn));
@@ -144,8 +144,7 @@ public class ReduceCastRuleTest {
             assertTrue(result.getChild(0) instanceof CastOperator);
             assertTrue(result.getChild(0).getType().isBigint());
         }
-        // float -> boolean changes the value the same way, and boolean is not caught by the size check
-        // when the outer type is 1 byte wide either
+        // float -> boolean changes the value the same way
         {
             ScalarOperator operator =
                     new CastOperator(IntegerType.TINYINT, new CastOperator(BooleanType.BOOLEAN, doubleColumn));
@@ -171,7 +170,46 @@ public class ReduceCastRuleTest {
     }
 
     @Test
-    public void testIntegralCastIsStillReduced() {
+    public void testIntegralToFloatCastIsNotReducedWhenItRounds() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+
+        // bigint above 2^53 is rounded by the cast to double
+        {
+            ScalarOperator bigintColumn = new ColumnRefOperator(0, IntegerType.BIGINT, "id_bigint", false);
+            ScalarOperator operator =
+                    new CastOperator(VarcharType.VARCHAR, new CastOperator(FloatType.DOUBLE, bigintColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isDouble());
+        }
+        // int does not fit the 24 bit float mantissa either
+        {
+            ScalarOperator intColumn = new ColumnRefOperator(0, IntegerType.INT, "id_int", false);
+            ScalarOperator operator =
+                    new CastOperator(VarcharType.VARCHAR, new CastOperator(FloatType.FLOAT, intColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isFloat());
+        }
+        // double -> float rounds as well
+        {
+            ScalarOperator doubleColumn = new ColumnRefOperator(0, FloatType.DOUBLE, "id_double", false);
+            ScalarOperator operator =
+                    new CastOperator(VarcharType.VARCHAR, new CastOperator(FloatType.FLOAT, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isFloat());
+        }
+    }
+
+    @Test
+    public void testValuePreservingCastIsStillReduced() {
         ScalarOperatorRewriteRule rule = new ReduceCastRule();
 
         // cast(cast(id_int as bigint) as varchar) -> cast(id_int as varchar)
@@ -186,17 +224,29 @@ public class ReduceCastRuleTest {
             assertTrue(result.getChild(0) instanceof ColumnRefOperator);
             assertTrue(result.getChild(0).getType().isInt());
         }
-        // the guard only covers a float grandchild: cast(cast(id_bigint as double) as varchar) still reduces
+        // int fits the 53 bit double mantissa exactly
         {
-            ScalarOperator bigintColumn = new ColumnRefOperator(0, IntegerType.BIGINT, "id_bigint", false);
+            ScalarOperator intColumn = new ColumnRefOperator(0, IntegerType.INT, "id_int", false);
             ScalarOperator operator =
-                    new CastOperator(VarcharType.VARCHAR, new CastOperator(FloatType.DOUBLE, bigintColumn));
+                    new CastOperator(FloatType.DOUBLE, new CastOperator(FloatType.DOUBLE, intColumn));
 
             ScalarOperator result = rule.apply(operator, null);
 
-            assertTrue(result.getType().isVarchar());
+            assertTrue(result.getType().isDouble());
             assertTrue(result.getChild(0) instanceof ColumnRefOperator);
-            assertTrue(result.getChild(0).getType().isBigint());
+            assertTrue(result.getChild(0).getType().isInt());
+        }
+        // smallint fits the 24 bit float mantissa
+        {
+            ScalarOperator smallintColumn = new ColumnRefOperator(0, IntegerType.SMALLINT, "id_smallint", false);
+            ScalarOperator operator =
+                    new CastOperator(FloatType.FLOAT, new CastOperator(FloatType.FLOAT, smallintColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isFloat());
+            assertTrue(result.getChild(0) instanceof ColumnRefOperator);
+            assertTrue(result.getChild(0).getType().isSmallint());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1448,7 +1448,7 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "CAST(11: id_bool AS VARCHAR(65533))");
 
-        // a float -> integral cast truncates the value, so it must not be reduced away
+        // float -> integral truncates, so the inner cast must survive
         sql = "select cast(cast(t1f as bigint) as string) from test_all_type;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "CAST(CAST(6: t1f AS BIGINT) AS VARCHAR(65533))");
@@ -1460,6 +1460,15 @@ public class ExpressionTest extends PlanTestBase {
         sql = "select cast(cast(t1f as bigint) as double) from test_all_type;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "CAST(CAST(6: t1f AS BIGINT) AS DOUBLE)");
+
+        // integral -> float rounds, so the inner cast must survive
+        sql = "select cast(cast(t1d as double) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(4: t1d AS DOUBLE) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(t1c as float) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(3: t1c AS FLOAT) AS VARCHAR(65533))");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1447,6 +1447,19 @@ public class ExpressionTest extends PlanTestBase {
         sql = "select cast(cast(id_bool as boolean) as string) from test_bool;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "CAST(11: id_bool AS VARCHAR(65533))");
+
+        // a float -> integral cast truncates the value, so it must not be reduced away
+        sql = "select cast(cast(t1f as bigint) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(6: t1f AS BIGINT) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(t1e as bigint) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(5: t1e AS BIGINT) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(t1f as bigint) as double) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(6: t1f AS BIGINT) AS DOUBLE)");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

`ReduceCastRule` collapses nested casts and drops the inner one when checkCastTypeReduceAble()

returns true. Its only narrowing guard compares byte width:

```java
if (parentSlotSize > childSlotSize && childSlotSize < grandChildSlotSize) 
{
    return false;
}
```

`PrimitiveType.getTypeSize()` reports 8 bytes for FLOAT, DOUBLE and BIGINT alike, so the guard
never fires for `double -> bigint and cast(cast(<float expr> as bigint) as varchar)` is reduced
to `cast(<float expr> as varchar)`. The truncation is silently lost, with no error raised:

```sql
select cast(100/3 as bigint);                    -- 33                   correct
select cast(cast(100/3 as bigint) as varchar);   -- 33.333333333333336   wrong, expected '33'
```
Byte width is the wrong test: float -> integral is lossy in value (truncation), not in width.

This also breaks histogram collection. `HistogramStatisticsCollectJob` emits
`cast(cast(<count expr> as bigint) as varchar)` to get an integer bucket count. With the inner
cast dropped, a fractional count reaches the JSON, Long.parseLong in
`HistogramUtils.convertBuckets` throws, and the bucket is dropped - leaving the column with no
histogram

## What I'm doing:
Reject the reduction in `checkCastTypeReduceAble` when the grandchild is a floating point type
and the middle type is not, before the size check. Decimals are rejected earlier and the middle
type is already known to be numeric or boolean, so this covers exactly the casts that discard the
fractional part. FLOAT is included because it is also reported as 8 bytes.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
