### PR TITLE
[Enhancement] Bump protobuf-java to 3.25.9

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -76,7 +76,7 @@ subprojects {
         set("parquet.version", "1.16.0")
         set("ranger.version", "2.8.0")
         set("orc.version", "1.9.1")
-        set("protobuf-java.version", "3.25.5")
+        set("protobuf-java.version", "3.25.9")
         set("puppycrawl.version", "10.21.1")
         set("spark.version", "3.5.7")
         set("staros.version", "4.2-rc4")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -77,7 +77,7 @@ under the License.
         <avro.version>1.12.0</avro.version>
         <dnsjava.version>3.6.3</dnsjava.version>
         <nimbusds.version>9.37.2</nimbusds.version>
-        <protobuf-java.version>3.25.5</protobuf-java.version>
+        <protobuf-java.version>3.25.9</protobuf-java.version>
         <paimon.version>1.3.1</paimon.version>
         <fluss.version>0.9.1-incubating</fluss.version>
         <delta-kernel.version>4.3.0</delta-kernel.version>


### PR DESCRIPTION
## Why I'm doing:

`fe/pom.xml` pins `protobuf-java` / `protobuf-java-util` to 3.25.5. Since #77171 bumped gRPC to 1.76.0, `grpc-protobuf:1.76.0` declares `protobuf-java:3.25.8` (and pulls in `proto-google-common-protos:2.59.2`, whose generated code was also produced with 3.25.8), so `dependencyManagement` has been silently downgrading the runtime below the version gRPC was built and tested against. The upcoming FE image v3 (protobuf-encoded image) work will add a `protoc` build step that must share this same version property, so the property should first point at a current 3.25.x patch release.

## What I'm doing:

Bump `protobuf-java.version` from 3.25.5 to 3.25.9 (the latest 3.25.x patch release, 2026-03-25) in `fe/pom.xml`, and mirror it in `fe/build.gradle.kts`.

Verification done on this branch:

- Bytecode check: every `com.google.protobuf` class/member referenced by `grpc-protobuf`, `grpc-protobuf-lite`, `proto-google-common-protos:2.59.2` and StarOS `starcommon:4.2-rc4` resolves against 3.25.9 (it already resolved against 3.25.5; the bump only moves the runtime up).
- FE build (`./build.sh --fe`) passes; targeted UTs covering ORC parsing (`OrcStripeStatisticsReaderTest`, 47 cases), StarOS protobuf (`StarOSAgent2ndTest`, `LakeTableCleanerTest`, `StorageInfoTest`) and Arrow Flight / gRPC (`ArrowFlightSqlServiceTest`) pass. (`AddFilesProcedureTest` fails identically on unmodified main in the local JDK 21 environment with Mockito "cannot mock this class" errors, unrelated to this change; CI covers it.)
- Runtime probe against the built `fe/lib` (classpath assembled the way `start_fe.sh` does): reading an ORC file through `OrcFile.createReader` + `getStripeStatistics` works on 3.25.9 and emits the warning described below; on 3.25.5 it is silent.

Behavior note: starting with 3.25.8, protobuf-java logs a one-time-per-message-type `java.util.logging` WARNING ("Vulnerable protobuf generated type in use") when it parses messages generated by `protoc` older than 3.21.7 (GHSA-h4h5-3hr4-j3g2). A scan of the FE runtime classpath shows the only such unshaded generated code is `OrcProto` in `orc-core:1.9.1`, reached from `OrcStripeStatisticsReader` (reshard pre-split) and the Iceberg `AddFilesProcedure` ORC path. Those two paths will now log that warning once per type; the exposure itself is unchanged from 3.25.5, the new runtime merely makes it visible. The real fix is an `orc-core` upgrade, tracked separately. 3.25.6 and 3.25.7 were deliberately skipped: they throw `UnsupportedOperationException` for that generated code instead of warning.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
