### PR TITLE
[Enhancement] Mask catalog credentials in CatalogMgr logs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
@@ -26,12 +26,25 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
 import java.util.Map;
 
 public class CredentialUtil {
     public static final Logger LOG = LogManager.getLogger(CredentialUtil.class);
 
     private static final String MASK_CLOUD_CREDENTIAL_WORDS = "******";
+
+    /**
+     * Returns a copy of {@code properties} with credentials masked, leaving the argument
+     * untouched. Prefer this over {@link #maskCredential} when the properties are only being
+     * rendered — for logging or display — since {@link #maskCredential} mutates in place and
+     * would otherwise corrupt live configuration.
+     */
+    public static Map<String, String> maskedCopy(Map<String, String> properties) {
+        Map<String, String> masked = new HashMap<>(properties);
+        maskCredential(masked);
+        return masked;
+    }
 
     public static void maskCredential(Map<String, String> properties) {
         // Mask for aws's credential

--- a/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/CatalogMgr.java
@@ -39,6 +39,7 @@ import com.starrocks.connector.ConnectorMgr;
 import com.starrocks.connector.ConnectorTableId;
 import com.starrocks.connector.ConnectorType;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.credential.CredentialUtil;
 import com.starrocks.persist.AlterCatalogLog;
 import com.starrocks.persist.DropCatalogLog;
 import com.starrocks.persist.ImageWriter;
@@ -197,7 +198,8 @@ public class CatalogMgr {
                     AlterCatalogLog alterCatalogLog = new AlterCatalogLog(catalogName, properties);
                     GlobalStateMgr.getCurrentState().getEditLog().logAlterCatalog(alterCatalogLog,
                             wal -> alterCatalogInternal(catalog, newConnector, properties));
-                    LOG.info("Recreate catalog [{}] with properties [{}]", catalogName, catalog.getConfig());
+                    LOG.info("Recreate catalog [{}] with properties [{}]", catalogName,
+                            CredentialUtil.maskedCopy(catalog.getConfig()));
                 } catch (Exception e) {
                     LOG.warn("alter catalog failed, shutdown new connector", e);
                     newConnector.shutdown();
@@ -370,7 +372,8 @@ public class CatalogMgr {
             }
 
             alterCatalogInternal(catalog, newConnector, properties);
-            LOG.info("Recreate catalog [{}] with properties [{}] in replay", catalog.getName(), catalog.getConfig());
+            LOG.info("Recreate catalog [{}] with properties [{}] in replay", catalog.getName(),
+                    CredentialUtil.maskedCopy(catalog.getConfig()));
         } finally {
             writeUnLock();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
@@ -180,4 +180,20 @@ public class CredentialUtilTest {
         Assertions.assertEquals("", path.getContainer());
         Assertions.assertEquals("", path.getStorageAccount());
     }
+
+    @Test
+    public void testMaskedCopyDoesNotMutateSource() {
+        String key = IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
+                OAuth2SecurityConfig.OAUTH2_TOKEN;
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "iceberg");
+        properties.put(key, "supersecrettoken");
+
+        Map<String, String> masked = CredentialUtil.maskedCopy(properties);
+
+        Assertions.assertEquals("su******en", masked.get(key));
+        Assertions.assertEquals("iceberg", masked.get("type"));
+        // the source map may be live configuration, so it must be left untouched
+        Assertions.assertEquals("supersecrettoken", properties.get(key));
+    }
 }


### PR DESCRIPTION
Fixes #78518

## Why I'm doing:

`CatalogMgr` logs the full external-catalog property map to the FE system log at `INFO`. For
catalogs that authenticate with a credential — for example an Iceberg REST catalog using
`iceberg.catalog.oauth2.token` — the value is written in clear text:

```
[CatalogMgr.alterCatalog():200] Recreate catalog [my_catalog] with properties
[{iceberg.catalog.oauth2.token=<clear text>, iceberg.catalog.uri=..., type=iceberg, ...}]
```

The same statement runs on the edit-log replay path, so the value is also written by every
follower that replays the entry, and again on FE restart until a checkpoint absorbs it.

StarRocks already masks this exact property elsewhere: `SHOW CREATE CATALOG` calls
`CredentialUtil.maskCredential`, which covers `iceberg.catalog.oauth2.token` and
`oauth2.credential` along with the AWS/Azure/GCS/Aliyun/ODPS keys. The logging path simply does
not call it, so the two surfaces disagree. This is the same change PR #55358 made for broker-load
profiles.

## What I'm doing:

`CredentialUtil` only exposed `maskCredential`, which mutates its argument. That is the right
shape for callers that own the map, but callers that merely want to *render* properties have to
remember to copy first — and forgetting silently corrupts live configuration. That footgun is why
this path was easy to get wrong.

So the fix is in two small parts:

1. **`CredentialUtil.maskedCopy(Map)`** — a non-mutating variant that returns a masked copy,
   sitting next to `maskCredential` in the class that already owns masking.
2. **`CatalogMgr`** calls it at both log sites — `:200` (live `ALTER CATALOG`) and `:373`
   (edit-log replay). Two lines changed, one import.

Only log output changes. Catalog behaviour, persistence and replay are untouched.

Before:
```
Recreate catalog [my_catalog] with properties [{iceberg.catalog.oauth2.token=dapi1234...,  ...}]
```
After:
```
Recreate catalog [my_catalog] with properties [{iceberg.catalog.oauth2.token=da******89,  ...}]
```

`CredentialUtilTest.testMaskedCopyDoesNotMutateSource` covers both halves: the credential is
masked in the returned copy, and the source map is unchanged. The second assertion is the one
that matters for regressions.

Verified against 4.1.4 (`starrocks/allin1-ubuntu:4.1.4`) with a REST catalog and a synthetic
token: before the change the token appears in `fe.log` on both the live and replay paths; the
masked form matches what `SHOW CREATE CATALOG` already returns for the same catalog.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

Note on backports: on 3.x the two paths share a single statement (`CatalogMgr.java:176`, reached
from `replayAlterCatalog:412 -> alterCatalog:271 -> reCreatCatalog:287`), which logs
`newProperties` rather than `catalog.getConfig()`. The same one-line change applies there, at a
single site.
