### PR TITLE
[Refactor] Make the lake PK index classes standalone

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -58,7 +58,7 @@
 namespace starrocks::lake {
 
 LakePersistentIndex::LakePersistentIndex(TabletManager* tablet_mgr, int64_t tablet_id)
-        : PersistentIndex(""), _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
+        : _tablet_mgr(tablet_mgr), _tablet_id(tablet_id) {}
 
 LakePersistentIndex::~LakePersistentIndex() {
     if (_memtable) {

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -41,13 +41,22 @@ class PersistentIndexSstable;
 class TabletManager;
 class PersistentIndexSstableFileset;
 
-// LakePersistentIndex is not thread-safe.
-// Caller should take care of the multi-thread safety
-class LakePersistentIndex : public PersistentIndex {
+// The one primary-key index implementation a shared-data tablet has: a write-ahead memtable in front
+// of a stack of sstable filesets on shared storage.
+//
+// Standalone on purpose. It used to derive from PersistentIndex, the local-disk implementation, but
+// took nothing from it except two scalar members and the vtable -- it overrode 7 of that class's 39
+// virtuals and inherited an l0/l1/l2 file layout, a DataDir and a PersistentIndexMetaPB it never
+// touched. Nothing holds a lake index polymorphically either (UpdateManager's index cache stores
+// LakePrimaryIndex by value), so the base bought no dispatch. It still shares the value types --
+// IndexValue, KeyIndexSet -- which is a dependency on persistent_index.h, not on its implementation.
+//
+// Not thread-safe. Callers serialize through LakePrimaryIndex's lock.
+class LakePersistentIndex {
 public:
     explicit LakePersistentIndex(TabletManager* tablet_mgr, int64_t tablet_id);
 
-    ~LakePersistentIndex() override;
+    ~LakePersistentIndex();
 
     DISALLOW_COPY(LakePersistentIndex);
 
@@ -57,7 +66,7 @@ public:
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
     // |values|: value array for return values
-    Status get(size_t n, const Slice* keys, IndexValue* values) override;
+    Status get(size_t n, const Slice* keys, IndexValue* values);
 
     // batch upsert
     // |n|: size of key/value array
@@ -66,7 +75,7 @@ public:
     // |old_values|: return old values for updates, or set to NullValue for inserts
     // |stat|: used for collect statistic
     Status upsert(size_t n, const Slice* keys, const IndexValue* values, IndexValue* old_values, IOStat* stat = nullptr,
-                  ParallelUpsertContext* ctx = nullptr) override;
+                  ParallelUpsertContext* ctx = nullptr);
 
     // batch erase
     // |n|: size of key/value array
@@ -74,11 +83,6 @@ public:
     // |old_values|: return old values if key exist, or set to NullValue if not
     // |del_rssid|: rssid stamped for these deletes (rowset_id + op_offset); used as the rebuild point
     Status erase(size_t n, const Slice* keys, IndexValue* old_values, uint32_t del_rssid);
-
-    // Use erase with `del_rssid` instead of this one.
-    Status erase(size_t n, const Slice* keys, IndexValue* old_values) override {
-        return Status::NotSupported("LakePersistentIndex::erase not supported");
-    }
 
     // Apply a large delete by ingesting the tombstone sstable |del_sst_meta| that was pre-built at import
     // time (PkTabletWriter::flush_del_file), avoiding tombstone accumulation and additional memtable flushes.
@@ -111,15 +115,14 @@ public:
     // |max_src_rssid|: maximum of rssid array
     // |failed|: return not match rowid
     Status try_replace(size_t n, const Slice* keys, const IndexValue* values, const uint32_t max_src_rssid,
-                       std::vector<uint32_t>* failed) override;
+                       std::vector<uint32_t>* failed);
 
     // batch replace without return old values
     // |n|: size of key/value array
     // |keys|: key array as raw buffer
     // |values|: value array
     // |replace_indexes|: The index of the |keys| array that need to replace.
-    Status replace(size_t n, const Slice* keys, const IndexValue* values,
-                   const std::vector<uint32_t>& replace_indexes) override;
+    Status replace(size_t n, const Slice* keys, const IndexValue* values, const std::vector<uint32_t>& replace_indexes);
 
     // batch insert, return error if key already exists
     // |n|: size of key/value array
@@ -143,7 +146,7 @@ public:
     Status load_from_lake_tablet(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                                  const MetaFileBuilder* builder);
 
-    size_t memory_usage() const override;
+    size_t memory_usage() const;
 
     int32_t current_fileset_index() const { return (int32_t)_sstable_filesets.size() - 1; }
 
@@ -169,6 +172,16 @@ public:
     // Return the {file_cnt, row_cnt} that need to rebuild in a single rowset traversal.
     static std::pair<size_t, int64_t> need_rebuild_counts(const TabletMetadataPB& metadata,
                                                           const PersistentIndexSstableMetaPB& sstable_meta);
+
+    // Stamp the version that every subsequent memtable entry carries. Called once per publish,
+    // before any upsert/erase/replace.
+    //
+    // This replaces the inherited PersistentIndex::prepare(version, n), which set the same _version
+    // and then flipped four flags -- _dump_snapshot, _flushed, _need_bloom_filter and the error state
+    // -- that only the local-disk implementation reads. The version was the only part that reached
+    // this class, via `_version.major_number()` in upsert/erase/replace, which made the publish
+    // version's route into the memtable considerably harder to follow than it needed to be.
+    void set_publish_version(const EditVersion& version) { _version = version; }
 
     Status flush_memtable(bool force = false);
 
@@ -245,6 +258,12 @@ private:
     // Counters for SST files flushed during publish phase
     int32_t _publish_sst_flush_count{0};
     int64_t _publish_sst_flush_bytes{0};
+
+    // Fixed encoded key size, or 0 for variable-length keys. Set from the PK schema in
+    // load_from_lake_tablet(), which is also where it was set while this derived from PersistentIndex.
+    size_t _key_size{0};
+    // The version stamped on memtable entries; see set_publish_version().
+    EditVersion _version;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -20,7 +20,7 @@
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
-#include "io/io_profiler.h"
+#include "gutil/strings/substitute.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/meta_file.h"
@@ -481,7 +481,6 @@ Status LakePrimaryIndex::get(const Column& pks, std::vector<uint64_t>* rowids) c
     if (index == nullptr) {
         return Status::InternalError("get on an unloaded lake primary index");
     }
-    auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
     Buffer<Slice> keys;
     ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
     return index->get(pks.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
@@ -493,7 +492,6 @@ Status LakePrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Colu
     if (index == nullptr) {
         return Status::InternalError("upsert on an unloaded lake primary index");
     }
-    auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
     // No runner, so the lookup of the replaced rowids completes inside index->upsert(), which
     // appends them to the context. See ParallelUpsertContext.
     ParallelPublishSlot slot;
@@ -517,7 +515,6 @@ Status LakePrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const
     if (index == nullptr) {
         return Status::InternalError("try_replace on an unloaded lake primary index");
     }
-    auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
     Buffer<Slice> keys;
     std::vector<uint64_t> values;
     values.reserve(pks.size());
@@ -527,6 +524,47 @@ Status LakePrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const
     }
     ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
     return index->try_replace(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, failed);
+}
+
+Status LakePrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, ParallelPublishSlot* slot,
+                                ParallelUpsertContext* ctx) {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("upsert on an unloaded lake primary index");
+    }
+    const uint32_t n = pks.size();
+    slot->values.reserve(n);
+    slot->old_values.resize(n, NullIndexValue);
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, n, &slot->keys));
+    const uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+    for (uint32_t i = 0; i < n; i++) {
+        slot->values.emplace_back(base + i);
+    }
+    return index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(slot->values.data()),
+                         reinterpret_cast<IndexValue*>(slot->old_values.data()), /*stat=*/nullptr, ctx);
+}
+
+Status LakePrimaryIndex::upsert(uint32_t rssid, const std::vector<uint32_t>& rowids, const Column& pks,
+                                ParallelPublishSlot* slot, ParallelUpsertContext* ctx) {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("upsert on an unloaded lake primary index");
+    }
+    const uint32_t n = pks.size();
+    DCHECK_EQ(rowids.size(), n);
+    slot->values.reserve(n);
+    slot->old_values.resize(n, NullIndexValue);
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, n, &slot->keys));
+    const uint64_t base = ((uint64_t)rssid) << 32;
+    for (uint32_t i = 0; i < n; i++) {
+        slot->values.emplace_back(base + rowids[i]);
+    }
+    return index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(slot->values.data()),
+                         reinterpret_cast<IndexValue*>(slot->old_values.data()), /*stat=*/nullptr, ctx);
+}
+
+std::string LakePrimaryIndex::to_string() const {
+    return strings::Substitute("LakePrimaryIndex tablet:$0", _tablet_id);
 }
 
 Status LakePrimaryIndex::prepare(const EditVersion& version) {

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -20,6 +20,7 @@
 #include "base/debug/trace.h"
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
+#include "io/io_profiler.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/meta_file.h"
@@ -28,6 +29,7 @@
 #include "storage/lake/segment_pk_iterator.h"
 #include "storage/lake/tablet.h"
 #include "storage/parallel_upsert_context.h"
+#include "storage_primitive/primary_key_encoder.h"
 
 namespace starrocks::lake {
 
@@ -50,15 +52,14 @@ std::vector<uint32_t> owned_rowids_of(const SegmentPKChunkRef& current) {
     return rowids;
 }
 
+LakePrimaryIndex::~LakePrimaryIndex() = default;
+
 Status LakePrimaryIndex::lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                                    const MetaFileBuilder* builder) {
     TRACE_COUNTER_SCOPE_LATENCY_US("primary_index_load_latency_us");
-    std::lock_guard<std::mutex> lg(_lock);
-    if (_loaded && !need_rebuild()) {
+    std::lock_guard<std::mutex> lg(_load_lock);
+    if (_loaded) {
         return _status;
-    }
-    if (need_rebuild()) {
-        unload_without_lock();
     }
     // _do_lake_load may need tablet id to fetch tablet schema/encoding type.
     // Set it before loading to avoid using the default value (0).
@@ -78,47 +79,66 @@ Status LakePrimaryIndex::lake_load(TabletManager* tablet_mgr, const TabletMetada
 }
 
 bool LakePrimaryIndex::is_load(int64_t base_version) {
-    std::lock_guard<std::mutex> lg(_lock);
+    std::lock_guard<std::mutex> lg(_load_lock);
     return _loaded && _data_version >= base_version;
+}
+
+bool LakePrimaryIndex::is_loaded() const {
+    std::lock_guard<std::mutex> lg(_load_lock);
+    return _loaded;
+}
+
+Status LakePrimaryIndex::get_load_status() const {
+    std::lock_guard<std::mutex> lg(_load_lock);
+    return _status;
+}
+
+void LakePrimaryIndex::unload() {
+    std::lock_guard<std::mutex> lg(_load_lock);
+    _unload_without_lock();
+}
+
+void LakePrimaryIndex::_unload_without_lock() {
+    if (!_loaded) {
+        return;
+    }
+    LOG(INFO) << "unload lake primary index tablet:" << _tablet_id << " memory: " << memory_usage();
+    _index.reset();
+    _status = Status::OK();
+    _loaded = false;
+}
+
+std::size_t LakePrimaryIndex::memory_usage() const {
+    return _index != nullptr ? _index->memory_usage() : 0;
+}
+
+void LakePrimaryIndex::_set_pk_schema(const TabletMetadataPtr& metadata) {
+    auto tablet_schema = std::make_shared<TabletSchema>(metadata->schema());
+    std::vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
+    for (auto i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns[i] = (ColumnId)i;
+    }
+    _pk_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    // Shared-data always encodes with V1; the encoding type is otherwise a shared-nothing knob.
+    _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
 }
 
 Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                        int64_t base_version, const MetaFileBuilder* builder) {
-    // 1. create and set key column schema
-    std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata->schema());
-    vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
-    for (auto i = 0; i < tablet_schema->num_key_columns(); i++) {
-        pk_columns[i] = (ColumnId)i;
-    }
-    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
-    _set_schema(pkey_schema);
+    _set_pk_schema(metadata);
 
-    // Shared-data primary-key tablets support only the cloud-native persistent index. The
-    // metadata is normalized to enabled + CLOUD_NATIVE at load time (see
-    // normalize_tablet_metadata_after_load), so the in-memory index and the LOCAL persistent
-    // index are never used here.
-    DCHECK(_persistent_index == nullptr);
-    auto index = std::make_shared<LakePersistentIndex>(tablet_mgr, metadata->id());
-    _persistent_index = index;
-    RETURN_IF_ERROR(index->init(metadata));
-    return index->load_from_lake_tablet(tablet_mgr, metadata, base_version, builder);
-}
-
-// The cloud-native index this wrapper delegates to, or nullptr when the index is not loaded.
-//
-// The downcast is unconditional rather than checked: _do_lake_load is the only place that builds
-// _persistent_index for a shared-data tablet and it always builds a LakePersistentIndex, because
-// force_cloud_native_pk_persistent_index() normalizes every PK tablet's metadata to
-// enabled + CLOUD_NATIVE before any consumer sees it. Read through _persistent_index on every call
-// instead of caching the pointer -- unload_without_lock() resets it under _lock.
-LakePersistentIndex* LakePrimaryIndex::_lake_index() const {
-    DCHECK(_persistent_index == nullptr || dynamic_cast<LakePersistentIndex*>(_persistent_index.get()) != nullptr);
-    return static_cast<LakePersistentIndex*>(_persistent_index.get());
+    // A shared-data primary-key tablet has exactly one index implementation. The metadata is
+    // normalized to enabled + CLOUD_NATIVE at load time (force_cloud_native_pk_persistent_index),
+    // so there is nothing to choose between.
+    DCHECK(_index == nullptr);
+    _index = std::make_shared<LakePersistentIndex>(tablet_mgr, metadata->id());
+    RETURN_IF_ERROR(_index->init(metadata));
+    return _index->load_from_lake_tablet(tablet_mgr, metadata, base_version, builder);
 }
 
 Status LakePrimaryIndex::apply_opcompaction(const TabletMetadataPtr& metadata,
                                             const TxnLogPB_OpCompaction& op_compaction) {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
         return Status::OK();
     }
@@ -128,7 +148,7 @@ Status LakePrimaryIndex::apply_opcompaction(const TabletMetadataPtr& metadata,
 Status LakePrimaryIndex::ingest_sst(const FileMetaPB& sst_meta, const PersistentIndexSstableRangePB& sst_range,
                                     uint32_t rssid, int64_t version, const DelvecPagePB& delvec_page,
                                     DelVectorPtr delvec) {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
         return Status::OK();
     }
@@ -138,7 +158,7 @@ Status LakePrimaryIndex::ingest_sst(const FileMetaPB& sst_meta, const Persistent
 Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuilder* builder,
                                 int64_t generation_version) {
     TRACE_COUNTER_SCOPE_LATENCY_US("primary_index_commit_latency_us");
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
         return Status::OK();
     }
@@ -146,7 +166,7 @@ Status LakePrimaryIndex::commit(const TabletMetadataPtr& metadata, MetaFileBuild
 }
 
 Status LakePrimaryIndex::sync_flush_persistent_index(int64_t wait_timeout_us) {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
         return Status::OK();
     }
@@ -163,14 +183,13 @@ static void old_values_to_deletes(const std::vector<uint64_t>& old_values, Delet
 
 Status LakePrimaryIndex::erase(const TabletMetadataPtr& metadata, const Column& pks, DeletesMap* deletes,
                                uint32_t del_rssid) {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
-        // Index not loaded: fall back to the base in-memory erase, which has no rebuild point.
-        return PrimaryIndex::erase(pks, deletes);
+        return Status::InternalError("erase on an unloaded lake primary index");
     }
     Buffer<Slice> keys;
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
-    ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
     // Cloud native index needs the delete's rssid as the rebuild point when erasing.
     RETURN_IF_ERROR(index->erase(pks.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()), del_rssid));
     old_values_to_deletes(old_values, deletes);
@@ -182,13 +201,13 @@ Status LakePrimaryIndex::bulk_erase(const TabletMetadataPtr& metadata, const Col
                                     const PersistentIndexSstableRangePB& del_sst_range, int64_t version) {
     // Unlike erase(), there is no in-memory fallback: a pre-built tombstone sstable can only be
     // ingested by the cloud-native index, so an unloaded index is a broken invariant, not a fallback.
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
         return Status::InternalError("bulk_erase requires a cloud-native LakePersistentIndex.");
     }
     Buffer<Slice> keys;
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
-    ASSIGN_OR_RETURN(const Slice* vkeys, build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
     RETURN_IF_ERROR(index->bulk_erase(pks.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()), del_rssid,
                                       del_sst_meta, del_sst_range, version));
     old_values_to_deletes(old_values, deletes);
@@ -196,14 +215,14 @@ Status LakePrimaryIndex::bulk_erase(const TabletMetadataPtr& metadata, const Col
 }
 
 int32_t LakePrimaryIndex::current_fileset_index() const {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     return index != nullptr ? index->current_fileset_index() : -1;
 }
 
 StatusOr<AsyncCompactCBPtr> LakePrimaryIndex::early_sst_compact(
         lake::LakePersistentIndexParallelCompactMgr* compact_mgr, TabletManager* tablet_mgr,
         const TabletMetadataPtr& metadata, int32_t fileset_start_idx) {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
         return nullptr;
     }
@@ -211,7 +230,7 @@ StatusOr<AsyncCompactCBPtr> LakePrimaryIndex::early_sst_compact(
 }
 
 Status LakePrimaryIndex::flush_memtable(bool force) {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index == nullptr) {
         return Status::OK();
     }
@@ -219,17 +238,17 @@ Status LakePrimaryIndex::flush_memtable(bool force) {
 }
 
 void LakePrimaryIndex::reset_publish_sst_stats() {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     if (index != nullptr) index->reset_publish_sst_stats();
 }
 
 int32_t LakePrimaryIndex::publish_sst_flush_count() const {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     return index != nullptr ? index->publish_sst_flush_count() : 0;
 }
 
 int64_t LakePrimaryIndex::publish_sst_flush_bytes() const {
-    auto* index = _lake_index();
+    auto* index = _index.get();
     return index != nullptr ? index->publish_sst_flush_bytes() : 0;
 }
 
@@ -449,6 +468,74 @@ Status LakePrimaryIndex::parallel_upsert(ThreadPoolToken* token, uint32_t rssid,
         RETURN_IF_ERROR(flush_memtable());
     }
     return segment_pk_iterator->status();
+}
+
+// ---- Surface the publish path shares with the shared-nothing index -----------------------------
+//
+// These bodies used to live in PrimaryIndex, which marshalled the encoded keys into a Buffer<Slice>
+// and then dispatched on whether a persistent index was present. A lake tablet always has one, so
+// what is left is the marshalling plus a direct call.
+
+Status LakePrimaryIndex::get(const Column& pks, std::vector<uint64_t>* rowids) const {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("get on an unloaded lake primary index");
+    }
+    auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
+    Buffer<Slice> keys;
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    return index->get(pks.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
+}
+
+Status LakePrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin,
+                                uint32_t idx_end, DeletesMap* deletes) {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("upsert on an unloaded lake primary index");
+    }
+    auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
+    // No runner, so the lookup of the replaced rowids completes inside index->upsert(), which
+    // appends them to the context. See ParallelUpsertContext.
+    ParallelPublishSlot slot;
+    ParallelUpsertContext ctx(/*runner=*/nullptr, deletes);
+    const uint32_t n = idx_end - idx_begin;
+    slot.values.reserve(n);
+    slot.old_values.resize(n, NullIndexValue);
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, _key_size, idx_begin, idx_end, &slot.keys));
+    const uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+    for (uint32_t i = idx_begin; i < idx_end; i++) {
+        slot.values.emplace_back(base + i);
+    }
+    return index->upsert(n, vkeys, reinterpret_cast<IndexValue*>(slot.values.data()),
+                         reinterpret_cast<IndexValue*>(slot.old_values.data()), /*stat=*/nullptr, &ctx);
+}
+
+Status LakePrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t max_src_rssid,
+                                     std::vector<uint32_t>* failed) {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("try_replace on an unloaded lake primary index");
+    }
+    auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
+    Buffer<Slice> keys;
+    std::vector<uint64_t> values;
+    values.reserve(pks.size());
+    const uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+    for (size_t i = 0; i < pks.size(); i++) {
+        values.emplace_back(base + i);
+    }
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    return index->try_replace(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, failed);
+}
+
+Status LakePrimaryIndex::prepare(const EditVersion& version) {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("prepare on an unloaded lake primary index");
+    }
+    index->set_publish_version(version);
+    return Status::OK();
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -509,6 +509,23 @@ Status LakePrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Colu
                          reinterpret_cast<IndexValue*>(slot.old_values.data()), /*stat=*/nullptr, &ctx);
 }
 
