### PR TITLE
[Doc] Add the JDK support policy

### DIFF
--- a/docs/en/deployment/preparation/environment_configurations.md
+++ b/docs/en/deployment/preparation/environment_configurations.md
@@ -114,6 +114,7 @@ Additional notes:
 - The FE compile target was raised from Java 11 to Java 17 in v3.5.0, which is why v3.5 and later require JDK 17 or later at runtime.
 - As of v3.5.0, StarRocks no longer ships JVM presets for specific JDK versions; all JDK versions share a single `JAVA_OPTS`. When upgrading to v3.5 or later from v3.4 or earlier, remove any `JAVA_OPTS` options in **fe.conf** that are incompatible with JDK 17 (for example, CMS-related options), and use the default `JAVA_OPTS` shipped with v3.5 and later.
 - Starting with v4.2, JDK 21 is recommended. The minimum runtime version remains JDK 17 (the FE compile target is Java 17), and JDK 21 is backward-compatible with the JDK 17 runtime target.
+- The minimum and recommended JDK follow the Java LTS calendar. The next change is scheduled for the first minor version released after October 2027, when the minimum JDK becomes JDK 21 and the recommended JDK becomes JDK 25. For details, see [JDK Support Policy](../../developers/versions.md#jdk-support-policy).
 
 :::note
 StarRocks does not support JRE. You must install a full JDK.

--- a/docs/en/developers/versions.md
+++ b/docs/en/developers/versions.md
@@ -81,3 +81,37 @@ The minor version status will change with some baseline triggers, as shown below
   - 5.3 is in the `bugfix-only` state
   - 5.2 is also in the `bugfix-only` state
   - 5.1 is in the `code-freeze` state
+
+## JDK Support Policy
+
+StarRocks FE, BE, and CN nodes depend on a JDK. The JDK versions that StarRocks requires and recommends follow the Java LTS calendar published by [Eclipse Adoptium](https://adoptium.net/support), not StarRocks version numbers. For the JDK versions of each StarRocks version, see [JDK version by StarRocks version](../deployment/preparation/environment_configurations.md#jdk-version-by-starrocks-version).
+
+Each StarRocks minor version defines two JDK versions:
+
+- **Minimum JDK**: the oldest Java LTS release that Adoptium still builds. The FE does not start on an older JDK. The BE and CN log an error on an older JDK, and Java-dependent features such as Java UDFs and JNI-based connectors are not supported on it.
+- **Recommended JDK**: the next Java LTS release. It is the JDK that the official container images ship, and it becomes the minimum JDK at the next change. Starting on a JDK that is older than the recommended JDK prints a deprecation warning that names the recommended JDK.
+
+Java LTS releases newer than the recommended JDK are not yet covered by this policy. They usually work but are not tested. Non-LTS Java releases are not supported.
+
+Currently, the minimum JDK is JDK 17 and the recommended JDK is JDK 21.
+
+### When the minimum JDK changes
+
+- The minimum JDK changes when the current minimum reaches its end of availability on Adoptium. At that point, the previous recommended JDK becomes the minimum, and the next Java LTS release becomes the recommended JDK.
+- The recommended JDK is published one full cycle before it becomes the minimum, so you get about two years of notice through this policy, the JDK matrix, and the startup warning.
+- The change takes effect in the first minor version released after the date, and only if the previous minor version already printed the startup warning for the new minimum. Otherwise, the change moves to the next minor version.
+- A minor version keeps its minimum and recommended JDK for its whole life. A patch version never raises the minimum JDK, so upgrading to a patch version never requires a JDK upgrade. Support for a newer JDK can be added to an existing minor version in a patch version.
+
+### Schedule
+
+| Effective from | Minimum JDK | Recommended JDK | Reason |
+| --- | --- | --- | --- |
+| Oct 2027 | JDK 21 | JDK 25 | Java 17 reaches end of availability |
+| Dec 2029 | JDK 25 | JDK 29 | Java 21 reaches end of availability |
+| Sep 2031 | JDK 29 | JDK 33 | Java 25 reaches end of availability |
+
+The dates are the end-of-availability dates published by Adoptium, which Adoptium states as "at least". They are fixed: if Adoptium later extends the availability of a Java version, the schedule does not change. Java 29 and Java 33 assume that Adoptium continues to designate an LTS release every two years.
+
+### Components that run in another JVM
+
+The Spark Load DPP library, the Hive Bitmap UDF library, and the Broker run inside another system's JVM. They target Java 8 and follow the JDK requirements of that system, not this policy.

--- a/docs/ja/deployment/preparation/environment_configurations.md
+++ b/docs/ja/deployment/preparation/environment_configurations.md
@@ -114,6 +114,7 @@ StarRocks の Java コンポーネントは JDK 上で動作します。Java コ
 - FE のコンパイルターゲットは v3.5.0 で Java 11 から Java 17 に引き上げられました。このため、v3.5 以降では実行時に JDK 17 以降が必要です。
 - v3.5.0 以降、StarRocks は特定の JDK バージョン向けの JVM プリセットを提供しなくなり、すべての JDK バージョンで単一の `JAVA_OPTS` を共有します。v3.4 以前から v3.5 以降にアップグレードする際は、**fe.conf** 内の JDK 17 と互換性のない `JAVA_OPTS` オプション（例: CMS 関連のオプション）を削除し、v3.5 以降に同梱されるデフォルトの `JAVA_OPTS` を使用してください。
 - v4.2 以降では JDK 21 が推奨されます。実行時の最小バージョンは JDK 17 のままです（FE のコンパイルターゲットは Java 17）。JDK 21 は JDK 17 の実行時ターゲットと後方互換性があります。
+- 最小 JDK と推奨 JDK は Java LTS カレンダーに従います。次回の変更は 2027 年 10 月以降に最初にリリースされるマイナーバージョンで予定されており、最小 JDK は JDK 21、推奨 JDK は JDK 25 になります。詳細は [JDK Support Policy](../../developers/versions.md#jdk-support-policy) を参照してください。
 
 :::note
 StarRocks は JRE をサポートしていません。完全な JDK をインストールする必要があります。

--- a/docs/ja/developers/versions.md
+++ b/docs/ja/developers/versions.md
@@ -81,3 +81,37 @@ bugfix-only
   - 5.3 は `bugfix-only` 状態です
   - 5.2 も `bugfix-only` 状態です
   - 5.1 は `code-freeze` 状態です
+
+## JDK Support Policy
+
+StarRocks の FE、BE、CN ノードは JDK に依存して動作します。StarRocks が要求および推奨する JDK バージョンは、StarRocks のバージョン番号ではなく、[Eclipse Adoptium](https://adoptium.net/support) が公開する Java LTS カレンダーに従います。StarRocks バージョンごとの JDK バージョンについては、[環境設定](../deployment/preparation/environment_configurations.md) を参照してください。
+
+各 StarRocks マイナーバージョンは、次の 2 つの JDK バージョンを定義します。
+
+- **最小 JDK**: Adoptium がまだビルドしている最も古い Java LTS リリースです。FE はこれより古い JDK では起動しません。BE と CN はこれより古い JDK ではエラーを記録し、Java UDF や JNI ベースのコネクタなど Java に依存する機能はサポートされません。
+- **推奨 JDK**: 次の Java LTS リリースです。公式コンテナイメージに同梱される JDK であり、次回の変更時に最小 JDK になります。推奨 JDK より古い JDK で起動すると、推奨 JDK のバージョンを示す非推奨警告が出力されます。
+
+推奨 JDK より新しい Java LTS リリースは、まだこのポリシーの対象外です。通常は動作しますが、テストされていません。非 LTS の Java リリースはサポートされません。
+
+現在、最小 JDK は JDK 17、推奨 JDK は JDK 21 です。
+
+### When the minimum JDK changes
+
+- 最小 JDK は、現在の最小 JDK が Adoptium での提供終了 (End of Availability) に達したときに変更されます。その時点で、それまでの推奨 JDK が最小 JDK になり、次の Java LTS リリースが推奨 JDK になります。
+- 推奨 JDK は最小 JDK になる 1 サイクル前に公開されるため、このポリシー、JDK バージョン表、および起動時の警告を通じて約 2 年前に通知されます。
+- 変更は、その日付以降に最初にリリースされるマイナーバージョンで有効になります。ただし、前のマイナーバージョンが新しい最小 JDK に関する起動時の警告をすでに出力している場合に限ります。そうでない場合、変更は次のマイナーバージョンに繰り越されます。
+- マイナーバージョンは、そのライフサイクル全体で最小 JDK と推奨 JDK を維持します。パッチバージョンが最小 JDK を引き上げることはないため、パッチバージョンへのアップグレードで JDK のアップグレードが必要になることはありません。新しい JDK のサポートは、パッチバージョンで既存のマイナーバージョンに追加されることがあります。
+
+### Schedule
+
+| 適用開始 | 最小 JDK | 推奨 JDK | 理由 |
+| --- | --- | --- | --- |
+| 2027 年 10 月 | JDK 21 | JDK 25 | Java 17 の提供終了 |
+| 2029 年 12 月 | JDK 25 | JDK 29 | Java 21 の提供終了 |
+| 2031 年 9 月 | JDK 29 | JDK 33 | Java 25 の提供終了 |
+
+これらの日付は Adoptium が公開している提供終了日で、Adoptium は「少なくとも (at least)」この日付までと表記しています。これらの日付は固定です。Adoptium が後にある Java バージョンの提供期間を延長しても、スケジュールは変わりません。Java 29 と Java 33 は、Adoptium が引き続き 2 年ごとに LTS リリースを指定することを前提としています。
+
+### Components that run in another JVM
+
+Spark Load の DPP ライブラリ、Hive Bitmap UDF ライブラリ、および Broker は、他のシステムの JVM 内で動作します。これらは Java 8 をターゲットとし、このポリシーではなく、そのシステムの JDK 要件に従います。

--- a/docs/zh/deployment/preparation/environment_configurations.md
+++ b/docs/zh/deployment/preparation/environment_configurations.md
@@ -114,6 +114,7 @@ StarRocks 的 Java 组件运行在 JDK 之上。这些 Java 组件包括：
 - FE 的编译目标在 v3.5.0 中从 Java 11 提升到 Java 17，因此 v3.5 及以后版本在运行时需要 JDK 17 或更高版本。
 - 从 v3.5.0 起，StarRocks 不再为特定 JDK 版本提供各自的 JVM 预设；所有 JDK 版本共用同一份 `JAVA_OPTS`。当从 v3.4 或更早版本升级到 v3.5 及以后版本时，请移除 **fe.conf** 中与 JDK 17 不兼容的 `JAVA_OPTS` 选项（例如 CMS 相关选项），并使用 v3.5 及以后版本自带的默认 `JAVA_OPTS`。
 - 从 v4.2 起，推荐使用 JDK 21。运行时的最低版本仍为 JDK 17（FE 的编译目标为 Java 17）；JDK 21 向后兼容 JDK 17 运行时目标。
+- 最低 JDK 和推荐 JDK 遵循 Java LTS 日历。下一次变更计划在 2027 年 10 月之后发布的第一个次版本中生效，届时最低 JDK 将变为 JDK 21，推荐 JDK 将变为 JDK 25。详情请参阅[版本发布指南](../../developers/versions.md)。
 
 :::note
 StarRocks 不支持 JRE。您必须安装完整的 JDK。

--- a/docs/zh/developers/versions.md
+++ b/docs/zh/developers/versions.md
@@ -81,3 +81,37 @@ bugfix-only
   - 5.3 处于 `bugfix-only` 状态
   - 5.2 也处于 `bugfix-only` 状态
   - 5.1 处于 `code-freeze` 状态
+
+## JDK 支持策略
+
+StarRocks 的 FE、BE 和 CN 节点依赖 JDK 运行。StarRocks 要求和推荐的 JDK 版本遵循 [Eclipse Adoptium](https://adoptium.net/support) 发布的 Java LTS 日历，而不是 StarRocks 的版本号。各 StarRocks 版本对应的 JDK 版本，请参阅[环境配置](../deployment/preparation/environment_configurations.md)。
+
+每个 StarRocks 次版本定义两个 JDK 版本：
+
+- **最低 JDK**：Adoptium 仍在构建的最旧 Java LTS 版本。FE 无法在更低版本的 JDK 上启动。BE 和 CN 在更低版本的 JDK 上会记录错误，且 Java UDF、基于 JNI 的 Connector 等依赖 Java 的功能不受支持。
+- **推荐 JDK**：下一个 Java LTS 版本。官方容器镜像使用该 JDK，并且在下一次变更时它将成为最低 JDK。使用低于推荐 JDK 的版本启动时，会打印弃用警告并指明推荐的 JDK 版本。
+
+比推荐 JDK 更新的 Java LTS 版本尚不在本策略覆盖范围内。它们通常可以正常运行，但未经测试。非 LTS 的 Java 版本不受支持。
+
+当前最低 JDK 为 JDK 17，推荐 JDK 为 JDK 21。
+
+### 最低 JDK 何时变更
+
+- 当前最低 JDK 在 Adoptium 上到达可用期结束（End of Availability）时，最低 JDK 发生变更。此时，原推荐 JDK 成为最低 JDK，下一个 Java LTS 版本成为推荐 JDK。
+- 推荐 JDK 会在成为最低 JDK 之前整整一个周期公布，因此您可以通过本策略、JDK 版本对照表和启动警告获得约两年的提前通知。
+- 变更在该日期之后发布的第一个次版本中生效，且前提是上一个次版本已经针对新的最低 JDK 打印了启动警告。否则，变更推迟到下一个次版本。
+- 一个次版本在其整个生命周期内保持相同的最低 JDK 和推荐 JDK。补丁版本永不提高最低 JDK，因此升级补丁版本永不需要升级 JDK。对更新 JDK 的支持可以通过补丁版本添加到现有次版本中。
+
+### 时间表
+
+| 生效时间 | 最低 JDK | 推荐 JDK | 原因 |
+| --- | --- | --- | --- |
+| 2027 年 10 月 | JDK 21 | JDK 25 | Java 17 可用期结束 |
+| 2029 年 12 月 | JDK 25 | JDK 29 | Java 21 可用期结束 |
+| 2031 年 9 月 | JDK 29 | JDK 33 | Java 25 可用期结束 |
+
+以上日期为 Adoptium 公布的可用期结束日期（Adoptium 注明为 "at least"，即不早于该日期）。这些日期是固定的：即使 Adoptium 之后延长某个 Java 版本的可用期，时间表也不会改变。Java 29 和 Java 33 假定 Adoptium 继续每两年指定一个 LTS 版本。
+
+### 在其他 JVM 中运行的组件
+
+Spark Load 的 DPP 库、Hive Bitmap UDF 库和 Broker 运行在其他系统的 JVM 中。它们以 Java 8 为目标，遵循所在系统的 JDK 要求，不适用本策略。

--- a/handbook/policies/index.md
+++ b/handbook/policies/index.md
@@ -7,3 +7,4 @@ Use these pages for repo-local operating rules that should remain stable, discov
 - [Reliability First](reliability-first.md): optimize for trustworthy signals before throughput.
 - [Internal vs Public Docs](internal-vs-public-docs.md): decide whether guidance belongs in `handbook/` or `docs/`.
 - [Agent Change Flow](agent-change-flow.md): expected loop for repo-local planning, validation, and human merge authority.
+- [JDK Support Policy](jdk-support-policy.md): derive the required and recommended JDK from the Java LTS calendar; rules, shift chain, and the floor-raise checklist.

--- a/handbook/policies/jdk-support-policy.md
+++ b/handbook/policies/jdk-support-policy.md
@@ -1,0 +1,150 @@
+# JDK Support Policy
+
+## Intent
+
+Derive the JDK versions StarRocks requires and recommends from the Java LTS calendar, not from StarRocks release numbers, so that every floor raise is announced a full cycle ahead and the required JDK is always still being built.
+
+StarRocks has moved its JDK floor three times: JDK 8 to 11 in v3.3, 11 to 17 in v3.5, and a JDK 21 recommendation on `main` (v4.2). Each move was right and each arrived as a surprise. A schedule of StarRocks release numbers cannot fix that, because release dates are not knowable far enough ahead to promise anything. The Java LTS calendar is published years ahead, so the policy anchors to it.
+
+The policy fixes two integers per release, the same two that `bin/start_fe.sh` and `bin/start_backend.sh` already sort JDKs by:
+
+- `MIN_JDK_VERSION`: below it, startup fails.
+- `RECOMMENDED_JDK_VERSION`: below it, startup warns that support will be removed.
+
+What the policy adds is the dates on which those integers change, and one commitment: recommended is the next minimum.
+
+## Applies To
+
+- The FE JVM: every module compiled at the FE target (`fe/fe-core/pom.xml` and the sibling `fe/fe-*` modules).
+- The BE and CN embedded JVM used for Java UDFs, connectors, and JNI readers (`bin/start_backend.sh`; `bin/start_cn.sh` delegates to it).
+- `java-extensions/` (`java.version` in `java-extensions/pom.xml`).
+- The startup checks in `bin/start_fe.sh` and `bin/start_backend.sh`.
+- Container images under `docker/dockerfiles/`.
+- The public JDK matrix in `docs/{en,zh,ja}/deployment/preparation/environment_configurations.md` and the JDK lines in `docs/{en,zh,ja}/deployment/preparation/deployment_prerequisites.md`.
+- Release notes for any minor that changes either integer.
+
+Artifacts that run inside a foreign JVM are governed by the Exceptions section, not by the ladder.
+
+## The Rule
+
+Three LTS versions are live at any time, and exactly two of them carry a promise. An LTS arrives as the **edge**, with nothing promised about it. It becomes the **recommendation** when the LTS two generations older stops being built, becomes the **minimum** when the previous LTS stops being built, and is **retired when it stops being built** itself.
+
+```
+minimum      = previous LTS end  ->  own LTS end
+recommended  = the next LTS      =   the next minimum
+edge         = any newer LTS, no commitment
+today        = min 17, rec 21    (Sep 2025 - Oct 2027)
+```
+
+Both ends of the minimum rung are LTS end dates, which makes the invariant exact: the minimum is always the oldest LTS still being built. One version hands the floor to the next at the instant it stops shipping. There are never two minimums at once, never an interval with none, and never a version required after its last build.
+
+A rung is therefore as long as the gap between two consecutive LTS end dates. That is nominally two years, because LTS releases land two years apart, but the published calendar gives 25, 26, and 21 months for Java 17, 21, and 25. The rung stretches or compresses; it never gaps or overlaps.
+
+### Why LTS end dates and not GA plus a constant
+
+A GA-anchored ladder needs a number: require an LTS at GA plus 42 months, or 48. The offset it implies is not constant, so any fixed choice tears at the seams:
+
+| LTS | GA | LTS end | Minimum rung | Length | A fixed two-year rung would |
+| --- | --- | --- | --- | --- | --- |
+| 17 | Sep 2021 | Oct 2027 | Sep 2025 - Oct 2027 | 25 mo | start Oct 2025, a month late |
+| 21 | Sep 2023 | Dec 2029 | Oct 2027 - Dec 2029 | 26 mo | start Dec 2027, leaving 2 months with no minimum |
+| 25 | Sep 2025 | Sep 2031 | Dec 2029 - Sep 2031 | 21 mo | start Sep 2029, giving 3 months with two minimums |
+
+Those are the two states a floor policy must never have: an interval where no version is the minimum, and an interval where two are. Aligning the rung to the previous LTS's end closes both by construction.
+
+End anchoring also keeps the full upgrade runway. A GA-plus-42-months rule would end Java 17 support in Mar 2027, seven months before the last Temurin 17 build ships, and would need its margin re-checked every cycle in case it goes negative. And it degrades safely in the case that actually worries us: Adoptium guarantees four years per LTS and has been publishing six. If some future LTS gets only four, a GA-anchored floor would require it for months after its builds stopped. End-anchored, the unpromised edge span absorbs the shortfall while the recommended and minimum rungs keep their full length. Operators never lose notice; the project loses lead time, which is the right place for the loss to land.
+
+The policy has no tunable parameter. The LTS cadence sets the nominal rung length, the LTS lifetime sets the rung count, and the published end dates set every boundary.
+
+## Version States
+
+| State | Window | Meaning |
+| --- | --- | --- |
+| Edge | GA until the start of its recommended rung | Any LTS newer than the recommendation: normally one, briefly two between a new LTS GA and the following shift. Not required, not recommended, not promised. It usually runs, since it is above the recommendation, but the policy claims nothing about it yet. |
+| Recommended | Until the previous LTS's end date | What the Ubuntu images ship, what the docs lead with, and what the startup warning names as the incoming floor. Published as the next minimum a full rung before it becomes one. |
+| Minimum | Previous LTS end date until its own | Required. The FE compile target equals it. The FE refuses to start below it with an actionable message. The BE and CN treat Java as optional, so they log an error and start; Java-dependent features are unsupported there. It holds the floor for exactly as long as it is the oldest LTS still built. |
+| Retired | After its own LTS end date | Off the ladder at the moment its last build ships. Existing release branches keep working; their floor was frozen at GA. |
+
+Only the middle two carry promises, and both are already implemented by the start scripts. The first states what the policy does not yet claim; the last, what it no longer does.
+
+## Rules
+
+1. **R1: Every rung boundary is an LTS end date.** An LTS is the minimum from the previous LTS's end until its own, the recommendation for the rung before that, and the edge from GA until then. Dates come from Adoptium's published end of availability, so the ladder is recomputed, never renegotiated, when a date is published or revised.
+2. **R2: The minimum is the oldest LTS still being built.** This is R1 restated as the invariant to test against. At every instant exactly one LTS is the minimum, it is still downloadable, and the handover happens at the instant the previous one stops shipping. A change that would create two minimums, none, or a required version with no builds is wrong regardless of what else recommends it.
+3. **R3: Recommended is the next minimum.** Publishing a recommendation commits the project to making that version the floor at the next shift. This is what lets the deprecation warning name a concrete version a full rung ahead, and why the container images ship the recommended JDK rather than the minimum one. A version may not be published as recommended until it is green in CI.
+4. **R4: A rung is as long as the gap between two LTS ends.** Nominally two years, because LTS releases land two years apart, but the published calendar gives 25, 26, and 21 months for Java 17, 21, and 25. The rung stretches or compresses; the boundaries do not move. The next three shifts are Oct 2027, Dec 2029, and Sep 2031, and each falls within a quarter of a new LTS GA, which is the cross-check that the calendar has not changed under the policy.
+5. **R5: A release resolves against the timeline at GA, then freezes.** A minor takes the pair in force on its GA date and keeps it for the life of its branch, because a patch release must never stop a running cluster from restarting. Support for a newer LTS may be backported when CI on that branch proves it; nothing that raises a floor may be. Raising the FE compile target is a minor-release change by definition.
+6. **R6: A slip past a shift date does not cost the notice period.** A release that GAs after a shift date takes the new pair only if the previous release already warned at startup about the incoming floor. If it did not, the release keeps the old pair and the shift moves to the next minor. A full rung of notice is the promise; a late release is not a reason to shorten it. A short LTS life is not either: if an LTS gets less than six years, the unpromised edge span absorbs the difference, and in the limit it arrives already recommended.
+7. **R7: Extended availability does not extend support.** Adoptium builds Java 8 until at least Dec 2030 and Java 11 until at least Oct 2027. Neither end date is earlier than the end date of the LTS that follows it, so neither can hold an end-date-bounded rung. Such an LTS leaves the ladder at the GA of the LTS three generations newer, the moment it stops being one of the three newest LTS releases. That retired Java 8 at Java 21's GA (Sep 2023) and Java 11 at Java 25's GA (Sep 2025) while Adoptium still built both, and it is why the current rung began in Sep 2025 rather than at Java 11's nominal end. The shift chain is monotonic: a shift is never dated earlier than the shift before it. Revisions follow the same rule: a shift date is fixed at the end-of-availability date first published for the LTS, and a later extension by Adoptium does not move it. Adoptium publishes its dates as "at least", so they do not move earlier. Non-LTS releases never appear on the ladder at all: never required, never blocking, never in the CI matrix, and a bug report against one needs a reproduction on a supported LTS.
+8. **R8: Artifacts that run in someone else's JVM are out of scope.** Anything loaded into a foreign runtime targets the lowest JDK its host ecosystem still supports, Java 8 today, and moves only when that ecosystem moves. Each declares its target beside a comment naming the host that pins it and the oldest host version StarRocks documents as supported. The target moves when that oldest documented host version no longer runs on Java 8, and the PR that drops support for that host version raises the target in the same change. The current list is in Exceptions.
+
+## Shift Chain
+
+Each row is a date on which the two integers move and the values that take effect from it. This is a projection of the rules, not an independent schedule. The last column records which minors happened to land in each rung: observed for the past, unknowable ahead, and in no case load-bearing.
+
+| Shift | Minimum | Recommended | Edge LTS | Triggered by | Holds for | StarRocks at the time |
+| --- | --- | --- | --- | --- | --- | --- |
+| Sep 2021 | 8 | 11 | 17 | Java 17 GA | 24 mo | v2.5 - v3.1 required 8, recommended 11 (matches) |
+| Sep 2023 | 11 | 17 | 21 | Java 21 GA; Java 8 leaves the ladder under R7 | 24 mo | v3.2 (Nov 2023) still required 8; v3.3 (Jun 2024) took the 11 floor, 9 months late |
+| **Sep 2025** | **17** | **21** | **25** | Java 25 GA; Java 11 leaves the ladder under R7 | 25 mo | v3.5 (Jun 2025) took the 17 floor, 3 months early; v3.5 - v4.1 require 17 with no separate recommendation; `main` (v4.2) carries (17, 21) and the startup warning (matches) |
+| Oct 2027 | 21 | 25 | 29 | Java 17 stops being built | 26 mo | floor raise: first minor to GA after this date, subject to R6 |
+| Dec 2029 | 25 | 29 | 33 | Java 21 stops being built | 21 mo | floor raise: first minor to GA after this date, subject to R6 |
+| Sep 2031 | 29 | 33 | 37 | Java 25 stops being built | - | subject to Java 29 and 33 GAing on the two-year cadence |
+
+Applied backwards the chain lands close to what the project actually did, and closer with each cycle, which is the case for trusting it forwards. Java 8 held the floor legitimately until the Sep 2023 shift, and v3.2 was two months past it. The Java 11 floor arrived nine months late, in v3.3. The Java 17 floor arrived three months early, in v3.5. `main` today carries exactly the pair the rule prescribes, which is the first time the project has been in front of its own JDK calendar rather than behind it.
+
+## Enforcement
+
+What upholds the policy today:
+
+- `bin/start_fe.sh` (`MIN_JDK_VERSION=17`, `RECOMMENDED_JDK_VERSION=21`) fails startup below the minimum and warns below the recommendation, naming the recommended version in both messages. `bin/start_backend.sh` carries the same pair and prints the same two messages for the BE and CN embedded JVM, and, because the BE treats Java as optional (a missing `JAVA_HOME` is also only a warning), logs an error below the minimum instead of exiting.
+- The FE compile target is 17 in `fe/fe-core/pom.xml` and the sibling `fe/fe-*` modules, and `java-extensions/pom.xml` sets `java.version` to 17. Both equal the minimum, as the Minimum state requires.
+- The Ubuntu images (`docker/dockerfiles/{fe,be,allin1}/*-ubuntu.Dockerfile`) install OpenJDK 21, the recommended version.
+- The public matrix in `docs/en/deployment/preparation/environment_configurations.md` (mirrored in `zh` and `ja`) lists the minimum and recommended JDK per StarRocks version and points at the next scheduled change, and the release notes for v3.3.0 and v3.5.0 state each floor raise.
+- The user-facing statement of this policy is the JDK Support Policy section of `docs/en/developers/versions.md` (mirrored in `zh` and `ja`): the two integers, when the minimum changes, the schedule, and the foreign-JVM components. Keep it in sync with this page; it carries no repo paths or rule numbers.
+
+Review rules derived from R1 to R8:
+
+- A PR that raises `MIN_JDK_VERSION` or the FE compile target is a minor-release change. It lands on `main` before the release branch is cut and is never backported (R5).
+- A PR that raises `RECOMMENDED_JDK_VERSION` must point at the next minimum in the shift chain, and that JDK must already be green in CI (R3).
+- A PR that adds JDK-specific behavior (for example `--add-opens` flags or JVM options) must work on both the minimum and the recommended JDK.
+- A PR that touches a foreign-JVM artifact keeps its Java 8 target and the comment that pins it, or moves the target together with the host ecosystem the comment names (R8).
+- A JDK bug report that reproduces only on a non-LTS release is closed pending a reproduction on a supported LTS (R7).
+
+Checklist for a shift, carried by whichever minor GAs first after the shift date:
+
+1. Confirm the previous minor already shipped the startup warning naming the new minimum (R6). If it did not, defer the shift to the next minor.
+2. Raise the FE compile target in `fe/fe-core/pom.xml` and the sibling `fe/fe-*` modules, and `java.version` in `java-extensions/pom.xml`, to the new minimum.
+3. Set the pair in `bin/start_fe.sh` and `bin/start_backend.sh` to (new minimum, new recommended).
+4. Move the Ubuntu images to the new recommended JDK.
+5. Add the row to the JDK matrix in `docs/en`, `docs/zh`, and `docs/ja`, and update the JDK lines in the deployment prerequisites pages.
+6. State the raise in the release notes and the upgrade notes for the minor.
+
+Scheduled actions this policy creates in the repo. New non-LTS releases need none (R7), and a new LTS GA needs none either: it is a cross-check that the calendar has not moved, not a task.
+
+| When | Action |
+| --- | --- |
+| Before Oct 2027 | Get JDK 25 green in CI. It becomes the recommendation at the first shift, and a recommendation is a commitment (R3), so it has to be provable before the shift rather than after. This is the only outstanding action in the current rung: the pair on `main` is correct and the warning naming 21 already ships, so R6's notice is satisfied. |
+| Oct 2027 shift | Raise the floor to 21 in one release: compile target 17 to 21, the pair to (21, 25), images to 25, the docs matrix, and the release notes. |
+| Before Dec 2029 | Get JDK 29 green in CI and ship the warning naming 25. Both earlier in the cycle than last time: the rung that follows is 21 months, the shortest in the published calendar, so there is less room between proving the incoming LTS and requiring it. |
+| Dec 2029 shift | Raise the floor to 25: compile target 21 to 25, the pair to (25, 29), images to 29. |
+| Sep 2031 shift | Raise the floor to 29: compile target 25 to 29, the pair to (29, 33), images to 33. |
+
+## Exceptions
+
+- **Foreign-JVM artifacts (R8).** These compile at Java 8 and move only when the oldest documented host version no longer runs on Java 8. Each must keep a comment beside the target naming the host that pins it and that oldest host version:
+  - `fe/plugin/spark-dpp/pom.xml`: external Spark clusters. Comment present.
+  - `fe/plugin/hive-udf/pom.xml`: UDF runtime environments. Comment present.
+  - `fe/fe-utils/pom.xml`: a dependency of both plugins above, so it inherits their target. No comment yet.
+  - `format-sdk/pom.xml`: consumers of the format SDK. No comment yet.
+  - `fs_brokers/apache_hdfs_broker/src/pom.xml`: the broker JVM. No comment yet.
+- **Non-LTS Java releases** are never on the ladder (R7). They are not required, not blocking, and not in the CI matrix.
+- **Release branches** keep the pair frozen at their GA (R5). Backporting support for a newer LTS is allowed once CI on that branch proves it; backporting anything that raises a floor is not.
+- **A late minor** keeps the old pair when taking the new one would cut the notice period short (R6).
+
+## References
+
+1. Eclipse Temurin release roadmap: https://adoptium.net/support. Source of every LTS GA and end-of-availability date in this page, and of the two statements the policy leans on: one feature release every two years is designated LTS, and each LTS is supported for at least four years. The published windows currently run about six years, which is what makes three rungs fit.
+2. Public JDK matrix: `docs/en/deployment/preparation/environment_configurations.md`. Public policy statement, release plan, and branch lifecycle: `docs/en/developers/versions.md`.
+
+Repo state verified at `main` commit 49091c482b3 (2026-09-02). StarRocks release dates are tag dates in this repository: v3.2.0 2023-11-29, v3.3.0 2024-06-20, v3.5.0 2025-06-11, v4.0.0 2025-10-15, v4.1.0 2026-04-09; v4.2 is not yet tagged. LTS end dates are Adoptium's published "at least" dates. Java 29, 33, and 37 assume the two-year LTS cadence holds.


### PR DESCRIPTION
StarRocks had no written JDK policy. The floor moved from JDK 8 to 11 in v3.3 and from 11 to 17 in v3.5, and main now recommends JDK 21, but each move arrived as a surprise because nothing said when the next one would come or what it would be tied to.

Anchor the required and recommended JDK to the Java LTS calendar published by Adoptium instead of to StarRocks release numbers: the minimum is the oldest LTS still being built, the recommended JDK is the next LTS and the next minimum, and a shift happens when the outgoing minimum reaches its end of availability. Shift dates are fixed once published. Releases freeze their pair at GA, patch releases never raise the floor, and a floor raise ships only after the previous minor warned about it at startup.

- handbook/policies: the full policy with the rules, the shift chain (Oct 2027 to JDK 21, Dec 2029 to 25, Sep 2031 to 29), the per-shift checklist, and the current enforcement gaps
- docs/{en,zh,ja}/developers/versions.md: the user-facing statement of the policy and the schedule
- docs/{en,zh,ja}/deployment/preparation: point the JDK matrix at the next scheduled change

Only start_fe.sh exits below the minimum; start_backend.sh logs an error and starts because Java is optional on the BE. The policy and the public docs describe that behavior as is.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5