### PR TITLE
[Enhancement] Upgrade simdutf to 9.1.0

### DIFF
--- a/nix/thirdparty-archives.nix
+++ b/nix/thirdparty-archives.nix
@@ -309,10 +309,10 @@ let
       md5 = "bdc1dfcb2a89dc0c09e8370808a946f5";
       sha256 = "0byazknlr5x941n9ba3j14prf29yk2dw7nwh3a4wbqd11zh3pwcv";
     };
-    "simdutf-5.2.8.tar.gz" = {
-      url = "https://github.com/simdutf/simdutf/archive/refs/tags/v5.2.8.tar.gz";
-      md5 = "731c78ab5a10c6073942dc93d5c4b04c";
-      sha256 = "0xwdx99qn4ckv4bd9ib5w3i00l8wiy2d7vrdz2c8avasz2zg21i7";
+    "simdutf-9.1.0.tar.gz" = {
+      url = "https://github.com/simdutf/simdutf/archive/refs/tags/v9.1.0.tar.gz";
+      md5 = "e55123960edadb8d9987fa30f877e588";
+      sha256 = "14yihiaalw4nxmjbbn6b64r7f4qdcpm7x8ml1zmydacm9h553qr4";
     };
     "snappy-1.1.8.tar.gz" = {
       url = "https://github.com/google/snappy/archive/1.1.8.tar.gz";
@@ -513,7 +513,7 @@ let
       "abseil-cpp-20220623.0.tar.gz"
       "cares-1_19_1.tar.gz"
       "grpc-1.43.0.tar.gz"
-      "simdutf-5.2.8.tar.gz"
+      "simdutf-9.1.0.tar.gz"
       "poco-1.12.5-release.tar.gz"
       "icu4c-76_1-src.zip"
       "xsimd-14.0.0.tar.gz"
@@ -582,7 +582,7 @@ let
       "abseil-cpp-20220623.0.tar.gz"
       "cares-1_19_1.tar.gz"
       "grpc-1.43.0.tar.gz"
-      "simdutf-5.2.8.tar.gz"
+      "simdutf-9.1.0.tar.gz"
       "poco-1.12.5-release.tar.gz"
       "icu4c-76_1-src.zip"
       "xsimd-14.0.0.tar.gz"
@@ -651,7 +651,7 @@ let
       "abseil-cpp-20220623.0.tar.gz"
       "cares-1_19_1.tar.gz"
       "grpc-1.43.0.tar.gz"
-      "simdutf-5.2.8.tar.gz"
+      "simdutf-9.1.0.tar.gz"
       "poco-1.12.5-release.tar.gz"
       "icu4c-76_1-src.zip"
       "xsimd-14.0.0.tar.gz"

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -438,10 +438,10 @@ GRPC_SOURCE="grpc-1.43.0"
 GRPC_MD5SUM="92559743e7b5d3f67486c4c0de2f5cbe"
 
 # simdutf
-SIMDUTF_DOWNLOAD="https://github.com/simdutf/simdutf/archive/refs/tags/v5.2.8.tar.gz"
-SIMDUTF_NAME="simdutf-5.2.8.tar.gz"
-SIMDUTF_SOURCE="simdutf-5.2.8"
-SIMDUTF_MD5SUM="731c78ab5a10c6073942dc93d5c4b04c"
+SIMDUTF_DOWNLOAD="https://github.com/simdutf/simdutf/archive/refs/tags/v9.1.0.tar.gz"
+SIMDUTF_NAME="simdutf-9.1.0.tar.gz"
+SIMDUTF_SOURCE="simdutf-9.1.0"
+SIMDUTF_MD5SUM="e55123960edadb8d9987fa30f877e588"
 
 # icu
 ICU_DOWNLOAD="https://github.com/unicode-org/icu/releases/download/release-76-1/icu4c-76_1-src.zip"


### PR DESCRIPTION
## Why I'm doing:

`simdutf` is used across the StarRocks backend for:
- Fast ASCII validation (`validate_ascii_fast` / `simdutf::validate_ascii`) to gate single-byte vs. multi-byte UTF-8 execution paths in SQL string functions (`substr`, `reverse`, `lpad`/`rpad`, `lower`/`upper`, `locate`), NGram tokenization, and storage index writers.
- UTF-8 validation (`simdutf::validate_utf8`) during CSV/JSON text ingestion.
- UTF-8 character length counting (`utf8_len` / `simdutf::count_utf8`).

Upgrading `simdutf` from v5.2.8 (released early 2024) to the latest upstream release (v9.1.0) brings modern SIMD vectorisation updates, improved AVX-512 routines, and updated compiler optimisations while preserving 100% API compatibility.

## What I'm doing:

1. Bumped `simdutf` from `5.2.8` to `9.1.0` in `thirdparty/vars.sh`.
2. Updated Nix third-party package archives and regenerated `nix/thirdparty-archives.nix` via `./nix/generate-thirdparty-archives.py`.

### Benchmark Results

#### 1. x86_64 (AMD Ryzen AI 9 HX 370 w/ AVX-512 & AVX2)
- ASCII Validation (64 B - 1 MB): +47% to +53.5% faster throughput improvement (92.1 GB/s → 141.4 GB/s on 1 MB chunks).
- UTF-8 Validation on ASCII (1 MB): +5.0% faster (116.2 GB/s → 122.0 GB/s).
- Multi-byte UTF-8 & Character Count: Stable parity at ~20.6 GB/s validation and ~130 GB/s counting.

| Benchmark Case | Payload Size | Iterations | Baseline v5.2.8 | Upgraded v9.1.0 | Improvement / Delta |
| :--- | :--- | :--- | :--- | :--- | :--- |
| ASCII Validation (64 B) | 64 B | 2,000,000 | 6.82 GB/s (17.5 ms) | 10.11 GB/s (11.8 ms) | +48.2% faster |
| ASCII Validation (1 KB) | 1 KB | 500,000 | 70.22 GB/s (6.8 ms) | 103.22 GB/s (4.6 ms) | +47.0% faster |
| ASCII Validation (64 KB) | 64 KB | 20,000 | 95.55 GB/s (12.8 ms) | 143.87 GB/s (8.5 ms) | +50.6% faster |
| ASCII Validation (1 MB) | 1 MB | 1,000 | 92.12 GB/s (10.6 ms) | 141.42 GB/s (6.9 ms) | +53.5% faster |
| UTF-8 Validation - ASCII (1 MB) | 1 MB | 1,000 | 116.17 GB/s (8.4 ms) | 121.96 GB/s (8.0 ms) | +5.0% faster |
| UTF-8 Validation - Mixed (1 MB) | 1 MB | 1,000 | 20.53 GB/s (47.6 ms) | 20.63 GB/s (47.4 ms) | Parity / Stable |
| UTF-8 Validation - CJK (1 MB) | 1 MB | 1,000 | 20.63 GB/s (47.3 ms) | 20.60 GB/s (47.4 ms) | Parity / Stable |
| UTF-8 Character Count (1 MB) | 1 MB | 1,000 | 130.33 GB/s (7.5 ms) | 132.23 GB/s (7.4 ms) | +1.5% faster |

#### 2. ARM64 (Google Cloud `t2a-standard-16`, Neoverse-N1)

- ASCII Validation (64 KB): ~59.2 GB/s (stable parity, saturates 128-bit NEON load pipeline).
- UTF-8 Validation - ASCII (1 MB): ~32.2 GB/s.
- UTF-8 Validation - Multi-byte (1 MB): ~4.24 GB/s.
- UTF-8 Character Count - CJK & Emoji (1 MB): ~18.4 GB/s (+0.88% faster).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5