### PR TITLE
[BugFix] Make the security integration group_provider fallback reachable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/AuthenticationHandler.java
@@ -157,10 +157,18 @@ public class AuthenticationHandler {
                 continue;
             }
 
+            // Fall back to the global group providers when the security integration does not name its own.
+            // getGroupProviderName() returns an empty list (never null) for an absent or blank property, so
+            // the fallback has to be keyed on emptiness -- a null check here never fires and leaves external
+            // users with no groups at all, which also makes a configured permitted_groups reject every login.
+            List<String> groupProviderNames = securityIntegration.getGroupProviderName();
+            if (groupProviderNames.isEmpty()) {
+                groupProviderNames = List.of(Config.group_provider);
+            }
+
             authenticationResult = new AuthenticationResult(
                     UserIdentity.createEphemeralUserIdent(user, remoteHost),
-                    securityIntegration.getGroupProviderName() == null ?
-                            List.of(Config.group_provider) : securityIntegration.getGroupProviderName(),
+                    groupProviderNames,
                     securityIntegration.getGroupAllowedLoginList(),
                     authMechanism);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
@@ -60,11 +60,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class SecurityIntegrationTest {
     private final MockTokenUtils mockTokenUtils = new MockTokenUtils();
     private ConnectContext ctx;
     private AuthenticationMgr authenticationMgr;
+    private String[] savedGroupProvider;
+    private String[] savedAuthenticationChain;
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -80,10 +83,18 @@ public class SecurityIntegrationTest {
         GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
 
         ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+
+        // Several tests below point these globals at providers and auth chains registered on the
+        // per-test AuthenticationMgr. Snapshot them so a test cannot leak names that no longer
+        // resolve once the next test installs a fresh manager.
+        savedGroupProvider = Config.group_provider;
+        savedAuthenticationChain = Config.authentication_chain;
     }
 
     @AfterEach
     public void tearDown() throws Exception {
+        Config.group_provider = savedGroupProvider;
+        Config.authentication_chain = savedAuthenticationChain;
     }
 
     /**
@@ -219,6 +230,60 @@ public class SecurityIntegrationTest {
         authenticationMgr.replayAlterSecurityIntegration("oidc", alterProperties);
         Assertions.assertThrows(AuthenticationException.class, () -> AuthenticationHandler.authenticate(
                 new ConnectContext(), "harbor", "127.0.0.1", outputStream.toByteArray()));
+    }
+
+    @Test
+    public void testGroupProviderFallsBackToGlobalConfig() throws Exception {
+        // A security integration that does not name its own group_provider must inherit the global
+        // Config.group_provider. getGroupProviderName() returns an empty list rather than null for an
+        // absent property, so a null-based fallback never fires and leaves the user with no groups,
+        // which in turn makes any configured permitted_groups reject the login outright.
+        GlobalStateMgr.getCurrentState().setJwkMgr(new MockTokenUtils.MockJwkMgr());
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(JWTSecurityIntegration.SECURITY_INTEGRATION_PROPERTY_TYPE_KEY, "authentication_jwt");
+        properties.put(JWTAuthenticationProvider.JWT_JWKS_URL, "jwks.json");
+        properties.put(JWTAuthenticationProvider.JWT_PRINCIPAL_FIELD, "preferred_username");
+        // Deliberately no SECURITY_INTEGRATION_PROPERTY_GROUP_PROVIDER here.
+        // Gate the login on a group that only the global provider can supply, so the assertion fails
+        // if the fallback is skipped instead of silently passing with an empty group set.
+        properties.put(SecurityIntegration.SECURITY_INTEGRATION_GROUP_ALLOWED_LOGIN, "group1");
+
+        AuthenticationMgr authenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
+        authenticationMgr.replayCreateSecurityIntegration("oidc_no_gp", properties);
+        Assertions.assertTrue(
+                authenticationMgr.getSecurityIntegration("oidc_no_gp").getGroupProviderName().isEmpty(),
+                "integration without the property must expose an empty provider list, not null");
+
+        new MockUp<FileGroupProvider>() {
+            @Mock
+            public InputStream getPath(String groupFileUrl) throws IOException {
+                String path = ClassLoader.getSystemClassLoader().getResource("auth").getPath() + "/" + "file_group";
+                return new FileInputStream(path);
+            }
+        };
+        Map<String, String> groupProvider = new HashMap<>();
+        groupProvider.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "file");
+        groupProvider.put(FileGroupProvider.GROUP_FILE_URL, "file_group");
+        authenticationMgr.replayCreateGroupProvider("global_file_group_provider", groupProvider);
+
+        Config.group_provider = new String[] {"global_file_group_provider"};
+        Config.authentication_chain = new String[] {"native", "oidc_no_gp"};
+
+        String idToken = mockTokenUtils.generateTestOIDCToken(3600 * 1000);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        MysqlCodec.writeInt1(outputStream, 1);
+        MysqlCodec.writeLenEncodedString(outputStream, idToken);
+
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setAuthPlugin(AuthPlugin.Client.AUTHENTICATION_OPENID_CONNECT_CLIENT.toString());
+        AuthenticationHandler.authenticate(
+                connectContext, "harbor", "127.0.0.1", outputStream.toByteArray());
+
+        // file_group grants harbor both group1 and group2; resolving them proves the global provider was used.
+        Assertions.assertEquals(Set.of("group1", "group2"),
+                connectContext.getAccessControlContext().getGroups(),
+                "groups must come from Config.group_provider when the integration names none");
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing

When a security integration does not name its own `group_provider`, authentication is supposed to fall back to the global `Config.group_provider`. **That fallback never runs.**

```java
// AuthenticationHandler.java
securityIntegration.getGroupProviderName() == null ?
        List.of(Config.group_provider) : securityIntegration.getGroupProviderName()
```

```java
// SecurityIntegration.java
public List<String> getGroupProviderName() {
    String property = propertyMap.get(SECURITY_INTEGRATION_PROPERTY_GROUP_PROVIDER);
    if (property == null || property.isBlank()) {
        return List.of();      // empty list, never null
    }
    return List.of(property.split(",\\s*"));
}
```

`getGroupProviderName()` returns an **empty list — not `null`** — for an absent or blank property, so the `== null` test is always `false` and the fallback branch is dead code.

Both pieces were introduced together in the same commit (`e8d65f52233`, #56763): a fallback branch was written and simultaneously made unreachable. That reads as `isEmpty()` having been intended, rather than a deliberate "each integration must opt in explicitly" design — otherwise the ternary would not have been written at all.

### Impact

External users authenticating through an integration that omits `group_provider` always end up with an **empty group set**:

- group-based authorization never matches
- if `permitted_groups` is configured, the intersection is empty and the login is rejected with `ERR_GROUP_ACCESS_DENY`

We hit this while auditing authorization configuration consistency across several clusters: the assumption that "an integration without `group_provider` inherits the value from `fe.conf`" simply does not hold.

## What I'm doing

Key the fallback on emptiness instead of nullness, and hoist it into a local so the getter is not called twice.

```java
List<String> groupProviderNames = securityIntegration.getGroupProviderName();
if (groupProviderNames.isEmpty()) {
    groupProviderNames = List.of(Config.group_provider);
}
```

### ⚠️ This changes behaviour

This is a bug fix, but it is not behaviour-neutral. Deployments that currently rely on the empty-group outcome (integration without `group_provider` while `Config.group_provider` is set) will now inherit the global providers, and logins previously rejected by `permitted_groups` may start succeeding.

If maintainers prefer the current per-integration isolation as the intended semantics, the right fix would instead be to **delete the unreachable fallback branch** so the intent is explicit. Happy to switch to that — either way the dead branch should not stay as-is, since it advertises a behaviour that does not exist.

Fixes the unreachable fallback introduced in #56763.

## What type of PR is this

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:
- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed/changed: an integration that omits `group_provider` now inherits `Config.group_provider` instead of resolving to no groups
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function

## Tests

`SecurityIntegrationTest.testGroupProviderFallsBackToGlobalConfig`:

- creates an integration **without** the `group_provider` property
- asserts `getGroupProviderName()` is empty rather than `null` (pins the precondition that makes the old check dead)
- gates the login via `permitted_groups` on a group that **only the global provider can supply**, so skipping the fallback fails the test rather than silently passing with an empty group set
- finally asserts the resolved groups came from `Config.group_provider`

While adding it I also noticed the same class overwrites the static `Config.group_provider` and `Config.authentication_chain` in several tests without restoring them. Since `setUp()` installs a fresh `AuthenticationMgr` per test, those leaked names no longer resolve in later tests. The previously empty `@AfterEach` now snapshots and restores both — this also covers the pre-existing leaks in `testAuthentication` and `testGroupProvider`.