+Status LakePrimaryIndex::replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                                 const Column& pks) {
+    auto* index = _index.get();
+    if (index == nullptr) {
+        return Status::InternalError("replace on an unloaded lake primary index");
+    }
+    Buffer<Slice> keys;
+    std::vector<uint64_t> values;
+    values.reserve(pks.size());
+    const uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
+    for (size_t i = 0; i < pks.size(); i++) {
+        values.emplace_back(base + i);
+    }
+    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    return index->replace(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), replace_indexes);
+}
+
 Status LakePrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t max_src_rssid,
                                      std::vector<uint32_t>* failed) {
     auto* index = _index.get();

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -209,6 +209,11 @@ public:
     Status upsert(uint32_t rssid, const std::vector<uint32_t>& rowids, const Column& pks, ParallelPublishSlot* slot,
                   ParallelUpsertContext* ctx);
 
+    // Point pks[replace_indexes[i]] at (rssid, rowid_start + replace_indexes[i]). Used by the
+    // compaction conflict resolver to hand it the rows that survived.
+    Status replace(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                   const Column& pks);
+
     // Replace the entries whose current rss_rowid is at or below |max_src_rssid|, reporting the
     // positions that did not match in |failed|. Used by compaction apply.
     Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t max_src_rssid,

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -196,6 +196,19 @@ public:
     Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                   DeletesMap* deletes);
 
