### PR TITLE
[Enhancement] Push down Hive partition filters to HMS

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -145,6 +145,11 @@ public class CatalogConnectorMetadata implements ConnectorMetadata, DelegatingCo
     }
 
     @Override
+    public Optional<List<String>> listPartitionNamesByFilter(String databaseName, String tableName, String filter) {
+        return normal.listPartitionNamesByFilter(databaseName, tableName, filter);
+    }
+
+    @Override
     public Table getTable(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfTable(tblName);
         if (metadata == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -123,6 +123,15 @@ public interface ConnectorMetadata {
     }
 
     /**
+     * Return partition names matching a native metastore filter.
+     *
+     * <p>An empty optional means this connector does not support server-side filter pruning.
+     */
+    default Optional<List<String>> listPartitionNamesByFilter(String databaseName, String tableName, String filter) {
+        return Optional.empty();
+    }
+
+    /**
      * Get Table descriptor for the table specific by `dbName`.`tblName`
      *
      * @param dbName  - the string represents the database name

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -300,6 +300,22 @@ public class CachingHiveMetastore extends CachingMetastore implements IHiveMetas
     }
 
     @Override
+    public Map<String, Partition> getPartitionsByFilter(String dbName, String tableName,
+                                                        List<String> partitionColumnNames, String filter) {
+        DatabaseTableName databaseTableName = DatabaseTableName.of(dbName, tableName);
+        lastAccessTimeMap.put(databaseTableName, System.currentTimeMillis());
+
+        Map<String, Partition> partitions =
+                metastore.getPartitionsByFilter(dbName, tableName, partitionColumnNames, filter);
+        Map<HivePartitionName, Partition> cachedPartitions = partitions.entrySet().stream()
+                .collect(Collectors.toMap(
+                        entry -> HivePartitionName.of(dbName, tableName, entry.getKey()),
+                        Map.Entry::getValue));
+        partitionCache.putAll(cachedPartitions);
+        return partitions;
+    }
+
+    @Override
     public boolean partitionExists(Table table, List<String> partitionValues) {
         return metastore.partitionExists(table, partitionValues);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -256,6 +256,14 @@ public class HiveMetaClient {
         }
     }
 
+    public List<Partition> getPartitionsByFilter(String dbName, String tableName, String filter) {
+        try (Timer ignored = Tracers.watchScope(EXTERNAL, "HMS.listPartitionsByFilter")) {
+            return callRPC("listPartitionsByFilter",
+                    String.format("Failed to get partitions by filter on [%s.%s]", dbName, tableName),
+                    dbName, tableName, filter, (short) -1);
+        }
+    }
+
     public Database getDb(String dbName) {
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "HMS.getDatabase")) {
             return callRPC("getDatabase", String.format("Failed to get database %s", dbName), dbName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -342,6 +342,11 @@ public class HiveMetadata implements ConnectorMetadata {
         return hmsOps.getPartitionKeysByValue(dbName, tblName, partitionValues);
     }
 
+    @Override
+    public Optional<List<String>> listPartitionNamesByFilter(String dbName, String tblName, String filter) {
+        return hmsOps.getPartitionKeysByFilter(dbName, tblName, filter);
+    }
+
     private List<Partition> buildGetRemoteFilesPartitions(Table table, GetRemoteFilesParams params) {
         ImmutableList.Builder<Partition> partitions = ImmutableList.builder();
         if (table.isUnPartitioned()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -158,6 +158,21 @@ public class HiveMetastore implements IHiveMetastore {
     }
 
     @Override
+    public Map<String, Partition> getPartitionsByFilter(String dbName, String tableName,
+                                                        List<String> partitionColumnNames, String filter) {
+        List<org.apache.hadoop.hive.metastore.api.Partition> hivePartitions =
+                client.getPartitionsByFilter(dbName, tableName, filter);
+        ImmutableMap.Builder<String, Partition> result = ImmutableMap.builder();
+        for (org.apache.hadoop.hive.metastore.api.Partition hivePartition : hivePartitions) {
+            String partitionName = PartitionUtil.toHivePartitionName(
+                    partitionColumnNames, hivePartition.getValues());
+            result.put(partitionName, HiveMetastoreApiConverter.toPartition(
+                    hivePartition.getSd(), hivePartition.getParameters()));
+        }
+        return result.build();
+    }
+
+    @Override
     public boolean partitionExists(Table table, List<String> partitionValues) {
         HiveTable hiveTable = (HiveTable) table;
         String dbName = hiveTable.getCatalogDBName();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -283,6 +283,18 @@ public class HiveMetastoreOperations {
         return metastore.getPartitionKeysByValue(dbName, tableName, partitionValues);
     }
 
+    public Optional<List<String>> getPartitionKeysByFilter(String dbName, String tableName, String filter) {
+        if (metastoreType != MetastoreType.HMS) {
+            return Optional.empty();
+        }
+        Table table = getTable(dbName, tableName);
+        if (!(table instanceof HiveTable) || partitionProjectionService.isEnabled(table)) {
+            return Optional.empty();
+        }
+        return Optional.of(new ArrayList<>(metastore.getPartitionsByFilter(
+                dbName, tableName, table.getPartitionColumnNames(), filter).keySet()));
+    }
+
     public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
         return metastore.getPartition(dbName, tableName, partitionValues);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -42,6 +42,9 @@ public interface IHiveMetastore extends IMetastore {
 
     List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues);
 
+    Map<String, Partition> getPartitionsByFilter(String dbName, String tableName,
+                                                 List<String> partitionColumnNames, String filter);
+
     default Map<HivePartitionName, Partition> getCachedPartitions(List<HivePartitionName> hivePartitionNames) {
         return Maps.newHashMap();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -212,6 +212,12 @@ public class UnifiedMetadata implements ConnectorMetadata, DelegatingConnectorMe
     }
 
     @Override
+    public Optional<List<String>> listPartitionNamesByFilter(String databaseName, String tableName, String filter) {
+        ConnectorMetadata metadata = metadataOfTable(databaseName, tableName);
+        return metadata.listPartitionNamesByFilter(databaseName, tableName, filter);
+    }
+
+    @Override
     public Table getTable(ConnectContext context, String dbName, String tblName) {
         ConnectorMetadata metadata = metadataOfTable(dbName, tblName);
         return metadata.getTable(context, dbName, tblName);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -709,6 +709,21 @@ public class MetadataMgr {
         return ImmutableList.copyOf(partitionNames.build());
     }
 
+    public Optional<List<String>> listPartitionNamesByFilter(String catalogName, String dbName, String tableName,
+                                                             String filter) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        if (connectorMetadata.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            return connectorMetadata.get().listPartitionNamesByFilter(dbName, tableName, filter);
+        } catch (Exception e) {
+            LOG.error("Failed to listPartitionNamesByFilter on [{}.{}.{}] with filter [{}]",
+                    catalogName, dbName, tableName, filter, e);
+            throw e;
+        }
+    }
+
     public Statistics getTableStatisticsFromInternalStatistics(Table table, Map<ColumnRefOperator, Column> columns) {
         Statistics.Builder statistics = Statistics.builder();
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/HivePartitionFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/HivePartitionFilterConverter.java
@@ -1,0 +1,251 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.Type;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** Converts safe partition predicates to the filter syntax accepted by Hive Metastore. */
+public final class HivePartitionFilterConverter {
+    private static final Pattern HIVE_IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+
+    private HivePartitionFilterConverter() {
+    }
+
+    public static Optional<Result> convert(LogicalScanOperator operator, List<Column> partitionColumns,
+                                           ScalarOperator predicate) {
+        if (predicate == null || partitionColumns.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<ColumnRefOperator, Column> partitionColumnMap = new HashMap<>();
+        for (Column partitionColumn : partitionColumns) {
+            partitionColumnMap.put(operator.getColumnReference(partitionColumn), partitionColumn);
+        }
+        return convert(predicate, partitionColumnMap);
+    }
+
+    static Optional<Result> convert(ScalarOperator predicate, Map<ColumnRefOperator, Column> partitionColumnMap) {
+        return convertPredicate(predicate, partitionColumnMap)
+                .map(converted -> new Result(converted.filter, converted.requiresFilterApi));
+    }
+
+    private static Optional<ConvertedPredicate> convertPredicate(
+            ScalarOperator predicate, Map<ColumnRefOperator, Column> partitionColumnMap) {
+        if (predicate instanceof BinaryPredicateOperator) {
+            return convertBinaryPredicate((BinaryPredicateOperator) predicate, partitionColumnMap);
+        }
+        if (predicate instanceof InPredicateOperator) {
+            return convertInPredicate((InPredicateOperator) predicate, partitionColumnMap);
+        }
+        if (predicate instanceof CompoundPredicateOperator) {
+            return convertCompoundPredicate((CompoundPredicateOperator) predicate, partitionColumnMap);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<ConvertedPredicate> convertBinaryPredicate(
+            BinaryPredicateOperator predicate, Map<ColumnRefOperator, Column> partitionColumnMap) {
+        ScalarOperator left = predicate.getChild(0);
+        ScalarOperator right = predicate.getChild(1);
+        BinaryType binaryType = predicate.getBinaryType();
+
+        ColumnRefOperator columnRef;
+        ConstantOperator constant;
+        boolean columnOnLeft;
+        if (left instanceof ColumnRefOperator && right instanceof ConstantOperator) {
+            columnRef = (ColumnRefOperator) left;
+            constant = (ConstantOperator) right;
+            columnOnLeft = true;
+        } else if (left instanceof ConstantOperator && right instanceof ColumnRefOperator) {
+            columnRef = (ColumnRefOperator) right;
+            constant = (ConstantOperator) left;
+            binaryType = binaryType.commutative();
+            columnOnLeft = false;
+        } else {
+            return Optional.empty();
+        }
+
+        Column column = partitionColumnMap.get(columnRef);
+        if (column == null || constant.isNull() || !isSupportedIdentifier(column.getName())) {
+            return Optional.empty();
+        }
+
+        Optional<String> literal = formatLiteral(column.getType(), constant);
+        Optional<String> operator = formatOperator(binaryType);
+        if (literal.isEmpty() || operator.isEmpty()) {
+            return Optional.empty();
+        }
+
+        boolean requiresFilterApi = binaryType != BinaryType.EQ || !column.getType().isStringType() || !columnOnLeft;
+        return Optional.of(new ConvertedPredicate(
+                column.getName() + " " + operator.get() + " " + literal.get(), requiresFilterApi));
+    }
+
+    private static Optional<ConvertedPredicate> convertInPredicate(
+            InPredicateOperator predicate, Map<ColumnRefOperator, Column> partitionColumnMap) {
+        if (predicate.isNotIn() || !(predicate.getChild(0) instanceof ColumnRefOperator)) {
+            return Optional.empty();
+        }
+
+        Column column = partitionColumnMap.get((ColumnRefOperator) predicate.getChild(0));
+        if (column == null || !isSupportedIdentifier(column.getName())) {
+            return Optional.empty();
+        }
+
+        List<String> literals = new ArrayList<>();
+        for (ScalarOperator child : predicate.getListChildren()) {
+            if (!(child instanceof ConstantOperator) || ((ConstantOperator) child).isNull()) {
+                return Optional.empty();
+            }
+            Optional<String> literal = formatLiteral(column.getType(), (ConstantOperator) child);
+            if (literal.isEmpty()) {
+                return Optional.empty();
+            }
+            literals.add(literal.get());
+        }
+        if (literals.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String filter = literals.stream()
+                .map(literal -> column.getName() + " = " + literal)
+                .collect(Collectors.joining(" or ", "(", ")"));
+        // Keep pure IN predicates on the partition-values fast path. When an IN predicate is combined
+        // with a range or another predicate that requires the filter API, the compound predicate still
+        // requires the filter API and includes this converted IN expression.
+        return Optional.of(new ConvertedPredicate(filter, false));
+    }
+
+    private static Optional<ConvertedPredicate> convertCompoundPredicate(
+            CompoundPredicateOperator predicate, Map<ColumnRefOperator, Column> partitionColumnMap) {
+        if (predicate.isNot()) {
+            return Optional.empty();
+        }
+
+        List<ConvertedPredicate> convertedChildren = predicate.getChildren().stream()
+                .map(child -> convertPredicate(child, partitionColumnMap))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toList());
+
+        if (predicate.isOr() && convertedChildren.size() != predicate.getChildren().size()) {
+            return Optional.empty();
+        }
+        if (convertedChildren.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String separator = predicate.isAnd() ? " and " : " or ";
+        String filter = convertedChildren.stream()
+                .map(converted -> converted.filter)
+                .collect(Collectors.joining(separator, "(", ")"));
+        boolean requiresFilterApi = predicate.isOr() || convertedChildren.stream()
+                .anyMatch(converted -> converted.requiresFilterApi);
+        return Optional.of(new ConvertedPredicate(filter, requiresFilterApi));
+    }
+
+    private static Optional<String> formatLiteral(Type partitionType, ConstantOperator constant) {
+        if (partitionType.isStringType() || partitionType.isDate()) {
+            return quoteStringLiteral(constant.toString());
+        }
+        if (partitionType.isIntegerType() || partitionType.isLargeIntType()) {
+            return Optional.of(constant.toString());
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> quoteStringLiteral(String value) {
+        // HMS filter literals use backslashes as escape characters. Falling back to FE pruning is safer than
+        // generating a filter that may represent a different partition value.
+        if (value.contains("\\")) {
+            return Optional.empty();
+        }
+        if (!value.contains("\"")) {
+            return Optional.of("\"" + value + "\"");
+        }
+        if (!value.contains("'")) {
+            return Optional.of("'" + value + "'");
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<String> formatOperator(BinaryType binaryType) {
+        switch (binaryType) {
+            case EQ:
+                return Optional.of("=");
+            case NE:
+                return Optional.of("!=");
+            case LT:
+                return Optional.of("<");
+            case LE:
+                return Optional.of("<=");
+            case GT:
+                return Optional.of(">");
+            case GE:
+                return Optional.of(">=");
+            default:
+                return Optional.empty();
+        }
+    }
+
+    private static boolean isSupportedIdentifier(String name) {
+        return HIVE_IDENTIFIER.matcher(name).matches();
+    }
+
+    public static final class Result {
+        private final String filter;
+        private final boolean requiresFilterApi;
+
+        private Result(String filter, boolean requiresFilterApi) {
+            this.filter = filter;
+            this.requiresFilterApi = requiresFilterApi;
+        }
+
+        public String getFilter() {
+            return filter;
+        }
+
+        public boolean requiresFilterApi() {
+            return requiresFilterApi;
+        }
+    }
+
+    private static final class ConvertedPredicate {
+        private final String filter;
+        private final boolean requiresFilterApi;
+
+        private ConvertedPredicate(String filter, boolean requiresFilterApi) {
+            this.filter = filter;
+            this.requiresFilterApi = requiresFilterApi;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -66,6 +66,9 @@ import org.apache.paimon.data.BinaryRow;
 import org.apache.paimon.table.source.DataSplit;
 import org.apache.paimon.table.source.Split;
 
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -73,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.stream.Collectors;
@@ -83,6 +87,7 @@ import static com.starrocks.connector.paimon.PaimonMetadata.getRowCount;
 
 public class OptExternalPartitionPruner {
     private static final Logger LOG = LogManager.getLogger(OptExternalPartitionPruner.class);
+    private static final int MAX_IN_COMBINATIONS = 64;
 
     public static LogicalScanOperator prunePartitions(OptimizerContext context,
                                                       LogicalScanOperator logicalScanOperator) {
@@ -163,6 +168,27 @@ public class OptExternalPartitionPruner {
             }
         }
         return equalPredicates;
+    }
+
+    private static Map<ColumnRefOperator, List<String>> getColumnINConstantValues(ScalarOperator predicate) {
+        List<ScalarOperator> predicateList = Utils.extractConjuncts(predicate);
+        Map<ColumnRefOperator, List<String>> result = Maps.newHashMap();
+        for (ScalarOperator op : predicateList) {
+            if (op instanceof InPredicateOperator) {
+                InPredicateOperator inOp = (InPredicateOperator) op;
+                if (!inOp.isNotIn() && inOp.getChild(0).isColumnRef()
+                        && inOp.allValuesMatch(ScalarOperator::isConstantRef)) {
+                    ColumnRefOperator colRef = (ColumnRefOperator) inOp.getChild(0);
+                    List<String> values = new ArrayList<>();
+                    for (int i = 1; i < inOp.getChildren().size(); i++) {
+                        ConstantOperator constant = inOp.getChild(i).cast();
+                        values.add(constant.toString());
+                    }
+                    result.put(colRef, values);
+                }
+            }
+        }
+        return result;
     }
 
     /**
@@ -267,6 +293,214 @@ public class OptExternalPartitionPruner {
         }
     }
 
+    private static List<Optional<List<String>>> getEffectiveInPartitionValues(
+            LogicalScanOperator operator, List<Column> partitionColumns, ScalarOperator predicate) {
+        Map<ColumnRefOperator, List<String>> inValues = getColumnINConstantValues(predicate);
+        Map<ColumnRefOperator, List<String>> dateRangeValues =
+                getDateRangeConstantValues(operator, partitionColumns, predicate);
+        if (dateRangeValues != null && !dateRangeValues.isEmpty()) {
+            for (ScalarOperator equality : getColumnEQConstantPredicates(predicate)) {
+                ColumnRefOperator column = (ColumnRefOperator) equality.getChild(0);
+                ConstantOperator constant = (ConstantOperator) equality.getChild(1);
+                mergePartitionValues(inValues, column, Lists.newArrayList(constant.toString()));
+            }
+            dateRangeValues.forEach((column, values) -> mergePartitionValues(inValues, column, values));
+        }
+        return buildEffectivePartitionValues(operator, partitionColumns, inValues);
+    }
+
+    private static void mergePartitionValues(Map<ColumnRefOperator, List<String>> valuesByColumn,
+                                             ColumnRefOperator column, List<String> values) {
+        valuesByColumn.merge(column, values, (left, right) -> {
+            List<String> intersection = new ArrayList<>(left);
+            intersection.retainAll(right);
+            return intersection;
+        });
+    }
+
+    private static List<Optional<List<String>>> buildEffectivePartitionValues(
+            LogicalScanOperator operator, List<Column> partitionColumns,
+            Map<ColumnRefOperator, List<String>> valuesByColumn) {
+        if (valuesByColumn.isEmpty()) {
+            return null;
+        }
+
+        List<Optional<List<String>>> result = new ArrayList<>();
+        boolean hasAny = false;
+        for (Column column : partitionColumns) {
+            ColumnRefOperator columnRef = operator.getColumnReference(column);
+            if (valuesByColumn.containsKey(columnRef)) {
+                result.add(Optional.of(valuesByColumn.get(columnRef)));
+                hasAny = true;
+            } else {
+                result.add(Optional.empty());
+            }
+        }
+        return hasAny ? result : null;
+    }
+
+    // Convert a bounded DATE range, including a normalized BETWEEN predicate, into discrete partition values.
+    // Returning null means that at least one DATE range cannot be included in the partition-value fast path.
+    private static Map<ColumnRefOperator, List<String>> getDateRangeConstantValues(
+            LogicalScanOperator operator, List<Column> partitionColumns, ScalarOperator predicate) {
+        Map<ColumnRefOperator, DateRangeBounds> dateRanges = Maps.newHashMap();
+        Set<ColumnRefOperator> datePartitionColumns = partitionColumns.stream()
+                .filter(column -> column.getType().isDate())
+                .map(operator::getColumnReference)
+                .collect(Collectors.toSet());
+        if (datePartitionColumns.isEmpty()) {
+            return Maps.newHashMap();
+        }
+
+        for (ScalarOperator conjunct : Utils.extractConjuncts(predicate)) {
+            if (!(conjunct instanceof BinaryPredicateOperator)) {
+                continue;
+            }
+            BinaryPredicateOperator binaryPredicate = (BinaryPredicateOperator) conjunct;
+            if (!(binaryPredicate.getChild(0) instanceof ColumnRefOperator) ||
+                    !(binaryPredicate.getChild(1) instanceof ConstantOperator)) {
+                continue;
+            }
+            ColumnRefOperator column = (ColumnRefOperator) binaryPredicate.getChild(0);
+            ConstantOperator constant = (ConstantOperator) binaryPredicate.getChild(1);
+            if (!datePartitionColumns.contains(column) || !constant.getType().isDate() || constant.isNull() ||
+                    !binaryPredicate.getBinaryType().isRange()) {
+                continue;
+            }
+            dateRanges.computeIfAbsent(column, ignored -> new DateRangeBounds())
+                    .update(binaryPredicate.getBinaryType(), constant.getDate().toLocalDate());
+        }
+
+        Map<ColumnRefOperator, List<String>> result = Maps.newHashMap();
+        for (Map.Entry<ColumnRefOperator, DateRangeBounds> entry : dateRanges.entrySet()) {
+            List<String> values = entry.getValue().enumerate();
+            if (values == null) {
+                return null;
+            }
+            result.put(entry.getKey(), values);
+        }
+        return result;
+    }
+
+    private static final class DateRangeBounds {
+        private LocalDate lowerBound;
+        private LocalDate upperBound;
+        private boolean lowerInclusive;
+        private boolean upperInclusive;
+
+        private void update(BinaryType binaryType, LocalDate value) {
+            switch (binaryType) {
+                case GE:
+                    updateLowerBound(value, true);
+                    break;
+                case GT:
+                    updateLowerBound(value, false);
+                    break;
+                case LE:
+                    updateUpperBound(value, true);
+                    break;
+                case LT:
+                    updateUpperBound(value, false);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void updateLowerBound(LocalDate value, boolean inclusive) {
+            if (lowerBound == null || value.isAfter(lowerBound)) {
+                lowerBound = value;
+                lowerInclusive = inclusive;
+            } else if (value.equals(lowerBound)) {
+                lowerInclusive &= inclusive;
+            }
+        }
+
+        private void updateUpperBound(LocalDate value, boolean inclusive) {
+            if (upperBound == null || value.isBefore(upperBound)) {
+                upperBound = value;
+                upperInclusive = inclusive;
+            } else if (value.equals(upperBound)) {
+                upperInclusive &= inclusive;
+            }
+        }
+
+        private List<String> enumerate() {
+            if (lowerBound == null || upperBound == null) {
+                return null;
+            }
+
+            try {
+                LocalDate first = lowerInclusive ? lowerBound : lowerBound.plusDays(1);
+                LocalDate last = upperInclusive ? upperBound : upperBound.minusDays(1);
+                long distance = ChronoUnit.DAYS.between(first, last);
+                if (distance < 0) {
+                    return new ArrayList<>();
+                }
+                if (distance >= MAX_IN_COMBINATIONS) {
+                    return null;
+                }
+
+                List<String> values = new ArrayList<>((int) distance + 1);
+                for (long offset = 0; offset <= distance; offset++) {
+                    values.add(first.plusDays(offset).toString());
+                }
+                return values;
+            } catch (DateTimeException e) {
+                return new ArrayList<>();
+            }
+        }
+    }
+
+    private static List<String> listPartitionNamesForInValues(
+            Table table, List<Optional<List<String>>> inPartitionValues) {
+        long combinations = 1;
+        for (Optional<List<String>> values : inPartitionValues) {
+            if (values.isPresent()) {
+                long size = values.get().size();
+                if (size == 0) {
+                    return new ArrayList<>();
+                }
+                combinations = Math.multiplyExact(combinations, size);
+                if (combinations > MAX_IN_COMBINATIONS) {
+                    return null;
+                }
+            }
+        }
+
+        List<List<Optional<String>>> allCombinations = new ArrayList<>();
+        allCombinations.add(new ArrayList<>());
+        for (Optional<List<String>> values : inPartitionValues) {
+            List<List<Optional<String>>> newCombinations = new ArrayList<>();
+            for (List<Optional<String>> existing : allCombinations) {
+                if (values.isPresent()) {
+                    for (String value : values.get()) {
+                        List<Optional<String>> copy = new ArrayList<>(existing);
+                        copy.add(Optional.of(value));
+                        newCombinations.add(copy);
+                    }
+                } else {
+                    List<Optional<String>> copy = new ArrayList<>(existing);
+                    copy.add(Optional.empty());
+                    newCombinations.add(copy);
+                }
+            }
+            allCombinations = newCombinations;
+        }
+
+        Set<String> partitionNames = Sets.newConcurrentHashSet();
+        CompletableFuture<?>[] futures = allCombinations.stream()
+                .map(values -> CompletableFuture.runAsync(() -> {
+                    List<String> names = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .listPartitionNamesByValue(table.getCatalogName(), table.getCatalogDBName(),
+                                    table.getCatalogTableName(), values);
+                    partitionNames.addAll(names);
+                }))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(futures).join();
+        return new ArrayList<>(partitionNames);
+    }
+
     // get equivalence predicate which column ref is partition column
     public static List<Optional<ScalarOperator>> getEffectivePartitionPredicate(LogicalScanOperator operator,
                                                                                 List<Column> partitionColumns,
@@ -336,16 +570,50 @@ public class OptExternalPartitionPruner {
                 checkPartitionFilterRequired(operator, context, table, partitionColumns);
 
                 // get partition names
-                List<String> partitionNames;
-                // check if the partition predicate could be used for filter partition names
+                List<String> partitionNames = null;
+                boolean partitionNamesFiltered = false;
+                // Prefer partition-value APIs for equality, IN, and small bounded DATE ranges.
                 List<Optional<ScalarOperator>> effectivePartitionPredicate =
                         getEffectivePartitionPredicate(operator, partitionColumns, operator.getPredicate());
-                if (effectivePartitionPredicate.stream().anyMatch(Optional::isPresent)) {
+                boolean hasEffectivePartitionPredicate =
+                        effectivePartitionPredicate.stream().anyMatch(Optional::isPresent);
+                if (hasEffectivePartitionPredicate) {
                     List<Optional<String>> partitionValues = getPartitionValue(effectivePartitionPredicate);
                     partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                             .listPartitionNamesByValue(table.getCatalogName(), table.getCatalogDBName(),
                                     table.getCatalogTableName(), partitionValues);
+                    partitionNamesFiltered = true;
                 } else {
+                    List<Optional<List<String>>> inPartitionValues =
+                            getEffectiveInPartitionValues(operator, partitionColumns, operator.getPredicate());
+                    if (inPartitionValues != null) {
+                        partitionNames = listPartitionNamesForInValues(table, inPartitionValues);
+                        partitionNamesFiltered = partitionNames != null;
+                    }
+                }
+
+                // Use the HMS filter API only when the partition-value fast paths cannot handle the predicate.
+                if (partitionNames == null) {
+                    Optional<HivePartitionFilterConverter.Result> metastoreFilter =
+                            HivePartitionFilterConverter.convert(
+                                    operator, partitionColumns, operator.getPredicate());
+                    if (metastoreFilter.isPresent() && metastoreFilter.get().requiresFilterApi()) {
+                        Optional<List<String>> filteredPartitionNames =
+                                GlobalStateMgr.getCurrentState().getMetadataMgr()
+                                        .listPartitionNamesByFilter(
+                                                table.getCatalogName(), table.getCatalogDBName(),
+                                                table.getCatalogTableName(), metastoreFilter.get().getFilter());
+                        if (filteredPartitionNames.isPresent()) {
+                            partitionNames = filteredPartitionNames.get();
+                            partitionNamesFiltered = true;
+                            LOG.debug("Use HMS partition filter [{}] for table {}.{}.{}",
+                                    metastoreFilter.get().getFilter(), table.getCatalogName(),
+                                    table.getCatalogDBName(), table.getCatalogTableName());
+                        }
+                    }
+                }
+
+                if (partitionNames == null) {
                     partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                             .listPartitionNames(table.getCatalogName(), table.getCatalogDBName(),
                                     table.getCatalogTableName(), ConnectorMetadataRequestContext.DEFAULT);
@@ -355,12 +623,11 @@ public class OptExternalPartitionPruner {
                 // reproduce the true denominator in partitions=X/Y. The list used for pruning above may
                 // already be value-filtered, which would collapse the denominator to the pruned count.
                 if (context.getDumpInfo() != null) {
-                    List<String> allPartitionNames =
-                            effectivePartitionPredicate.stream().anyMatch(Optional::isPresent)
-                                    ? GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
-                                            table.getCatalogName(), table.getCatalogDBName(),
-                                            table.getCatalogTableName(), ConnectorMetadataRequestContext.DEFAULT)
-                                    : partitionNames;
+                    List<String> allPartitionNames = partitionNamesFiltered
+                            ? GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
+                                    table.getCatalogName(), table.getCatalogDBName(),
+                                    table.getCatalogTableName(), ConnectorMetadataRequestContext.DEFAULT)
+                            : partitionNames;
                     context.getDumpInfo().getHMSTable(table.getResourceName(), table.getCatalogDBName(),
                             table.getCatalogTableName()).setPartitionNames(allPartitionNames);
                 }

--- a/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/fe/fe-core/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1278,14 +1278,14 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     @Override
     public List<Partition> listPartitionsByFilter(String db_name, String tbl_name, String filter, short max_parts)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return client.get_partitions_by_filter(db_name, tbl_name, filter, max_parts);
     }
 
     @Override
     public List<Partition> listPartitionsByFilter(String catName, String db_name, String tbl_name, String filter,
                                                   int max_parts)
             throws MetaException, NoSuchObjectException, TException {
-        throw new TException("method not implemented");
+        return listPartitionsByFilter(db_name, tbl_name, filter, shrinkMaxtoShort(max_parts));
     }
 
     @Override
@@ -2580,4 +2580,3 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         throw new TException("method not implemented");
     }
 }
-

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -333,6 +333,40 @@ public class CachingHiveMetastoreTest {
     }
 
     @Test
+    public void testGetPartitionsByFilterPopulatesPartitionCache() {
+        AtomicInteger getPartitionsByNamesCalls = new AtomicInteger();
+        HiveMetaClient filteredClient = new HiveMetastoreTest.MockedHiveMetaClient() {
+            @Override
+            public List<org.apache.hadoop.hive.metastore.api.Partition> getPartitionsByFilter(
+                    String dbName, String tableName, String filter) {
+                return super.getPartitionsByNames(
+                        dbName, tableName, Lists.newArrayList("col1=1", "col1=2"));
+            }
+
+            @Override
+            public List<org.apache.hadoop.hive.metastore.api.Partition> getPartitionsByNames(
+                    String dbName, String tableName, List<String> partitionNames) {
+                getPartitionsByNamesCalls.incrementAndGet();
+                return super.getPartitionsByNames(dbName, tableName, partitionNames);
+            }
+        };
+        HiveMetastore filteredMetastore = new HiveMetastore(
+                filteredClient, "hive_catalog", MetastoreType.HMS);
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                filteredMetastore, executor, executor,
+                expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+
+        Map<String, Partition> filteredPartitions = cachingHiveMetastore.getPartitionsByFilter(
+                "db1", "table1", Lists.newArrayList("col1"), "col1 >= 1");
+        Map<String, Partition> cachedPartitions = cachingHiveMetastore.getPartitionsByNames(
+                "db1", "table1", Lists.newArrayList("col1=1", "col1=2"));
+
+        Assertions.assertEquals(2, filteredPartitions.size());
+        Assertions.assertEquals(2, cachedPartitions.size());
+        Assertions.assertEquals(0, getPartitionsByNamesCalls.get());
+    }
+
+    @Test
     public void testRefreshTable() {
         new Expectations(metastore) {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreClientTest.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.GetTableRequest;
 import org.apache.hadoop.hive.metastore.api.GetTableResult;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
 import org.apache.thrift.TException;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.net.SocketTimeoutException;
+import java.util.List;
 
 public class HiveMetastoreClientTest {
     @Test
@@ -104,5 +106,34 @@ public class HiveMetastoreClientTest {
         // otherwise get_table_req reads get_table's stale response and the Thrift seqid desyncs.
         Assertions.assertTrue(reconnected[0], "reconnect() should be invoked before the get_table_req fallback");
         Assertions.assertTrue(reqRanAfterReconnect[0], "get_table_req() must run after reconnect()");
+    }
+
+    @Test
+    public void testListPartitionsByFilter(@Mocked ThriftHiveMetastore.Iface client) throws Exception {
+        new MockUp<TSocket>() {
+            @Mock
+            public boolean isOpen() {
+                return true;
+            }
+        };
+
+        new MockUp<ThriftHiveMetastore.Client>() {
+            @Mock
+            public List<Partition> get_partitions_by_filter(
+                    String dbName, String tableName, String filter, short maxParts) {
+                Partition partition = new Partition();
+                partition.setValues(List.of("2026-05-25", "3091", "app_create"));
+                return List.of(partition);
+            }
+        };
+
+        Configuration configuration = new HiveConf();
+        configuration.set("metastore.thrift.uris", "thrift://127.0.0.1:1234");
+        HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(configuration);
+        List<Partition> partitions = metaStoreClient.listPartitionsByFilter(
+                "dw", "dw_log_511", "s_date >= \"2026-05-25\"", (short) -1);
+
+        Assertions.assertEquals(1, partitions.size());
+        Assertions.assertEquals("2026-05-25", partitions.get(0).getValues().get(0));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -133,6 +134,22 @@ public class HiveMetastoreOperationsTest {
     @Test
     public void testGetPartitionKeys() {
         Assertions.assertEquals(Lists.newArrayList("col1"), hmsOps.getPartitionKeys("db1", "tbl1"));
+    }
+
+    @Test
+    public void testGetPartitionKeysByFilterOnlyForHms() {
+        Optional<List<String>> partitionNames =
+                hmsOps.getPartitionKeysByFilter("db1", "table1", "col1 >= 1");
+
+        Assertions.assertTrue(partitionNames.isPresent());
+        Assertions.assertEquals(2, partitionNames.get().size());
+        Assertions.assertTrue(partitionNames.get().contains("col1=1"));
+        Assertions.assertTrue(partitionNames.get().contains("col1=2"));
+
+        HiveMetastoreOperations glueOps = new HiveMetastoreOperations(
+                cachingHiveMetastore, true, new Configuration(), MetastoreType.GLUE, "hive_catalog");
+        Assertions.assertTrue(glueOps.getPartitionKeysByFilter(
+                "db1", "table1", "col1 >= 1").isEmpty());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -115,6 +115,19 @@ public class HiveMetastoreTest {
     }
 
     @Test
+    public void testGetPartitionsByFilter() {
+        HiveMetaClient client = new MockedHiveMetaClient();
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+
+        Map<String, com.starrocks.connector.hive.Partition> partitions = metastore.getPartitionsByFilter(
+                "db1", "table1", Lists.newArrayList("col1"), "col1 >= 1");
+
+        Assertions.assertEquals(2, partitions.size());
+        Assertions.assertTrue(partitions.containsKey("col1=1"));
+        Assertions.assertTrue(partitions.containsKey("col1=2"));
+    }
+
+    @Test
     public void testGetPartition() {
         HiveMetaClient client = new MockedHiveMetaClient();
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
@@ -539,6 +552,10 @@ public class HiveMetastoreTest {
                 res.add(partition);
             }
             return res;
+        }
+
+        public List<Partition> getPartitionsByFilter(String dbName, String tableName, String filter) {
+            return getPartitionsByNames(dbName, tableName, Lists.newArrayList("col1=1", "col1=2"));
         }
 
         public List<ColumnStatisticsObj> getTableColumnStats(String dbName, String tableName, List<String> columns) {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorHiveTest.java
@@ -255,7 +255,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
 
-        assertPlanContains(execPlan, "partitions=1/7");
+        assertPlanContains(execPlan, "partitions=1/1");
         Collection<Partition> partitions = materializedView.getPartitions();
         Assertions.assertEquals(7, partitions.size());
 
@@ -300,7 +300,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         processor = getPartitionBasedRefreshProcessor(taskRun);
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
-        assertPlanContains(execPlan, "par_date >= '2020-01-03', 9: par_date < '2020-01-04'", "partitions=2/6");
+        assertPlanContains(execPlan, "par_date >= '2020-01-03', 9: par_date < '2020-01-04'", "partitions=2/2");
 
         mockedHiveMetadata.updatePartitions("partitioned_db", "t1",
                 ImmutableList.of("par_col=0"));
@@ -351,7 +351,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         execPlan = mvContext.getExecPlan();
 
         assertPlanContains(execPlan, "l_shipdate >= '1998-01-04', 16: l_shipdate < '1998-01-05'",
-                "partitions=1/6");
+                "partitions=1/1");
 
         mockedHiveMetadata.updateTable("tpch", "orders");
 
@@ -444,7 +444,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan,
                 "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
-                "partitions=2/6");
+                "partitions=2/2");
 
         Collection<Partition> partitions = materializedView.getPartitions();
         Assertions.assertEquals(6, partitions.size());
@@ -590,7 +590,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan,
                 "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
-                "partitions=2/6");
+                "partitions=2/2");
 
         Collection<Partition> partitions = materializedView.getPartitions();
         Assertions.assertEquals(6, partitions.size());
@@ -645,7 +645,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan,
                 "PARTITION PREDICATES: 16: l_shipdate >= '1998-01-02', 16: l_shipdate < '1998-01-04'",
-                "partitions=2/6");
+                "partitions=2/2");
 
         Collection<Partition> partitions = materializedView.getPartitions();
         Assertions.assertEquals(6, partitions.size());
@@ -739,7 +739,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
         Assertions.assertTrue(plan.contains("PARTITION PREDICATES: 16: l_shipdate >= '1998-01-01', " +
                 "16: l_shipdate < '1998-01-03'"));
-        Assertions.assertTrue(plan.contains("partitions=2/6"));
+        Assertions.assertTrue(plan.contains("partitions=2/2"));
     }
 
     @Test
@@ -761,7 +761,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
         Assertions.assertTrue(
                 plan.contains("PARTITION PREDICATES: 15: l_shipdate >= '1998-01-01', 15: l_shipdate < '1998-01-03'"));
-        Assertions.assertTrue(plan.contains("partitions=5/8"));
+        Assertions.assertTrue(plan.contains("partitions=5/5"));
     }
 
     @Test
@@ -862,11 +862,11 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             PlanTestBase.assertContains(plan, "     TABLE: part_tbl1\n" +
                     "     PARTITION PREDICATES: 4: par_date IS NOT NULL, 4: par_date >= '2020-01-05', 4: par_date < " +
                     "'2020-01-06'\n" +
-                    "     partitions=1/5");
+                    "     partitions=1/1");
             PlanTestBase.assertContains(plan, "     TABLE: part_tbl2\n" +
                     "     PARTITION PREDICATES: 8: par_date IS NOT NULL, 8: par_date >= '2020-01-05', 8: par_date < " +
                     "'2020-01-06'\n" +
-                    "     partitions=1/5");
+                    "     partitions=1/1");
         }
 
         // run 4
@@ -959,7 +959,7 @@ public class PartitionBasedMvRefreshProcessorHiveTest extends MVTestBase {
             PlanTestBase.assertContains(plan, "TABLE: t1_par\n" +
                     "     PARTITION PREDICATES: 10: par_date >= '2020-01-05', " +
                     "10: par_date < '2020-01-06'\n" +
-                    "     partitions=1/7");
+                    "     partitions=1/1");
             // TODO: multi-column partitions cannot prune partitions.
             PlanTestBase.assertContains(plan, "TABLE: t2_par\n" +
                     "     PARTITION PREDICATES: 4: par_col IS NOT NULL\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/HivePartitionFilterConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/HivePartitionFilterConverterTest.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class HivePartitionFilterConverterTest {
+    private final ColumnRefOperator dateRef = new ColumnRefOperator(1, VarcharType.VARCHAR, "s_date", true);
+    private final ColumnRefOperator pidRef = new ColumnRefOperator(2, IntegerType.INT, "u_pid", true);
+    private final ColumnRefOperator eventRef = new ColumnRefOperator(3, VarcharType.VARCHAR, "b_event", true);
+    private final ColumnRefOperator userRef = new ColumnRefOperator(4, VarcharType.VARCHAR, "u_id", true);
+
+    private final Map<ColumnRefOperator, Column> partitionColumns = ImmutableMap.of(
+            dateRef, new Column("s_date", VarcharType.VARCHAR),
+            pidRef, new Column("u_pid", IntegerType.INT),
+            eventRef, new Column("b_event", VarcharType.VARCHAR));
+
+    @Test
+    public void testConvertRangeAndInPredicates() {
+        ScalarOperator predicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND,
+                Lists.newArrayList(
+                        BinaryPredicateOperator.ge(dateRef, ConstantOperator.createVarchar("2026-05-25")),
+                        BinaryPredicateOperator.le(dateRef, ConstantOperator.createVarchar("2026-05-26")),
+                        new InPredicateOperator(false, pidRef, ConstantOperator.createInt(3091)),
+                        new InPredicateOperator(false, eventRef,
+                                ConstantOperator.createVarchar("app_create"),
+                                ConstantOperator.createVarchar("app_timer")),
+                        BinaryPredicateOperator.ne(userRef, ConstantOperator.createVarchar(""))));
+
+        Optional<HivePartitionFilterConverter.Result> result =
+                HivePartitionFilterConverter.convert(predicate, partitionColumns);
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertTrue(result.get().requiresFilterApi());
+        Assertions.assertTrue(result.get().getFilter().contains("s_date >= \"2026-05-25\""));
+        Assertions.assertTrue(result.get().getFilter().contains("s_date <= \"2026-05-26\""));
+        Assertions.assertTrue(result.get().getFilter().contains("u_pid = 3091"));
+        Assertions.assertTrue(result.get().getFilter().contains("b_event = \"app_create\""));
+        Assertions.assertTrue(result.get().getFilter().contains("b_event = \"app_timer\""));
+        Assertions.assertFalse(result.get().getFilter().contains("u_id"));
+    }
+
+    @Test
+    public void testStringEqualityKeepsPartitionValuesFastPath() {
+        Optional<HivePartitionFilterConverter.Result> result = HivePartitionFilterConverter.convert(
+                BinaryPredicateOperator.eq(dateRef, ConstantOperator.createVarchar("2026-05-25")),
+                partitionColumns);
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertFalse(result.get().requiresFilterApi());
+        Assertions.assertEquals("s_date = \"2026-05-25\"", result.get().getFilter());
+    }
+
+    @Test
+    public void testIntegerEqualityRequiresFilterApiAndInKeepsPartitionValuesFastPath() {
+        Optional<HivePartitionFilterConverter.Result> equality = HivePartitionFilterConverter.convert(
+                BinaryPredicateOperator.eq(pidRef, ConstantOperator.createInt(3091)), partitionColumns);
+        Optional<HivePartitionFilterConverter.Result> in = HivePartitionFilterConverter.convert(
+                new InPredicateOperator(false, eventRef,
+                        ConstantOperator.createVarchar("app_create"),
+                        ConstantOperator.createVarchar("app_timer")),
+                partitionColumns);
+
+        Assertions.assertTrue(equality.isPresent());
+        Assertions.assertTrue(equality.get().requiresFilterApi());
+        Assertions.assertTrue(in.isPresent());
+        Assertions.assertFalse(in.get().requiresFilterApi());
+    }
+
+    @Test
+    public void testCommuteBinaryPredicate() {
+        Optional<HivePartitionFilterConverter.Result> result = HivePartitionFilterConverter.convert(
+                BinaryPredicateOperator.le(ConstantOperator.createInt(3091), pidRef), partitionColumns);
+
+        Assertions.assertTrue(result.isPresent());
+        Assertions.assertTrue(result.get().requiresFilterApi());
+        Assertions.assertEquals("u_pid >= 3091", result.get().getFilter());
+    }
+
+    @Test
+    public void testOrRequiresEveryBranchToBeConvertible() {
+        ScalarOperator predicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.OR,
+                BinaryPredicateOperator.gt(dateRef, ConstantOperator.createVarchar("2026-05-25")),
+                BinaryPredicateOperator.eq(userRef, ConstantOperator.createVarchar("user1")));
+
+        Assertions.assertTrue(HivePartitionFilterConverter.convert(predicate, partitionColumns).isEmpty());
+    }
+
+    @Test
+    public void testBackslashLiteralFallsBackSafely() {
+        ScalarOperator unsafePredicate = BinaryPredicateOperator.ge(
+                dateRef, ConstantOperator.createVarchar("2026-05-25\\"));
+        Assertions.assertTrue(HivePartitionFilterConverter.convert(
+                unsafePredicate, partitionColumns).isEmpty());
+
+        ScalarOperator safePredicate = BinaryPredicateOperator.ge(
+                dateRef, ConstantOperator.createVarchar("2026-05-01"));
+        ScalarOperator andPredicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.AND, safePredicate, unsafePredicate);
+        Optional<HivePartitionFilterConverter.Result> andResult =
+                HivePartitionFilterConverter.convert(andPredicate, partitionColumns);
+        Assertions.assertTrue(andResult.isPresent());
+        Assertions.assertEquals("(s_date >= \"2026-05-01\")", andResult.get().getFilter());
+
+        ScalarOperator orPredicate = new CompoundPredicateOperator(
+                CompoundPredicateOperator.CompoundType.OR, safePredicate, unsafePredicate);
+        Assertions.assertTrue(HivePartitionFilterConverter.convert(
+                orPredicate, partitionColumns).isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -451,7 +451,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
                 "     PARTITION PREDICATES: 25: l_shipdate IN ('1998-01-02')\n" +
                 "     NON-PARTITION PREDICATES: 23: l_orderkey > 100\n" +
                 "     MIN/MAX PREDICATES: 23: l_orderkey > 100\n" +
-                "     partitions=1/6");
+                "     partitions=1/1");
         dropMv("test", "hive_parttbl_mv_2");
     }
 
@@ -514,7 +514,7 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
         query = "SELECT `o_orderkey`, `o_orderstatus`, `o_orderdate`  FROM `hive0`.`partitioned_db`.`orders` ";
         plan = getFragmentPlan(query);
         PlanTestBase.assertContains(plan, "hive_parttbl_mv_5", "orders",
-                "     partitions=28/1095");
+                "     partitions=28/28");
 
         // updated partitions are not in the query's partition range
         query = "SELECT `o_orderkey`, `o_orderstatus`, `o_orderdate`  FROM `hive0`.`partitioned_db`.`orders` " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneLimitTest.java
@@ -80,7 +80,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
                 "OR (4: par_col = 5), 4: par_col IN (0, 5)\n" +
                 "     NO EVAL-PARTITION PREDICATES: ((4: par_col = 0) AND (abs(4: par_col) = 3)) " +
                 "OR (4: par_col = 5)\n" +
-                "     partitions=1/3");
+                "     partitions=1/1");
 
         sql = "select * from t1 where abs(par_col) = 3 and par_col = 0 or par_col = 2";
         plan = getFragmentPlan(sql);
@@ -88,7 +88,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
                 "OR (4: par_col = 2), 4: par_col IN (0, 2)\n" +
                 "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 0)) " +
                 "OR (4: par_col = 2)\n" +
-                "     partitions=2/3");
+                "     partitions=2/2");
 
         sql = "select * from t1 where abs(par_col) = 3 and par_col = 10 or par_col = 2";
         plan = getFragmentPlan(sql);
@@ -96,7 +96,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
                 "OR (4: par_col = 2), 4: par_col IN (10, 2)\n" +
                 "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 10)) " +
                 "OR (4: par_col = 2)\n" +
-                "     partitions=1/3");
+                "     partitions=1/1");
 
         String sql1 = "select * from t1 where abs(par_col) = 1 and abs(par_col) = 3 or par_col = 10";
         plan = getFragmentPlan(sql);
@@ -105,7 +105,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
         sql = "select * from t1 where par_col = 1 or par_col = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "PARTITION PREDICATES: 4: par_col IN (1, 2)\n" +
-                "     partitions=2/3");
+                "     partitions=2/2");
 
         String sql2 = "select * from t1 where par_col = 1 or abs(par_col) = 2";
         Assertions.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql2));
@@ -122,7 +122,7 @@ public class HivePartitionPruneLimitTest extends ConnectorPlanTestBase {
                 "AND (abs(4: par_col) = 2)), 4: par_col IN (0, 1)\n" +
                 "     NO EVAL-PARTITION PREDICATES: (4: par_col = 0) OR ((4: par_col = 1) " +
                 "AND (abs(4: par_col) = 2))\n" +
-                "     partitions=2/3");
+                "     partitions=2/2");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -17,11 +17,16 @@ package com.starrocks.sql.plan;
 import com.starrocks.common.DdlException;
 import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.server.MetadataMgr;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class HivePartitionPruneTest extends ConnectorPlanTestBase {
     @BeforeEach
@@ -73,6 +78,49 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
     }
 
     @Test
+    public void testHivePartitionRangeFilterPushdown() throws Exception {
+        AtomicReference<String> pushedFilter = new AtomicReference<>();
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Optional<List<String>> listPartitionNamesByFilter(
+                    String catalogName, String dbName, String tableName, String filter) {
+                pushedFilter.set(filter);
+                if ("part_tbl1".equals(tableName)) {
+                    return Optional.of(List.of(
+                            "par_date=2020-01-01", "par_date=2020-01-02",
+                            "par_date=2020-01-03", "par_date=2020-01-04"));
+                }
+                return Optional.of(List.of("par_col=1", "par_col=2"));
+            }
+        };
+
+        String inPlan = getFragmentPlan("select * from t1 where par_col in (1, 2)");
+        Assertions.assertNull(pushedFilter.get());
+        assertContains(inPlan, "partitions=2/2");
+
+        String dateBetweenPlan = getFragmentPlan(
+                "select * from part_tbl1 where par_date between '2020-01-01' and '2020-01-03'");
+        Assertions.assertNull(pushedFilter.get());
+        assertContains(dateBetweenPlan, "partitions=3/3");
+
+        String plan = getFragmentPlan("select * from t1 where par_col >= 1 and par_col <= 2");
+        Assertions.assertNotNull(pushedFilter.get());
+        Assertions.assertTrue(pushedFilter.get().contains("par_col >= 1"));
+        Assertions.assertTrue(pushedFilter.get().contains("par_col <= 2"));
+        assertContains(plan, "4: par_col >= 1");
+        assertContains(plan, "4: par_col <= 2");
+        assertContains(plan, "partitions=2/2");
+
+        pushedFilter.set(null);
+        String largeDateRangePlan = getFragmentPlan(
+                "select * from part_tbl1 where par_date between '2020-01-01' and '2020-03-31'");
+        Assertions.assertNotNull(pushedFilter.get());
+        Assertions.assertTrue(pushedFilter.get().contains("par_date >= \"2020-01-01\""));
+        Assertions.assertTrue(pushedFilter.get().contains("par_date <= \"2020-03-31\""));
+        assertContains(largeDateRangePlan, "partitions=4/4");
+    }
+
+    @Test
     public void testCompoundPartitionPrune() throws Exception {
         String sql = "select * from t1 where par_col = 0 and par_col = 5";
         String plan = getFragmentPlan(sql);
@@ -84,7 +132,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "OR (4: par_col = 5), 4: par_col IN (0, 5)\n" +
                 "     NO EVAL-PARTITION PREDICATES: ((4: par_col = 0) AND (abs(4: par_col) = 3)) " +
                 "OR (4: par_col = 5)\n" +
-                "     partitions=1/3");
+                "     partitions=1/1");
 
         sql = "select * from t1 where abs(par_col) = 3 and par_col = 0 or par_col = 2";
         plan = getFragmentPlan(sql);
@@ -92,7 +140,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "OR (4: par_col = 2), 4: par_col IN (0, 2)\n" +
                 "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 0)) " +
                 "OR (4: par_col = 2)\n" +
-                "     partitions=2/3");
+                "     partitions=2/2");
 
         sql = "select * from t1 where abs(par_col) = 3 and par_col = 10 or par_col = 2";
         plan = getFragmentPlan(sql);
@@ -100,7 +148,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "OR (4: par_col = 2), 4: par_col IN (10, 2)\n" +
                 "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 10)) " +
                 "OR (4: par_col = 2)\n" +
-                "     partitions=1/3");
+                "     partitions=1/1");
 
         sql = "select * from t1 where abs(par_col) = 1 and abs(par_col) = 3 or par_col = 10";
         plan = getFragmentPlan(sql);
@@ -113,7 +161,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         sql = "select * from t1 where par_col = 1 or par_col = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "PARTITION PREDICATES: 4: par_col IN (1, 2)\n" +
-                "     partitions=2/3");
+                "     partitions=2/2");
 
         sql = "select * from t1 where par_col = 1 or abs(par_col) = 2";
         plan = getFragmentPlan(sql);
@@ -139,7 +187,7 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
                 "AND (abs(4: par_col) = 2)), 4: par_col IN (0, 1)\n" +
                 "     NO EVAL-PARTITION PREDICATES: (4: par_col = 0) OR ((4: par_col = 1) " +
                 "AND (abs(4: par_col) = 2))\n" +
-                "     partitions=2/3");
+                "     partitions=2/2");
     }
 
     @Test


### PR DESCRIPTION
  ## Why I'm doing:

  StarRocks currently uses `listPartitionNamesByValue` to prune Hive partitions at the metastore side, but this path only supports simple equality predicates on string partition columns.

  Predicates such as the following cannot use this fast path:

  - Range predicates: `<`, `<=`, `>`, `>=`, and `BETWEEN`
  - `IN` predicates
  - Equality predicates on integer or date partition columns
  - Compound `AND` and `OR` predicates

  For these predicates, StarRocks has to fetch all partition names from HMS and then prune them locally in FE. For Hive tables containing a large number of partitions, fetching the complete partition list can cause high HMS load, long planning
  latency, or metadata request timeouts even when the query only accesses a small partition range.

  This is a follow-up to #50143 for predicates that cannot be represented by `listPartitionNamesByValue`.

  ## What I'm doing:

  This PR adds server-side Hive partition filter pushdown through the HMS `get_partitions_by_filter` API.

  The main changes are:

  1. Convert supported StarRocks scalar predicates into Hive Metastore filter expressions.
     - Support `=`, `!=`, `<`, `<=`, `>`, and `>=`.
     - Support `IN`.
     - Support partial pushdown for `AND`.
     - Push down `OR` only when every branch can be converted.
     - Support string, date, and integer partition columns.

  2. Add `listPartitionNamesByFilter` to the connector metadata interface.
     - `Optional.empty()` means the connector does not support this capability.
     - `Optional.of(emptyList())` means the filter was executed successfully but matched no partitions.

  3. Implement `HiveMetaStoreClient.listPartitionsByFilter` using the underlying Thrift `get_partitions_by_filter` API.

  4. Convert returned HMS partitions into StarRocks partition names and populate the partition metadata cache, avoiding an additional `getPartitionsByNames` request.

  5. Use this optimization only for native HMS-backed Hive tables.
     - Glue and DLF catalogs keep the existing path.
     - Hudi and ODPS tables keep the existing path.
     - Hive partition projection keeps the existing path.
     - Paimon is unaffected because it performs split pruning through Paimon's scan planner.

  6. Keep FE-side `ListPartitionPruner` as the final correctness layer.
     HMS filtering only reduces the candidate partition set. Unsupported conjuncts are still evaluated by the existing FE partition pruning logic.

  7. Preserve complete partition lists in query dumps so dump replay remains reproducible.

## Benchmark

### Test setup

- Hive Metastore version: 3.1.3
- HMS metadata scale: 20 tables, 100,000 partitions per table, about 2,000,000 partitions in total
- Target table: 100,000 partitions
- Filter result: 200 matching partitions
- Catalog settings:
  - `enable_metastore_cache = true`
  - `enable_cache_list_names = false`
- Session settings:
  - `hive_partition_stats_sample_size = 300`
  - `new_planner_optimize_timeout = 10000`
  - `enable_query_trigger_analyze = false`

The benchmark sends concurrent `EXPLAIN` requests for:

```sql
SELECT count(*)
FROM hive_rds_benchmark.hms_filter_benchmark.dw_log_511_100k
WHERE s_date BETWEEN '2026-05-25' AND '2026-05-26';
```

Only the FE version was switched during the comparison. The HMS, table metadata, Catalog configuration, and session variables remained unchanged.

### HMS API latency

| API | Returned partitions | Latency |
| --- | ---: | ---: |
| `listPartitionNames` | 100,000 names | 309-360 ms |
| `listPartitionsByFilter` | 200 partitions | 134-172 ms |

The filtered API was approximately 2.2x faster and reduced the returned partition count from 100,000 to 200.

### FE planning result

Before this change:

```text
partitions=200/100000
```

After this change:

```text
partitions=200/200
```

### Planning latency and concurrency

| Concurrent EXPLAIN requests | Before: success | Before: max latency | After: success | After: max latency |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 1/1 | 1,781 ms | 1/1 | 171 ms |
| 10 | 10/10 | 2,471 ms | 10/10 | 817 ms |
| 20 | 20/20 | 4,949 ms | 20/20 | 1,483 ms |
| 50 | 14/50 | 9,924 ms for successful requests | 50/50 | 3,818 ms |
| 100 | 0/100 | All timed out | 100/100 | 7,410 ms |

The single cold-planning latency decreased from 1,781 ms to 171 ms, approximately a 10.4x improvement. Under a burst of 100 concurrent planning requests, the original implementation timed out for every request, while the filtered implementation completed all requests successfully.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
