### PR TITLE
[Tool] Unpack CI UT report tarballs outside the tracked source dirs

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -119,6 +119,10 @@ jobs:
       BASE_REF: ${{ needs.INFO.outputs.BASE_REF }}
       bucket_prefix: ${{ needs.INFO.outputs.BUCKET_PREFIX }}
       SKIP_COV: ${{ needs.INFO.outputs.SKIP_COV }}
+      # Scratch dir the FE UT tarball unpacks into. Deliberately NOT the repo's own `fe/`:
+      # that is a tracked path, so it survives `git clean` and collides. Untracked, so the
+      # CLEAN / Clean ENV steps clear it between runs.
+      FE_UT_UNPACK_DIR: fe-ut-report
     outputs:
       FE_INCREMENTAL_RESULT: ${{ steps.fe_incremental_check.outputs.fe_incremental_check }}
     steps:
@@ -133,7 +137,22 @@ jobs:
           size=$(ossutil64 --config-file ~/.ossutilconfig ls ${oss_path}/fe_ut_report.tar.gz | grep "Object Number is" | awk '{print $NF}')
           echo "size=${size}" >> $GITHUB_OUTPUT
           if [[ "$size" != "0" ]]; then
-            mkdir fe && cd fe
+            # Unpack into a dedicated scratch dir, NOT the repo's own `fe/`.
+            #
+            # This used to be `mkdir fe && cd fe`, which broke on any runner whose workspace
+            # still held a checkout: `fe` is a TRACKED directory, so it survives the
+            # `git clean -ffdxq` in CLEAN / Clean ENV, mkdir failed, the `cd` was skipped,
+            # and `set -e` did not abort (a non-final member of an && list is exempt). The
+            # tarball -- whose root is fe-core/... -- then unpacked into the workspace ROOT,
+            # so every consumer looked under fe/fe-core/... and found nothing: 0 surefire
+            # XMLs parsed, then `cp: cannot stat .../fe/fe-core/target/jacoco.exec`.
+            #
+            # A scratch name cannot collide with a tracked path, and being untracked it is
+            # cleared by `git clean -ffdxq` between runs -- so no stale jacoco.exec from a
+            # previous PR can be silently reused. The tarball carries the whole fe/ tree
+            # (sources included, see elastic-ut.sh: `cp -rf .../fe/* ${cov_dir}`), so this
+            # job needs nothing from the workspace checkout.
+            rm -rf ${FE_UT_UNPACK_DIR} && mkdir ${FE_UT_UNPACK_DIR} && cd ${FE_UT_UNPACK_DIR}
             ossutil64 --config-file ~/.ossutilconfig cp ${oss_path}/ . --recursive
             tar zxf fe_ut_report.tar.gz
           fi
@@ -159,13 +178,13 @@ jobs:
           detailed_summary: true
           fail_on_failure: true
           commit: ${{ github.event.workflow_run.head_sha }}