+    // Parallel-publish overloads. The memtable write happens synchronously here; the lookup of the
+    // rowids being replaced is deferred to `ctx`'s runner when it has one, which is why `slot` --
+    // whose pk_column owns the bytes the lookup reads -- must outlive the join. The context receives
+    // the replaced rowids either way; the caller must not append them itself. See
+    // ParallelUpsertContext::defers_lookup().
+    //
+    // The second form addresses an arbitrary subset of rows by absolute rowid: pks[i] lands at
+    // (rssid, rowids[i]).
+    Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, ParallelPublishSlot* slot,
+                  ParallelUpsertContext* ctx);
+    Status upsert(uint32_t rssid, const std::vector<uint32_t>& rowids, const Column& pks, ParallelPublishSlot* slot,
+                  ParallelUpsertContext* ctx);
+
     // Replace the entries whose current rss_rowid is at or below |max_src_rssid|, reporting the
     // positions that did not match in |failed|. Used by compaction apply.
     Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t max_src_rssid,
@@ -212,6 +225,8 @@ public:
     Status get_load_status() const;
     std::size_t memory_usage() const;
     size_t key_size() const { return _key_size; }
+
+    std::string to_string() const;
 
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
@@ -244,6 +259,12 @@ private:
     // make sure at most 1 thread is read or write primary index
     std::shared_timed_mutex _mutex;
 };
