### PR TITLE
[BugFix] Hash decimal256 literals the same way the BE buckets rows

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DecimalLiteral.java
@@ -346,6 +346,29 @@ public class DecimalLiteral extends LiteralExpr {
                 }
                 break;
             }
+            case DECIMAL256: {
+                // Must match the BE, which crc32-hashes the raw 32-byte little-endian int256
+                // representation of the scaled value (see DecimalV3Column<int256_t> in
+                // be/src/column/column_hash/column_hash.cpp). Hashing anything else sends
+                // point lookups on a decimal256 distribution key to the wrong bucket.
+                checkType(type);
+                int scale = ((ScalarType) type).getScalarScale();
+                BigDecimal scaledValue = value.multiply(SCALE_FACTOR[scale]);
+                buffer = ByteBuffer.allocate(type.getTypeSize());
+                buffer.order(ByteOrder.LITTLE_ENDIAN);
+                // BigInteger::toByteArray returns a big-endian byte[], so copy in reverse order one by one byte.
+                byte[] bytes = scaledValue.toBigInteger().toByteArray();
+                for (int i = bytes.length - 1; i >= 0; --i) {
+                    buffer.put(bytes[i]);
+                }
+                // pad with sign bits
+                byte prefixByte = scaledValue.signum() >= 0 ? (byte) 0 : (byte) 0xff;
+                int numPaddingBytes = type.getTypeSize() - bytes.length;
+                for (int i = 0; i < numPaddingBytes; ++i) {
+                    buffer.put(prefixByte);
+                }
+                break;
+            }
             default:
                 return super.getHashValue(type);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
@@ -504,4 +504,64 @@ public class DecimalLiteralTest {
             Assertions.assertEquals(expected, integer);
         }
     }
+
+    @Test
+    public void testGetHashValueOfDecimal256() throws AnalysisException {
+        // The buffer must be the 32-byte little-endian two's-complement int256 of the scaled
+        // value: the BE crc32-hashes exactly those raw bytes when bucketing rows on a
+        // decimal256 distribution key, so any other layout prunes point lookups to the
+        // wrong tablet.
+        String[] testCases = new String[] {
+                "0.0",
+                "99.526",
+                "-99.526",
+                Strings.repeat("9", 73) + "." + Strings.repeat("9", 3),
+                "-" + Strings.repeat("9", 73) + "." + Strings.repeat("9", 3),
+                "0.001",
+                "-0.001",
+                "3.14",
+                "-3.14",
+                "12345678901234567890.123",
+                "-12345678901234567890.123",
+        };
+        Type decimal256Type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 3);
+        BigInteger twoTo256 = BigInteger.ONE.shiftLeft(256);
+        BigInteger byteMask = BigInteger.valueOf(0xff);
+        for (String tc : testCases) {
+            DecimalLiteral decimalLiteral = new DecimalLiteral(tc);
+            ByteBuffer buffer = decimalLiteral.getHashValue(decimal256Type);
+            Assertions.assertEquals(32, buffer.limit(), tc);
+            BigInteger scaled = decimalLiteral.getValue().multiply(new BigDecimal("1000")).toBigIntegerExact();
+            // interpret the scaled value as an unsigned 256-bit integer (two's complement)
+            BigInteger unsigned = scaled.mod(twoTo256);
+            for (int i = 0; i < 32; ++i) {
+                byte expected = unsigned.shiftRight(8 * i).and(byteMask).byteValue();
+                Assertions.assertEquals(expected, buffer.get(i), tc + " byte " + i);
+            }
+        }
+    }
+
+    @Test
+    public void testGetHashValueOfDecimal256KnownBytes() throws AnalysisException {
+        Type decimal256Type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 3);
+
+        // 99.526 scaled by 10^3 is 99526 = 0x184C6
+        ByteBuffer positive = new DecimalLiteral("99.526").getHashValue(decimal256Type);
+        Assertions.assertEquals(32, positive.limit());
+        Assertions.assertEquals((byte) 0xC6, positive.get(0));
+        Assertions.assertEquals((byte) 0x84, positive.get(1));
+        Assertions.assertEquals((byte) 0x01, positive.get(2));
+        for (int i = 3; i < 32; ++i) {
+            Assertions.assertEquals((byte) 0x00, positive.get(i));
+        }
+
+        // -1.000 scaled by 10^3 is -1000; two's complement is 0xFF...FFFC18
+        ByteBuffer negative = new DecimalLiteral("-1.000").getHashValue(decimal256Type);
+        Assertions.assertEquals(32, negative.limit());
+        Assertions.assertEquals((byte) 0x18, negative.get(0));
+        Assertions.assertEquals((byte) 0xFC, negative.get(1));
+        for (int i = 2; i < 32; ++i) {
+            Assertions.assertEquals((byte) 0xFF, negative.get(i));
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

DecimalLiteral.getHashValue() had no DECIMAL256 case, so literals fell through to the default path that hashes the UTF-8 string representation. The BE buckets rows on a decimal256 distribution key by crc32-hashing the raw 32-byte little-endian int256 of the scaled value, so on tables DISTRIBUTED BY HASH(<decimal256 column>) the HashDistributionPruner sent point lookups (=, IN, collapsed ranges) to the wrong tablet and silently returned no rows.

Found by a TLP fuzzing oracle: on a decimal(76,3) hash-bucketed table, `WHERE k1 = 99.526` lost exactly the row holding 99.526.

Fix: hash DECIMAL256 literals as the 32-byte little-endian two's complement of the scaled value, matching the layout packDecimal() already uses and the bytes DecimalV3Column<int256_t> feeds to crc32 on the BE. Verified against a live cluster that the fixed hash predicts the exact bucket the BE wrote each row to (positive, negative, and large values).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