-          report_paths: ./fe/fe-core/target/surefire-reports/*.xml
+          report_paths: ./${{ env.FE_UT_UNPACK_DIR }}/fe-core/target/surefire-reports/*.xml
 
       - name: Merge FE Coverage
         id: merge_report
         if: steps.publish_report.outcome == 'success' && env.BASE_REF == 'main' && env.SKIP_COV != 'true'
         env:
-          fe_path: ${{ github.workspace }}/fe
+          fe_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}
         run: |
           export JAVA_HOME=/var/local/env/jdk1.8.0_202;
           export PATH=$JAVA_HOME/bin:$PATH;
@@ -189,8 +208,8 @@ jobs:
         id: generate-xml-report
         env:
           package_path: ${{ github.workspace }}/ci-tool/package
-          fe_path: ${{ github.workspace }}/fe
-          fe_core_path: ${{ github.workspace }}/fe/fe-core
+          fe_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}
+          fe_core_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}/fe-core
         if: steps.merge_report.outcome == 'success'
         run: |
           rm -rf result
@@ -211,7 +230,7 @@ jobs:
         if: steps.generate-xml-report.outcome == 'success'
         id: fe_incremental_check
         env:
-          fe_path: ${{ github.workspace }}/fe
+          fe_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}
         run: |
           rm -rf ./coverchecker && ln -s /var/local/env/coverchecker ./coverchecker && cd coverchecker && git pull
           export JAVA_HOME=/var/local/env/jdk1.8.0_202;
@@ -456,6 +475,8 @@ jobs:
       PR_NUMBER: ${{ needs.INFO.outputs.PR_NUMBER }}
       BASE_REF: ${{ needs.INFO.outputs.BASE_REF }}
       bucket_prefix: ${{ needs.INFO.outputs.BUCKET_PREFIX }}
+      # Scratch dir, deliberately not the tracked `java-extensions/`. See FE_UT_UNPACK_DIR.
+      JAVA_EXT_UT_UNPACK_DIR: java-extensions-ut-report
     steps:
       - name: CLEAN
         run: |
@@ -468,7 +489,10 @@ jobs:
           size=$(ossutil64 --config-file ~/.ossutilconfig ls ${oss_path}/java_extension_ut_report.tar.gz | grep "Object Number is" | awk '{print $NF}')
           echo "size=${size}" >> $GITHUB_OUTPUT
           if [[ "$size" != "0" ]]; then
-            mkdir java-extensions && cd java-extensions
+            # Same defect as the FE report above: `java-extensions` is a TRACKED repo
+            # directory, so it survives `git clean`, mkdir fails, and the `cd` is silently
+            # skipped. Unpack into a scratch dir that cannot collide with a tracked path.
+            rm -rf ${JAVA_EXT_UT_UNPACK_DIR} && mkdir ${JAVA_EXT_UT_UNPACK_DIR} && cd ${JAVA_EXT_UT_UNPACK_DIR}
             ossutil64 --config-file ~/.ossutilconfig cp ${oss_path}/java_extension_ut_report.tar.gz . --recursive
             tar zxf java_extension_ut_report.tar.gz
           elif [[ "${BASE_REF}" == "main" ]]; then
@@ -493,13 +517,13 @@ jobs:
           detailed_summary: true
           fail_on_failure: true
           commit: ${{ github.event.workflow_run.head_sha }}
-          report_paths: ./java-extensions/xml_dir/*.xml
+          report_paths: ./${{ env.JAVA_EXT_UT_UNPACK_DIR }}/xml_dir/*.xml
 
       # Incremental Total Coverage
       - name: Publish Incremental Coverage Report - Total
         if: steps.publish_report.outcome == 'success' && env.BASE_REF == 'main'
         env:
-          code_path: ${{ github.workspace }}/java-extensions
+          code_path: ${{ github.workspace }}/${{ env.JAVA_EXT_UT_UNPACK_DIR }}
         run: |
           rm -rf ./coverchecker && ln -s /var/local/env/coverchecker ./coverchecker && cd coverchecker && git pull
           export JAVA_HOME=/var/local/env/jdk1.8.0_202;

--- a/.github/workflows/inspection-fe-coverage.yml
+++ b/.github/workflows/inspection-fe-coverage.yml
@@ -49,6 +49,9 @@ jobs:
     env:
       OSS_CMD: "ossutil64 --config-file /root/.ossutilconfig"
       JAVA_HOME: /var/local/env/jdk1.8.0_202
+      # Scratch dir the FE UT tarball unpacks into. Deliberately NOT the repo's own `fe/`,
+      # which is tracked and so survives `git clean`. See ci-report.yml.
+      FE_UT_UNPACK_DIR: fe-ut-report
     outputs:
       FE_COV_RES_FILE: ${{ steps.incremental_cov_report.outputs.FE_COV_RES_FILE }}
 
@@ -70,14 +73,17 @@ jobs:
             echo "::error::FE UT result not exit!"
             exit 1
           fi
-          mkdir fe && cd fe
+          # Unpack into a scratch dir, not the tracked `fe/`: that survives
+          # `git clean -ffdxq`, so a bare mkdir fails and the `cd` is skipped without
+          # tripping `set -e`, unpacking into the workspace root. See ci-report.yml.
+          rm -rf ${FE_UT_UNPACK_DIR} && mkdir ${FE_UT_UNPACK_DIR} && cd ${FE_UT_UNPACK_DIR}
           ${OSS_CMD} cp ${oss_path}/ . --recursive
           tar zxf fe_ut_report.tar.gz
 
       - name: Merge FE Coverage
         id: merge_report
         env:
-          fe_path: ${{ github.workspace }}/fe
+          fe_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}
         run: |
           export PATH=$JAVA_HOME/bin:$PATH;
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull && source lib/init.sh
@@ -91,8 +97,8 @@ jobs:
         id: generate-xml-report
         env:
           package_path: ${{ github.workspace }}/ci-tool/package
-          fe_path: ${{ github.workspace }}/fe
-          fe_core_path: ${{ github.workspace }}/fe/fe-core
+          fe_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}
+          fe_core_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}/fe-core
         run: |
           rm -rf result
           export PATH=$JAVA_HOME/bin:$PATH;
@@ -109,7 +115,7 @@ jobs:
       - name: Incremental Coverage Report - Total
         id: incremental_cov_report
         env:
-          fe_path: ${{ github.workspace }}/fe
+          fe_path: ${{ github.workspace }}/${{ env.FE_UT_UNPACK_DIR }}
         run: |
           rm -rf ./coverchecker && ln -s /var/local/env/coverchecker ./coverchecker && cd coverchecker && git pull
           export PATH=$JAVA_HOME/bin:$PATH;

--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -216,6 +216,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BRANCH: ${{ needs.info.outputs.BRANCH }}
       PR_NUMBER: ${{ needs.info.outputs.PR_NUMBER }}
+      # Scratch dir the FE UT tarball unpacks into. Deliberately NOT the repo's own `fe/`,
+      # which is tracked and so survives `git clean`. See ci-report.yml.
+      FE_UT_UNPACK_DIR: fe-ut-report
     steps:
       - name: clean
         run: |
@@ -261,7 +264,10 @@ jobs:
         env:
           oss_path: ${{ steps.run_ut.outputs.oss_path }}
         run: |
-          mkdir fe && cd fe
+          # Unpack into a scratch dir, not the tracked `fe/`: that survives
+          # `git clean -ffdxq`, so a bare mkdir fails and the `cd` is skipped without
+          # tripping `set -e`, unpacking into the workspace root. See ci-report.yml.
+          rm -rf ${FE_UT_UNPACK_DIR} && mkdir ${FE_UT_UNPACK_DIR} && cd ${FE_UT_UNPACK_DIR}
           ossutil64 --config-file ~/.ossutilconfig cp ${oss_path}/ . --recursive
           tar zxf fe_ut_report.tar.gz
 
@@ -276,7 +282,7 @@ jobs:
           check_name: 'FE UT Report'
           detailed_summary: true
           fail_on_failure: true
-          report_paths: ./fe/fe-core/target/surefire-reports/*.xml
+          report_paths: ./${{ env.FE_UT_UNPACK_DIR }}/fe-core/target/surefire-reports/*.xml
 
       - name: Clean ENV
         if: always() && (steps.run_ut.outcome == 'success' || steps.run_ut.outcome == 'failure')


### PR DESCRIPTION
The FE and Java-extension report jobs downloaded their UT tarball with `mkdir fe && cd fe` (and `mkdir java-extensions && cd java-extensions`). Both names are tracked repo directories, so they survive the `git clean -ffdxq` in the CLEAN / Clean ENV steps on any runner whose workspace still holds a checkout. mkdir then failed and the `cd` was skipped, and `set -e` did not abort because a non-final member of an && list is exempt from it. The tarball, whose root is fe-core/..., therefore unpacked into the workspace root, so every consumer looked under fe/fe-core/... and found nothing: 0 surefire XMLs parsed, no testsuites reported, and finally `cp: cannot stat .../fe/fe-core/target/jacoco.exec` in Merge FE Coverage, three steps after the actual cause. This is why the break looked intermittent -- only `fe` and `java-extensions` collide, being the only scratch names that are tracked and so survive the clean; the other scratch dirs are untracked and get removed.

Unpack into dedicated untracked scratch directories instead, and repoint the consumers at them. A scratch name cannot collide with a tracked path, and because it is untracked the existing clean steps clear it between runs, so no stale jacoco.exec from a previous PR can be silently reused. This is preferred over `mkdir -p`, which would overlay the tarball onto the tracked sources and leave freshness depending on `git clean -x` having succeeded, and over removing `fe` outright, which would delete tracked sources from a shared workspace. It is safe because the tarball already carries the whole fe/ tree including sources (elastic-ut.sh copies fe/* into cov_dir), so these report jobs need nothing from the workspace checkout.

The new variables are named *_UT_UNPACK_DIR rather than FE_REPORT_DIR, which is already an unrelated `run_ut` step output naming the directory that holds the surefire XMLs. SONAR_FE_CHECKER keeps using the repo's own fe/, since it does its own checkout and builds FE with maven.

ci-report.yml is triggered by workflow_run and so always runs from the default branch; it takes effect only once merged to main.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