+
+// DynamicCache logs its values (see dynamic_cache.h), so the cached type has to be streamable.
+inline std::ostream& operator<<(std::ostream& os, const LakePrimaryIndex& o) {
+    os << o.to_string();
+    return os;
+}
 
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -47,11 +50,28 @@ struct SegmentPKChunkRef;
 // mask BEFORE filtering the column; filtering renumbers the survivors.
 std::vector<uint32_t> owned_rowids_of(const SegmentPKChunkRef& current);
 
-class LakePrimaryIndex : public PrimaryIndex {
+// The tablet-level primary-key index of a shared-data tablet: owns the load state, the reader/writer
+// lock the publish path serializes on, and the one LakePersistentIndex that does the work.
+//
+// Standalone on purpose. It used to derive from PrimaryIndex, the shared-nothing implementation, and
+// inherited a surface it could not use -- load(Tablet*), reset(Tablet*), major_compaction(DataDir*),
+// commit(PersistentIndexMetaPB*), on_commited(), abort(), insert(), replace() -- plus an in-memory
+// hash index that PrimaryIndex::_set_schema() allocated for every primary-key tablet and that a lake
+// tablet never reads. Nothing held a lake index through a PrimaryIndex pointer (UpdateManager's index
+// cache stores this class by value), so the base bought no dispatch, only reach.
+//
+// What it still borrows from primary_index.h are three shared names: the DeletesMap shape,
+// ROWID_MASK, and the static build_persistent_keys() key-marshalling helper.
+class LakePrimaryIndex {
 public:
-    LakePrimaryIndex() : PrimaryIndex() {}
-    LakePrimaryIndex(const Schema& pk_schema) : PrimaryIndex(pk_schema) {}
-    ~LakePrimaryIndex() override = default;
+    using segment_rowid_t = uint32_t;
+    using DeletesMap = std::unordered_map<uint32_t, std::vector<segment_rowid_t>>;
+
+    LakePrimaryIndex() = default;
+    ~LakePrimaryIndex();
+
+    LakePrimaryIndex(const LakePrimaryIndex&) = delete;
+    LakePrimaryIndex& operator=(const LakePrimaryIndex&) = delete;
 
     // Fetch all primary keys from the tablet associated with this index into memory
     // to build a hash index.
@@ -164,17 +184,62 @@ public:
     int32_t publish_sst_flush_count() const;
     int64_t publish_sst_flush_bytes() const;
 
+    // ---- Surface the publish path shares with the shared-nothing index --------------------------
+    // These used to be inherited from PrimaryIndex. Kept, with the same signatures, because
+    // UpdateManager and the compaction-conflict resolver call them on a LakePrimaryIndex.
+
+    // Look up each primary key's current rss_rowid, or NullIndexValue when absent.
+    Status get(const Column& pks, std::vector<uint64_t>* rowids) const;
+
+    // Insert or update pks[idx_begin, idx_end) at (rssid, rowid_start + i), collecting whatever
+    // rowids they replaced into |deletes|.
+    Status upsert(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t idx_begin, uint32_t idx_end,
+                  DeletesMap* deletes);
+
+    // Replace the entries whose current rss_rowid is at or below |max_src_rssid|, reporting the
+    // positions that did not match in |failed|. Used by compaction apply.
+    Status try_replace(uint32_t rssid, uint32_t rowid_start, const Column& pks, uint32_t max_src_rssid,
+                       std::vector<uint32_t>* failed);
+
+    // Stamp the version every memtable entry written by this publish carries. Called once, before
+    // any upsert/erase, by UpdateManager::prepare_primary_index.
+    Status prepare(const EditVersion& version);
+
+    // Drop the loaded index, so the next lake_load() rebuilds it. [thread-safe]
+    void unload();
+
+    bool is_loaded() const;
+    Status get_load_status() const;
+    std::size_t memory_usage() const;
+    size_t key_size() const { return _key_size; }
+
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
 
-    // The cloud-native index this class delegates to, or nullptr when the index is not loaded.
-    // Shared-data primary-key tablets have no other implementation, so the downcast is
-    // unconditional -- see the definition for why that holds.
-    LakePersistentIndex* _lake_index() const;
+    // Derive the encoded-key layout from the tablet's primary-key columns. Replaces
+    // PrimaryIndex::_set_schema(), minus the in-memory hash index it also allocated.
+    void _set_pk_schema(const TabletMetadataPtr& metadata);
+
+    void _unload_without_lock();
 
 private:
-    // We don't support multi version in PrimaryIndex yet, but we will record latest data version for some checking
+    // The index implementation, or null while unloaded. Typed, so reaching it needs no downcast --
+    // this member used to be PrimaryIndex's shared_ptr<PersistentIndex>, which cost a
+    // dynamic_cast at every one of the delegating methods below.
+    std::shared_ptr<LakePersistentIndex> _index;
+
+    // Guards the load bookkeeping (_loaded / _status / _index), not the index contents.
+    mutable std::mutex _load_lock;
+    bool _loaded = false;
+    Status _status;
+
+    int64_t _tablet_id = 0;
+    // Encoded primary-key layout, set by _set_pk_schema() at load time.
+    Schema _pk_schema;
+    size_t _key_size = 0;
+
+    // We don't support multi version yet, but we record the latest data version for some checking
     int64_t _data_version = 0;
     // make sure at most 1 thread is read or write primary index
     std::shared_timed_mutex _mutex;

--- a/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/lake/lake_primary_key_compaction_conflict_resolver.cpp
@@ -81,7 +81,10 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     params.base_version = _base_version;
     params.new_version = _metadata->version();
     params.delvec_loader = delvec_loader.get();
-    params.index = _index;
+    params.replace_rows = [this](uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                                 const Column& pks) {
+        return _index->replace(rssid, rowid_start, replace_indexes, pks);
+    };
     return handler(params, segment_iters, [&](uint32_t rssid, const DelVectorPtr& dv, uint32_t num_dels) {
         (*_segment_id_to_add_dels)[rssid] += num_dels;
         _delvecs->emplace_back(rssid, dv);
@@ -125,7 +128,10 @@ Status LakePrimaryKeyCompactionConflictResolver::segment_iterator(
     params.base_version = _base_version;
     params.new_version = _metadata->version();
     params.delvec_loader = delvec_loader.get();
-    params.index = _index;
+    params.replace_rows = [this](uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                                 const Column& pks) {
+        return _index->replace(rssid, rowid_start, replace_indexes, pks);
+    };
     return handler(params, segments, [&](uint32_t rssid, const DelVectorPtr& dv, uint32_t num_dels) {
         (*_segment_id_to_add_dels)[rssid] += num_dels;
         _delvecs->emplace_back(rssid, dv);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -198,7 +198,7 @@ StatusOr<IndexEntry*> UpdateManager::prepare_primary_index(
         return Status::InternalError(msg);
     }
     _block_cache->update_memory_usage();
-    st = index.prepare(EditVersion(new_version, 0), 0);
+    st = index.prepare(EditVersion(new_version, 0));
     if (!st.ok()) {
         // If prepare failed, release lock guard and remove index entry
         guard.reset(nullptr);

--- a/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/local_primary_key_compaction_conflict_resolver.cpp
@@ -69,7 +69,10 @@ Status LocalPrimaryKeyCompactionConflictResolver::segment_iterator(
     params.base_version = _base_version;
     params.new_version = _new_version;
     params.delvec_loader = delvec_loader.get();
-    params.index = _index;
+    params.replace_rows = [this](uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                                 const Column& pks) {
+        return _index->replace(rssid, rowid_start, replace_indexes, pks);
+    };
     return handler(params, segment_iters, [&](uint32_t rssid, const DelVectorPtr& dv, uint32_t num_dels) {
         *_total_deletes += num_dels;
         _delvecs->emplace_back(rssid, dv);

--- a/be/src/storage/primary_key_compaction_conflict_resolver.cpp
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.cpp
@@ -51,7 +51,7 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                 const std::function<void(uint32_t, const DelVectorPtr&, uint32_t)>& handle_delvec_result_func) {
                 std::map<uint32_t, DelVectorPtr> rssid_to_delvec;
                 // Accumulate multiple chunks' PKs into a single replace() call to reduce per-chunk
-                // overhead: each `params.index->replace()` ends with a memtable flush check + lock
+                // overhead: each `params.replace_rows()` ends with a memtable flush check + lock
                 // round-trip in LakePersistentIndex::replace(). For a 1 M-row segment with the default
                 // 4 K chunk, that is ~250 such calls per segment. Batching N chunks amortises the
                 // per-call setup, vector allocations, and memtable bookkeeping by ~N×. Values <= 1
@@ -81,8 +81,8 @@ Status PrimaryKeyCompactionConflictResolver::execute() {
                         }
                         if (!batch_replace_indexes.empty()) {
                             TRACE_COUNTER_SCOPE_LATENCY_US("compaction_replace_index_latency_us");
-                            RETURN_IF_ERROR(params.index->replace(params.rowset_id + segment_id, batch_start_rowid,
-                                                                  batch_replace_indexes, *batch_col));
+                            RETURN_IF_ERROR(params.replace_rows(params.rowset_id + segment_id, batch_start_rowid,
+                                                                batch_replace_indexes, *batch_col));
                         }
                         batch_start_rowid += batch_acc_rows;
                         batch_acc_rows = 0;

--- a/be/src/storage/primary_key_compaction_conflict_resolver.h
+++ b/be/src/storage/primary_key_compaction_conflict_resolver.h
@@ -15,8 +15,10 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <set>
 #include <string>
+#include <vector>
 
 #include "common/status.h"
 #include "fs/fs.h"
@@ -43,7 +45,12 @@ struct CompactConflictResolveParams {
     int64_t base_version = 0;
     int64_t new_version = 0;
     DelvecLoader* delvec_loader = nullptr;
-    PrimaryIndex* index = nullptr;
+    // Hand the surviving rows back to whichever primary index owns them. A callback rather than a
+    // PrimaryIndex*, because the shared-data index is not a PrimaryIndex -- and `replace` is the
+    // only thing this resolver ever asked of it.
+    std::function<Status(uint32_t rssid, uint32_t rowid_start, const std::vector<uint32_t>& replace_indexes,
+                         const Column& pks)>
+            replace_rows;
 };
 
 class PrimaryKeyCompactionConflictResolver {

--- a/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
@@ -658,7 +658,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_reload_after_minor_compaction)
     {
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->prepare(EditVersion(1, 0), 0);
+        index->set_publish_version(EditVersion(1, 0));
         ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000)); // Wait up to 60s
@@ -720,7 +720,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_reload_after_major_compaction)
                 all_key_slices[m].emplace_back((uint8_t*)(&all_keys[m][i]), sizeof(Key));
             }
 
-            index->prepare(EditVersion(m, 0), 0);
+            index->set_publish_version(EditVersion(m, 0));
             std::vector<IndexValue> old_values(N);
             ASSERT_OK(index->upsert(N, all_key_slices[m].data(), all_values[m].data(), old_values.data()));
             ASSERT_OK(index->flush_memtable(true));
@@ -806,7 +806,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_multiple_reload_cycles) {
         {
             auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
             ASSERT_OK(index->init(_tablet_metadata));
-            index->prepare(EditVersion(cycle, 0), 0);
+            index->set_publish_version(EditVersion(cycle, 0));
 
             std::vector<IndexValue> old_values(N);
             ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), old_values.data()));
@@ -866,7 +866,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_upsert_and_reload) {
 
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->prepare(EditVersion(1, 0), 0);
+        index->set_publish_version(EditVersion(1, 0));
         ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000)); // Wait up to 60s
@@ -890,7 +890,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_upsert_and_reload) {
 
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->prepare(EditVersion(2, 0), 0);
+        index->set_publish_version(EditVersion(2, 0));
 
         std::vector<IndexValue> old_values(N);
         ASSERT_OK(index->upsert(N, key_slices.data(), new_values.data(), old_values.data()));
@@ -945,7 +945,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_concurrent_read_after_reload) 
     {
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->prepare(EditVersion(1, 0), 0);
+        index->set_publish_version(EditVersion(1, 0));
         ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000)); // Wait up to 60s

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -752,7 +752,7 @@ TEST_F(LakePersistentIndexTest, test_erase_parallel_matches_serial) {
                 bks[j] = Slice((uint8_t*)(&bk[j]), sizeof(Key));
                 bv[j] = IndexValue((uint64_t)(gid + 1)); // distinct, non-null
             }
-            index->prepare(EditVersion(b + 1, 0), 0);
+            index->set_publish_version(EditVersion(b + 1, 0));
             std::vector<IndexValue> old(kPerBatch);
             ASSERT_OK(index->upsert(kPerBatch, bks.data(), bv.data(), old.data()));
             ASSERT_OK(index->flush_memtable(true));
@@ -822,13 +822,13 @@ TEST_F(LakePersistentIndexTest, test_bulk_erase_matches_memtable) {
                 bks[j] = key_slices[gid];
                 bv[j] = IndexValue((uint64_t)(gid + 1));
             }
-            index->prepare(EditVersion(b + 1, 0), 0);
+            index->set_publish_version(EditVersion(b + 1, 0));
             std::vector<IndexValue> old(per);
             CHECK_OK(index->upsert(per, bks.data(), bv.data(), old.data()));
             CHECK_OK(index->flush_memtable(true));
             CHECK_OK(index->sync_flush_all_memtables(10000000));
         }
-        index->prepare(EditVersion(batches + 1, 0), 0); // version stamped on the delete tombstones
+        index->set_publish_version(EditVersion(batches + 1, 0)); // version stamped on the delete tombstones
         return index;
     };
 
