### PR TITLE
[Enhancement] Add observability awareness to agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,12 @@ cd test && python3 run.py -v
 - User-facing config or metric changes must update the matching docs in `docs/en/` and `docs/zh/` when applicable.
 - When editing any file under `docs/`, read `docs/CLAUDE.md` for documentation-specific rules before making changes.
 
+## Observability Awareness
+
+Before generating or modifying production code for a feature, bug fix, or performance optimization, review the existing observability of the affected end-to-end path. Follow the [Observability Awareness policy](./handbook/policies/observability-awareness.md) and the matching domain guide before deciding whether existing signals must be preserved or extended.
+
+In the final change summary or PR description, state which existing signals were reviewed, what was preserved or extended, or why no observability change was needed.
+
 ## PR Contract
 
 - Commit messages: English, imperative, concise.

--- a/handbook/domains/backend.md
+++ b/handbook/domains/backend.md
@@ -24,6 +24,18 @@ Map the BE development surface for execution, storage, runtime, services, and th
 - Reviewed legacy debt in `build-support/be_module_boundary_baseline.json` is shrink-only.
 - BE config or metric changes must update matching public docs.
 
+## Observability Touchpoints
+
+Apply the [Observability Awareness policy](../policies/observability-awareness.md) with these existing BE mechanisms in mind whenever the affected path uses or should use them:
+
+- **Query Profile**: Follow profile creation, counter or timer updates, reporting, and aggregation when changing query execution. A new operator, strategy, fast path, or fallback must not bypass the applicable profile updates.
+- **Load Profile**: Follow the load profile from BE counter or timer updates through reporting and FE-side aggregation and exposure. Check new load modes, sink paths, optimizations, and failure paths against that entire flow.
+- **Primary Key publish trace logs**: Follow the existing trace and its parent/child context around tablet publish work. Keep new phases, retries, waits, I/O, fallbacks, and errors connected to that trace path.
+- **Metrics**: Inspect the owning module's existing registration, update, and cleanup patterns. Keep affected metrics accurate and extend the nearby metric set when a new operationally relevant state or outcome would otherwise be missing.
+- **Errors and logs**: Preserve the original `Status` cause and the identifiers already used for correlation; keep logging at the established ownership boundary.
+
+When one of these mechanisms needs to be extended, follow its existing naming, hierarchy, lifetime, batching or sampling, and tests rather than introducing a parallel convention.
+
 ## Metrics Ownership
 
 - `be/src/base/metrics.h` owns only low-level metric primitives such as `Metric`, `MetricRegistry`, labels, visitors, and hooks.

--- a/handbook/domains/frontend.md
+++ b/handbook/domains/frontend.md
@@ -23,6 +23,13 @@ Map the FE surface for SQL parsing, optimization, metadata, coordination, and sh
 - Connectors and plugins should depend on FE SPI boundaries, not FE internals.
 - Shared test utilities belong in `fe/fe-testing/` instead of ad hoc local fixtures.
 
+## Observability Touchpoints
+
+Apply the [Observability Awareness policy](../policies/observability-awareness.md) to the existing FE mechanisms used by the affected path:
+
+- **Query and Load Profiles**: Follow BE profile reports through FE aggregation, finalization, storage, and exposure. Ensure a new path preserves the existing profile lifecycle and does not drop reports, aggregate them incorrectly, or finish the profile prematurely.
+- **Metrics**: Inspect the owning component's existing metric registration, update, and cleanup path. Keep those metrics accurate when adding branches, retries, fallbacks, or terminal outcomes; extend the nearby metric set when an important new state or outcome would otherwise be missing, following [Adding/Modifying FE Metrics](../../fe/AGENTS.md#addingmodifying-fe-metrics).
+
 ## Test and Validation
 
 - Use focused `run-fe-ut.sh --test ...` loops for planner, analyzer, optimizer, and catalog changes.

--- a/handbook/policies/index.md
+++ b/handbook/policies/index.md
@@ -5,5 +5,6 @@ Use these pages for repo-local operating rules that should remain stable, discov
 ## Policies
 
 - [Reliability First](reliability-first.md): optimize for trustworthy signals before throughput.
