### PR TITLE
[BugFix] Prevent lake alter jobs from getting stuck after failover

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -107,6 +107,15 @@ public abstract class AlterHandler extends LeaderDaemon {
         LOG.info("add {} job {}", alterJob.getType(), alterJob.getJobId());
     }
 
+    protected final void runAlterJobV2Safely(AlterJobV2 alterJob) {
+        try {
+            alterJob.run();
+        } catch (Exception e) {
+            LOG.warn("alter job {} type {} state {} failed in scheduler; will retry without blocking sibling jobs",
+                    alterJob.getJobId(), alterJob.getType(), alterJob.getJobState(), e);
+        }
+    }
+
     public List<AlterJobV2> getUnfinishedAlterJobV2ByTableId(long tblId) {
         List<AlterJobV2> unfinishedAlterJobList = new ArrayList<>();
         for (AlterJobV2 alterJob : alterJobsV2.values()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -66,7 +66,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
@@ -561,12 +560,9 @@ public abstract class AlterJobV2 implements Writable {
 
     protected boolean publishVersion() {
         if (publishVersionFuture == null) {
-            Callable<Boolean> task = () -> {
-                return lakePublishVersion();
-            };
             ThreadPoolExecutor executor = GlobalStateMgr.getCurrentState().getLakeAlterPublishExecutor();
             try {
-                publishVersionFuture = executor.submit(task);
+                publishVersionFuture = executor.submit(this::lakePublishVersion);
             } catch (RejectedExecutionException e) {
                 LOG.warn("failed to submit publish task for job: {}: activeCount={}, poolSize={}, maximumPoolSize={}",
                         jobId, executor.getActiveCount(), executor.getPoolSize(), executor.getMaximumPoolSize(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -575,6 +575,7 @@ public abstract class AlterJobV2 implements Writable {
                 try {
                     return publishVersionFuture.get();
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     return false;
                 } catch (ExecutionException e) {
                     LOG.warn("failed to publish version for job: {}", jobId, e.getCause());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -69,6 +69,8 @@ import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 
 /*
  * Version 2 of AlterJob, for replacing the old version of AlterJob.
@@ -562,14 +564,24 @@ public abstract class AlterJobV2 implements Writable {
             Callable<Boolean> task = () -> {
                 return lakePublishVersion();
             };
-            publishVersionFuture = GlobalStateMgr.getCurrentState().getLakeAlterPublishExecutor().submit(task);
+            ThreadPoolExecutor executor = GlobalStateMgr.getCurrentState().getLakeAlterPublishExecutor();
+            try {
+                publishVersionFuture = executor.submit(task);
+            } catch (RejectedExecutionException e) {
+                LOG.warn("failed to submit publish task for job: {}: activeCount={}, poolSize={}, maximumPoolSize={}",
+                        jobId, executor.getActiveCount(), executor.getPoolSize(), executor.getMaximumPoolSize(), e);
+                return false;
+            }
             LOG.info("submit publish task for job: {}", jobId);
             return false;
         } else {
             if (publishVersionFuture.isDone()) {
                 try {
                     return publishVersionFuture.get();
-                } catch (InterruptedException | ExecutionException e) {
+                } catch (InterruptedException e) {
+                    return false;
+                } catch (ExecutionException e) {
+                    LOG.warn("failed to publish version for job: {}", jobId, e.getCause());
                     return false;
                 } finally {
                     publishVersionFuture = null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeOnlineRewriteJobBase.java
@@ -1765,15 +1765,16 @@ public abstract class LakeOnlineRewriteJobBase
             }
 
             if (jobState == JobState.PENDING) {
-                // A PENDING job has installed NO durable catalog state yet. On the leader the shadow index
-                // meta + tablets are registered only inside the WAITING_TXN applier (runPendingJob),
+                // A PENDING job has installed no durable shadow catalog state yet. On the leader the shadow
+                // index meta + tablets are registered only inside the WAITING_TXN applier (runPendingJob),
                 // atomically with the WAITING_TXN journal entry, so the only PENDING journal entry (the
                 // initial ALTER log) carries empty partitionStates and nothing installed. Reconstructing
                 // here would call registerShadowIndexMeta with no per-partition shadow index, leaving the
                 // table with a shadow schema that OlapTableSink.createSchema() sees while createPartition()
                 // has no matching partition index -- loads to the table then fail until the job advances.
-                // So replay installs nothing for PENDING; the resuming leader's runPendingJob builds the
-                // shadow fresh.
+                // Replay must still restore the table reservation; the resuming leader's runPendingJob builds
+                // the shadow fresh.
+                table.setState(jobTableState());
                 LOG.info("Replaying PENDING online rewrite job {}; no durable shadow state to reconstruct.", jobId);
             } else if (jobState == JobState.WAITING_TXN || jobState == JobState.RUNNING) {
                 // WAITING_TXN and RUNNING share the same durable catalog state: the shadow index meta is

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -1159,7 +1159,7 @@ public class MaterializedViewHandler extends AlterHandler {
 
         if (rollupJobV2.isTimeout()) {
             // in run(), the timeout job will be cancelled.
-            rollupJobV2.run();
+            runAlterJobV2Safely(rollupJobV2);
             return;
         }
 
@@ -1185,7 +1185,7 @@ public class MaterializedViewHandler extends AlterHandler {
         }
 
         if (shouldJobRun) {
-            rollupJobV2.run();
+            runAlterJobV2Safely(rollupJobV2);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -79,6 +79,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.InvalidOlapTableStateException;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.StarRocksException;
@@ -3166,6 +3167,9 @@ public class SchemaChangeHandler extends AlterHandler {
 
     public ShowResultSet processLakeTableAlterMeta(AlterClause alterClause, Database db, OlapTable olapTable)
             throws StarRocksException {
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+            throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
+        }
         AlterJobV2 alterMetaJob = createAlterMetaJob(alterClause, db, olapTable);
         if (alterMetaJob == null) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2471,11 +2471,15 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     private void runAlterJobV2() {
-        for (AlterJobV2 alterJob : alterJobsV2.values()) {
-            if (alterJob.jobState.isFinalState()) {
-                continue;
+        runAlterJobV2(alterJobsV2.values());
+    }
+
+    @VisibleForTesting
+    void runAlterJobV2(Iterable<AlterJobV2> jobs) {
+        for (AlterJobV2 alterJob : jobs) {
+            if (!alterJob.jobState.isFinalState()) {
+                runAlterJobV2Safely(alterJob);
             }
-            alterJob.run();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -725,6 +725,7 @@ public class GlobalStateMgr {
                 new SystemHandler());
         this.lakeAlterPublishExecutor = ThreadPoolManager.newDaemonCacheThreadPool(
                 Config.publish_version_max_threads, "alter-publish", false);
+        this.lakeAlterPublishExecutor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
 
         this.load = new Load();
         this.streamLoadMgr = new StreamLoadMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterHandlerTest.java
@@ -18,9 +18,15 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -40,6 +46,40 @@ public class AlterHandlerTest {
     public void testGetActiveTxnIdOfTableReturnsEmptyWhenNoJobs() {
         Optional<Long> result = handler.getActiveTxnIdOfTable(123L);
         Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testRunAlterJobV2SafelyContainsOrdinaryExceptionsButPropagatesErrors() {
+        AlterJobV2 bad = mock(AlterJobV2.class);
+        when(bad.getJobId()).thenReturn(1L);
+        when(bad.getJobState()).thenReturn(AlterJobV2.JobState.RUNNING);
+        doThrow(new IllegalStateException("NORMAL")).when(bad).run();
+
+        Assertions.assertDoesNotThrow(() -> handler.runAlterJobV2Safely(bad));
+
+        AlterJobV2 fatal = mock(AlterJobV2.class);
+        doThrow(new AssertionError("fatal")).when(fatal).run();
+
+        Assertions.assertThrows(AssertionError.class, () -> handler.runAlterJobV2Safely(fatal));
+    }
+
+    @Test
+    public void testRunAlterJobV2ContinuesWithSiblingAfterOrdinaryException() {
+        LakeTableAddIndexJob bad = spy(new LakeTableAddIndexJob(
+                1L, 2L, 3L, "bad", 60_000L, new ArrayList<>(), new ArrayList<>()));
+        LakeTableAddIndexJob healthy = spy(new LakeTableAddIndexJob(
+                2L, 2L, 3L, "healthy", 60_000L, new ArrayList<>(), new ArrayList<>()));
+        bad.setJobState(AlterJobV2.JobState.PENDING);
+        healthy.setJobState(AlterJobV2.JobState.PENDING);
+        AtomicInteger healthyRuns = new AtomicInteger();
+        doThrow(new IllegalStateException("NORMAL")).when(bad).run();
+        doAnswer(invocation -> {
+            healthyRuns.incrementAndGet();
+            return null;
+        }).when(healthy).run();
+
+        Assertions.assertDoesNotThrow(() -> handler.runAlterJobV2(List.of(bad, healthy)));
+        Assertions.assertEquals(1, healthyRuns.get());
     }
 
     @Test
@@ -255,4 +295,3 @@ public class AlterHandlerTest {
         return job;
     }
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2PublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2PublishTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-public class AlterJobV2PublishTest {
+class AlterJobV2PublishTest {
     private static final class TestJob extends LakeTableAddIndexJob {
         @Override
         protected boolean lakePublishVersion() {
@@ -59,7 +59,7 @@ public class AlterJobV2PublishTest {
     }
 
     @Test
-    public void testRejectedPublishIsRetryable() throws Exception {
+    void testRejectedPublishIsRetryable() throws Exception {
         SwitchableExecutor executor = new SwitchableExecutor();
         new MockUp<GlobalStateMgr>() {
             @Mock
@@ -76,19 +76,16 @@ public class AlterJobV2PublishTest {
 
             executor.setReject(false);
             Assertions.assertFalse(job.pollPublish());
-            boolean published = false;
-            for (int i = 0; i < 100 && !published; i++) {
-                Thread.sleep(10L);
-                published = job.pollPublish();
-            }
-            Assertions.assertTrue(published);
+            executor.shutdown();
+            Assertions.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+            Assertions.assertTrue(job.pollPublish());
         } finally {
             executor.shutdownNow();
         }
     }
 
     @Test
-    public void testFailedPublishFutureIsCleared() {
+    void testFailedPublishFutureIsCleared() {
         TestJob job = new TestJob();
         job.publishVersionFuture = CompletableFuture.failedFuture(new RuntimeException("publish failed"));
 
@@ -97,7 +94,31 @@ public class AlterJobV2PublishTest {
     }
 
     @Test
-    public void testLakeAlterPublishExecutorRejectsSaturatedSubmissions() {
+    void testInterruptedPublishFutureRestoresInterrupt() {
+        TestJob job = new TestJob();
+        job.publishVersionFuture = new CompletableFuture<>() {
+            @Override
+            public boolean isDone() {
+                return true;
+            }
+
+            @Override
+            public Boolean get() throws InterruptedException {
+                throw new InterruptedException("injected interrupt");
+            }
+        };
+
+        try {
+            Assertions.assertFalse(job.pollPublish());
+            Assertions.assertTrue(Thread.currentThread().isInterrupted());
+            Assertions.assertNull(job.publishVersionFuture);
+        } finally {
+            Thread.interrupted();
+        }
+    }
+
+    @Test
+    void testLakeAlterPublishExecutorRejectsSaturatedSubmissions() {
         ThreadPoolExecutor executor = GlobalStateMgr.getCurrentState().getLakeAlterPublishExecutor();
 
         Assertions.assertInstanceOf(ThreadPoolExecutor.AbortPolicy.class, executor.getRejectedExecutionHandler());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2PublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2PublishTest.java
@@ -1,0 +1,105 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class AlterJobV2PublishTest {
+    private static final class TestJob extends LakeTableAddIndexJob {
+        @Override
+        protected boolean lakePublishVersion() {
+            return true;
+        }
+
+        boolean pollPublish() {
+            return publishVersion();
+        }
+    }
+
+    private static final class SwitchableExecutor extends ThreadPoolExecutor {
+        private volatile boolean reject = true;
+
+        SwitchableExecutor() {
+            super(0, 1, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), new AbortPolicy());
+        }
+
+        void setReject(boolean reject) {
+            this.reject = reject;
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            if (reject) {
+                throw new RejectedExecutionException("injected rejection");
+            }
+            super.execute(command);
+        }
+    }
+
+    @Test
+    public void testRejectedPublishIsRetryable() throws Exception {
+        SwitchableExecutor executor = new SwitchableExecutor();
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public ThreadPoolExecutor getLakeAlterPublishExecutor() {
+                return executor;
+            }
+        };
+
+        try {
+            TestJob job = new TestJob();
+
+            Assertions.assertFalse(job.pollPublish());
+            Assertions.assertNull(job.publishVersionFuture);
+
+            executor.setReject(false);
+            Assertions.assertFalse(job.pollPublish());
+            boolean published = false;
+            for (int i = 0; i < 100 && !published; i++) {
+                Thread.sleep(10L);
+                published = job.pollPublish();
+            }
+            Assertions.assertTrue(published);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void testFailedPublishFutureIsCleared() {
+        TestJob job = new TestJob();
+        job.publishVersionFuture = CompletableFuture.failedFuture(new RuntimeException("publish failed"));
+
+        Assertions.assertFalse(job.pollPublish());
+        Assertions.assertNull(job.publishVersionFuture);
+    }
+
+    @Test
+    public void testLakeAlterPublishExecutorRejectsSaturatedSubmissions() {
+        ThreadPoolExecutor executor = GlobalStateMgr.getCurrentState().getLakeAlterPublishExecutor();
+
+        Assertions.assertInstanceOf(ThreadPoolExecutor.AbortPolicy.class, executor.getRejectedExecutionHandler());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeRangeRewriteSchemaChangeJobTest.java
@@ -477,7 +477,7 @@ public class LakeRangeRewriteSchemaChangeJobTest {
         Assertions.assertEquals(AlterJobV2.JobState.PENDING, job.getJobState());
         Assertions.assertNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()),
                 "precondition: no shadow meta before runPendingJob");
-        OlapTable.OlapTableState stateBefore = table.getState();
+        Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, table.getState());
 
         String text = GsonUtils.GSON.toJson(job.copyForPersist());
         LakeRangeRewriteSchemaChangeJob replayed =
@@ -488,8 +488,13 @@ public class LakeRangeRewriteSchemaChangeJobTest {
 
         Assertions.assertNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()),
                 "replay of a PENDING entry must not register the shadow MaterializedIndexMeta");
-        Assertions.assertEquals(stateBefore, table.getState(),
-                "replay of a PENDING entry must not change the table state");
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING, inMemory.getJobState());
+
+        inMemory.replay(replayed);
+        Assertions.assertNull(table.getIndexMetaByMetaId(job.getShadowIndexMetaId()),
+                "a repeated PENDING replay must not register the shadow MaterializedIndexMeta");
+        Assertions.assertEquals(OlapTable.OlapTableState.SCHEMA_CHANGE, table.getState());
         Assertions.assertEquals(AlterJobV2.JobState.PENDING, inMemory.getJobState());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -69,9 +69,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -63,10 +63,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class RollupJobV2Test extends DDLTestBase {
     private static AddRollupClause clause;
@@ -104,6 +112,37 @@ public class RollupJobV2Test extends DDLTestBase {
     @AfterEach
     public void tearDown() {
         GlobalStateMgr.getCurrentState().getRollupHandler().clearJobs();
+    }
+
+    @Test
+    public void testRunAlterJobV2CleansUpCompletedJobAfterRunThrows() {
+        long dbId = Long.MAX_VALUE;
+        long tableId = Long.MAX_VALUE - 1;
+        long jobId = 1L;
+        AtomicBoolean done = new AtomicBoolean(false);
+        AlterJobV2 job = mock(AlterJobV2.class);
+        when(job.getDbId()).thenReturn(dbId);
+        when(job.getTableId()).thenReturn(tableId);
+        when(job.getJobId()).thenReturn(jobId);
+        when(job.getType()).thenReturn(AlterJobV2.JobType.ROLLUP);
+        when(job.getJobState()).thenReturn(AlterJobV2.JobState.RUNNING);
+        when(job.isDone()).thenAnswer(invocation -> done.get());
+        when(job.isTimeout()).thenReturn(false);
+        doAnswer(invocation -> {
+            done.set(true);
+            throw new RuntimeException("NORMAL");
+        }).when(job).run();
+
+        MaterializedViewHandler handler = new MaterializedViewHandler();
+        handler.getAlterJobsV2().put(jobId, job);
+        handler.getTableRunningJobMap().computeIfAbsent(tableId, key -> new HashSet<>()).add(jobId);
+        Map<Long, Set<Long>> tableNotFinalStateJobMap =
+                Deencapsulation.getField(handler, "tableNotFinalStateJobMap");
+        tableNotFinalStateJobMap.computeIfAbsent(tableId, key -> new HashSet<>()).add(jobId);
+
+        assertDoesNotThrow(() -> Deencapsulation.invoke(handler, "runAlterJobV2"));
+        assertFalse(handler.getTableRunningJobMap().getOrDefault(tableId, Set.of()).contains(jobId));
+        assertFalse(tableNotFinalStateJobMap.getOrDefault(tableId, Set.of()).contains(jobId));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerEditLogTest.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.lake.LakeTable;
@@ -64,7 +65,9 @@ import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class SchemaChangeHandlerEditLogTest {
     private static final String DB_NAME = "test_schema_change_handler_editlog";
@@ -699,6 +702,39 @@ public class SchemaChangeHandlerEditLogTest {
             Assertions.assertEquals("EditLog write failed", exception.getMessage());
             Assertions.assertEquals(OlapTable.OlapTableState.NORMAL, lakeTable.getState());
             Assertions.assertTrue(handler.getUnfinishedAlterJobV2ByTableId(lakeTable.getId()).isEmpty());
+        } finally {
+            GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
+        }
+    }
+
+    @Test
+    public void testProcessLakeTableAlterMetaRejectsReservedTableBeforeWritingEditLog() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Assertions.assertNotNull(db);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "true");
+        ModifyTablePropertiesClause clause = new ModifyTablePropertiesClause(properties);
+
+        EditLog originalEditLog = GlobalStateMgr.getCurrentState().getEditLog();
+        EditLog spyEditLog = spy(originalEditLog);
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        SchemaChangeHandler handler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        try {
+            for (OlapTable.OlapTableState reservedState : List.of(OlapTable.OlapTableState.SCHEMA_CHANGE,
+                    OlapTable.OlapTableState.TABLET_RESHARD)) {
+                LakeTable lakeTable = createHashLakeTable(GlobalStateMgr.getCurrentState().getNextId(),
+                        "lake_table_reserved_" + reservedState.name(), 3);
+                db.registerTableUnlocked(lakeTable);
+                lakeTable.setState(reservedState);
+
+                Assertions.assertThrows(DdlException.class,
+                        () -> handler.processLakeTableAlterMeta(clause, db, lakeTable));
+                Assertions.assertEquals(reservedState, lakeTable.getState());
+                Assertions.assertTrue(handler.getUnfinishedAlterJobV2ByTableId(lakeTable.getId()).isEmpty());
+                verify(spyEditLog, never()).logAlterJob(any(AlterJobV2.class), any());
+            }
         } finally {
             GlobalStateMgr.getCurrentState().setEditLog(originalEditLog);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerEditLogTest.java
@@ -708,7 +708,7 @@ public class SchemaChangeHandlerEditLogTest {
     }
 
     @Test
-    public void testProcessLakeTableAlterMetaRejectsReservedTableBeforeWritingEditLog() throws Exception {
+    public void testProcessLakeTableAlterMetaRejectsReservedTableBeforeWritingEditLog() {
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
         Assertions.assertNotNull(db);
 


### PR DESCRIPTION
## Why I'm doing:

After an FE leader handoff, replaying a PENDING lake online rewrite job did not restore its table-state reservation. This allowed a conflicting same-table alter job to be admitted. Once the conflicting job reset the table to NORMAL, the original rewrite repeatedly threw an unchecked exception; because the alter scheduler had no per-job exception boundary, later jobs were starved and could remain in FINISHED_REWRITING indefinitely.

There is also an independent liveness defect in the lake alter publish executor: its silent discard policy can return a Future for a task that was never accepted, causing the job to poll that Future forever.

## What I'm doing:

- Restore the PENDING online-rewrite table reservation during replay without reconstructing shadow metadata.
- Recheck lake alter-meta admission under the existing table write lock before creating or journaling a job.
- Isolate ordinary AlterJobV2 scheduler exceptions so one job cannot starve its siblings, while preserving Error propagation and MV terminal bookkeeping.
- Make lake alter publish rejection explicit and retryable by using AbortPolicy and retaining a null Future after rejected submission.
- Add focused regression coverage for replay/admission, scheduler sibling liveness, fatal-error policy, MV bookkeeping, and publish rejection retry.

The range/IDG replay and scheduler changes are main-only because that feature has not shipped. The generic publish rejection hardening will be backported separately as a minimal patch to affected release branches; automatic whole-PR backport labels are intentionally not selected.

Fixes StarRocks/StarRocksTest#11963

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
