### PR TITLE
[BugFix] Clear discarded PK compaction state after full snapshot

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -5049,6 +5049,18 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta, bool rest
             return Status::Cancelled("snapshot version too small");
         }
 
+        // A full snapshot replaces every unapplied edit. If one of those edits is a compaction,
+        // its apply task will never complete the compaction lifecycle and release the running state.
+        bool discarded_pending_compaction = false;
+        if (!restore_from_backup) {
+            for (size_t i = _apply_version_idx + 1; i < _edit_version_infos.size(); ++i) {
+                if (_edit_version_infos[i]->compaction != nullptr) {
+                    discarded_pending_compaction = true;
+                    break;
+                }
+            }
+        }
+
         std::stringstream ss;
         uint32_t new_next_rowset_id = _next_rowset_id;
         ss << "next_rowset_id before:" << _next_rowset_id << " rowsets:";
@@ -5177,6 +5189,12 @@ Status TabletUpdates::load_snapshot(const SnapshotMeta& snapshot_meta, bool rest
             auto* pindex_load_executor = manager->get_pindex_load_executor();
             (void)pindex_load_executor->submit_task_and_wait_for(
                     std::static_pointer_cast<Tablet>(_tablet.shared_from_this()), rebuild_pk_index_wait_seconds);
+        }
+
+        if (discarded_pending_compaction) {
+            // Reset the abandoned in-memory state before allowing another compaction.
+            _compaction_state.reset();
+            _compaction_running = false;
         }
 
         LOG(INFO) << "load full snapshot done " << _debug_string(false) << ss.str();


### PR DESCRIPTION
## Why I'm doing:

For a shared-nothing primary-key tablet, `_compaction_running` remains true after a compaction EditVersion is committed and is normally cleared when `_apply_compaction_commit()` finishes.

A newer full snapshot can replace `_edit_version_infos` before the compaction edit is applied. The discarded edit can no longer reach `_apply_compaction_commit()`, leaving `_compaction_running` stuck at true. As a result, `get_compaction_score()` always returns `-1`, and the tablet is permanently skipped by the compaction scheduler while rowsets continue to accumulate.

## What I'm doing:

When loading a full snapshot:

- Inspect the unapplied EditVersions before replacing the version history.
- Record whether a pending compaction edit will be discarded.
- After the full snapshot succeeds, reset `_compaction_state` and `_compaction_running`.

Fixes #78506

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5