### PR TITLE
[BugFix] Refresh only recently accessed and changed Paimon tables in background (backport #78057)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/ConnectorTableMetadataProcessor.java
@@ -28,15 +28,13 @@ import com.starrocks.connector.CacheUpdateProcessor;
 import com.starrocks.connector.DatabaseTableName;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog;
 import com.starrocks.connector.iceberg.IcebergCatalog;
+import com.starrocks.connector.paimon.CachingPaimonCatalog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.paimon.catalog.CachingCatalog;
-import org.apache.paimon.catalog.Catalog;
-import org.apache.paimon.catalog.Identifier;
 
 import java.util.List;
 import java.util.Map;
@@ -46,7 +44,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
 public class ConnectorTableMetadataProcessor extends FrontendDaemon {
@@ -59,7 +56,7 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
 
     private final ExecutorService refreshRemoteFileExecutor;
     private final Map<String, IcebergCatalog> cachingIcebergCatalogs = new ConcurrentHashMap<>();
-    private final Map<String, Catalog> paimonCatalogs = new ConcurrentHashMap<>();
+    private final Map<String, CachingPaimonCatalog> cachingPaimonCatalogs = new ConcurrentHashMap<>();
 
     public void registerTableInfo(BaseTableInfo tableInfo) {
         registeredTableInfos.add(tableInfo);
@@ -87,14 +84,14 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
         cachingIcebergCatalogs.remove(catalogName);
     }
 
-    public void registerPaimonCatalog(String catalogName, Catalog paimonCatalog) {
+    public void registerPaimonCatalog(String catalogName, CachingPaimonCatalog paimonCatalog) {
         LOG.info("register to caching paimon catalog on {} in the ConnectorTableMetadataProcessor", catalogName);
-        paimonCatalogs.put(catalogName, paimonCatalog);
+        cachingPaimonCatalogs.put(catalogName, paimonCatalog);
     }
 
     public void unRegisterPaimonCatalog(String catalogName) {
         LOG.info("unregister to caching paimon catalog on {} in the ConnectorTableMetadataProcessor", catalogName);
-        paimonCatalogs.remove(catalogName);
+        cachingPaimonCatalogs.remove(catalogName);
     }
 
     public ConnectorTableMetadataProcessor() {
@@ -114,7 +111,7 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
         if (Config.enable_background_refresh_connector_metadata) {
             refreshCatalogTable();
             refreshIcebergCachingCatalog();
-            refreshPaimonCatalog();
+            refreshPaimonCachingCatalog();
         }
     }
 
@@ -173,44 +170,18 @@ public class ConnectorTableMetadataProcessor extends FrontendDaemon {
     }
 
     @VisibleForTesting
-    public void refreshPaimonCatalog() {
-        List<String> catalogNames = Lists.newArrayList(paimonCatalogs.keySet());
+    public void refreshPaimonCachingCatalog() {
+        List<String> catalogNames = Lists.newArrayList(cachingPaimonCatalogs.keySet());
         for (String catalogName : catalogNames) {
-            Catalog paimonCatalog = paimonCatalogs.get(catalogName);
+            CachingPaimonCatalog paimonCatalog = cachingPaimonCatalogs.get(catalogName);
             if (paimonCatalog == null) {
-                LOG.error("Failed to get paimonCatalog by catalog {}.", catalogName);
+                LOG.error("Failed to get cachingPaimonCatalog by catalog {}.", catalogName);
                 continue;
             }
-            LOG.info("Start to refresh paimon catalog {}", catalogName);
-            for (String dbName : paimonCatalog.listDatabases()) {
-                try {
-                    for (String tblName : paimonCatalog.listTables(dbName)) {
-                        List<Future<?>> futures = Lists.newArrayList();
-                        futures.add(refreshRemoteFileExecutor.submit(() ->
-                                paimonCatalog.invalidateTable(new Identifier(dbName, tblName))
-                        ));
-                        futures.add(refreshRemoteFileExecutor.submit(() ->
-                                paimonCatalog.getTable(new Identifier(dbName, tblName))
-                        ));
-                        if (paimonCatalog instanceof CachingCatalog) {
-                            futures.add(refreshRemoteFileExecutor.submit(() -> {
-                                        try {
-                                            ((CachingCatalog) paimonCatalog).refreshPartitions(new Identifier(dbName, tblName));
-                                        } catch (Catalog.TableNotExistException e) {
-                                            throw new RuntimeException(e);
-                                        }
-                                    }
-                            ));
-                        }
-                        for (Future<?> future : futures) {
-                            future.get();
-                        }
-                    }
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            LOG.info("Finish to refresh paimon catalog {}", catalogName);
+            long startTime = System.currentTimeMillis();
+            paimonCatalog.refreshCatalog();
+            LOG.info("Finish to refresh paimon caching catalog {}, cost: {} ms",
+                    catalogName, System.currentTimeMillis() - startTime);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/CachingPaimonCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/CachingPaimonCatalog.java
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.paimon;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.common.Config;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.paimon.catalog.CachingCatalog;
+import org.apache.paimon.catalog.Catalog;
+import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.Options;
+import org.apache.paimon.schema.TableSchema;
+import org.apache.paimon.table.DataTable;
+import org.apache.paimon.table.Table;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Paimon's caching catalog plus the bookkeeping background refresh needs to prune its work:
+ * per-table last access time, and the snapshot / schema revision each table was last refreshed at.
+ * Mirrors CachingIcebergCatalog.
+ */
+public class CachingPaimonCatalog extends CachingCatalog {
+    private static final Logger LOG = LogManager.getLogger(CachingPaimonCatalog.class);
+
+    private final String catalogName;
+    private final Map<Identifier, Long> tableLatestAccessTime = new ConcurrentHashMap<>();
+    private final Map<Identifier, TableRevision> lastRefreshedRevision = new ConcurrentHashMap<>();
+
+    /** What the lake looked like when a table was last refreshed. */
+    private record TableRevision(long snapshotId, long schemaId) {
+    }
+
+    public CachingPaimonCatalog(String catalogName, Catalog wrapped, Options options) {
+        super(wrapped, options);
+        this.catalogName = catalogName;
+    }
+
+    @Override
+    public Table getTable(Identifier id) throws Catalog.TableNotExistException {
+        Table table = super.getTable(id);
+        // a system table has no snapshot of its own, a branch/tag pins a fixed version: neither goes stale
+        if (!id.isSystemTable() && id.getBranchName() == null) {
+            tableLatestAccessTime.put(id, System.currentTimeMillis());
+        }
+        return table;
+    }
+
+    @Override
+    public void invalidateTable(Identifier id) {
+        super.invalidateTable(id);
+        // the revision described the evicted entry, not the next one
+        lastRefreshedRevision.remove(id);
+    }
+
+    /** Refresh one table if the lake moved. Background daemon only. */
+    public void refreshTable(Identifier id) {
+        try {
+            // via super: probing must not count as an access
+            Table table = super.getTable(id);
+            if (!(table instanceof DataTable)) {
+                return;
+            }
+            DataTable dataTable = (DataTable) table;
+            Long latestSnapshotId = dataTable.snapshotManager().latestSnapshotId();
+            if (latestSnapshotId == null) {
+                return;
+            }
+            // a schema-only ALTER TABLE bumps the schema id without creating a snapshot
+            long latestSchemaId = dataTable.schemaManager().latest().map(TableSchema::id).orElse(-1L);
+            TableRevision latest = new TableRevision(latestSnapshotId, latestSchemaId);
+            if (latest.equals(lastRefreshedRevision.get(id))) {
+                return;
+            }
+
+            super.invalidateTable(id);
+            super.getTable(id); // repopulate, so queries don't pay for the reload
+            super.refreshPartitions(id);
+            lastRefreshedRevision.put(id, latest);
+            LOG.debug("Refreshed paimon table {} of catalog {} to snapshot {} schema {}",
+                    id.getFullName(), catalogName, latestSnapshotId, latestSchemaId);
+        } catch (Exception e) {
+            LOG.warn("Failed to refresh paimon table {} of catalog {}, evict it",
+                    id.getFullName(), catalogName, e);
+            invalidateTable(id);
+            tableLatestAccessTime.remove(id);
+        }
+    }
+
+    public void refreshCatalog() {
+        // negative means never expire, as in CachingHiveMetastore
+        long idleWindowSec = Config.background_refresh_metadata_time_secs_since_last_access_secs;
+        for (Map.Entry<Identifier, Long> entry : tableLatestAccessTime.entrySet()) {
+            long idleSec = (System.currentTimeMillis() - entry.getValue()) / 1000;
+            if (idleWindowSec >= 0 && idleSec > idleWindowSec) {
+                invalidateTable(entry.getKey());
+                tableLatestAccessTime.remove(entry.getKey());
+                continue;
+            }
+            refreshTable(entry.getKey());
+        }
+    }
+
+    @VisibleForTesting
+    Map<Identifier, Long> getTableLatestAccessTime() {
+        return tableLatestAccessTime;
+    }
+
+    @VisibleForTesting
+    Map<Identifier, TableRevision> getLastRefreshedRevision() {
+        return lastRefreshedRevision;
+    }
+
+    @VisibleForTesting
+    static TableRevision revision(long snapshotId, long schemaId) {
+        return new TableRevision(snapshotId, schemaId);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonConnector.java
@@ -31,11 +31,16 @@ import com.starrocks.credential.aws.AwsCloudConfiguration;
 import com.starrocks.credential.aws.AwsCloudCredential;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
 import org.apache.paimon.catalog.CatalogFactory;
+import org.apache.paimon.options.CatalogOptions;
+import org.apache.paimon.options.MemorySize;
 import org.apache.paimon.options.Options;
+import org.apache.paimon.privilege.PrivilegedCatalog;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -49,6 +54,12 @@ public class PaimonConnector implements Connector {
     public static final String PAIMON_CATALOG_WAREHOUSE = "paimon.catalog.warehouse";
     private static final String HIVE_METASTORE_URIS = "hive.metastore.uris";
     private static final String DLF_CATGALOG_ID = "dlf.catalog.id";
+    // implicit for user, mirrors iceberg_meta_cache_ttl_sec
+    public static final String PAIMON_META_CACHE_TTL = "paimon_meta_cache_ttl_sec";
+    private static final long DEFAULT_META_CACHE_TTL_SEC = 24L * 60 * 60;
+    private static final long CACHE_PARTITION_MAX_NUM = 1000L;
+    private static final MemorySize CACHE_MANIFEST_FILE_THRESHOLD = MemorySize.ofMebiBytes(10);
+    private static final MemorySize CACHE_MANIFEST_MEMORY = MemorySize.ofMebiBytes(1024);
     private final HdfsEnvironment hdfsEnvironment;
     private Catalog paimonNativeCatalog;
     private final String catalogName;
@@ -93,14 +104,18 @@ public class PaimonConnector implements Connector {
         }
         initFsOption(cloudConfiguration);
 
-        // cache expire time, set to 2h
-        this.paimonOptions.set("cache.expiration-interval", "7200s");
+        // Both must be set, or the one left out keeps its default (10min / 30min) and binds instead.
+        // With equal values expire-after-write binds, which is Iceberg's write-only TTL semantics.
+        Duration metaCacheTtl = Duration.ofSeconds(
+                PropertyUtil.propertyAsLong(properties, PAIMON_META_CACHE_TTL, DEFAULT_META_CACHE_TTL_SEC));
+        this.paimonOptions.set(CatalogOptions.CACHE_EXPIRE_AFTER_ACCESS, metaCacheTtl);
+        this.paimonOptions.set(CatalogOptions.CACHE_EXPIRE_AFTER_WRITE, metaCacheTtl);
         // max num of cached partitions of a Paimon catalog
-        this.paimonOptions.set("cache.partition.max-num", "1000");
+        this.paimonOptions.set(CatalogOptions.CACHE_PARTITION_MAX_NUM, CACHE_PARTITION_MAX_NUM);
         // max size of cached manifest files, 10m means cache all since files usually no more than 8m
-        this.paimonOptions.set("cache.manifest.small-file-threshold", "10m");
+        this.paimonOptions.set(CatalogOptions.CACHE_MANIFEST_SMALL_FILE_THRESHOLD, CACHE_MANIFEST_FILE_THRESHOLD);
         // max size of memory manifest cache uses
-        this.paimonOptions.set("cache.manifest.small-file-memory", "1g");
+        this.paimonOptions.set(CatalogOptions.CACHE_MANIFEST_SMALL_FILE_MEMORY, CACHE_MANIFEST_MEMORY);
 
         String keyPrefix = "paimon.option.";
         Set<String> optionKeys = properties.keySet().stream().filter(k -> k.startsWith(keyPrefix)).collect(Collectors.toSet());
@@ -149,9 +164,16 @@ public class PaimonConnector implements Connector {
         if (paimonNativeCatalog == null) {
             Configuration configuration = new Configuration();
             hdfsEnvironment.getCloudConfiguration().applyToConfiguration(configuration);
-            this.paimonNativeCatalog = CatalogFactory.createCatalog(CatalogContext.create(getPaimonOptions(), configuration));
+            CatalogContext context = CatalogContext.create(getPaimonOptions(), configuration);
+            // Build the cache layer ourselves so background refresh can track access time and
+            // snapshot/schema revisions; privilege wrapper stays outside, as in createCatalog.
+            Catalog unwrapped = CatalogFactory.createUnwrappedCatalog(context,
+                    CatalogFactory.class.getClassLoader());
+            CachingPaimonCatalog cachingCatalog =
+                    new CachingPaimonCatalog(catalogName, unwrapped, getPaimonOptions());
+            this.paimonNativeCatalog = PrivilegedCatalog.tryToCreate(cachingCatalog, getPaimonOptions());
             GlobalStateMgr.getCurrentState().getConnectorTableMetadataProcessor()
-                    .registerPaimonCatalog(catalogName, this.paimonNativeCatalog);
+                    .registerPaimonCatalog(catalogName, cachingCatalog);
         }
         return paimonNativeCatalog;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonConnectorTest.java
@@ -25,6 +25,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.types.DataField;
@@ -32,6 +33,7 @@ import org.apache.paimon.types.IntType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,6 +58,45 @@ public class PaimonConnectorTest {
         properties.put("paimon.catalog.warehouse", "hdfs://127.0.0.1:9999/warehouse");
 
         new PaimonConnector(new ConnectorContext("paimon_catalog", "paimon", properties));
+    }
+
+    @Test
+    public void testCacheLifetimeMatchesIceberg() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("paimon.catalog.type", "filesystem");
+        properties.put("paimon.catalog.warehouse", "hdfs://127.0.0.1:9999/warehouse");
+        PaimonConnector connector = new PaimonConnector(new ConnectorContext("paimon_catalog", "paimon", properties));
+        Options options = connector.getPaimonOptions();
+        // 24h to match iceberg_meta_cache_ttl_sec; both must be set or a default becomes binding
+        Assertions.assertEquals(Duration.ofHours(24), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_ACCESS));
+        Assertions.assertEquals(Duration.ofHours(24), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_WRITE));
+    }
+
+    @Test
+    public void testMetaCacheTtlProperty() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("paimon.catalog.type", "filesystem");
+        properties.put("paimon.catalog.warehouse", "hdfs://127.0.0.1:9999/warehouse");
+        properties.put(PaimonConnector.PAIMON_META_CACHE_TTL, "3600");
+        PaimonConnector connector = new PaimonConnector(new ConnectorContext("paimon_catalog", "paimon", properties));
+        Options options = connector.getPaimonOptions();
+        Assertions.assertEquals(Duration.ofHours(1), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_ACCESS));
+        Assertions.assertEquals(Duration.ofHours(1), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_WRITE));
+    }
+
+    @Test
+    public void testCacheOptionsCanBeOverridden() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("paimon.catalog.type", "filesystem");
+        properties.put("paimon.catalog.warehouse", "hdfs://127.0.0.1:9999/warehouse");
+        properties.put("paimon.option.cache.expire-after-write", "1h");
+        properties.put("paimon.option.cache.partition.max-num", "50");
+        PaimonConnector connector = new PaimonConnector(new ConnectorContext("paimon_catalog", "paimon", properties));
+        Options options = connector.getPaimonOptions();
+        // the paimon.option. passthrough runs after our defaults
+        Assertions.assertEquals(Duration.ofHours(1), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_WRITE));
+        Assertions.assertEquals(50L, options.get(CatalogOptions.CACHE_PARTITION_MAX_NUM));
+        Assertions.assertEquals(Duration.ofHours(24), options.get(CatalogOptions.CACHE_EXPIRE_AFTER_ACCESS));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -216,7 +216,8 @@ public class PaimonMetadataTest {
                         "  `col3` double DEFAULT NULL\n" +
                         ")\n" +
                         "PRIMARY KEY (`col2`)\n" +
-                        "PARTITION BY (col1);",
+                        "PARTITION BY (col1)\n" +
+                        "PROPERTIES (\"location\" = \"hdfs://127.0.0.1:10000/paimon\");",
                 AstToStringBuilder.getExternalCatalogTableDdlStmt(paimonTable));
         assertEquals(Lists.newArrayList("col1"), paimonTable.getPartitionColumnNames());
         assertEquals("hdfs://127.0.0.1:10000/paimon", paimonTable.getTableLocation());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.paimon;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.FunctionName;
@@ -59,6 +58,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import mockit.Verifications;
 import org.apache.paimon.CoreOptions;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.CatalogContext;
@@ -78,9 +78,12 @@ import org.apache.paimon.predicate.Predicate;
 import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.schema.Schema;
+import org.apache.paimon.schema.SchemaManager;
+import org.apache.paimon.schema.TableSchema;
 import org.apache.paimon.stats.ColStats;
 import org.apache.paimon.stats.Statistics;
 import org.apache.paimon.table.FileStoreTable;
+import org.apache.paimon.table.FormatTable;
 import org.apache.paimon.table.sink.BatchTableCommit;
 import org.apache.paimon.table.sink.BatchTableWrite;
 import org.apache.paimon.table.sink.BatchWriteBuilder;
@@ -105,6 +108,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.utils.JsonSerdeUtil;
 import org.apache.paimon.utils.SerializationUtils;
+import org.apache.paimon.utils.SnapshotManager;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -344,19 +348,343 @@ public class PaimonMetadataTest {
                 Lists.newArrayList("dt=2024-01-01", "dt=__DEFAULT_PARTITION__"));
     }
 
+    private static CachingPaimonCatalog newCachingCatalog(Catalog wrapped) {
+        Options options = new Options();
+        // default max-num is 0, i.e. no partition cache at all
+        options.set(CatalogOptions.CACHE_PARTITION_MAX_NUM, 1000L);
+        return new CachingPaimonCatalog("paimon_catalog", wrapped, options);
+    }
+
     @Test
-    public void testRefreshPaimonMetadata() throws Catalog.DatabaseNotExistException {
+    public void testBackgroundRefreshChangedTable(@Mocked FileStoreTable paimonTable,
+                                                  @Mocked SnapshotManager snapshotManager) throws Exception {
+        Identifier id = new Identifier("db", "tbl");
         new Expectations() {
             {
-                paimonNativeCatalog.listDatabases();
-                result = ImmutableList.of("db");
-                paimonNativeCatalog.listTables((String) any);
-                result = ImmutableList.of("tbl");
+                paimonNativeCatalog.getTable(id);
+                result = paimonTable;
+                paimonTable.snapshotManager();
+                result = snapshotManager;
+                snapshotManager.latestSnapshotId();
+                result = 5L;
             }
         };
-        ConnectorTableMetadataProcessor connectorTableMetadataProcessor = new ConnectorTableMetadataProcessor();
-        connectorTableMetadataProcessor.registerPaimonCatalog("paimon_catalog", paimonNativeCatalog);
-        connectorTableMetadataProcessor.refreshPaimonCatalog();
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTable(id);
+        ConnectorTableMetadataProcessor processor = new ConnectorTableMetadataProcessor();
+        processor.registerPaimonCatalog("paimon_catalog", cachingCatalog);
+        processor.refreshPaimonCachingCatalog();
+        assertEquals(CachingPaimonCatalog.revision(5L, -1L), cachingCatalog.getLastRefreshedRevision().get(id));
+        // dropped and reloaded by the refresh
+        assertEquals(1, cachingCatalog.estimatedCacheSizes().tableCacheSize());
+    }
+
+    @Test
+    public void testBackgroundRefreshSkipsUnchangedSnapshot(@Mocked FileStoreTable paimonTable,
+                                                            @Mocked SnapshotManager snapshotManager) throws Exception {
+        Identifier id = new Identifier("db", "tbl");
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(id);
+                result = paimonTable;
+                paimonTable.snapshotManager();
+                result = snapshotManager;
+                snapshotManager.latestSnapshotId();
+                result = 5L;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTable(id);
+        cachingCatalog.getLastRefreshedRevision().put(id, CachingPaimonCatalog.revision(5L, -1L));
+        cachingCatalog.refreshCatalog();
+        // the cached entry survived the round
+        assertEquals(1, cachingCatalog.estimatedCacheSizes().tableCacheSize());
+    }
+
+    @Test
+    public void testBackgroundRefreshOnSchemaOnlyChange(@Mocked FileStoreTable paimonTable,
+                                                        @Mocked SnapshotManager snapshotManager,
+                                                        @Mocked SchemaManager schemaManager,
+                                                        @Mocked TableSchema tableSchema) throws Exception {
+        Identifier id = new Identifier("db", "tbl");
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(id);
+                result = paimonTable;
+                paimonTable.snapshotManager();
+                result = snapshotManager;
+                snapshotManager.latestSnapshotId();
+                result = 5L;
+                paimonTable.schemaManager();
+                result = schemaManager;
+                schemaManager.latest();
+                result = java.util.Optional.of(tableSchema);
+                tableSchema.id();
+                result = 2L;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTable(id);
+        cachingCatalog.getLastRefreshedRevision().put(id, CachingPaimonCatalog.revision(5L, 1L));
+        // schema id moved, snapshot did not: still a change
+        cachingCatalog.refreshCatalog();
+        assertEquals(CachingPaimonCatalog.revision(5L, 2L), cachingCatalog.getLastRefreshedRevision().get(id));
+        // dropped and reloaded by the refresh
+        assertEquals(1, cachingCatalog.estimatedCacheSizes().tableCacheSize());
+    }
+
+    @Test
+    public void testBackgroundRefreshSkipsNonDataTable(@Mocked FormatTable formatTable) throws Exception {
+        Identifier id = new Identifier("db", "format_tbl");
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(id);
+                result = formatTable;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTable(id);
+        cachingCatalog.refreshCatalog();
+        assertTrue(cachingCatalog.getLastRefreshedRevision().isEmpty());
+        // the cached entry survived the round
+        assertEquals(1, cachingCatalog.estimatedCacheSizes().tableCacheSize());
+    }
+
+    @Test
+    public void testBackgroundRefreshEvictsIdleTable() {
+        Identifier id = new Identifier("db", "tbl");
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        long idleWindowSec = Config.background_refresh_metadata_time_secs_since_last_access_secs;
+        cachingCatalog.getTableLatestAccessTime().put(id, System.currentTimeMillis() - (idleWindowSec + 10) * 1000);
+        cachingCatalog.getLastRefreshedRevision().put(id, CachingPaimonCatalog.revision(5L, 1L));
+        cachingCatalog.refreshCatalog();
+        assertTrue(cachingCatalog.getTableLatestAccessTime().isEmpty());
+        assertTrue(cachingCatalog.getLastRefreshedRevision().isEmpty());
+    }
+
+    @Test
+    public void testBackgroundRefreshEvictsTableOnFailure(@Mocked FileStoreTable paimonTable,
+                                                          @Mocked SnapshotManager snapshotManager,
+                                                          @Mocked SchemaManager schemaManager,
+                                                          @Mocked TableSchema tableSchema) throws Exception {
+        Identifier id = new Identifier("db", "object_tbl");
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(id);
+                result = paimonTable;
+                paimonTable.snapshotManager();
+                result = snapshotManager;
+                snapshotManager.latestSnapshotId();
+                result = 5L;
+                paimonTable.schemaManager();
+                result = schemaManager;
+                schemaManager.latest();
+                result = java.util.Optional.of(tableSchema);
+                tableSchema.id();
+                result = 0L;
+                // refreshPartitions delegates down to listPartitions
+                paimonNativeCatalog.listPartitions(id);
+                result = new ClassCastException(
+                        "class org.apache.paimon.table.object.ObjectTableImpl cannot be cast to " +
+                                "class org.apache.paimon.table.FileStoreTable");
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTable(id);
+        // must not throw: the table is evicted instead
+        cachingCatalog.refreshCatalog();
+        assertTrue(cachingCatalog.getTableLatestAccessTime().isEmpty());
+        assertTrue(cachingCatalog.getLastRefreshedRevision().isEmpty());
+    }
+
+    @Test
+    public void testManualRefreshTableReachesPartitionCache(@Mocked FileStoreTable paimonNativeTable) throws Exception {
+        List<DataField> fields = new ArrayList<>();
+        fields.add(new DataField(1, "col2", new IntType(false)));
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable((Identifier) any);
+                result = paimonNativeTable;
+                paimonNativeTable.rowType().getFields();
+                result = fields;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        PaimonMetadata newMetadata = new PaimonMetadata("paimon_catalog", new HdfsEnvironment(), cachingCatalog,
+                new ConnectorProperties(ConnectorType.PAIMON));
+        com.starrocks.catalog.Table table = newMetadata.getTable(connectContext, "db1", "tbl1");
+        newMetadata.refreshTable("db1", table, new ArrayList<>(), false);
+        // REFRESH EXTERNAL TABLE must reach the partition cache
+        new Verifications() {
+            {
+                paimonNativeCatalog.listPartitions(new Identifier("db1", "tbl1"));
+                minTimes = 1;
+            }
+        };
+    }
+
+    @Test
+    public void testInvalidateTableKeepsAccessTime() {
+        Identifier id = new Identifier("db", "tbl");
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTableLatestAccessTime().put(id, System.currentTimeMillis());
+        cachingCatalog.getLastRefreshedRevision().put(id, CachingPaimonCatalog.revision(5L, 1L));
+        cachingCatalog.invalidateTable(id);
+        // ledgers cleared, but the table stays in the refresh set
+        assertTrue(cachingCatalog.getLastRefreshedRevision().isEmpty());
+        assertEquals(1, cachingCatalog.getTableLatestAccessTime().size());
+        assertEquals(0, cachingCatalog.estimatedCacheSizes().tableCacheSize());
+    }
+
+    @Test
+    public void testBackgroundRefreshOnSnapshotRollback(@Mocked FileStoreTable paimonTable,
+                                                        @Mocked SnapshotManager snapshotManager) throws Exception {
+        Identifier id = new Identifier("db", "tbl");
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(id);
+                result = paimonTable;
+                paimonTable.snapshotManager();
+                result = snapshotManager;
+                snapshotManager.latestSnapshotId();
+                result = 3L;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTable(id);
+        cachingCatalog.getLastRefreshedRevision().put(id, CachingPaimonCatalog.revision(5L, -1L));
+        // rollbackTo moves the snapshot backwards: still a change
+        cachingCatalog.refreshCatalog();
+        assertEquals(CachingPaimonCatalog.revision(3L, -1L), cachingCatalog.getLastRefreshedRevision().get(id));
+        // dropped and reloaded by the refresh
+        assertEquals(1, cachingCatalog.estimatedCacheSizes().tableCacheSize());
+    }
+
+    @Test
+    public void testAccessTimeSkipsSystemAndBranchTables(@Mocked FileStoreTable paimonTable) throws Exception {
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable((Identifier) any);
+                result = paimonTable;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        // a branch reference pins a fixed version
+        cachingCatalog.getTable(new Identifier("db", "tbl$branch_dev"));
+        assertTrue(cachingCatalog.getTableLatestAccessTime().isEmpty());
+        // a system table resolves through its base table, so the base table is what gets recorded
+        cachingCatalog.getTable(new Identifier("db", "tbl$snapshots"));
+        Assertions.assertThat(cachingCatalog.getTableLatestAccessTime().keySet())
+                .containsExactly(new Identifier("db", "tbl"));
+    }
+
+    @Test
+    public void testNegativeIdleWindowNeverEvicts(@Mocked FileStoreTable paimonTable,
+                                                  @Mocked SnapshotManager snapshotManager) throws Exception {
+        Identifier id = new Identifier("db", "tbl");
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(id);
+                result = paimonTable;
+                paimonTable.snapshotManager();
+                result = snapshotManager;
+                snapshotManager.latestSnapshotId();
+                result = 5L;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTableLatestAccessTime().put(id, 0L);
+        long saved = Config.background_refresh_metadata_time_secs_since_last_access_secs;
+        Config.background_refresh_metadata_time_secs_since_last_access_secs = -1;
+        try {
+            cachingCatalog.refreshCatalog();
+        } finally {
+            Config.background_refresh_metadata_time_secs_since_last_access_secs = saved;
+        }
+        assertEquals(1, cachingCatalog.getTableLatestAccessTime().size());
+        assertEquals(CachingPaimonCatalog.revision(5L, -1L), cachingCatalog.getLastRefreshedRevision().get(id));
+    }
+
+    @Test
+    public void testBackgroundRefreshSkipsEmptyTable(@Mocked FileStoreTable paimonTable,
+                                                     @Mocked SnapshotManager snapshotManager) throws Exception {
+        Identifier id = new Identifier("db", "tbl");
+        new Expectations() {
+            {
+                paimonNativeCatalog.getTable(id);
+                result = paimonTable;
+                paimonTable.snapshotManager();
+                result = snapshotManager;
+                snapshotManager.latestSnapshotId();
+                result = null;
+            }
+        };
+        CachingPaimonCatalog cachingCatalog = newCachingCatalog(paimonNativeCatalog);
+        cachingCatalog.getTable(id);
+        cachingCatalog.refreshCatalog();
+        assertTrue(cachingCatalog.getLastRefreshedRevision().isEmpty());
+        // the cached entry survived the round
+        assertEquals(1, cachingCatalog.estimatedCacheSizes().tableCacheSize());
+    }
+
+    @Test
+    public void testBackgroundRefreshLifecycleWithRealCatalog() throws Exception {
+        java.nio.file.Path tmpDir = Files.createTempDirectory("tmp_");
+        Options catalogOptions = new Options();
+        catalogOptions.setString(CatalogOptions.WAREHOUSE.key(), tmpDir.toString());
+        // mirror PaimonConnector: without it the partition cache is disabled (default max-num is 0)
+        catalogOptions.setString("cache.partition.max-num", "1000");
+        CatalogContext context = CatalogContext.create(catalogOptions);
+        // same chain PaimonConnector builds
+        Catalog unwrapped = CatalogFactory.createUnwrappedCatalog(context, CatalogFactory.class.getClassLoader());
+        CachingPaimonCatalog realCatalog = new CachingPaimonCatalog("paimon_catalog", unwrapped, catalogOptions);
+
+        realCatalog.createDatabase("test_db", true);
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        schemaBuilder.partitionKeys("dt");
+        schemaBuilder.column("dt", DataTypes.STRING());
+        schemaBuilder.column("user", DataTypes.STRING());
+        Options options = new Options();
+        options.set(CoreOptions.BUCKET, 2);
+        options.set(CoreOptions.BUCKET_KEY, "user");
+        schemaBuilder.options(options.toMap());
+        Identifier id = Identifier.create("test_db", "test_tbl");
+        realCatalog.createTable(id, schemaBuilder.build(), true);
+        org.apache.paimon.table.Table table = realCatalog.getTable(id);
+
+        // snapshot 1: partition dt=1
+        BatchWriteBuilder writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite()) {
+            write.write(GenericRow.of(BinaryString.fromString("1"), BinaryString.fromString("u1")));
+            try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                commit.commit(write.prepareCommit());
+            }
+        }
+
+        CachingPaimonCatalog cachingCatalog = realCatalog;
+        cachingCatalog.getTable(id);
+        cachingCatalog.refreshCatalog();
+        assertEquals(CachingPaimonCatalog.revision(1L, 0L), cachingCatalog.getLastRefreshedRevision().get(id));
+        assertEquals(1, cachingCatalog.listPartitions(id).size());
+
+        // snapshot 2: new partition dt=2
+        writeBuilder = table.newBatchWriteBuilder();
+        try (BatchTableWrite write = writeBuilder.newWrite()) {
+            write.write(GenericRow.of(BinaryString.fromString("2"), BinaryString.fromString("u1")));
+            try (BatchTableCommit commit = writeBuilder.newCommit()) {
+                commit.commit(write.prepareCommit());
+            }
+        }
+        // our cache still serves the old list, the lake already has two
+        assertEquals(1, cachingCatalog.listPartitions(id).size());
+        assertEquals(2, unwrapped.listPartitions(id).size());
+        cachingCatalog.refreshCatalog();
+        assertEquals(CachingPaimonCatalog.revision(2L, 0L), cachingCatalog.getLastRefreshedRevision().get(id));
+        assertEquals(2, cachingCatalog.listPartitions(id).size());
+
+        // no write: the ledger stays put
+        cachingCatalog.refreshCatalog();
+        assertEquals(CachingPaimonCatalog.revision(2L, 0L), cachingCatalog.getLastRefreshedRevision().get(id));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -72,6 +72,7 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.fs.Path;
 import org.apache.paimon.io.DataFileMeta;
+import org.apache.paimon.options.CatalogOptions;
 import org.apache.paimon.options.Options;
 import org.apache.paimon.partition.Partition;
 import org.apache.paimon.predicate.Predicate;
@@ -129,6 +130,7 @@ import static org.apache.paimon.io.DataFileMeta.EMPTY_MAX_KEY;
 import static org.apache.paimon.io.DataFileMeta.EMPTY_MIN_KEY;
 import static org.apache.paimon.stats.SimpleStats.EMPTY_STATS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PaimonMetadataTest {
     @Mocked


### PR DESCRIPTION
## Why I'm doing:

The background metadata refresh for Paimon catalogs enumerated the whole warehouse every cycle: `refreshPaimonCatalog()` walked `listDatabases() × listTables()` and unconditionally invalidated and reloaded every table, including tables StarRocks had never queried. On a warehouse with thousands of tables that is a large amount of remote metadata I/O every 10 minutes (`listPartitions` re-aggregates every manifest of every table), and the per-round invalidate+reload kept resetting Paimon's cache TTLs so idle entries could never expire. None of the pruning the Iceberg and Hive paths already have was in place.

The three refresh steps were also submitted as concurrent futures with no ordering, so `invalidateTable` could run last and wipe the entries the other two had just reloaded.

## What I'm doing:

Make `CachingPaimonCatalog` a StarRocks subclass of Paimon's `CachingCatalog`, mirroring what `CachingIcebergCatalog` does for Iceberg, and have it keep the bookkeeping the pruning needs:

- `tableLatestAccessTime`, stamped by `getTable()` on real accesses (system tables and branch/tag references excluded, since neither can go stale). Background refresh only walks this set, so tables nobody queried are never touched, and tables idle for longer than `background_refresh_metadata_time_secs_since_last_access_secs` (default 24h; negative means never expire, same convention as `CachingHiveMetastore`) are evicted from both the refresh set and the caches.
- `lastRefreshedRevision`, the `(snapshotId, schemaId)` pair a table was last refreshed at, compared against the table's current pair (both are cheap hint-file reads) each round, so unchanged tables are skipped without invalidating anything. Comparing by equality rather than ordering also catches `rollbackTo`, and tracking the schema id catches a schema-only `ALTER TABLE`, which writes a new schema file without creating a snapshot.

Because the class *is* the caching catalog rather than a wrapper around it, the existing `instanceof CachingCatalog` checks in `PaimonMetadata` keep working unchanged — that file is untouched by this PR. `PaimonConnector` builds the chain with `CatalogFactory.createUnwrappedCatalog()` and re-applies Paimon's privilege wrapper on the outside, exactly as `CatalogFactory.createCatalog()` would.

The refresh steps now run serially (invalidate → reload table → refresh partitions), and a per-table failure evicts that table instead of breaking the whole round.

Cache lifetime is brought in line with the Iceberg connector as well: a new `paimon_meta_cache_ttl_sec` catalog property, defaulting to the same 24h as `iceberg_meta_cache_ttl_sec`. Both of Paimon's expiry options have to be set, or whichever is left out keeps its default (10min for access, 30min for write) and becomes the binding one — which is what used to cap the effective lifetime at 30min. The cache options now go through Paimon's own `CatalogOptions` constants with typed values instead of string literals.

`refreshPaimonCatalog()` is renamed to `refreshPaimonCachingCatalog()` to match `refreshIcebergCachingCatalog()`.

### Tests

16 new unit tests:

- Background refresh behaviour (`PaimonMetadataTest`): refresh on snapshot change / skip unchanged / schema-only change / snapshot rollback / non-`DataTable` skipped / empty table skipped / idle eviction / eviction on failure / system-and-branch exclusion / negative idle window never evicts / `invalidateTable` clears the ledgers but keeps the access record / manual `REFRESH EXTERNAL TABLE` reaches the partition cache.
- A lifecycle test against a real filesystem catalog in a temp dir: real snapshots across commits, the cached partition list stays stale until the refresh runs, and a no-change round leaves the ledger untouched.
- Cache configuration (`PaimonConnectorTest`): the 24h default, the `paimon_meta_cache_ttl_sec` property, and that the `paimon.option.` passthrough still overrides our defaults.

End-to-end on a real HMS + HDFS Paimon warehouse (Spark writers, StarRocks FE built from this branch):

- only accessed tables are refreshed — untouched tables and other databases in the same warehouse never appear in a round;
- with no writes, consecutive rounds do zero refresh work (each round is a couple of hint-file reads);
- a new snapshot is picked up on the next round;
- a schema-only `ALTER TABLE ADD COLUMN` (new schema file, snapshot unchanged) is picked up on the next round and the new column becomes visible;
- an evicted table is not refreshed even when new snapshots land, stays fully queryable (the cold path reloads on demand), and re-enters the refresh set on the next access.

### Behavior change

- After an FE restart the access ledger is empty, so background refresh warms nothing until tables are queried again — the same behavior as the Iceberg and Hive connectors, but a change from the previous whole-warehouse preheat.
- The effective metadata cache lifetime goes from 30min to 24h (see above); `paimon_meta_cache_ttl_sec` is there to tune it.
- The cache expiry options are now set under their canonical keys. A catalog that overrode the deprecated `paimon.option.cache.expiration-interval` should use `paimon.option.cache.expire-after-access` (or the new property) instead.
- Note for reviewers: tables with statistics metadata are periodically touched by the statistics subsystem, which counts as an access and keeps them in the refresh set. This matches `CachingIcebergCatalog`'s semantics.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

---

## Why this lands on a bugfix-only branch as `[BugFix]`

This is a backport of #78057, which merged to `main` titled `[Enhancement]`. It is opened as a
fix on purpose, and here is the reasoning so the decision can be made with the facts in view.

Before this change the Paimon background refresh walked `listDatabases × listTables` every round
and invalidated, reloaded and re-listed partitions for **every** table in the catalog, whether or
not anyone had queried it and whether or not the lake had moved. The cost grows with the number
of tables, not with the amount of change: on a catalog with many tables, one round of "metadata
refresh" is a full metadata storm against the metastore and the filesystem every 10 minutes. The
change bounds that work to tables accessed within
`background_refresh_metadata_time_secs_since_last_access_secs` whose snapshot or schema actually
changed. Query semantics are untouched (`PaimonMetadata` is not modified); what changes is how
much work the daemon does to reach the same state.

#78057 introduced one regression on `main`, fixed by #78271 (`paimon.option.cache-enabled=false`
stopped disabling the cache). #78271 applies on top of this change, so its backport to this branch
follows as soon as this one merges.

The same change has been running on the enterprise 4.1 / 4.0 / 3.5 branches since 2026-08-27.

If the maintainers would rather keep this as an enhancement and off the release branches, closing
this is the right call — no argument from me.


