### PR TITLE
[BugFix] Fix typos in exception messages

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/AliasGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/AliasGenerator.java
@@ -44,7 +44,7 @@ public abstract class AliasGenerator {
                 return candidateAlias;
             }
             if (numGeneratedAliases < 0) {
-                throw new IllegalStateException("Overflow occured during alias generation.");
+                throw new IllegalStateException("Overflow occurred during alias generation.");
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/StatisticsUtils.java
@@ -43,12 +43,12 @@ public class StatisticsUtils {
         Preconditions.checkState(splits.length == 4);
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, splits[0], splits[1], splits[2]);
         if (table == null) {
-            throw new SemanticException("Table [%s.%s.%s] is not existed", splits[0], splits[1], splits[2]);
+            throw new SemanticException("Table [%s.%s.%s] does not exist", splits[0], splits[1], splits[2]);
         }
         if (table.getUUID().equals(tableUUID)) {
             return table;
         } else {
-            throw new SemanticException("Table [%s.%s.%s] is not existed", splits[0], splits[1], splits[2]);
+            throw new SemanticException("Table [%s.%s.%s] does not exist", splits[0], splits[1], splits[2]);
         }
     }
 
@@ -58,15 +58,15 @@ public class StatisticsUtils {
         Preconditions.checkState(splits.length == 4);
         Database db = GlobalStateMgr.getCurrentState().getMetadataMgr().getDb(context, splits[0], splits[1]);
         if (db == null) {
-            throw new SemanticException("Database [%s.%s] is not existed", splits[0], splits[1]);
+            throw new SemanticException("Database [%s.%s] does not exist", splits[0], splits[1]);
         }
 
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, splits[0], splits[1], splits[2]);
         if (table == null) {
-            throw new SemanticException("Table [%s.%s.%s] is not existed", splits[0], splits[1], splits[2]);
+            throw new SemanticException("Table [%s.%s.%s] does not exist", splits[0], splits[1], splits[2]);
         }
         if (!table.getUUID().equals(tableUUID)) {
-            throw new SemanticException("Table [%s.%s.%s] is not existed", splits[0], splits[1], splits[2]);
+            throw new SemanticException("Table [%s.%s.%s] does not exist", splits[0], splits[1], splits[2]);
         }
 
         return ImmutableTriple.of(splits[0], db, table);

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLChannelImp.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLChannelImp.java
@@ -166,7 +166,7 @@ public class SSLChannelImp implements SSLChannel {
                     myNetData = enlargePacketBuffer(sslEngine, myNetData);
                     break;
                 case BUFFER_UNDERFLOW:
-                    throw new SSLException("Buffer underflow occured after a wrap. " +
+                    throw new SSLException("Buffer underflow occurred after a wrap. " +
                             "I don't think we should ever get here.");
                 case CLOSED:
                     throw new IOException("client closed the connection");
@@ -339,7 +339,7 @@ public class SSLChannelImp implements SSLChannel {
                             myNetData = enlargePacketBuffer(sslEngine, myNetData);
                             break;
                         case BUFFER_UNDERFLOW:
-                            throw new SSLException("Buffer underflow occured after a wrap. " +
+                            throw new SSLException("Buffer underflow occurred after a wrap. " +
                                     "I don't think we should ever get here.");
                         case CLOSED:
                             try {


### PR DESCRIPTION
## Why I'm doing:

Several exception messages in the FE codebase contain typos ("occured" instead of "occurred") and a grammar error ("is not existed" instead of "does not exist"), which is confusing/unprofessional when surfaced to users or in logs.

## What I'm doing:

Fix the wording of these exception messages:
- `AliasGenerator.java` and `SSLChannelImp.java`: "occured" -> "occurred" (2 occurrences)
- `StatisticsUtils.java`: "is not existed" -> "does not exist" (5 occurrences)

No logic changes; verified no test in the repo asserts on the exact (now-changed) strings.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5