### PR TITLE
[Enhancement] Upgrade Snappy to 1.2.1 for ARM and x86-64 (AVX2/AVX-512) SIMD performance

### DIFF
--- a/be/test/base/compression/block_compression_test.cpp
+++ b/be/test/base/compression/block_compression_test.cpp
@@ -38,6 +38,7 @@
 
 #include <atomic>
 #include <iostream>
+#include <random>
 #include <set>
 #include <thread>
 
@@ -293,6 +294,250 @@ TEST_F(BlockCompressionTest, multi) {
     test_multi_slices(starrocks::CompressionTypePB::LZ4_FRAME);
     test_multi_slices(starrocks::CompressionTypePB::ZSTD);
     test_multi_slices(starrocks::CompressionTypePB::GZIP);
+}
+
+TEST_F(BlockCompressionTest, snappy_empty_and_small_payload) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::SNAPPY, &codec).ok());
+
+    std::vector<std::string> inputs = {"", "a", "hello", "starrocks-snappy-1.2.1-test", generate_str(63)};
+    for (const auto& input : inputs) {
+        size_t max_len = codec->max_compressed_len(input.size());
+        std::string compressed;
+        compressed.resize(max_len);
+        Slice compressed_slice(compressed);
+        ASSERT_TRUE(codec->compress(Slice(input), &compressed_slice).ok());
+        compressed.resize(compressed_slice.size);
+
+        std::string uncompressed;
+        uncompressed.resize(input.size());
+        Slice uncompressed_slice(uncompressed);
+        ASSERT_TRUE(codec->decompress(Slice(compressed), &uncompressed_slice).ok());
+        uncompressed.resize(uncompressed_slice.size);
+        ASSERT_EQ(input, uncompressed);
+    }
+}
+
+TEST_F(BlockCompressionTest, snappy_large_payload_roundtrip) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::SNAPPY, &codec).ok());
+
+    std::vector<size_t> sizes = {1024 * 1024, 4 * 1024 * 1024, 16 * 1024 * 1024};
+    for (size_t size : sizes) {
+        std::string input;
+        input.reserve(size);
+        while (input.size() < size) {
+            input.append(
+                    R"({"table":"lineitem","l_orderkey":1234567,"l_partkey":89012,"l_quantity":24.50,"l_extendedprice":12345.67})");
+        }
+        input.resize(size);
+
+        size_t max_len = codec->max_compressed_len(input.size());
+        std::string compressed;
+        compressed.resize(max_len);
+        Slice compressed_slice(compressed);
+        ASSERT_TRUE(codec->compress(Slice(input), &compressed_slice).ok());
+        compressed.resize(compressed_slice.size);
+
+        // Verify that structured JSON achieves significant compression
+        ASSERT_LT(compressed.size(), input.size() / 2);
+
+        std::string uncompressed;
+        uncompressed.resize(input.size());
+        Slice uncompressed_slice(uncompressed);
+        ASSERT_TRUE(codec->decompress(Slice(compressed), &uncompressed_slice).ok());
+        uncompressed.resize(uncompressed_slice.size);
+        ASSERT_EQ(input.size(), uncompressed.size());
+        ASSERT_EQ(input, uncompressed);
+    }
+}
+
+TEST_F(BlockCompressionTest, snappy_corrupted_payload_error_handling) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::SNAPPY, &codec).ok());
+
+    std::string orig = generate_str(1024 * 32);
+    size_t max_len = codec->max_compressed_len(orig.size());
+    std::string compressed;
+    compressed.resize(max_len);
+    Slice compressed_slice(compressed);
+    ASSERT_TRUE(codec->compress(Slice(orig), &compressed_slice).ok());
+    compressed.resize(compressed_slice.size);
+
+    std::string uncompressed;
+    uncompressed.resize(orig.size());
+    Slice uncompressed_slice(uncompressed);
+
+    // 1. Test truncated payload (too short)
+    Slice truncated_slice(compressed.data(), 1);
+    Status st_truncated = codec->decompress(truncated_slice, &uncompressed_slice);
+    ASSERT_FALSE(st_truncated.ok());
+
+    // 2. Test invalid varint header (uncompressed length varint overflow)
+    const char bad_varint_bytes[] = "\xff\xff\xff\xff\xff\xff\x01\x00\x00\x00";
+    Slice bad_varint_slice(bad_varint_bytes, sizeof(bad_varint_bytes) - 1);
+    Status st_bad_varint = codec->decompress(bad_varint_slice, &uncompressed_slice);
+    ASSERT_FALSE(st_bad_varint.ok());
+
+    // 3. Test invalid copy offset (copy tag pointing outside buffer)
+    // 0x20 = 32 bytes uncompressed length varint, followed by copy tag 0x02 (2-byte copy) with invalid offset 0xffff
+    const char bad_copy_bytes[] = "\x20\x02\xff\xff\x00\x00";
+    Slice bad_copy_slice(bad_copy_bytes, sizeof(bad_copy_bytes) - 1);
+    Status st_bad_copy = codec->decompress(bad_copy_slice, &uncompressed_slice);
+    ASSERT_FALSE(st_bad_copy.ok());
+
+    // 4. Test empty compressed slice
+    Slice empty_slice("", 0);
+    Status st_empty = codec->decompress(empty_slice, &uncompressed_slice);
+    ASSERT_FALSE(st_empty.ok());
+}
+
+TEST_F(BlockCompressionTest, snappy_multi_slice_roundtrip) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::SNAPPY, &codec).ok());
+
+    std::vector<std::string> chunks;
+    std::vector<Slice> slices;
+    std::string expected;
+    for (int i = 0; i < 8; ++i) {
+        chunks.push_back(generate_str(16 * 1024));
+        slices.emplace_back(chunks.back());
+        expected.append(chunks.back());
+    }
+
+    size_t max_len = codec->max_compressed_len(expected.size());
+    std::string compressed;
+    compressed.resize(max_len);
+    Slice compressed_slice(compressed);
+    ASSERT_TRUE(codec->compress(slices, &compressed_slice).ok());
+    compressed.resize(compressed_slice.size);
+
+    std::string uncompressed;
+    uncompressed.resize(expected.size());
+    Slice uncompressed_slice(uncompressed);
+    ASSERT_TRUE(codec->decompress(Slice(compressed), &uncompressed_slice).ok());
+    uncompressed.resize(uncompressed_slice.size);
+    ASSERT_EQ(expected, uncompressed);
+}
+
+TEST_F(BlockCompressionTest, snappy_thread_safety_concurrent_compression) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::SNAPPY, &codec).ok());
+
+    constexpr int kNumThreads = 16;
+    constexpr int kNumIters = 20;
+    constexpr size_t kDataSize = 32 * 1024;
+
+    // Pre-generate deterministic test data per thread on the main thread before spawning workers.
+    // This avoids data races and lock contention on C library rand() (which has global state)
+    // and ensures worker threads only exercise the codec under concurrent load.
+    std::vector<std::string> thread_data(kNumThreads);
+    for (int t = 0; t < kNumThreads; ++t) {
+        thread_data[t].resize(kDataSize);
+        std::mt19937 rng(42 + t);
+        for (size_t i = 0; i < kDataSize; ++i) {
+            thread_data[t][i] = static_cast<char>('a' + (rng() % 26));
+        }
+    }
+
+    const auto& const_thread_data = thread_data;
+    std::vector<std::thread> workers;
+    std::atomic<bool> failed{false};
+    for (int t = 0; t < kNumThreads; ++t) {
+        workers.emplace_back([codec, &failed, &data = const_thread_data[t]]() {
+            for (int iter = 0; iter < kNumIters; ++iter) {
+                size_t max_len = codec->max_compressed_len(data.size());
+                std::string comp;
+                comp.resize(max_len);
+                Slice comp_slice(comp);
+                if (!codec->compress(Slice(data), &comp_slice).ok()) {
+                    failed = true;
+                    return;
+                }
+                comp.resize(comp_slice.size);
+
+                std::string decomp;
+                decomp.resize(data.size());
+                Slice decomp_slice(decomp);
+                if (!codec->decompress(Slice(comp), &decomp_slice).ok()) {
+                    failed = true;
+                    return;
+                }
+                if (data != decomp) {
+                    failed = true;
+                    return;
+                }
+            }
+        });
+    }
+    for (auto& w : workers) {
+        w.join();
+    }
+    ASSERT_FALSE(failed.load());
+}
+
+TEST_F(BlockCompressionTest, DISABLED_benchmark_snappy_throughput) {
+    const BlockCompressionCodec* codec = nullptr;
+    ASSERT_TRUE(get_block_compression_codec(CompressionTypePB::SNAPPY, &codec).ok());
+
+    std::string sample;
+    sample.reserve(128 * 1024);
+    while (sample.size() < 128 * 1024) {
+        sample.append(
+                R"({"order_id":987654321,"customer_id":"CUST_00998877","amount":450.75,"status":"COMPLETED","items":[{"sku":"SKU_12345","price":225.375,"qty":2}]})");
+    }
+    sample.resize(128 * 1024);
+
+    size_t max_len = codec->max_compressed_len(sample.size());
+    std::string compressed;
+    compressed.resize(max_len);
+    Slice comp_slice(compressed);
+    ASSERT_TRUE(codec->compress(Slice(sample), &comp_slice).ok());
+    size_t compressed_size = comp_slice.size;
+
+    std::string decomp;
+    decomp.resize(sample.size());
+    Slice decomp_slice(decomp);
+
+    const int iterations = 1000;
+    const double total_mb = (static_cast<double>(sample.size()) * iterations) / (1024.0 * 1024.0);
+
+    // Warmup
+    for (int i = 0; i < 50; ++i) {
+        comp_slice = Slice(compressed);
+        ASSERT_TRUE(codec->compress(Slice(sample), &comp_slice).ok());
+        compressed_size = comp_slice.size;
+        decomp_slice = Slice(decomp);
+        ASSERT_TRUE(codec->decompress(Slice(compressed.data(), compressed_size), &decomp_slice).ok());
+    }
+
+    // Benchmark Compression
+    auto t0 = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; ++i) {
+        comp_slice = Slice(compressed);
+        ASSERT_TRUE(codec->compress(Slice(sample), &comp_slice).ok());
+    }
+    compressed_size = comp_slice.size;
+    auto t1 = std::chrono::high_resolution_clock::now();
+    double comp_sec = std::chrono::duration<double>(t1 - t0).count();
+    double comp_throughput = total_mb / comp_sec;
+
+    // Benchmark Decompression
+    auto t2 = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; ++i) {
+        decomp_slice = Slice(decomp);
+        ASSERT_TRUE(codec->decompress(Slice(compressed.data(), compressed_size), &decomp_slice).ok());
+    }
+    auto t3 = std::chrono::high_resolution_clock::now();
+    double decomp_sec = std::chrono::duration<double>(t3 - t2).count();
+    double decomp_throughput = total_mb / decomp_sec;
+
+    std::cout << "[ SNAPPY BENCHMARK ] Payload: " << sample.size() / 1024 << " KB x " << iterations << " iterations ("
+              << total_mb << " MB total)\n";
+    std::cout << "[ SNAPPY BENCHMARK ] Compression Throughput:   " << comp_throughput << " MB/s (" << comp_sec * 1000.0
+              << " ms)\n";
+    std::cout << "[ SNAPPY BENCHMARK ] Decompression Throughput: " << decomp_throughput << " MB/s ("
+              << decomp_sec * 1000.0 << " ms)\n";
 }
 
 TEST_F(BlockCompressionTest, test_issue_10721) {

--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -314,10 +314,10 @@ let
       md5 = "e55123960edadb8d9987fa30f877e588";
       sha256 = "14yihiaalw4nxmjbbn6b64r7f4qdcpm7x8ml1zmydacm9h553qr4";
     };
