### PR TITLE
[BugFix] Fix FE max tablet compaction score collection

### DIFF
--- a/be/src/service/service_be/backend_service.cpp
+++ b/be/src/service/service_be/backend_service.cpp
@@ -35,6 +35,7 @@
 
 #include "backend_service.h"
 
+#include <algorithm>
 #include <memory>
 
 #include "agent/agent_server.h"
@@ -44,6 +45,7 @@
 #include "common/util/thrift_server.h"
 #include "exec/exec_env.h"
 #include "storage/storage_engine.h"
+#include "storage/storage_metrics.h"
 #include "storage/tablet_manager.h"
 
 namespace starrocks {
@@ -86,6 +88,9 @@ void BackendService::publish_cluster_state(TAgentResult& result, const TAgentPub
 
 void BackendService::get_tablets_info(TGetTabletsInfoResult& result_, const TGetTabletsInfoRequest& request) {
     result_.__set_report_version(curr_report_version());
+    result_.__set_tablet_max_compaction_score(
+            std::max(StorageMetrics::instance()->tablet_cumulative_max_compaction_score.value(),
+                     StorageMetrics::instance()->tablet_base_max_compaction_score.value()));
     result_.__isset.tablets = true;
     TStatus t_status;
     Status st_report = StorageEngine::instance()->tablet_manager()->report_all_tablets_info(&result_.tablets);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -152,6 +152,7 @@ set(EXEC_FILES
         ./service/mem_hook_test.cpp
         ./service/service_metrics_test.cpp
         ./service/service_be/arrow_flight_call_header_utils_test.cpp
+        ./service/service_be/backend_service_test.cpp
         ./service/service_be/http_auth_response_test.cpp
         ./service/service_be/internal_service_test.cpp
         )

--- a/be/test/service/service_be/backend_service_test.cpp
+++ b/be/test/service/service_be/backend_service_test.cpp
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "service/service_be/backend_service.h"
+
+#include <gtest/gtest.h>
+
+#include "base/utility/defer_op.h"
+#include "exec/exec_env.h"
+#include "storage/storage_metrics.h"
+
+namespace starrocks {
+
+TEST(BackendServiceTest, get_tablets_info_returns_max_compaction_score) {
+    auto* metrics = StorageMetrics::instance();
+    const auto old_cumulative_score = metrics->tablet_cumulative_max_compaction_score.value();
+    const auto old_base_score = metrics->tablet_base_max_compaction_score.value();
+    const auto old_update_score = metrics->tablet_update_max_compaction_score.value();
+    DeferOp restore_metrics([&] {
+        metrics->tablet_cumulative_max_compaction_score.set_value(old_cumulative_score);
+        metrics->tablet_base_max_compaction_score.set_value(old_base_score);
+        metrics->tablet_update_max_compaction_score.set_value(old_update_score);
+    });
+
+    BackendService service(ExecEnv::GetInstance(), nullptr);
+    TGetTabletsInfoRequest request;
+
+    metrics->tablet_cumulative_max_compaction_score.set_value(17);
+    metrics->tablet_base_max_compaction_score.set_value(11);
+    metrics->tablet_update_max_compaction_score.set_value(99);
+    TGetTabletsInfoResult cumulative_result;
+    service.get_tablets_info(cumulative_result, request);
+    ASSERT_EQ(TStatusCode::OK, cumulative_result.status.status_code);
+    ASSERT_TRUE(cumulative_result.__isset.tablet_max_compaction_score);
+    EXPECT_EQ(17, cumulative_result.tablet_max_compaction_score);
+
+    metrics->tablet_cumulative_max_compaction_score.set_value(7);
+    metrics->tablet_base_max_compaction_score.set_value(23);
+    TGetTabletsInfoResult base_result;
+    service.get_tablets_info(base_result, request);
+    ASSERT_EQ(TStatusCode::OK, base_result.status.status_code);
+    ASSERT_TRUE(base_result.__isset.tablet_max_compaction_score);
+    EXPECT_EQ(23, base_result.tablet_max_compaction_score);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
@@ -108,6 +108,7 @@ public class TabletCollector extends LeaderDaemon {
                     client -> client.get_tablets_info(new TGetTabletsInfoRequest()));
 
             if (result.getStatus().getStatus_code() == TStatusCode.OK) {
+                updateTabletMaxCompactionScore(backend, result);
                 GlobalStateMgr.getCurrentState().getReportHandler()
                         .putTabletReportTask(backend.getId(), result.getReport_version(), result.getTablets());
                 LOG.debug("collect tablet from backend {} successfully, time used: {}ms", backend.getId(),
@@ -127,6 +128,12 @@ public class TabletCollector extends LeaderDaemon {
         // otherwise it will block the collection of other backends.
         collectStat.lastCollectTime = System.currentTimeMillis();
         collectQueue.add(collectStat);
+    }
+
+    static void updateTabletMaxCompactionScore(Backend backend, TGetTabletsInfoResult result) {
+        if (result.isSetTablet_max_compaction_score()) {
+            backend.setTabletMaxCompactionScore(result.getTablet_max_compaction_score());
+        }
     }
 
     public static class CollectStat implements Comparable<CollectStat> {

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -89,7 +89,7 @@ public class Backend extends ComputeNode {
     private boolean initPathInfo = false;
 
     // the max tablet compaction score of this backend.
-    // this field is set by tablet report, and just for metric monitor, no need to persist.
+    // this field is set by tablet report or collection, and just for metric monitor, no need to persist.
     private volatile long tabletMaxCompactionScore = 0;
 
     // additional backendStatus information for BE, display in JSON format

--- a/fe/fe-core/src/test/java/com/starrocks/leader/TabletCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/TabletCollectorTest.java
@@ -15,6 +15,10 @@
 package com.starrocks.leader;
 
 import com.starrocks.leader.TabletCollector.CollectStat;
+import com.starrocks.system.Backend;
+import com.starrocks.thrift.TGetTabletsInfoResult;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
 import org.junit.jupiter.api.Assertions;
@@ -61,5 +65,20 @@ public class TabletCollectorTest {
 
         Assertions.assertTrue(queue.isEmpty(), "collectQueue should be cleared on demotion");
         Assertions.assertTrue(queuedBeIds.isEmpty(), "queuedBeIds should be cleared on demotion");
+    }
+
+    @Test
+    public void testUpdateTabletMaxCompactionScore() {
+        Backend backend = new Backend(1L, "127.0.0.1", 9050);
+        backend.setTabletMaxCompactionScore(10L);
+
+        TGetTabletsInfoResult oldBeResult = new TGetTabletsInfoResult(new TStatus(TStatusCode.OK));
+        TabletCollector.updateTabletMaxCompactionScore(backend, oldBeResult);
+        Assertions.assertEquals(10L, backend.getTabletMaxCompactionScore());
+
+        TGetTabletsInfoResult newBeResult = new TGetTabletsInfoResult(new TStatus(TStatusCode.OK));
+        newBeResult.setTablet_max_compaction_score(42L);
+        TabletCollector.updateTabletMaxCompactionScore(backend, newBeResult);
+        Assertions.assertEquals(42L, backend.getTabletMaxCompactionScore());
     }
 }

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -146,6 +146,8 @@ struct TGetTabletsInfoResult {
     1: required Status.TStatus status;
     2: optional i64 report_version;
     3: optional map<Types.TTabletId, MasterService.TTablet> tablets;
+    // Keep the FE compaction score metrics up to date when regular tablet reports are disabled.
+    4: optional i64 tablet_max_compaction_score;
 }
 
 service BackendService {


### PR DESCRIPTION
## Why I'm doing:

In shared-nothing clusters, the FE disables regular tablet reports and actively pulls tablet information from BEs. The active `get_tablets_info` response did not include the maximum tablet compaction score, so a restarted FE kept every backend's in-memory score at zero. As a result, `starrocks_fe_max_tablet_compaction_score` stayed at zero on the leader even when BEs reported non-zero base or cumulative compaction scores.

## What I'm doing:

- Add an optional maximum compaction score to `TGetTabletsInfoResult` for rolling-upgrade compatibility.
- Populate it on the BE with the same `max(base, cumulative)` semantics used by regular tablet reports.
- Refresh the backend score after a successful active tablet collection on the FE.
- Keep the existing value when an older BE omits the new field, and cover both old- and new-BE results in a unit test.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

## Test results:

- `mvn test -Dtest=TabletCollectorTest -Dsurefire.failIfNoSpecifiedTests=false -Dpython=python3`
- `python3 build-support/check_gensrc_schema_compatibility.py --mode changed --base upstream/main`
- `python3 build-support/check_be_module_boundaries.py --mode full`
- `python3 build-support/render_be_agents.py --check`
- Generated C++ Thrift sources and compiled `BackendService_types.cpp` with `clang++ -fsyntax-only`.
