### PR TITLE
[BugFix] Reject cross-scope recursive CTE reference instead of stack overflow

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -247,6 +247,13 @@ public class ConnectContext {
     // cycle routed through a subquery would otherwise reset the per-Visitor set on every hop.
     private final Set<String> viewExpansionPath = Sets.newHashSet();
 
+    // Names of the recursive CTEs whose recursive member is currently being analyzed. Like
+    // viewExpansionPath it lives on the session (not on a single QueryAnalyzer.Visitor) so it is
+    // shared across the fresh QueryAnalyzer instances spawned for scalar/IN/EXISTS subqueries; a
+    // recursive reference routed through such a subquery would otherwise not see the enclosing
+    // recursive CTE, fall through to the optimizer and expand without end (StackOverflowError).
+    private final Set<String> recursiveCteAnalysisPath = Sets.newHashSet();
+
     private final Map<String, PrepareStmtContext> preparedStmtCtxs = Maps.newHashMap();
 
     // Control whether to read Iceberg caches without populating/updating them for the current execution.
@@ -1375,6 +1382,10 @@ public class ConnectContext {
 
     public Set<String> getViewExpansionPath() {
         return viewExpansionPath;
+    }
+
+    public Set<String> getRecursiveCteAnalysisPath() {
+        return recursiveCteAnalysisPath;
     }
 
     public void setForwardTimes(int forwardTimes) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -426,12 +426,21 @@ public class QueryAnalyzer {
     }
 
     private class Visitor implements AstVisitorExtendInterface<Scope, Scope> {
-        // for recursive cte analyze
-        private String currentRecursiveCTE = null;
+        // Names of the recursive CTEs whose recursive members are currently being analyzed, innermost
+        // on top. A stack, not a single value: a recursive CTE nested inside another one must not
+        // overwrite the outer name and then clear it, or a reference back to the outer CTE stops being
+        // recognized as recursive and its definition gets expanded without end (StackOverflowError /
+        // hang in the table collectors).
+        private final Deque<String> recursiveCteStack = new ArrayDeque<>();
         // Fallback for cyclic view detection when there is no session; the shared path lives on the
         // session (see viewExpansionStack()) so it survives the fresh QueryAnalyzer that each
         // scalar/IN/EXISTS subquery spawns.
         private final Set<String> localViewExpansionStack = new HashSet<>();
+        // Fallback for the recursive-CTE analysis path when there is no session; see
+        // recursiveCteAnalysisPath(). recursiveCteStack above is per-Visitor and cannot see a
+        // recursive reference that a subquery resolves in its own fresh Visitor, so the shared path
+        // on the session is what catches those.
+        private final Set<String> localRecursiveCtePath = new HashSet<>();
         private final Deque<AnalyzeState> queryBlockAnalyzeStates = new ArrayDeque<>();
 
         public Visitor() {
@@ -442,6 +451,14 @@ public class QueryAnalyzer {
         // still observed; only when session is null do we fall back to the per-Visitor set.
         private Set<String> viewExpansionStack() {
             return session != null ? session.getViewExpansionPath() : localViewExpansionStack;
+        }
+
+        // Names of the recursive CTEs currently being analyzed, shared via the session so a recursive
+        // reference routed through a scalar/IN/EXISTS subquery (which gets its own QueryAnalyzer/Visitor,
+        // hence an empty recursiveCteStack) is still observed; only when session is null do we fall back
+        // to the per-Visitor set.
+        private Set<String> recursiveCteAnalysisPath() {
+            return session != null ? session.getRecursiveCteAnalysisPath() : localRecursiveCtePath;
         }
 
         public Scope process(ParseNode node, Scope scope) {
@@ -532,27 +549,38 @@ public class QueryAnalyzer {
             withQuery.setScope(new Scope(RelationId.of(withQuery), new RelationFields(cteOutputs)));
             cteScope.addCteQueries(cteName, withQuery);
             int outputSize = anchorScope.getRelationFields().size();
-            this.currentRecursiveCTE = cteName;
-            for (int i = 1; i < unionRelation.getRelations().size(); ++i) {
-                Scope relation = process(unionRelation.getRelations().get(i), cteScope);
-                if (relation.getRelationFields().size() != outputSize) {
-                    throw new SemanticException("Operands have unequal number of columns");
+            this.recursiveCteStack.push(cteName);
+            // Also mark it on the session-shared path so a reference resolved inside a subquery's own
+            // Visitor can still tell this CTE is mid-analysis. addedToPath guards a same-named CTE
+            // nested inside another so only the outermost occurrence clears the entry.
+            boolean addedToPath = recursiveCteAnalysisPath().add(cteName);
+            try {
+                for (int i = 1; i < unionRelation.getRelations().size(); ++i) {
+                    Scope relation = process(unionRelation.getRelations().get(i), cteScope);
+                    if (relation.getRelationFields().size() != outputSize) {
+                        throw new SemanticException("Operands have unequal number of columns");
+                    }
+                    for (int fieldIdx = 0; fieldIdx < relation.getRelationFields().size(); ++fieldIdx) {
+                        Field field = relation.getRelationFields().getAllFields().get(fieldIdx);
+                        Type fieldType = field.getType();
+                        if (fieldType.isOnlyMetricType() && !unionRelation.getQualifier().equals(SetQualifier.ALL)) {
+                            throw new SemanticException("%s not support set operation", fieldType);
+                        }
+                        Type childRelationType = relation.getRelationFields().getFieldByIndex(fieldIdx).getType();
+                        if (!childRelationType.matchesType(outputTypes[fieldIdx])
+                                && !TypeManager.canCastTo(childRelationType, outputTypes[fieldIdx])) {
+                            throw new SemanticException(
+                                    String.format("Unequality return types '%s' and '%s' in recursive cte",
+                                            outputTypes[fieldIdx], childRelationType));
+                        }
+                    }
                 }
-                for (int fieldIdx = 0; fieldIdx < relation.getRelationFields().size(); ++fieldIdx) {
-                    Field field = relation.getRelationFields().getAllFields().get(fieldIdx);
-                    Type fieldType = field.getType();
-                    if (fieldType.isOnlyMetricType() && !unionRelation.getQualifier().equals(SetQualifier.ALL)) {
-                        throw new SemanticException("%s not support set operation", fieldType);
-                    }
-                    Type childRelationType = relation.getRelationFields().getFieldByIndex(fieldIdx).getType();
-                    if (!childRelationType.matchesType(outputTypes[fieldIdx])
-                            && !TypeManager.canCastTo(childRelationType, outputTypes[fieldIdx])) {
-                        throw new SemanticException(String.format("Unequality return types '%s' and '%s' in recursive cte",
-                                outputTypes[fieldIdx], childRelationType));
-                    }
+            } finally {
+                this.recursiveCteStack.pop();
+                if (addedToPath) {
+                    recursiveCteAnalysisPath().remove(cteName);
                 }
             }
-            this.currentRecursiveCTE = null;
             if (!withQuery.isRecursive()) {
                 return false;
             }
@@ -811,9 +839,30 @@ public class QueryAnalyzer {
                         newCteRelation.setResolvedInFromClause(true);
                         newCteRelation.setScope(
                                 new Scope(RelationId.of(newCteRelation), new RelationFields(outputFields.build())));
-                        if (currentRecursiveCTE != null && currentRecursiveCTE.equals(tableName.getTbl())) {
-                            newCteRelation.setRecursive(true);
-                            withRelation.setRecursive(true);
+                        if (!recursiveCteStack.isEmpty() && recursiveCteStack.contains(tableName.getTbl())) {
+                            if (tableName.getTbl().equals(recursiveCteStack.peek())) {
+                                // Direct self-reference in the recursive member of the CTE being analyzed.
+                                newCteRelation.setRecursive(true);
+                                withRelation.setRecursive(true);
+                            } else {
+                                // Reference to an OUTER recursive CTE from inside a nested CTE/subquery. This
+                                // cross-scope recursive reference is not supported (and left the analyzer to
+                                // expand it forever); reject it instead of hanging. Use the same message as
+                                // RecursiveCTEAstCheck (the enable_recursive_cte=true path) so multi-level
+                                // recursive CTEs are rejected consistently however they reach the analyzer.
+                                throw new SemanticException("Doesn't support multi-level recursive CTE",
+                                        tableRelation.getPos());
+                            }
+                        } else if (recursiveCteAnalysisPath().contains(tableName.getTbl())) {
+                            // The name is a recursive CTE whose recursive member is still being analyzed in
+                            // an enclosing scope, yet this reference is resolved by a nested QueryAnalyzer
+                            // whose own recursiveCteStack does not contain it -- i.e. the reference sits
+                            // inside a scalar/IN/EXISTS subquery of the recursive member. A recursive
+                            // reference is only legal in the recursive member's FROM clause; inside a
+                            // subquery it previously slipped past the guard and expanded forever
+                            // (StackOverflowError / "Unknown error"). Reject it with the same message.
+                            throw new SemanticException("Doesn't support multi-level recursive CTE",
+                                    tableRelation.getPos());
                         }
                         return newCteRelation;
                     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/RecursiveCTETest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/RecursiveCTETest.java
@@ -176,6 +176,101 @@ public class RecursiveCTETest extends PlanTestBase {
     }
 
     @Test
+    public void testNestedRecursiveCteCrossScopeReferenceRejected() throws Exception {
+        // A recursive CTE nested inside another one, whose recursive member references the OUTER
+        // recursive CTE. The single-value recursive-CTE marker used to lose the outer name, so the
+        // table collectors expanded the outer CTE without end (StackOverflowError / hang). It must be
+        // rejected with a clear error, not blow the stack.
+        String sql = "with recursive q as ("
+                + " select v1, v2, v3 from t0"
+                + " union all ("
+                + "   with recursive x as ("
+                + "     select v1, v2, v3 from t0"
+                + "     union all ("
+                + "       select v1, v2, v3 from q where v1 < 10"
+                + "       union all"
+                + "       select v1, v2, v3 from x where v2 < 10"
+                + "     )"
+                + "   )"
+                + "   select v1, v2, v3 from x"
+                + " )"
+                + ") select v1 from q";
+        connectContext.getSessionVariable().setEnableRecursiveCTE(true);
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+        Assertions.assertTrue(e.getMessage().contains("Doesn't support multi-level recursive CTE"),
+                e.getMessage());
+    }
+
+    @Test
+    public void testNestedRecursiveCteEnableFalseAlsoRejected() throws Exception {
+        // With enable_recursive_cte=false the RecursiveCTEAstCheck multi-level guard does not run
+        // (it is gated on the session var), so the nested reference reaches QueryAnalyzer. It must
+        // still be rejected there instead of overflowing the stack in the table collectors.
+        String sql = "with recursive q as ("
+                + " select v1, v2, v3 from t0"
+                + " union all ("
+                + "   with recursive x as ("
+                + "     select v1, v2, v3 from t0"
+                + "     union all ("
+                + "       select v1, v2, v3 from q where v1 < 10"
+                + "       union all"
+                + "       select v1, v2, v3 from x where v2 < 10"
+                + "     )"
+                + "   )"
+                + "   select v1, v2, v3 from x"
+                + " )"
+                + ") select v1 from q";
+        connectContext.getSessionVariable().setEnableRecursiveCTE(false);
+        Assertions.assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+    }
+
+    @Test
+    public void testRecursiveCteReferencedOnlyInScalarSubqueryRejected() throws Exception {
+        // The recursive member's FROM is a base table; the recursive CTE q is referenced only inside a
+        // scalar subquery. That reference is resolved by the fresh QueryAnalyzer the subquery spawns,
+        // whose own recursiveCteStack is empty, so the per-Visitor guard cannot see it. The
+        // session-shared recursive-CTE path must catch it; before the fix it slipped through and the
+        // table collectors expanded q forever ("Unknown error" / StackOverflowError).
+        String sql = "with recursive q as ("
+                + " select v1, v2, v3 from t0"
+                + " union all"
+                + " select v1, v2, v3 from t0 where v1 < (select max(v1) from q)"
+                + ") select v1 from q";
+        connectContext.getSessionVariable().setEnableRecursiveCTE(false);
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+        Assertions.assertTrue(e.getMessage().contains("Doesn't support multi-level recursive CTE"),
+                e.getMessage());
+    }
+
+    @Test
+    public void testRecursiveCteReferencedOnlyInInSubqueryRejected() throws Exception {
+        // Same as above but the reference hides in an IN subquery instead of a scalar one.
+        String sql = "with recursive q as ("
+                + " select v1, v2, v3 from t0"
+                + " union all"
+                + " select v1, v2, v3 from t0 where v1 in (select v1 from q)"
+                + ") select v1 from q";
+        connectContext.getSessionVariable().setEnableRecursiveCTE(false);
+        SemanticException e = Assertions.assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+        Assertions.assertTrue(e.getMessage().contains("Doesn't support multi-level recursive CTE"),
+                e.getMessage());
+    }
+
+    @Test
+    public void testRecursiveMemberSubqueryOverOtherRelationNotRejected() throws Exception {
+        // Negative control: a subquery inside the recursive member that does NOT reference the
+        // recursive CTE (only a base table) must plan normally. The session-shared path only holds
+        // the recursive CTE's own name, so an unrelated subquery is never rejected.
+        String sql = "with recursive cte as ("
+                + " select v1 from t0"
+                + " union all"
+                + " select v1 + 1 from cte where v1 < (select max(v1) from t0)"
+                + ") select * from cte";
+        String plan = explainRecursiveCte(sql);
+        assertContains(plan, "Recursive Statement:");
+    }
+
+    @Test
     public void testRecursiveCTEInNormalProcess() {
         String sql = "with recursive cte as " +
                 "(select v1 from t0 union select v1 + 1 from cte where v1 < 10) " +

--- a/test/sql/test_cte/R/test_recursive_cte
+++ b/test/sql/test_cte/R/test_recursive_cte
@@ -385,3 +385,39 @@ SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=20, enable
 4	3.5
 5	4.5
 -- !result
+WITH RECURSIVE q AS (
+    SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+    UNION ALL (
+        WITH RECURSIVE x AS (
+            SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+            UNION ALL (
+                SELECT employee_id, name, manager_id FROM q WHERE employee_id < 10
+                UNION ALL
+                SELECT employee_id, name, manager_id FROM x WHERE manager_id < 10
+            )
+        )
+        SELECT employee_id, name, manager_id FROM x
+    )
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true)*/ employee_id FROM q;
+-- result:
+[REGEX].*Doesn't support multi-level recursive CTE.*
+-- !result
+WITH RECURSIVE q AS (
+    SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+    UNION ALL
+    SELECT employee_id, name, manager_id FROM employees WHERE employee_id < (SELECT max(employee_id) FROM q)
+)
+SELECT employee_id FROM q;
+-- result:
+[REGEX].*Doesn't support multi-level recursive CTE.*
+-- !result
+WITH RECURSIVE q AS (
+    SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+    UNION ALL
+    SELECT employee_id, name, manager_id FROM employees WHERE employee_id IN (SELECT employee_id FROM q)
+)
+SELECT employee_id FROM q;
+-- result:
+[REGEX].*Doesn't support multi-level recursive CTE.*
+-- !result

--- a/test/sql/test_cte/T/test_recursive_cte
+++ b/test/sql/test_cte/T/test_recursive_cte
@@ -267,3 +267,42 @@ WITH RECURSIVE r AS (
     SELECT n + 1, bal + 1 FROM r WHERE n < 5
 )
 SELECT /*+ SET_VAR(enable_recursive_cte=true, recursive_cte_max_depth=20, enable_insert_strict=true, insert_max_filter_ratio=0)*/ * FROM r ORDER BY n;
+
+-- Test 14: Error case - a recursive CTE nested inside another one whose recursive member references
+-- the OUTER recursive CTE. This cross-scope recursive reference is unsupported; it must be rejected
+-- with a clear error instead of expanding the outer CTE without end (StackOverflowError / hang).
+WITH RECURSIVE q AS (
+    SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+    UNION ALL (
+        WITH RECURSIVE x AS (
+            SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+            UNION ALL (
+                SELECT employee_id, name, manager_id FROM q WHERE employee_id < 10
+                UNION ALL
+                SELECT employee_id, name, manager_id FROM x WHERE manager_id < 10
+            )
+        )
+        SELECT employee_id, name, manager_id FROM x
+    )
+)
+SELECT /*+ SET_VAR(enable_recursive_cte=true)*/ employee_id FROM q;
+
+-- Test 15: Error case - the recursive CTE q is referenced only inside a scalar subquery of its own
+-- recursive member (the member's FROM is a base table). That reference is resolved by the fresh
+-- QueryAnalyzer the subquery spawns, whose recursiveCteStack is empty, so it used to slip past the
+-- guard and expand q without end. It must be rejected. enable_recursive_cte is left at its default
+-- (false) so this exercises the QueryAnalyzer guard rather than the RecursiveCTEAstCheck path.
+WITH RECURSIVE q AS (
+    SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+    UNION ALL
+    SELECT employee_id, name, manager_id FROM employees WHERE employee_id < (SELECT max(employee_id) FROM q)
+)
+SELECT employee_id FROM q;
+
+-- Test 16: Error case - same, but the reference hides in an IN subquery instead of a scalar one.
+WITH RECURSIVE q AS (
+    SELECT employee_id, name, manager_id FROM employees WHERE manager_id IS NULL
+    UNION ALL
+    SELECT employee_id, name, manager_id FROM employees WHERE employee_id IN (SELECT employee_id FROM q)
+)
+SELECT employee_id FROM q;


### PR DESCRIPTION
## Why I'm doing:

The recursive-CTE analyzer tracked the CTE whose recursive member it was analyzing in a single String field, set on entry and cleared to null on exit. With one recursive CTE nested inside another, the inner CTE overwrote the outer name and then cleared it, so a reference from the inner recursive member back to the OUTER recursive CTE was never marked recursive. The table collectors (AnalyzerUtils.TableCollector / AstTraverser) then expanded that CTE's definition without end -- the outer CTE contains the inner, which references the outer again -- producing a StackOverflowError or an unbounded hang while planning:

  WITH RECURSIVE q AS (
    SELECT ... FROM t
    UNION ALL (
      WITH RECURSIVE x AS (
        SELECT ... FROM t
        UNION ALL (SELECT ... FROM q ... UNION ALL SELECT ... FROM x ...)
      ) SELECT ... FROM x
    )
  ) SELECT ... FROM q;

Referencing an outer recursive CTE from inside a nested CTE/subquery is not a form the executor supports (SQL standard and PostgreSQL reject it too). Track the in-progress recursive CTE names on a stack so nesting no longer loses the outer name, treat a reference to the innermost as the legal self-reference, and reject a reference to any outer one with a clear SemanticException instead of hanging.

Tests: RecursiveCTETest (FE unit, with a negative control) and a SQLTest case in test_cte/test_recursive_cte covering the same rejection.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
