### PR TITLE
[BugFix] Bounds-check JSON path array index instead of throwing per row

### DIFF
--- a/be/src/exprs/jsonpath.cpp
+++ b/be/src/exprs/jsonpath.cpp
@@ -54,13 +54,23 @@ bool ArraySelectorSlice::match(const std::string& input) {
 }
 
 void ArraySelectorSingle::iterate(vpack::Slice array_slice, std::function<void(vpack::Slice)> callback) {
-    try {
-        callback(array_slice.at(index));
-    } catch (const vpack::Exception& e) {
-        if (e.errorCode() == vpack::Exception::IndexOutOfBounds) {
-            callback(noneJsonSlice());
+    // Bounds-check up front instead of relying on velocypack to throw. Slice::at() raises IndexOutOfBounds
+    // for every row whose array is shorter than the index, and a C++ throw per row is extremely expensive:
+    // the unwinder serializes on a process-wide lock, so a scan over millions of short/empty arrays turns
+    // into a lock convoy that burns most of the node's CPU in the kernel. The try/catch stays as a safety
+    // net for malformed data (it costs nothing unless something is actually thrown); in the common
+    // out-of-range case it is never reached.
+    vpack::Slice item = noneJsonSlice();
+    if (array_slice.isArray() && index >= 0) {
+        try {
+            if (static_cast<vpack::ValueLength>(index) < array_slice.length()) {
+                item = array_slice.at(index);
+            }
+        } catch (const vpack::Exception&) {
+            item = noneJsonSlice();
         }
     }
+    callback(item);
 }
 
 void ArraySelectorWildcard::iterate(vpack::Slice array_slice, std::function<void(vpack::Slice)> callback) {

--- a/be/test/exprs/json_functions_test.cpp
+++ b/be/test/exprs/json_functions_test.cpp
@@ -217,6 +217,50 @@ TEST_F(JsonFunctionsTest, get_json_string_array) {
                         .ok());
 }
 
+TEST_F(JsonFunctionsTest, get_json_string_array_index_out_of_bounds) {
+    // Mirrors the production shape GET_JSON_STRING(col, '[0].value.url') over rows whose array is empty
+    // or too short: every such row must come back NULL, and rows that do have the element still resolve.
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto jsons = BinaryColumn::create();
+    auto paths = BinaryColumn::create();
+
+    std::string values[] = {R"([])",
+                            R"([{"value": {"url": "http://x"}}])",
+                            R"([{"value": {}}])",
+                            R"({"value": {"url": "http://y"}})",
+                            R"([[], [1]])",
+                            R"([])"};
+    std::string strs[] = {"[0].value.url", "[0].value.url", "[0].value.url", "[0].value.url", "[1][0]", "$[3]"};
+    bool expect_null[] = {true, false, true, true, false, true};
+    std::string expected[] = {"", "http://x", "", "", "1", ""};
+
+    for (int j = 0; j < std::size(values); ++j) {
+        jsons->append(values[j]);
+        paths->append(strs[j]);
+    }
+    columns.emplace_back(jsons);
+    columns.emplace_back(paths);
+
+    ctx.get()->set_constant_columns(columns);
+    ASSERT_TRUE(JsonFunctions::native_json_path_prepare(ctx.get(), FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+
+    ColumnPtr result = JsonFunctions::get_json_string(ctx.get(), columns).value();
+    auto v = ColumnHelper::as_column<NullableColumn>(result);
+    ASSERT_EQ(std::size(values), v->size());
+    for (int j = 0; j < std::size(values); ++j) {
+        ASSERT_EQ(expect_null[j], v->is_null(j)) << "row " << j;
+        if (!expect_null[j]) {
+            ASSERT_EQ(expected[j], v->get(j).get_slice().to_string()) << "row " << j;
+        }
+    }
+
+    ASSERT_TRUE(JsonFunctions::native_json_path_close(
+                        ctx.get(), FunctionContext::FunctionContext::FunctionStateScope::FRAGMENT_LOCAL)
+                        .ok());
+}
+
 TEST_F(JsonFunctionsTest, get_json_string_invalid_json_respects_allow_throw_exception) {
     Columns columns;
     auto strings = BinaryColumn::create();
@@ -516,6 +560,18 @@ INSTANTIATE_TEST_SUITE_P(
                 std::make_tuple(R"( {"k1": [1,2,3]} )", "$.k1[0]", R"( 1 )"),
                 std::make_tuple(R"( {"k1": [1,2,3]} )", "$.k1[3]", R"( NULL )"),
                 std::make_tuple(R"( {"k1": [1,2,3]} )", "$.k1[-1]", R"( NULL )"),
+                // index beyond a short or empty array must yield NULL without throwing per row
+                std::make_tuple(R"( [] )", "$[0]", R"( NULL )"),
+                std::make_tuple(R"( {"k1": []} )", "$.k1[0]", R"( NULL )"),
+                std::make_tuple(R"( {"k1": []} )", "$.k1[7]", R"( NULL )"),
+                std::make_tuple(R"( {"k1": [[]]} )", "$.k1[0][0]", R"( NULL )"),
+                std::make_tuple(R"( {"k1": [{"value": {"url": "u"}}]} )", "$.k1[0].value.url", R"( "u" )"),
+                std::make_tuple(R"( {"k1": [{"value": {"url": "u"}}]} )", "$.k1[1].value.url", R"( NULL )"),
+                std::make_tuple(R"( {"k1": [{"value": {}}]} )", "$.k1[0].value.url", R"( NULL )"),
+                std::make_tuple(R"( {"k1": [1,2,3,4,5,6,7,8,9,10]} )", "$.k1[9]", R"( 10 )"),
+                std::make_tuple(R"( {"k1": [1,2,3,4,5,6,7,8,9,10]} )", "$.k1[10]", R"( NULL )"),
+                std::make_tuple(R"( {"k1": [1,"a",[2],{"b":3},null,4.5,6,7,8,9]} )", "$.k1[9]", R"( 9 )"),
+                std::make_tuple(R"( {"k1": [1,"a",[2],{"b":3},null,4.5,6,7,8,9]} )", "$.k1[10]", R"( NULL )"),
                 std::make_tuple(R"( {"k1": [[1,2,3], [4,5,6]]} )", "$.k1[0][0]", R"( 1 )"),
                 std::make_tuple(R"( {"k1": [[1,2,3], [4,5,6]]} )", "$.k1[0][1]", R"( 2 )"),
                 std::make_tuple(R"( {"k1": [[1,2,3], [4,5,6]]} )", "$.k1[0][2]", R"( 3 )"),


### PR DESCRIPTION
## Why I'm doing:

`ArraySelectorSingle::iterate` resolved `[N]` with `vpack::Slice::at()` and caught the `IndexOutOfBounds` exception it throws whenever the array is shorter than the index. Every row whose array is empty or too short therefore paid a full C++ throw and unwind. The unwinder resolves frame info under a process-wide lock (`_Unwind_Find_FDE` -> `dl_iterate_phdr`), so a scan over hundreds of millions of rows with a path like `'[0].value.url'` degenerated into a lock convoy: on a production cluster one query drove BEs to 80% system CPU with ~1M context switches per second, and on a 20M-row repro the query took 160-330s instead of under a second.

Check `isArray()` and `index < length()` up front and return the none slice for out-of-range indexes, so the hot path never throws. Semantics are unchanged: out-of-range indexes still yield NULL.

Measured on a 20M-row table of empty arrays, branch-3.5 Release BE: before 163-334s wall with 1800-3500s of system CPU and 57M-118M context switches; after 0.2-0.6s with under 0.3s of system CPU.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