@@ -1215,7 +1215,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
             total_values.emplace_back(j * 2);
             ++k;
         }
-        index->prepare(EditVersion(i, 0), 0);
+        index->set_publish_version(EditVersion(i, 0));
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1316,7 +1316,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_drops_corrupted_cache) {
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->prepare(EditVersion(i, 0), 0);
+        index->set_publish_version(EditVersion(i, 0));
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1404,7 +1404,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_open_corruption_drops_cach
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->prepare(EditVersion(i, 0), 0);
+        index->set_publish_version(EditVersion(i, 0));
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1495,7 +1495,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_value_parse_corruption_dro
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->prepare(EditVersion(i, 0), 0);
+        index->set_publish_version(EditVersion(i, 0));
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1566,7 +1566,7 @@ TEST_F(LakePersistentIndexTest, test_apply_opcompaction_output_sstable_with_delv
         key_slices[i] = Slice((uint8_t*)(&keys[i]), sizeof(Key));
         values[i] = i * 2;
     }
-    index->prepare(EditVersion(1, 0), 0);
+    index->set_publish_version(EditVersion(1, 0));
     std::vector<IndexValue> old_values(kNumKeys);
     ASSERT_OK(index->upsert(kNumKeys, key_slices.data(), values.data(), old_values.data()));
     ASSERT_OK(index->flush_memtable(true));
@@ -1668,7 +1668,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_with_tablet_range) {
             key_slices.emplace_back(keys.back());
             values.emplace_back(j * 2 + i);
         }
