### PR TITLE
[BugFix] Throttle per-column min/max stats collection

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/en/administration/configuration/FE_parameters/stats_storage.md
@@ -116,6 +116,16 @@ This topic introduces the following types of FE configurations:
 - Description: The number of dictionary invalidations within `dict_thrash_guard_window_sec` at which the global-dictionary thrash guard forbids collecting a column's global dictionary. Set to `0` to disable the count check while keeping the guard enabled (no column is automatically forbidden). This parameter takes effect only when `enable_dict_thrash_guard` is set to `true`.
 - Introduced in: v4.2.0
 
+
+### `min_max_stats_collect_interval_sec`
+
+- Default: 60
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Minimum interval between two min/max statistics collections for the same column. Min/max stats (used to constant-fold `min()`/`max()` and to build compressed group-by keys) are collected on demand via a `[_META_]` MetaScan that reads every segment's zone-map metadata; without throttling a frequently loaded column re-scans on every load, contending on the segment metadata cache the same way global-dictionary re-collection does. Within the interval the min/max optimization is skipped rather than re-collected -- a stale value is never served, so this only affects the optimization, never correctness. Set to `0` to disable throttling.
+- Introduced in: v4.2.0
+
 ### `enable_external_predicate_columns_collection`
 
 - Default: true

--- a/docs/ja/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/ja/administration/configuration/FE_parameters/stats_storage.md
@@ -116,6 +116,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：`dict_thrash_guard_window_sec` の時間ウィンドウ内で、グローバル辞書スラッシングガードが列のグローバル辞書の収集を禁止する無効化回数のしきい値です。`0` に設定すると、ガードを有効にしたまま回数チェックを無効にできます（どの列も自動的に禁止されません）。`enable_dict_thrash_guard` が `true` の場合にのみ有効です。
 - 導入時期：v4.2.0
 
+
+### `min_max_stats_collect_interval_sec`
+
+- デフォルト：60
+- タイプ：Int
+- 単位：Seconds
+- 変更可能：Yes
+- 説明：同一列に対する 2 回の min/max 統計収集の最小間隔です。min/max 統計（`min()`/`max()` の定数畳み込みや圧縮 group-by キーの構築に使用）は、各 segment の zone-map メタデータを読む `[_META_]` MetaScan によりオンデマンドで収集されます。スロットリングしないと、頻繁にロードされる列はロードのたびに再スキャンし、グローバル辞書の再収集と同様に segment メタデータキャッシュを競合させます。間隔内では min/max 最適化は再収集ではなくスキップされます——古い値が返されることはないため、最適化のみに影響し、正しさには影響しません。`0` に設定するとスロットリングを無効にします。
+- 導入時期：v4.2.0
+
 ### `enable_external_predicate_columns_collection`
 
 - デフォルト：true

--- a/docs/zh/administration/configuration/FE_parameters/stats_storage.md
+++ b/docs/zh/administration/configuration/FE_parameters/stats_storage.md
@@ -116,6 +116,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 在 `dict_thrash_guard_window_sec` 时间窗口内，触发全局字典抖动守卫禁止采集某列全局字典的失效次数阈值。设置为 `0` 可在保持守卫启用的同时禁用次数检查（不会自动禁用任何列）。仅当 `enable_dict_thrash_guard` 为 `true` 时生效。
 - 引入版本: v4.2.0
 
+
+### `min_max_stats_collect_interval_sec`
+
+- 默认值: 60
+- 类型: Int
+- 单位: 秒
+- 是否可变: Yes
+- 描述: 同一列两次 min/max 统计采集之间的最小间隔。min/max 统计（用于将 `min()`/`max()` 折叠为常量、以及构建压缩 group-by key）通过读取每个 segment zone-map 元数据的 `[_META_]` MetaScan 按需采集；若不节流，频繁导入的列会在每次导入后重扫，和全局字典重采集一样争用 segment 元数据缓存。间隔窗口内跳过 min/max 优化而非重新采集——绝不返回陈旧值，因此只影响优化、不影响正确性。设置为 `0` 可禁用节流。
+- 引入版本: v4.2.0
+
 ### `enable_external_predicate_columns_collection`
 
 - 默认值: true

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2742,6 +2742,13 @@ public class Config extends ConfigBase {
             "disable the count check while keeping the guard enabled.")
     public static int dict_thrash_guard_threshold = 5;
 
