### PR TITLE
[BugFix] Keep the autovacuum retain floor at or above a reshard takeover

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -627,6 +627,7 @@ public class MergeTabletJob extends TabletReshardJob {
                 for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
                         .getReshardingIndexes().values()) {
                     MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
+                    newIndex.setTakeoverVersion(commitVersion);
                     physicalPartition.addMaterializedIndex(newIndex,
                             newIndex.getMetaId() == olapTable.getBaseIndexMetaId());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -925,6 +925,7 @@ public class SplitTabletJob extends TabletReshardJob {
                         physicalPartition.pinQueryableIndex(
                                 newIndex.getMetaId(), reshardingIndex.getMaterializedIndexId());
                     }
+                    newIndex.setTakeoverVersion(commitVersion);
                     physicalPartition.addMaterializedIndex(newIndex,
                             newIndex.getMetaId() == olapTable.getBaseIndexMetaId());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -112,6 +112,16 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
     @SerializedName(value = "shardGroupId")
     private long shardGroupId = PhysicalPartition.INVALID_SHARD_GROUP_ID;
 
+    // The partition version at which this index generation became the serving generation: the
+    // tablet split/merge commit version that installed it. 0 for a generation created with the
+    // partition and for any index not produced by a reshard, so a 0 here means "start of this
+    // partition's history" rather than "version 0". The tablets of this generation hold no
+    // metadata below it -- the retiring generation's last data version is takeoverVersion - 1 --
+    // which is what the autovacuum retain floor needs in order not to ask a backend to retain a
+    // version that does not exist for the tablets it is sending.
+    @SerializedName(value = "takeoverVersion")
+    private long takeoverVersion = 0;
+
     // If this is an index of LakeTable and the index state is SHADOW, all transactions
     // whose txn id is less than 'visibleTxnId' will ignore this index when sending
     // PublishVersionRequest requests to BE nodes.
@@ -197,6 +207,14 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
 
     public long getShardGroupId() {
         return shardGroupId;
+    }
+
+    public void setTakeoverVersion(long takeoverVersion) {
+        this.takeoverVersion = takeoverVersion;
+    }
+
+    public long getTakeoverVersion() {
+        return takeoverVersion;
     }
 
     public List<Tablet> getTablets() {
@@ -361,6 +379,7 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         buffer.append("index meta id: ").append(metaId).append("; ");
         buffer.append("index state: ").append(state.name()).append("; ");
         buffer.append("shardGroupId: ").append(shardGroupId).append("; ");
+        buffer.append("takeoverVersion: ").append(takeoverVersion).append("; ");
         buffer.append("row count: ").append(rowCount).append("; ");
         buffer.append("visibleTxnId: ").append(visibleTxnId).append("; ");
         buffer.append("tablets size: ").append(tablets.size()).append("; ");

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -287,6 +287,17 @@ public class AutovacuumDaemon extends LeaderDaemon {
                 minRetainVersion = Math.min(minRetainVersion, 
                                         partition.getVisibleVersion() - Config.lake_autovacuum_max_previous_versions);
             }
+            // Apply the same takeover clamp the request path applies, so scheduling is decided on the
+            // floor that will actually be sent. Without it a partition whose lastSuccVacuumVersion has
+            // already caught up with the lower unclamped floor is rejected here and never gets a round
+            // carrying the higher one. The OrNull variant is deliberate: this runs both under the
+            // collection's table read lock and lock-free from submitPendingCandidates, and a
+            // schedulability decision does not warrant taking a lock -- the request path re-reads the
+            // takeover under the table lock and remains authoritative.
+            MaterializedIndex latestBaseIndex = partition.getLatestBaseIndexOrNull();
+            if (latestBaseIndex != null && latestBaseIndex.getTakeoverVersion() > minRetainVersion) {
+                minRetainVersion = latestBaseIndex.getTakeoverVersion();
+            }
             // the file before minRetainVersion vacuum success
             if (partition.getLastSuccVacuumVersion() >= minRetainVersion) {
                 return false;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -377,6 +377,7 @@ public class AutovacuumDaemon extends LeaderDaemon {
         final long txnLogSweepWatermark = lastMinActiveTxnId;
         partition.setLastMinActiveTxnId(minActiveTxnId);
 
+        long baseGenerationTakeover = 0;
         long preExtraFileSize = 0;
         // If shared file cleanup is enabled, vacuum runs on a single aggregator node.
         Map<ComputeNode, List<TabletInfoPB>> nodeToTablets = new HashMap<>();
@@ -387,6 +388,10 @@ public class AutovacuumDaemon extends LeaderDaemon {
         try {
             for (MaterializedIndex index : partition.getMaterializedIndicesForVacuum(IndexExtState.VISIBLE)) {
                 tablets.addAll(index.getTablets());
+            }
+            MaterializedIndex latestBaseIndex = partition.getLatestBaseIndex();
+            if (latestBaseIndex != null) {
+                baseGenerationTakeover = latestBaseIndex.getTakeoverVersion();
             }
             visibleVersion = partition.getVisibleVersion();
             minRetainVersion = partition.getMinRetainVersion();
@@ -405,6 +410,24 @@ public class AutovacuumDaemon extends LeaderDaemon {
 
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
+
+        // Versions below the base generation's takeover do not exist for its tablets: a tablet
+        // created by a tablet split/merge has no metadata below the reshard commit version. Asking
+        // the backend to retain them is not merely vacuous -- the vacuum walk starts at the entry
+        // version and cannot anchor, so it steps down one version at a time paying a remote
+        // NotFound per step, records no resume cursor for an un-anchored walk, and contributes an
+        // empty range that the partition-level intersection turns into no progress for the whole
+        // partition, round after round. Clamp with the BASE generation only: raising the floor to a
+        // non-base index's newer takeover would un-retain base versions that are still wanted. A
+        // partition can also be PARTIALLY resharded (a split skips indexes whose tablets are all
+        // under the target size), so a live non-base index may still hold metadata below this
+        // clamp; that is safe because in-flight readers are grace-timestamp-protected on the
+        // backend. A non-base index whose tablets start above this floor can still stall the
+        // proposal -- that generic case needs per-tablet handling in the backend propose path and
+        // is out of scope here.
+        if (baseGenerationTakeover > minRetainVersion) {
+            minRetainVersion = baseGenerationTakeover;
         }
 
         boolean enableSharedFileCleanup = fileBundling || rangeDistribution;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -311,6 +311,46 @@ public class VacuumTest {
     }
 
     /**
+     * The scheduling check must use the clamped floor too. A partition whose lastSuccVacuumVersion has
+     * already caught up with the lower unclamped floor would otherwise be rejected before any round
+     * carrying the takeover floor is ever sent.
+     */
+    @Test
+    public void testShouldVacuumUsesTheClampedRetainFloor() throws Exception {
+        partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+        Assertions.assertNotNull(partition);
+        partition.setVisibleVersion(100L, System.currentTimeMillis());
+        partition.setMinRetainVersion(0L);
+        partition.setLastVacuumTime(0L);
+        // Vacuum has already reached the unclamped floor of max(1, 100 - 80) = 20.
+        partition.setLastSuccVacuumVersion(20L);
+
+        MaterializedIndex baseIndex = partition.getLatestBaseIndex();
+        long savedTakeover = baseIndex.getTakeoverVersion();
+        int savedMaxPrevious = Config.lake_autovacuum_max_previous_versions;
+        boolean savedDetect = Config.lake_autovacuum_detect_vaccumed_version;
+        try {
+            Config.lake_autovacuum_max_previous_versions = 80;
+            Config.lake_autovacuum_detect_vaccumed_version = true;
+            AutovacuumDaemon daemon = new AutovacuumDaemon();
+
+            baseIndex.setTakeoverVersion(0L);
+            Assertions.assertFalse(daemon.shouldVacuum(partition),
+                    "with the floor already vacuumed and no reshard, the partition must stay unscheduled");
+
+            baseIndex.setTakeoverVersion(30L);
+            Assertions.assertTrue(daemon.shouldVacuum(partition),
+                    "the takeover raises the floor above lastSuccVacuumVersion, so a round is still owed");
+        } finally {
+            Config.lake_autovacuum_detect_vaccumed_version = savedDetect;
+            Config.lake_autovacuum_max_previous_versions = savedMaxPrevious;
+            baseIndex.setTakeoverVersion(savedTakeover);
+            partition.setLastSuccVacuumVersion(0L);
+            partition.setLastVacuumTime(0L);
+        }
+    }
+
+    /**
      * Runs one vacuum round and returns the minRetainVersion it sent. The first round only seeds
      * lastMinActiveTxnId; a round runs for real once that value has a confirmed, non-decreasing
      * predecessor, so the seeding round is discarded here.

--- a/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/VacuumTest.java
@@ -275,6 +275,57 @@ public class VacuumTest {
         Assertions.assertTrue(round3.isEmpty(), "regression round must be skipped entirely");
     }
 
+    /**
+     * A tablet split/merge installs a new index generation at the reshard commit version, and its
+     * tablets hold no metadata below that version. The retain floor must therefore never be sent
+     * below the base generation's takeoverVersion, however low the configured floor is.
+     */
+    @Test
+    public void testAutovacuumClampsMinRetainVersionToBaseTakeoverVersion() throws Exception {
+        partition = olapTable.getPhysicalPartitions().stream().findFirst().orElse(null);
+        Assertions.assertNotNull(partition);
+        partition.setVisibleVersion(100L, System.currentTimeMillis());
+        // No explicit pin, so the floor comes from the config alone.
+        partition.setMinRetainVersion(0L);
+        partition.setLastSuccVacuumVersion(0L);
+
+        MaterializedIndex baseIndex = partition.getLatestBaseIndex();
+        long savedTakeover = baseIndex.getTakeoverVersion();
+        int savedMaxPrevious = Config.lake_autovacuum_max_previous_versions;
+        try {
+            // Floor becomes max(1, 100 - 80) = 20, i.e. below the reshard commit version below.
+            Config.lake_autovacuum_max_previous_versions = 80;
+
+            baseIndex.setTakeoverVersion(30L);
+            Assertions.assertEquals(30L, captureMinRetainVersion(),
+                    "the floor must be raised to the takeover: version 20 does not exist for these tablets");
+
+            baseIndex.setTakeoverVersion(0L);
+            Assertions.assertEquals(20L, captureMinRetainVersion(),
+                    "a generation that was not installed by a reshard must leave the floor alone");
+        } finally {
+            Config.lake_autovacuum_max_previous_versions = savedMaxPrevious;
+            baseIndex.setTakeoverVersion(savedTakeover);
+            partition.setLastVacuumTime(0L);
+        }
+    }
+
+    /**
+     * Runs one vacuum round and returns the minRetainVersion it sent. The first round only seeds
+     * lastMinActiveTxnId; a round runs for real once that value has a confirmed, non-decreasing
+     * predecessor, so the seeding round is discarded here.
+     */
+    private long captureMinRetainVersion() throws Exception {
+        partition.setLastVacuumTime(0L);
+        partition.setLastMinActiveTxnId(0L);
+        runVacuumCaptureRequests();
+        partition.setLastMinActiveTxnId(Math.max(1L, partition.getLastMinActiveTxnId() - 1));
+        partition.setLastVacuumTime(0L);
+        List<VacuumRequest> requests = runVacuumCaptureRequests();
+        Assertions.assertFalse(requests.isEmpty(), "the vacuum round must have sent a request");
+        return requests.get(0).minRetainVersion;
+    }
+
     private List<VacuumRequest> runVacuumCaptureRequests() throws Exception {
         VacuumResponse mockResponse = new VacuumResponse();
         mockResponse.status = new StatusPB();


### PR DESCRIPTION
## Why I'm doing:

After a tablet split or merge, the autovacuum retain floor can be sent below the version at which the new tablets begin to exist, and that stalls metadata vacuum for the whole partition.

A reshard installs a new materialized-index generation at its commit version S. The tablets of that generation hold no metadata below S — the retiring generation's last data version is S-1. Nothing stops the retain floor from landing below S: with no explicit pin the floor is `max(1, visibleVersion - lake_autovacuum_max_previous_versions)`, so any cluster running with `lake_autovacuum_max_previous_versions` above zero has a window right after a split where `visibleVersion - N < S`. A live `minRetainVersion` pin taken before the reshard and still held after it lands in the same place.

Asking a backend to retain a version that does not exist for the tablets in the request is not merely vacuous. In `collect_files_to_vacuum` the walk starts at the entry version and cannot anchor, so with a positive grace timestamp it steps down one version at a time toward the tablet's `min_version`, paying a remote `NotFound` per step. An un-anchored walk deliberately records no resume cursor, so the frontend never learns where the chain bottom is and the next round repeats the whole descent. Because the partition-level `vacuum_version_range` is an intersection, one tablet contributing an empty range turns the round into no progress for the entire partition, and a long enough descent can trip `check_vacuum_deadline` and fail the round outright. The symptom is silent: no error, no failed transaction — just metadata and garbage files that stop being reclaimed for that partition, plus a stream of wasted remote reads.

## What I'm doing:

Record where a generation starts, and never propose a retain floor below it.

- `MaterializedIndex` gains `takeoverVersion`: the partition version at which this generation became the serving generation, i.e. the reshard commit version that installed it. It is `0` for a generation created with the partition and for any index not produced by a reshard, so `0` means "start of this partition's history" rather than "version 0". Only the split and merge jobs set it, at the point where they install the new index.
- `AutovacuumDaemon` clamps the outgoing `minRetainVersion` up to the base generation's `takeoverVersion`, reading it inside the table read lock it already takes.

The clamp uses the base generation only. Raising the floor to a non-base index's newer takeover would un-retain base versions that are still wanted. A partition can also be partially resharded — a split skips indexes whose tablets are all under the target size — so a live non-base index may still hold metadata below the clamp; that is safe because in-flight readers are grace-timestamp-protected on the backend. A non-base index whose tablets all start above the floor can still stall the proposal; that generic case needs per-tablet handling in the backend propose path and is out of scope here.

There is a second floor computation in `shouldVacuum` (gated by `lake_autovacuum_detect_vaccumed_version`) that this PR deliberately leaves alone: it only decides whether the partition is worth scheduling, not what floor the request carries.

Test: `VacuumTest.testAutovacuumClampsMinRetainVersionToBaseTakeoverVersion` drives the reachable configuration — `visibleVersion` 100, no explicit pin, `lake_autovacuum_max_previous_versions` 80, so the floor computes to 20 — and asserts the request carries 30 when the base generation's takeover is 30, and still carries 20 when the takeover is 0. Without the clamp it fails with `expected: <30> but was: <20>`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
