### PR TITLE
[BugFix] Skip order-by hints when the TopN filter probes a column-less slot

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1112,13 +1112,18 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             if (RuntimeFilterDescription.RuntimeFilterType.TOPN_FILTER.equals(
                     probeRuntimeFilter.runtimeFilterType())) {
                 Expr expr = probeRuntimeFilter.getNodeIdToProbeExpr().get(getId().asInt());
-                if (expr instanceof SlotRef) {
+                // The probe slot may carry no column: a heavy expr pushed into this scan
+                // (PlanFragmentBuilder#buildProjectNode) occupies a slot in the scan's tuple with
+                // no backing column, and a TopN filter on that expr probes it here. Such a slot is
+                // never a sort key or partition column, so there is no hint to assign.
+                SlotDescriptor probeSlot =
+                        expr instanceof SlotRef ? desc.getSlot(((SlotRef) expr).getSlotId().asInt()) : null;
+                if (probeSlot != null && probeSlot.getColumn() != null) {
                     // check key columns
-                    SlotId cid = ((SlotRef) expr).getSlotId();
                     // Identify the probe column by its storage-side id, the one handle a rename does
                     // not change, and compare both checks below against ids as well - keyColumnNames
                     // holds ids, and a partition column's name is just as mutable as this one's.
-                    String probeColumnId = desc.getSlot(cid.asInt()).getColumn().getColumnId().getId();
+                    String probeColumnId = probeSlot.getColumn().getColumnId().getId();
                     if (!keyColumnNames.isEmpty() && keyColumnNames.get(0).equals(probeColumnId)) {
                         sortKeyAscHint = outputAscHint;
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
@@ -155,4 +155,15 @@ public class PushDownHeavyExprsTest {
                 "          <slot 12> : regexp_replace(get_json_object(7: field_text_1, '$.key_json_2'), " +
                 "'^\\\\[\\\\\"|\\\\\"]$', '')\n"), plan);
     }
+
+    @Test
+    public void testTopNFilterProbeOnHeavyExprSlot() throws Exception {
+        // ORDER BY a heavy expr + LIMIT puts a TopN runtime filter probe on the heavy-expr
+        // slot, which has no backing column. Serializing the scan node used to NPE in
+        // assignOrderByHints; only toThrift takes that path, so plan the query to thrift.
+        String q = "SELECT regexp_replace(field_varchar_1, 'x', 'y') AS s " +
+                "FROM tbl_transaction_001 ORDER BY s LIMIT 3";
+        String plan = UtFrameUtils.getPlanThriftString(ctx, q);
+        Assertions.assertTrue(plan.contains("SORT_NODE"), plan);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

A heavy expr pushed into an OLAP scan (push_down_heavy_exprs, on by default) occupies a slot in the scan's tuple with no backing column, and the projection above degenerates to an identity mapping for it. When the query also sorts by that expr with a LIMIT, the TopN runtime filter's probe reaches the scan as a SlotRef of that slot, and OlapScanNode.assignOrderByHints dereferenced its null Column while serializing the plan:

  SELECT regexp_replace(cast(a as varchar), 'x', 'y') AS s
  FROM t ORDER BY s LIMIT 3;
  -> NullPointerException: ... SlotDescriptor.getColumn() is null

failing the query with an INTERNAL_ERROR under default session settings. Found by a cluster fuzzing campaign (two signatures, same defect).

Such a slot can never be the sort key or a partition column, so there is no hint to assign: skip the hint assignment when the probe slot is missing or has no column.

The regression test plans the query to thrift, since only toThrift takes the assignOrderByHints path; explain does not reach it.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
