### PR TITLE
[Doc] Clarify array_difference return types

### DIFF
--- a/docs/en/sql-reference/sql-functions/array-functions/array_difference.md
+++ b/docs/en/sql-reference/sql-functions/array-functions/array_difference.md
@@ -21,7 +21,16 @@ array_difference(input)
 
 ## Return value
 
-Returns an array of the same data type and length as the array that you specify in the `input` parameter.
+Returns an array with the same length as `input`. The return element type is determined by the input element type as follows:
+
+| Input element type | Return element type |
+| --- | --- |
+| `BOOLEAN`, `TINYINT`, `SMALLINT`, `INT`, or `BIGINT` | `BIGINT` |
+| `LARGEINT` | `LARGEINT` |
+| `FLOAT` or `DOUBLE` | `DOUBLE` |
+| `DECIMAL(P, S)`, where `P <= 38` | `DECIMAL(min(P + 1, 38), S)` |
+
+`ARRAY<DECIMAL256>` (`P > 38`) is not supported.
 
 ## Examples
 

--- a/docs/ja/sql-reference/sql-functions/array-functions/array_difference.md
+++ b/docs/ja/sql-reference/sql-functions/array-functions/array_difference.md
@@ -19,7 +19,16 @@ array_difference(input)
 
 ## Return value
 
-`input` パラメータで指定した配列と同じデータ型と長さの配列を返します。
+入力配列と同じ長さの配列を返します。戻り値の要素型は、入力の要素型に応じて次のように決まります。
+
+| 入力要素型 | 戻り値要素型 |
+| --- | --- |
+| `BOOLEAN`、`TINYINT`、`SMALLINT`、`INT`、または `BIGINT` | `BIGINT` |
+| `LARGEINT` | `LARGEINT` |
+| `FLOAT` または `DOUBLE` | `DOUBLE` |
+| `DECIMAL(P, S)`（`P <= 38`） | `DECIMAL(min(P + 1, 38), S)` |
+
+`ARRAY<DECIMAL256>`（`P > 38`）は現在サポートされていません。
 
 ## Examples
 

--- a/docs/zh/sql-reference/sql-functions/array-functions/array_difference.md
+++ b/docs/zh/sql-reference/sql-functions/array-functions/array_difference.md
@@ -21,7 +21,16 @@ output array_difference(input)
 
 ## 返回值说明
 
-类型为 ARRAY (与输入 `input` 保持一致)，内容为将输入 `input` 中相邻两元素的差，长度与 `input` 保持一致。
+返回一个与输入数组长度相同的数组。返回元素类型根据输入元素类型确定，具体映射如下：
+
+| 输入元素类型 | 返回元素类型 |
+| --- | --- |
+| `BOOLEAN`、`TINYINT`、`SMALLINT`、`INT` 或 `BIGINT` | `BIGINT` |
+| `LARGEINT` | `LARGEINT` |
+| `FLOAT` 或 `DOUBLE` | `DOUBLE` |
+| `DECIMAL(P, S)`，其中 `P <= 38` | `DECIMAL(min(P + 1, 38), S)` |
+
+目前不支持 `ARRAY<DECIMAL256>`（`P > 38`）。
 
 ## 示例
 


### PR DESCRIPTION
## Why I'm doing:

The `array_difference` reference currently says that the return array has the same data type as the input array. However, the built-in overloads widen several input element types, such as `INT` to `BIGINT` and `FLOAT` to `DOUBLE`. The documentation also does not state the current DECIMAL256 limitation.

## What I'm doing:

- Document the return element type mapping for all supported input categories.
- Clarify the return type of `DECIMAL(P, S)` inputs with `P <= 38`.
- Document that `ARRAY<DECIMAL256>` is currently unsupported.
- Keep the English, Chinese, and Japanese references synchronized.

Fixes #76612

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Testing

- `git diff --check`
- Validated the Markdown table structure in all three language versions.

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5