### PR TITLE
[BugFix] Do not dictionarize an expression returning ARRAY/STRUCT (backport #78488)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -1155,7 +1155,10 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         }
 
         private ScalarOperator merge(List<ScalarOperator> collectors, ScalarOperator scalarOperator) {
-            if (collectors.stream().anyMatch(s -> s.getType().isArrayType())) {
+            // the result becomes a new dictionary, so it must be a scalar string; the collectors are
+            // BOOLEAN sentinels for constant operands and cannot report the operator's own type
+            if (scalarOperator.getType().isArrayType()
+                    || collectors.stream().anyMatch(s -> s.getType().isArrayType())) {
                 return forbidden(collectors, scalarOperator);
             }
             return mergeWithArray(collectors, scalarOperator);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -2001,4 +2001,23 @@ public class LowCardinalityTest extends PlanTestBase {
                 "  |  offset: 0");
     }
 
+    // an ARRAY-returning expr must not define a dictionary: the BE reads the result as a BinaryColumn and crashes
+    @Test
+    public void testNoDictDefineForArrayResultOnScalarDictColumn() throws Exception {
+        String sql = "select upper(S_ADDRESS) as t from supplier limit 10";
+        assertContains(getVerboseExplain(sql), "DictDefine");
+
+        sql = "select case S_ADDRESS when 'a' then ['123','1234'] end as t from supplier limit 10";
+        assertNotContains(getVerboseExplain(sql), "DictDefine");
+
+        sql = "select case S_ADDRESS when 'a' then ['123','1234'] else ['x'] end as t from supplier limit 10";
+        assertNotContains(getVerboseExplain(sql), "DictDefine");
+
+        sql = "select if(S_ADDRESS = 'a', ['123','1234'], null) as t from supplier limit 10";
+        assertNotContains(getVerboseExplain(sql), "DictDefine");
+
+        sql = "select coalesce(if(S_ADDRESS = 'a', ['1'], null), ['2']) as t from supplier limit 10";
+        assertNotContains(getVerboseExplain(sql), "DictDefine");
+    }
+
 }


### PR DESCRIPTION
Backport of #78488 to `branch-3.5`.

## Why I'm doing:

A `CASE`/`if()` that returns `ARRAY<VARCHAR>` over a low-cardinality VARCHAR column crashes the BE at fragment prepare:

```
PC: @ DictOptimizeParser::_eval_and_rewrite(RuntimeState*, ExprContext*, Expr*, DictOptimizeContext*, int)
*** SIGSEGV received ***
    @ DictOptimizeParser::eval_dict_expr(RuntimeState*, int)
    @ pipeline::DictDecodeOperatorFactory::prepare(RuntimeState*)
    @ pipeline::NormalExecutionGroup::prepare_pipelines(RuntimeState*)
    @ pipeline::FragmentContext::prepare_all_pipelines()
```

Reproducer (needs a warmed global dict on `status`, and the `LIMIT` — without it the expression takes the decode path and is safe):

```sql
CREATE TABLE t_repro (id INT, status VARCHAR(40)) DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ("replication_num" = "1");
-- 10240 rows, NDV(status) = 5, then a few `group by status` to populate the dict
SELECT CASE status WHEN 1 THEN ['123','1234'] END AS t FROM t_repro LIMIT 10;   -- BE dies
```

Reproduced end to end on 3.5.20 and on main. `SET cbo_enable_low_cardinality_optimize = false` avoids it; `array_low_cardinality_optimize = false` does not.

## What I'm doing:

`DecodeCollector.merge()` guarded against ARRAY/STRUCT by inspecting `collectors`, but those are the per-child *verdicts* — a dict column ref, or the `CONSTANTS`/`VARIABLES` sentinels, whose type is BOOLEAN. An array literal therefore reaches the guard as `ConstantOperator.TRUE`, and `if(dict_col = 'a', ['x','y'], null)` was judged dictionarizable.

`DecodeContext.define()` then built the `DictMappingOperator` with the shadow column type (INT) while the origin expr stayed `ARRAY<VARCHAR>`. In `parser.cpp` that type mismatch is exactly the signal for "this define produces a new dictionary", so the BE read the `ArrayColumn` result through `ColumnViewer<TYPE_VARCHAR>` and crashed.

Fix: also check the operator's own result type. `merge()` is the scalar/string path — array functions are routed to `mergeWithArray()` earlier in `visitCall()` — so this cannot disable legitimate array low-cardinality optimization.

STRUCT is included because `supportLowCardinality()` accepts structs on main and the existing guard has the same blind spot there.

Plan before / after, same query:

```
- 5 <-> DictDefine([4: status, INT, true], [if(<place-holder> = '1', ['123','1234'], NULL); result: ARRAY<VARCHAR>])
+ 3 <-> DictDecode([4: status, INT, true], [if(<place-holder> = '1', ['123','1234'], NULL); result: ARRAY<VARCHAR>])
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: an expression returning ARRAY/STRUCT no longer defines a new dictionary; the dictionary is still used for the rest of the plan

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

`LowCardinalityTest.testNoDictDefineForArrayResultOnScalarDictColumn` covers `CASE`, `CASE ... ELSE`, `if()` and `coalesce()`, and asserts that a string-returning expression over the same column still gets its `DictDefine`.

Regression run, all green (267 tests): `LowCardinalityTest` 75, `LowCardinalityTest2` 109, `LowCardinalityArrayTest` 45, `LowCardinalityStructTest` 33, `LowCardinalityJoinTest` 1, `LowCardinalityAggStateTest` 4. `mvn checkstyle:check -pl fe-core` passes.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5


---

## Backport note

`merge()` on this branch only guards ARRAY (no STRUCT — `supportLowCardinality()` here is
`isVarchar() || ARRAY<VARCHAR>`), so the STRUCT half of the mainline change is dropped and only the
operator's own ARRAY result type is added. That is the same conflict Mergify hit in #78500.

Regression on this branch: `LowCardinalityTest` 72, `LowCardinalityTest2` 87, `LowCardinalityArrayTest` 40
— **199 tests, 0 failures**.