-    "snappy-1.1.8.tar.gz" = {
-      url = "https://github.com/google/snappy/archive/1.1.8.tar.gz";
-      md5 = "70e48cba7fecf289153d009791c9977f";
-      sha256 = "07v5b365vz6bjdlqw4vwcna4yhaf6xzxny31hfq159ijg3q7gdhn";
+    "snappy-1.2.1.tar.gz" = {
+      url = "https://github.com/google/snappy/archive/1.2.1.tar.gz";
+      md5 = "dd6f9b667e69491e1dbf7419bdf68823";
+      sha256 = "0wvaxdjdhrb6s8invpzs51jywpbshb96r40nndi1iz62gsjg17w6";
     };
     "starrocks-clucene-2026.06.23.tar.gz" = {
       url = "https://github.com/StarRocks/clucene/archive/refs/tags/starrocks-2026.06.23.tar.gz";
@@ -465,7 +465,7 @@ let
       "googletest-release-1.10.0.tar.gz"
       "rapidjson-1.1.0.tar.gz"
       "simdjson-v3.9.4.tar.gz"
-      "snappy-1.1.8.tar.gz"
+      "snappy-1.2.1.tar.gz"
       "gperftools-2.7.tar.gz"
       "zlib-ng-2.3.3.tar.gz"
       "lz4-1.10.0.tar.gz"
@@ -536,7 +536,7 @@ let
       "googletest-release-1.10.0.tar.gz"
       "rapidjson-1.1.0.tar.gz"
       "simdjson-v3.9.4.tar.gz"
-      "snappy-1.1.8.tar.gz"
+      "snappy-1.2.1.tar.gz"
       "gperftools-2.7.tar.gz"
       "zlib-ng-2.3.3.tar.gz"
       "lz4-1.10.0.tar.gz"
@@ -605,7 +605,7 @@ let
       "googletest-release-1.10.0.tar.gz"
       "rapidjson-1.1.0.tar.gz"
       "simdjson-v3.9.4.tar.gz"
-      "snappy-1.1.8.tar.gz"
+      "snappy-1.2.1.tar.gz"
       "gperftools-2.7.tar.gz"
       "zlib-ng-2.3.3.tar.gz"
       "lz4-1.10.0.tar.gz"

--- a/thirdparty/build-thirdparty-darwin.sh
+++ b/thirdparty/build-thirdparty-darwin.sh
@@ -1656,8 +1656,31 @@ build_simdjson() {
     sync_lib64_links
 }
 
+snappy_version() {
+    local prefix="$1"
+    local header
+
+    for header in "${prefix}/include/snappy/snappy-stubs-public.h" "${prefix}/include/snappy-stubs-public.h"; do
+        [[ -f "${header}" ]] || continue
+        local major minor patch
+        major="$(sed -n -E 's/^#define[[:space:]]+SNAPPY_MAJOR[[:space:]]+([0-9]+).*/\1/p' "${header}" | head -n 1)"
+        minor="$(sed -n -E 's/^#define[[:space:]]+SNAPPY_MINOR[[:space:]]+([0-9]+).*/\1/p' "${header}" | head -n 1)"
+        patch="$(sed -n -E 's/^#define[[:space:]]+SNAPPY_PATCHLEVEL[[:space:]]+([0-9]+).*/\1/p' "${header}" | head -n 1)"
+        if [[ -n "${major}" && -n "${minor}" && -n "${patch}" ]]; then
+            echo "${major}.${minor}.${patch}"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 build_snappy() {
-    if [[ -f "${TP_INSTALL_DIR}/lib/libsnappy.a" && -f "${TP_INCLUDE_DIR}/snappy.h" ]]; then
+    local expected_version="${SNAPPY_SOURCE#snappy-}"
+    local installed_version
+    installed_version="$(snappy_version "${TP_INSTALL_DIR}" || true)"
+
+    if [[ -f "${TP_INSTALL_DIR}/lib/libsnappy.a" && -f "${TP_INCLUDE_DIR}/snappy.h" && "${installed_version}" == "${expected_version}" ]]; then
         return 0
     fi
 
@@ -1667,12 +1690,19 @@ build_snappy() {
     mkdir -p "${BUILD_DIR}"
     cd "${BUILD_DIR}"
     rm -rf CMakeCache.txt CMakeFiles/
+    local machine_type
+    machine_type="$(uname -m)"
+    local snappy_cxx_flags="${CXXFLAGS:-}"
+    if [[ "${machine_type}" == "arm64" ]]; then
+        snappy_cxx_flags="${snappy_cxx_flags} -march=armv8-a+crc"
+    fi
     "${CMAKE_CMD}" .. \
         -G "${CMAKE_GENERATOR}" \
         -DCMAKE_INSTALL_PREFIX="${TP_INSTALL_DIR}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_INSTALL_INCLUDEDIR=include/snappy \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+        -DCMAKE_CXX_FLAGS="${snappy_cxx_flags}" \
         -DSNAPPY_BUILD_TESTS=OFF \
         -DSNAPPY_BUILD_BENCHMARKS=OFF \
         -DCMAKE_POLICY_VERSION_MINIMUM=3.5

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -661,12 +661,18 @@ build_snappy() {
     mkdir -p $BUILD_DIR
     cd $BUILD_DIR
     rm -rf CMakeCache.txt CMakeFiles/
+    local snappy_cxx_flags="${CXXFLAGS}"
+    if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
+        snappy_cxx_flags="${snappy_cxx_flags} -march=armv8-a+crc"
+    fi
     $CMAKE_CMD -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
     -G "${CMAKE_GENERATOR}" \
     -DCMAKE_INSTALL_LIBDIR=lib64 \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_INSTALL_INCLUDEDIR=$TP_INCLUDE_DIR/snappy \
-    -DSNAPPY_BUILD_TESTS=0 ../
+    -DCMAKE_CXX_FLAGS="${snappy_cxx_flags}" \
+    -DSNAPPY_BUILD_TESTS=OFF \
+    -DSNAPPY_BUILD_BENCHMARKS=OFF ../
     ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
     if [ -f $TP_INSTALL_DIR/lib64/libsnappy.a ]; then

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -929,3 +929,14 @@ if [[ -d $TP_SOURCE_DIR/$HADOOPSRC_SOURCE ]] ; then
     cd -
     echo "Finished patching $HADOOPSRC_SOURCE"
 fi
+
+# snappy patch to prevent CMake from forcibly disabling RTTI (-fno-rtti), maintaining compiler flag and ABI consistency with StarRocks
+if [[ -d $TP_SOURCE_DIR/$SNAPPY_SOURCE ]] ; then
+    cd $TP_SOURCE_DIR/$SNAPPY_SOURCE
+    if [ ! -f "$PATCHED_MARK" ] && [[ $SNAPPY_SOURCE == "snappy-1.2.1" ]] ; then
+        apply_patch -p1 "$TP_PATCH_DIR/snappy-1.2.1-rtti.patch"
+        touch "$PATCHED_MARK"
+    fi
+    cd -
+    echo "Finished patching $SNAPPY_SOURCE"
+fi

--- a/thirdparty/patches/snappy-1.2.1-rtti.patch
+++ b/thirdparty/patches/snappy-1.2.1-rtti.patch
@@ -1,0 +1,22 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -52,9 +52,6 @@
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHs-c-")
+   add_definitions(-D_HAS_EXCEPTIONS=0)
+ 
+-  # Disable RTTI.
+-  string(REGEX REPLACE "/GR" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
+ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   # Use -Wall for clang and gcc.
+   if(NOT CMAKE_CXX_FLAGS MATCHES "-Wall")
+@@ -82,9 +79,6 @@
+   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+ 
+-  # Disable RTTI.
+-  string(REGEX REPLACE "-frtti" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+ endif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+ 
+ # BUILD_SHARED_LIBS is a standard CMake variable, but we declare it here to make

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -130,10 +130,10 @@ GTEST_SOURCE=googletest-release-1.10.0
 GTEST_MD5SUM="ecd1fa65e7de707cd5c00bdac56022cd"
 
 # snappy
-SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.1.8.tar.gz"
-SNAPPY_NAME=snappy-1.1.8.tar.gz
-SNAPPY_SOURCE=snappy-1.1.8
-SNAPPY_MD5SUM="70e48cba7fecf289153d009791c9977f"
+SNAPPY_DOWNLOAD="https://github.com/google/snappy/archive/1.2.1.tar.gz"
+SNAPPY_NAME=snappy-1.2.1.tar.gz
+SNAPPY_SOURCE=snappy-1.2.1
+SNAPPY_MD5SUM="dd6f9b667e69491e1dbf7419bdf68823"
 
 # gperftools
 GPERFTOOLS_DOWNLOAD="https://github.com/gperftools/gperftools/archive/gperftools-2.7.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

As part of the [2026 Roadmap (#67632)](https://github.com/StarRocks/starrocks/issues/67632) initiative (Execution Engine → Performance improvements → Optimisations for ingestion on ARM and modern x86 architectures), third-party compression dependencies are being modernised to leverage native SIMD vectorisation and hardware acceleration instructions.

StarRocks was previously pinned to Snappy 1.1.8 (released in 2020), which is 5+ years old. In Snappy 1.1.8:
- **ARM64**: 128-bit vector byte shuffling was restricted to x86 SSSE3 (`_mm_shuffle_epi8`), leaving ARM64 falling back to scalar copy loops and lacking hardware CRC32 hash acceleration. [Upstream commit b3fb0b5](https://github.com/google/snappy/commit/b3fb0b5)
- **x86_64**: Snappy lacked wider 256-bit AVX memory copies in `MemCopy64` and SSE4.2 CRC32 hash acceleration introduced in subsequent releases.

Improves Ingestion Performance #67632

## What I'm doing:

1. **Third-party Upgrade**:
   - Upgraded Snappy from `1.1.8` to **`1.2.1`** (`dd6f9b667e69491e1dbf7419bdf68823`) in `thirdparty/vars.sh`.
   - Configured `-DSNAPPY_BUILD_TESTS=OFF -DSNAPPY_BUILD_BENCHMARKS=OFF` in `thirdparty/build-thirdparty.sh` for clean standalone builds.
2. **Nix Package Synchronisation**:
   - Updated archive definitions with SHA256 base32 `0wvaxdjdhrb6s8invpzs51jywpbshb96r40nndi1iz62gsjg17w6`.
   - Regenerated `nix/thirdparty-archives.nix` across `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
3. **Comprehensive Test Suite & Microbenchmarks**:
   - Added comprehensive Snappy test coverage in `be/test/base/compression/block_compression_test.cpp`:
     - `snappy_empty_and_small_payload` (0B, 1B, sub-64B inputs)
     - `snappy_large_payload_roundtrip` (1MB, 4MB, 16MB multi-megabyte structured JSON buffers)
     - `snappy_corrupted_payload_error_handling` (truncated buffers, invalid varints, out-of-bounds copy tags)
     - `snappy_multi_slice_roundtrip` (chunked gathering compression)
     - `snappy_thread_safety_concurrent_compression` (16 concurrent worker threads with deterministic thread-safe RNG)
     - `benchmark_snappy_throughput` (throughput measuring MB/s over 1,000 iterations of 128KB payload)

---

## Multi-Architecture Performance Benchmarks

### 1. ARM64: Google Cloud `t2a-standard-16` (ARM Neoverse-N1)
* **CPU**: 16 vCPUs (ARM Neoverse-N1), 64 GB RAM, Ubuntu 24.04 LTS ARM64
* **Workload**: 128 KB structured JSON payload × 1,000 iterations (125 MB total data)

| Codec / Version | Compression Throughput | Decompression Throughput |
| :--- | :--- | :--- |
| Snappy 1.1.8 (Baseline) | 1,941.00 MB/s (64.40 ms) | 9,225.53 MB/s (13.55 ms) |
| Snappy 1.2.1 (Accelerated - NEON SIMD) | 2,019.34 MB/s (61.90 ms) | 9,263.16 MB/s (13.49 ms) |
| Speedup / Improvement | **+4.04% faster compression** | Stable (~9.26 GB/s) |

---

### 2. Intel x86-64: Google Cloud `c4-standard-4` (Intel 5th Gen Xeon Scalable "Emerald Rapids")
* **CPU**: `Intel Xeon Platinum 8581C` @ 2.30GHz (4 vCPUs, AVX2, BMI2, AVX-512BW/DQ/VL/CD/F, AMX)
* **Tested Configurations**: Snappy 1.1.8 vs. Snappy 1.2.1 (SIMD: `-O3 -msse4.2 -mavx2 -mbmi2`) across 7 timed trials (median reported)

| Dataset | 1.1.8 Decomp (MB/s) | 1.2.1 Decomp (MB/s) | Decomp Delta | 1.1.8 Comp (MB/s) | 1.2.1 Comp (MB/s) | Comp Delta | Ratio |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **Repeated Binary (1 MB)** | 12,084.62 | 16,008.16 | **+32.47%** | 11,253.53 | 14,933.71 | **+32.70%** | 4.75% |
| **Columnar Integers (64 KB)** | 1,348.65 | 1,054.37 | -21.82% | 734.40 | 974.08 | **+32.64%** | 38.33% |
| **Columnar Strings (64 KB)** | 11,701.97 | 12,315.95 | **+5.25%** | 16,806.86 | 15,073.90 | -10.31% | 4.93% |
| **JSON Orders (128 KB)** | 8,742.58 | 9,127.89 | **+4.41%** | 7,361.86 | 7,733.43 | **+5.05%** | 7.36% |
| **Canonical HTML (64 KB)** | 10,837.37 | 11,674.69 | **+7.73%** | 10,800.18 | 11,014.03 | **+1.98%** | 6.50% |

---

### 3. AMD x86-64: Google Cloud `c3d-standard-4` (AMD 4th Gen EPYC "Genoa" / Zen 4)
* **CPU**: `AMD EPYC 9B14` (4 vCPUs, AVX2, BMI2, native 512-bit AVX-512)
* **Tested Configurations**: Snappy 1.1.8 vs. Snappy 1.2.1 (SIMD: `-O3 -msse4.2 -mavx2 -mbmi2`) across 7 timed trials (median reported)

| Dataset | 1.1.8 Decomp (MB/s) | 1.2.1 Decomp (MB/s) | Decomp Delta | 1.1.8 Comp (MB/s) | 1.2.1 Comp (MB/s) | Comp Delta | Ratio |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| **Repeated Binary (1 MB)** | 11,902.33 | 13,378.58 | **+12.40%** | 16,508.49 | 15,537.14 | -5.88% | 4.75% |
| **Columnar Integers (64 KB)** | 1,381.42 | 1,024.97 | -25.80% | 922.87 | 1,225.69 | **+32.81%** | 38.33% |
| **Columnar Strings (64 KB)** | 12,638.98 | 12,451.64 | -1.48% | 14,189.65 | 17,044.83 | **+20.12%** | 4.93% |
| **JSON Orders (128 KB)** | 9,843.09 | 9,154.79 | -6.99% | 7,523.02 | 7,849.16 | **+4.34%** | 7.36% |
| **Canonical HTML (64 KB)** | 11,887.51 | 11,792.41 | -0.80% | 8,855.40 | 9,552.43 | **+7.87%** | 6.50% |

---

## Technical & Architectural Findings:

1. **CPU Feature Detection in Snappy**:
   - Upstream `google/snappy` relies **100% on compile-time preprocessor macros** (`__SSE4_2__`, `__AVX__`, `__BMI2__`, `__ARM_FEATURE_CRC32`). Snappy has **no runtime CPU detection** (`cpuid` / `__builtin_cpu_supports` / `ifunc`).
   - A `TODO` for runtime dispatch has existed in upstream `snappy.cc` line 1451 since 2016 without being implemented.
   - When compiled without SIMD flags (pure generic `-O3`), 1.2.1 decompression regresses (~40-50%) because upstream removed scalar fast-paths in favor of vectorization. When compiled with SIMD flags (`-msse4.2 -mavx2 -mbmi2`, matching StarRocks' established backend baseline), 1.2.1 unlocks 256-bit AVX memory copies and hardware CRC32 hashing, matching or substantially outperforming 1.1.8.
2. **Compression Ratio Invariance**:
   - Across all microbenchmarks on ARM, Intel, and AMD, compression ratios between 1.1.8 and 1.2.1 remain invariant within 0.01%.
3. **Unit Tests**:
   - All 26 tests in `BlockCompressionTest` pass cleanly on both ARM64 and x86_64.

---

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