+- [Observability Awareness](observability-awareness.md): preserve and extend existing observability when changing production code.
 - [Internal vs Public Docs](internal-vs-public-docs.md): decide whether guidance belongs in `handbook/` or `docs/`.
 - [Agent Change Flow](agent-change-flow.md): expected loop for repo-local planning, validation, and human merge authority.

--- a/handbook/policies/observability-awareness.md
+++ b/handbook/policies/observability-awareness.md
@@ -1,0 +1,34 @@
+# Observability Awareness
+
+## Intent
+
+Prevent feature development, bug fixes, and performance optimizations from bypassing or weakening the observability already present in an affected production path.
+
+## Applies To
+
+- Feature development, bug fixes, and performance optimizations in BE and FE production paths.
+- Agent implementation, review, verification, and PR handoff for those changes.
+
+## Enforcement
+
+- Before implementation, read neighboring code and trace callers and callees to identify existing metrics, logs, traces, profiles, error codes and messages, audit records, system tables, and administrative APIs. Understand where each signal is created, updated, aggregated, and exposed.
+- When adding or changing a state, branch, asynchronous phase, retry, timeout, cancellation, fallback, or error path, check whether every applicable existing signal still runs once and retains accurate semantics. Extend the established mechanism when needed instead of creating a parallel one.
+- For a new feature, ask whether operators can tell when it is used, whether it is progressing or healthy, why it failed, and where time or resources are spent. Reuse and extend an applicable existing mechanism; add a new signal only when the existing mechanisms cannot answer an operationally relevant question.
+- For a bug fix, make sure the fix does not hide the original failure, discard useful context, or bypass an existing diagnostic signal.
+- For a performance change, keep the optimized and fallback behavior explainable through the existing benchmark and profiling workflow, and ensure observability work does not materially distort the affected hot path.
+- Follow the existing ownership and local conventions for names, units, labels, profile hierarchy, trace relationships, lifetimes, batching or sampling, error context, tests, and documentation. Avoid unbounded labels, sensitive payloads, and noisy logs.
+
+## Verification and Handoff
+
+- Exercise the relevant success, failure, and fallback paths and inspect the affected signals. Update focused tests when an existing or new observability surface changes.
+- In the final change summary or PR description, name the signals reviewed, describe what was preserved or extended, or explain why the existing observability was already sufficient.
+
+## Exceptions
+
+- No new signal is required when the review shows that the existing observability remains accurate and sufficient; record that conclusion in the change summary or PR description.
+- Changes limited to tests, documentation, generated code, Java extensions, or CI/tooling are outside this policy unless they directly change or validate an existing observability surface.
+
+Use the matching domain guide for concrete observability touchpoints:
+
+- [Backend](../domains/backend.md#observability-touchpoints)
+- [Frontend](../domains/frontend.md#observability-touchpoints)


### PR DESCRIPTION
## Why I am doing:

Agents can focus on completing feature, bug-fix, or performance code while overlooking the observability already wired into the affected path. New branches or phases can then bypass existing profiles, traces, metrics, logs, or error propagation even though the surrounding implementation is observable.

The guidance should remind agents to inspect and preserve existing mechanisms first. Detailed engineering knowledge belongs in the handbook, while `AGENTS.md` should remain a concise entrypoint.

## What I am doing:

- Add a concise repository-wide trigger in the root `AGENTS.md` requiring an observability review and an explicit handoff summary.
- Add a handbook policy describing the common review workflow for features, bug fixes, and performance changes.
- Add backend-domain touchpoints for existing Query Profile, Load Profile, Primary Key publish trace logs, metrics, and Status/log propagation.
- Add frontend-domain touchpoints for Query and Load Profile aggregation and lifecycle, plus FE-owned metrics.
- Keep detailed guidance out of nested `AGENTS.md` files to avoid duplication and drift.

Observability impact: this PR changes agent development and review guidance only. It does not add or change StarRocks runtime telemetry.

Fixes: N/A

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Validation:

- `git diff --check`
- `python3 build-support/render_be_agents.py --check`
- `python3 build-support/check_be_module_boundaries.py --mode full`

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature (not applicable: agent-guidance-only change)
- [ ] This pr needs user documentation (not applicable: no user-facing product behavior)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

Not applicable; this is an enhancement to contributor guidance.

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