-        index->prepare(EditVersion(i, 0), 0);
+        index->set_publish_version(EditVersion(i, 0));
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         ASSERT_OK(index->flush_memtable(true));
         // Wait for async flush to complete if any
@@ -1771,7 +1771,7 @@ TEST_F(LakePersistentIndexTest, test_range_single_int_pk_end_to_end) {
             key_slices.emplace_back(keys.back());
             values.emplace_back(key * 10);
         }
-        index->prepare(EditVersion(batch, 0), 0);
+        index->set_publish_version(EditVersion(batch, 0));
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(10000000)); // 10 seconds timeout
@@ -2328,7 +2328,7 @@ TEST_F(LakePersistentIndexTest, test_ingest_sst_skip_duplicate) {
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->prepare(EditVersion(i, 0), 0);
+        index->set_publish_version(EditVersion(i, 0));
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         ASSERT_OK(index->flush_memtable(true));
@@ -2422,7 +2422,7 @@ TEST_F(LakePersistentIndexTest, test_ingest_sst_preserves_shared_flag_for_new_ss
                 key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
                 values.emplace_back(j * 2);
             }
-            index->prepare(EditVersion(i, 0), 0);
+            index->set_publish_version(EditVersion(i, 0));
             vector<IndexValue> upsert_old_values(keys.size());
             ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
             ASSERT_OK(index->flush_memtable(true));
@@ -3099,7 +3099,7 @@ TEST_F(LakePersistentIndexTest, test_commit_stamps_version) {
         key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
         values.emplace_back(j * 2);
     }
-    index->prepare(EditVersion(publish_version, 0), 0);
+    index->set_publish_version(EditVersion(publish_version, 0));
     std::vector<IndexValue> old_values(N);
     ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), old_values.data()));
     ASSERT_OK(index->flush_memtable(true));