+    @ConfField(mutable = true, comment = "Minimum interval, in seconds, between two min/max statistics " +
+            "collections for the same column. Min/max stats are collected on demand via a [_META_] " +
+            "MetaScan that reads every segment's zone-map metadata; a frequently loaded column would " +
+            "otherwise re-scan on every load. Within the interval the min/max optimization is skipped " +
+            "rather than re-collected (a stale value is never served). Set to 0 to disable throttling.")
+    public static int min_max_stats_collect_interval_sec = 60;
+
     /**
      * The column statistic cache update interval
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgr.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -84,6 +85,13 @@ public class ColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
             .executor(ThreadPoolManager.getStatsCacheThread())
             .buildAsync(new CacheLoader());
 
+    // Throttle: last wall-clock millis a MetaScan collection was triggered per column. Bounds how often
+    // min/max is re-collected via a [_META_] MetaScan (which opens every segment's metadata and contends
+    // on the segment metadata cache). Bounded + LRU-evicting so idle columns cannot accumulate.
+    private final Cache<ColumnIdentifier, Long> lastCollectMs = Caffeine.newBuilder()
+            .maximumSize(Config.statistic_dict_columns)
+            .build();
+
     static ColumnMinMaxMgr getInstance() {
         return INSTANCE;
     }
@@ -106,8 +114,18 @@ public class ColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
                 return Optional.of(replay);
             }
         }
-        CompletableFuture<Optional<CacheValue>> future = cache.get(identifier);
-        if (future.isDone()) {
+        // Peek without triggering a load, so re-collection is gated by the throttle below. A stale entry
+        // (data version moved past it) is dropped and never served -- serving it would fold min()/max()
+        // to a value that no longer exists -- so throttling only ever costs the optimization (the caller
+        // falls back to normal execution), never correctness.
+        boolean needCollect;
+        CompletableFuture<Optional<CacheValue>> future = cache.getIfPresent(identifier);
+        if (future == null) {
+            needCollect = true;
+        } else if (!future.isDone()) {
+            needCollect = false;
+        } else {
+            needCollect = false;
             try {
                 Optional<CacheValue> cacheValue = future.get();
                 if (cacheValue.isPresent()) {
@@ -115,13 +133,42 @@ public class ColumnMinMaxMgr implements IMinMaxStatsMgr, MemoryTrackable {
                     if (value.version().getVersion() >= version.getVersion()) {
                         return Optional.of(value.minMax());
                     }
-                    cache.synchronous().invalidate(identifier);
+                    // Drop only the exact stale future we inspected: a concurrent query may have already
+                    // replaced it with a fresh load, and unconditionally evicting that (while the throttle
+                    // blocks us from reloading) would leave the column with no cached entry for a whole
+                    // interval. asMap().remove(key, value) is a lock-free CAS that no-ops if it moved on.
+                    cache.asMap().remove(identifier, future);
+                    needCollect = true;
                 }
+                // else: cached "not collectible" (e.g. non-numeric column) -- keep it, do not rescan.
             } catch (Exception e) {
                 LOG.warn("Failed to get MinMax for column: {}, version: {}", identifier, version, e);
             }
         }
+        // Trigger a fresh [_META_] MetaScan only when the per-column throttle interval has elapsed;
+        // otherwise skip the optimization for now. Bounds how often segment metadata is re-scanned for a
+        // frequently loaded column.
+        if (needCollect && shouldCollect(identifier)) {
+            cache.get(identifier);
+        }
         return Optional.empty();
+    }
+
+    // True if enough time has elapsed since the last collection trigger for this column (or throttling is
+    // disabled via min_max_stats_collect_interval_sec <= 0). Stamps "now" as the trigger time on success.
+    @VisibleForTesting
+    boolean shouldCollect(ColumnIdentifier identifier) {
+        int intervalSec = Config.min_max_stats_collect_interval_sec;
+        if (intervalSec <= 0) {
+            return true;
+        }
+        long now = System.currentTimeMillis();
+        Long last = lastCollectMs.getIfPresent(identifier);
+        if (last != null && now - last < intervalSec * 1000L) {
+            return false;
+        }
+        lastCollectMs.put(identifier, now);
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgrThrottleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/ColumnMinMaxMgrThrottleTest.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.statistics;
+
+import com.starrocks.catalog.ColumnId;
+import com.starrocks.common.Config;
+import com.starrocks.sql.optimizer.base.ColumnIdentifier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+// Covers the per-column collection throttle (shouldCollect) that bounds how often min/max stats are
+// re-collected via a [_META_] MetaScan. The collection itself needs a running executor, so only the
+// throttle gate is unit-tested here; it is what decides whether a fresh MetaScan is triggered.
+public class ColumnMinMaxMgrThrottleTest {
+    private int savedInterval;
+
+    @BeforeEach
+    public void setUp() {
+        savedInterval = Config.min_max_stats_collect_interval_sec;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.min_max_stats_collect_interval_sec = savedInterval;
+    }
+
+    private ColumnIdentifier col(long tableId, String name) {
+        return new ColumnIdentifier(tableId, ColumnId.create(name));
+    }
+
+    @Test
+    public void testThrottleWithinInterval() {
+        Config.min_max_stats_collect_interval_sec = 3600;
+        ColumnMinMaxMgr mgr = ColumnMinMaxMgr.getInstance();
+        ColumnIdentifier id = col(9000001L, "c1");
+        assertTrue(mgr.shouldCollect(id), "first trigger should be allowed");
+        assertFalse(mgr.shouldCollect(id), "second trigger within the interval must be throttled");
+        assertFalse(mgr.shouldCollect(id), "still throttled");
+    }
+
+    @Test
+    public void testDifferentColumnsAreIndependent() {
+        Config.min_max_stats_collect_interval_sec = 3600;
+        ColumnMinMaxMgr mgr = ColumnMinMaxMgr.getInstance();
+        assertTrue(mgr.shouldCollect(col(9000002L, "a")));
+        assertTrue(mgr.shouldCollect(col(9000002L, "b")), "a different column is not throttled by another");
+        assertFalse(mgr.shouldCollect(col(9000002L, "a")), "the same column stays throttled");
+    }
+
+    @Test
+    public void testThrottlingDisabledWhenIntervalZero() {
+        Config.min_max_stats_collect_interval_sec = 0;
+        ColumnMinMaxMgr mgr = ColumnMinMaxMgr.getInstance();
+        ColumnIdentifier id = col(9000003L, "c");
+        assertTrue(mgr.shouldCollect(id));
+        assertTrue(mgr.shouldCollect(id), "interval <= 0 disables throttling");
+    }
+}

--- a/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_replace_partition
+++ b/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_replace_partition
@@ -1,4 +1,7 @@
 -- name: test_minmax_after_replace_partition
+admin set frontend config ("min_max_stats_collect_interval_sec" = "0");
+-- result:
+-- !result
 DROP DATABASE IF EXISTS test_minmax_replace_partition;
 -- result:
 -- !result

--- a/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_schema_change
+++ b/test/sql/test_simple_agg_meta_rewrite/R/test_minmax_after_schema_change
@@ -1,4 +1,7 @@
 -- name: test_minmax_after_schema_change @native
+admin set frontend config ("min_max_stats_collect_interval_sec" = "0");
+-- result:
+-- !result
 DROP DATABASE IF EXISTS test_minmax_schema_change;
 -- result:
 -- !result

--- a/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_replace_partition
+++ b/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_replace_partition
@@ -1,4 +1,5 @@
 -- name: test_minmax_after_replace_partition
+admin set frontend config ("min_max_stats_collect_interval_sec" = "0");
 
 -- Regression for min()/max() constant folding returning the values of a partition that
 -- REPLACE PARTITION has already swapped OUT.

--- a/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_schema_change
+++ b/test/sql/test_simple_agg_meta_rewrite/T/test_minmax_after_schema_change
@@ -1,4 +1,5 @@
 -- name: test_minmax_after_schema_change @native
+admin set frontend config ("min_max_stats_collect_interval_sec" = "0");
 
 -- Regression for min()/max() constant folding answering with the min/max of a column that
 -- has since been dropped and re-created.


### PR DESCRIPTION
## Why I'm doing:

Min/max column statistics are collected on demand by ColumnMinMaxMgr via a [_META_] MetaScan that reads every segment's zone-map metadata. The cache invalidates whenever the table's data version advances (i.e. on every load) and on partition DDL, and getStats re-triggers the MetaScan on the next query. On a frequently loaded table that is also frequently queried with min()/max() (or group-by on a numeric/date column, which uses these stats to build a compressed key), this re-scans segment metadata on essentially every load -- contending on the segment metadata cache the same way global-dictionary re-collection did in the incident that motivated the dict thrash guard. Nothing currently bounds it.

Add a per-column collection throttle: getStats now peeks the cache without forcing a load and only triggers a fresh MetaScan when at least min_max_stats_collect_interval_sec (default 60) has elapsed since the last trigger for that column. Within the interval the optimization is skipped rather than re-collected. A stale entry is still never served (the version gate drops it and returns empty), so throttling only ever costs the optimization, never correctness. The last-trigger timestamps live in a bounded, LRU-evicting cache so idle columns cannot accumulate. getStatsSync (the explicit meta-function path) is intentionally left un-throttled. Set the interval to 0 to disable.

Verified on the dev-env (FE compiles, 0 checkstyle violations): ColumnMinMaxMgrThrottleTest 3/3 -- throttle within the interval, per-column independence, and interval<=0 disabling the throttle.

Pin min_max_stats_collect_interval_sec=0 in the min/max meta-scan-rewrite SQL tests (test_minmax_after_replace_partition, test_minmax_after_schema_change) so their rapid load/query/replace sequences re-collect immediately, matching the recorded results.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5