### PR TITLE
[Tool] Run ai-sr-skills assign-reviewer on the [ubuntu, ai] host (bare claude)

### DIFF
--- a/.github/workflows/ai-sr-skills.yml
+++ b/.github/workflows/ai-sr-skills.yml
@@ -15,7 +15,11 @@ permissions:
 
 jobs:
   assign-reviewer:
-    runs-on: [self-hosted, normal]
+    # Runs on the dedicated AI host (bare `claude`, claudeci pre-authed, the
+    # starrocks-assign-pr-reviewer skill installed) instead of the shared build pool
+    # + the claude-cli docker sandbox. Isolates this pull_request_target job away from
+    # the general build fleet (defense-in-depth) and drops the container dependency.
+    runs-on: [self-hosted, ubuntu, ai]
     continue-on-error: true
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -47,14 +51,12 @@ jobs:
           echo "CLAUDE_CODE_OAUTH_TOKEN length: ${#CLAUDE_CODE_OAUTH_TOKEN}"
           echo "GITHUB_TOKEN length: ${#GITHUB_TOKEN}"
           echo "=== RUN ==="
-          # Runs inside claude-cli docker; produces only "Recommended reviewer: <login>"
-          # output. The host-side "Apply Reviewer" step below actually attaches it
-          # (gh is not available inside the container).
-          # tee captures the skill's stdout for the downstream steps to parse.
-          docker exec -i -u claudeuser \
-            -e GITHUB_TOKEN="${GITHUB_TOKEN}" \
-            -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN}" \
-            claude-cli claude --dangerously-skip-permissions \
+          # Bare `claude` on the [ubuntu, ai] host (claudeci is pre-authed via its own
+          # credentials; the starrocks-assign-pr-reviewer skill is installed there).
+          # Produces only "Recommended reviewer: <login>" lines; the host-side
+          # "Apply Reviewer" step below does the actual attach (kept separate so this
+          # model-running step needs no write token). tee captures stdout for parsing.
+          claude --dangerously-skip-permissions \
             -p "/starrocks-assign-pr-reviewer https://github.com/${REPO}/pull/${PR_NUMBER}" \
             2>&1 | tee "${RUNNER_TEMP}/ai_output.txt" || true
 


### PR DESCRIPTION
## Why I'm doing:

Follow-up to the `ai-sr-skills` script-injection hardening (#78528). Defense-in-depth: move the `pull_request_target` assign-reviewer job off the shared `[self-hosted, normal]` build pool (where a compromise could reach the general CI fleet) onto the dedicated `[self-hosted, ubuntu, ai]` host, and drop the `claude-cli` docker sandbox in favor of bare `claude` (the established pattern for AI jobs on that host, e.g. `bugfix-version-index`).

## What I'm doing:

- `assign-reviewer` job: `runs-on: [self-hosted, normal]` → `[self-hosted, ubuntu, ai]`.
- Replace `docker exec -i -u claudeuser ... claude-cli claude ...` with bare `claude --dangerously-skip-permissions -p "..."`. The ai host's `claudeci` user is pre-authed and has the `starrocks-assign-pr-reviewer` skill installed; job env keeps `GITHUB_TOKEN` / `CLAUDE_CODE_OAUTH_TOKEN` (same as other ai-host workflows).
- Output format is unchanged (`Recommended reviewer: <login>` …), so the downstream **Apply Reviewer** / Slack steps are untouched.

**Verified end-to-end on the ai host**: `claude -p "/starrocks-assign-pr-reviewer <PR url>"` resolves the skill, reads the PR via `gh`, and emits the same recommendation lines (`Recommended reviewer: banmoy / Affinity reviewer: wyb`).

`module-risk` / `module-risk-comment` stay on `[self-hosted, normal]` for now — they depend on the `context-base` MCP, which is separately unavailable (tracked apart).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