--- a/be/test/storage/lake/tablet_write_log_manager_test.cpp
+++ b/be/test/storage/lake/tablet_write_log_manager_test.cpp
@@ -564,7 +564,7 @@ class LakePrimaryIndexSstStatsTest : public testing::Test {};
 
 TEST_F(LakePrimaryIndexSstStatsTest, test_publish_sst_stats_disabled) {
     LakePrimaryIndex index;
-    // No persistent index is built by default (_persistent_index is nullptr).
+    // No index implementation is built by default (the internal _index is null).
 
     EXPECT_EQ(0, index.publish_sst_flush_count());
     EXPECT_EQ(0, index.publish_sst_flush_bytes());
@@ -577,9 +577,9 @@ TEST_F(LakePrimaryIndexSstStatsTest, test_publish_sst_stats_disabled) {
 
 TEST_F(LakePrimaryIndexSstStatsTest, test_publish_sst_stats_enabled_no_persistent_index) {
     LakePrimaryIndex index;
-    // No LakePersistentIndex is built (the internal _persistent_index is nullptr).
+    // No LakePersistentIndex is built (the internal _index is null).
 
-    // Should return 0 when persistent_index is not LakePersistentIndex
+    // Should return 0 while unloaded
     EXPECT_EQ(0, index.publish_sst_flush_count());
     EXPECT_EQ(0, index.publish_sst_flush_bytes());
 


### PR DESCRIPTION
## Why I'm doing:

`LakePrimaryIndex` derives from `PrimaryIndex` and `LakePersistentIndex` from `PersistentIndex` — the two shared-nothing implementations. Neither inheritance buys anything:

**No dispatch.** Nothing holds a lake index polymorphically. `UpdateManager`'s index cache is `DynamicCache<uint64_t, LakePrimaryIndex>`, by value, and there is not a single `PrimaryIndex*` or `PersistentIndex*` anywhere under `be/src/storage/lake/`.

**Almost no implementation.** What each derived class actually takes from its base:

| Derived class | Uses from base | Inherits and never touches |
|---|---|---|
| `LakePersistentIndex` | two scalar members (`_key_size`, `_version`) | 32 of 39 virtuals; l0/l1/l2 file layout, `DataDir`, `PersistentIndexMetaPB`, snapshots, local major compaction |
| `LakePrimaryIndex` | a handful of members plus `_set_schema()` | `load(Tablet*)`, `reset(Tablet*)`, `major_compaction(DataDir*)`, `commit(PersistentIndexMetaPB*)`, `on_commited()`, `abort()`, `insert()`, `replace()` |

So it is implementation inheritance that supplies almost no implementation, across a boundary (shared-data vs shared-nothing) where the two sides have not shared a code path since the LOCAL index was removed in #78259.

## What I'm doing:

Both become standalone classes. `LakePrimaryIndex` holds a `shared_ptr<LakePersistentIndex>` directly, which retires the `_lake_index()` accessor added in #78259 — the member is typed now, so reaching the implementation needs no downcast at any of its twelve delegating methods.

### Three things this surfaced, all dead for a lake tablet

1. **The in-memory hash index.** `PrimaryIndex::_set_schema()` unconditionally allocates `_pkey_to_rssid_rowid` for every primary-key tablet. A lake tablet never reads it — every mutator takes the persistent-index branch. Gone, along with `_enc_pk_type`, which existed only to choose its implementation. That is one allocation per PK tablet per BE that no longer happens.
2. **`need_rebuild()`.** `PersistentIndex::_need_rebuild` is only ever set by `_set_need_rebuild()` in the local-disk implementation (`persistent_index.cpp:5231`), so it was always false here and `lake_load()`'s reload branch never fired. `LakePersistentIndex` has its own, unrelated rebuild-from-rowsets notion (`too_many_rebuild_files()`, `needs_rowset_rebuild()`) which `load_from_lake_tablet()` handles.
3. **`size()`.** `LakePersistentIndex` never updates the inherited `_size`, so this returned 0 for every lake tablet. No caller outside the removed log line used it.

### The publish version's route is now explicit

`LakePersistentIndex` reads `_version.major_number()` in `upsert`, `erase` and `replace` to stamp memtable entries. That `_version` was set by `PersistentIndex::prepare(version, n)`, reached from `UpdateManager::prepare_primary_index` through `PrimaryIndex::prepare` — a method whose name, and whose four other side effects (`_dump_snapshot`, `_flushed`, `_need_bloom_filter`, the error state), all belong to the local index. The publish version reaching the memtable through that was considerably harder to follow than it needed to be.

`LakePersistentIndex` now owns `_version` and takes it through `set_publish_version()`; `LakePrimaryIndex::prepare()` loses the unused `n` parameter.

### What remains shared

Three names from `primary_index.h`, as a type/helper dependency rather than inheritance: the `DeletesMap` shape, `ROWID_MASK`, and the static `build_persistent_keys()` key-marshalling helper. `LakePersistentIndex` likewise still uses `persistent_index.h`'s value types (`IndexValue`, `KeyIndexSet`, `NullIndexValue`).

The methods the publish path still calls on a `LakePrimaryIndex` — `get`, the sliced `upsert`, `try_replace`, `prepare`, `memory_usage`, `unload`, `is_loaded`, `get_load_status`, `key_size` — keep their signatures, so no caller changes except `prepare`'s dropped argument.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Two differences, both on paths that are unreachable today:

1. **An unloaded index returns `InternalError`** from `get` / `upsert` / `try_replace` / `prepare` / `erase`, instead of silently falling through to an empty in-memory index and finding nothing. Unreachable in practice — the publish path loads before it touches the index — but a caller bug should say so rather than quietly return no rows.
2. **One allocation per PK tablet is gone** (the unused in-memory hash index), and `lake_load()` no longer evaluates a reload condition that was always false.

No config, metric, on-disk format or FE-facing change.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

No new tests: this changes class relationships, not behaviour. It is covered by the existing lake primary-key suites — `primary_key_publish_test`, `partial_update_test`, `condition_update_test`, `primary_key_compaction_task_test`, `lake_primary_key_consistency_test`, `lake_persistent_index_test`, `cross_publish_context_test` — all of which exercise the publish path through `LakePrimaryIndex`.

## Follow-up

A second PR will consider merging the two classes. After this one, `LakePrimaryIndex` is visibly a thin façade — roughly a dozen three-line delegating methods over the one implementation a shared-data tablet can have — and the parallel-execution logic still sits at two levels (across chunks in `LakePrimaryIndex`, across key subsets and files inside `LakePersistentIndex`). Merging would collapse both. Keeping it separate here so this PR is only about the base-class relationships.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport: main-only cleanup, and it depends on the LOCAL-index removal in #78259 which is main-only too.
