### PR TITLE
[BugFix] Move external base table partition resolution out of the MV write lock

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -868,6 +868,12 @@ public abstract class MVRefreshProcessor {
                 .map(t -> t.getId())
                 .collect(Collectors.toSet());
 
+        MVVersionManager mvVersionManager = new MVVersionManager(this.mv, mvContext, runRefreshMode);
+        // Resolve the external base tables' partition names before locking: it is the only remote metadata call
+        // the version update needs, and the mv write lock below is contended by other refresh runs and DDLs.
+        Map<PCTTableSnapshotInfo, List<String>> externalTablePartitionNames =
+                mvVersionManager.collectExternalTablePartitionNames(snapshotBaseTables, refBaseTableIds);
+
         Locker locker = new Locker();
         // update the meta if succeed
         if (!locker.tryLockTableWithIntensiveDbLock(db.getId(), mv.getId(), LockType.WRITE,
@@ -878,10 +884,22 @@ public abstract class MVRefreshProcessor {
                     db.getFullName(), this.mv.getName(), db.getFullName(), Config.mv_refresh_try_lock_timeout_ms);
         }
 
+<<<<<<< HEAD
         MVVersionManager mvVersionManager = new MVVersionManager(this.mv, mvContext);
+=======
+>>>>>>> 30c74b31ce0 ([BugFix] Resolve external base table partition names before taking the MV lock (#61528))
         try {
+            // The existence check above ran before the unlocked connector call, so re-verify under the lock:
+            // a DROP that landed in that window must abort the refresh instead of persisting a refresh-scheme
+            // journal entry and an MV_REFRESHED event for a detached mv.
+            if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), this.mv.getId()) == null) {
+                throw new DmlException("update meta failed: materialized view %s.%s does not exist, " +
+                                "it may have been dropped during refresh",
+                        db.getFullName(), this.mv.getName());
+            }
             mvVersionManager.updateMVVersionInfo(snapshotBaseTables, mvRefreshedPartitions,
-                    refBaseTableIds, refTableAndPartitionNames, tvrDeltaToPromote, !hasNextBatchRun());
+                    refBaseTableIds, refTableAndPartitionNames, tvrDeltaToPromote, externalTablePartitionNames,
+                    !hasNextBatchRun());
         } catch (Exception e) {
             logger.warn("update final meta failed after mv refreshed:", DebugUtil.getRootStackTrace(e));
             throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVVersionManager.java
@@ -67,6 +67,9 @@ public class MVVersionManager {
      * @param refBaseTableIds  mv's ref base table ids
      * @param refTableAndPartitionNames mv's ref base table and partition names
      * @param tvrDeltaToPromote TVR version ranges to promote into the persistent baseTableInfoTvrVersionRangeMap
+     * @param externalTablePartitionNames the external base tables whose meta this run updates, mapped to their
+     *                                    partition names; produced by {@link #collectExternalTablePartitionNames}
+     *                                    outside the mv lock
      * @param isFinalBatchRun whether this run is the batch's final task run (only then is freshness confirmed)
      */
     public void updateMVVersionInfo(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables,
@@ -74,6 +77,7 @@ public class MVVersionManager {
                                     Set<Long> refBaseTableIds,
                                     Map<BaseTableSnapshotInfo, PCellSortedSet> refTableAndPartitionNames,
                                     Map<BaseTableInfo, TvrVersionRange> tvrDeltaToPromote,
+                                    Map<PCTTableSnapshotInfo, List<String>> externalTablePartitionNames,
                                     boolean isFinalBatchRun) {
         MaterializedView.MvRefreshScheme copiedScheme = mv.getRefreshScheme().copy(); // copy on write
         MaterializedView.AsyncRefreshContext refreshContext = copiedScheme.getAsyncRefreshContext();
@@ -86,7 +90,10 @@ public class MVVersionManager {
         List<BaseTableSnapshotInfo> olapTables = snapshotInfoSplits.getOrDefault(true, List.of());
         List<BaseTableSnapshotInfo> externalTables = snapshotInfoSplits.getOrDefault(false, List.of());
         boolean isOlapTableRefreshed = updateMetaForOlapTable(refreshContext, olapTables, refBaseTableIds);
-        boolean isExternalTableRefreshed = updateMetaForExternalTable(refreshContext, externalTables, refBaseTableIds);
+        updateMetaForExternalTable(refreshContext, externalTablePartitionNames);
+        // Unchanged semantics: having any external base table at all counts as "meta changed", even when every
+        // one of them is deferred to the batch's final run.
+        boolean isExternalTableRefreshed = !externalTables.isEmpty();
 
         if (!isOlapTableRefreshed && !isExternalTableRefreshed) {
             return;
@@ -261,27 +268,29 @@ public class MVVersionManager {
         return isOlapTableRefreshed;
     }
 
-    private boolean updateMetaForExternalTable(MaterializedView.AsyncRefreshContext refreshContext,
-                                               List<BaseTableSnapshotInfo> changedTablePartitionInfos,
-                                               Set<Long> refBaseTableIds) {
-        if (changedTablePartitionInfos.isEmpty()) {
-            return false;
-        }
-        logger.info("Update meta for mv {} with external tables:{}, refBaseTableIds:{}", mv.getName(),
-                changedTablePartitionInfos, refBaseTableIds);
-        Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> currentVersionMap =
-                refreshContext.getBaseTableInfoVisibleVersionMap();
+    /**
+     * Decide which external base tables this run must update the version map for, and resolve the live partition
+     * names each one will be pruned against. This is the single place that filter lives:
+     * {@link #updateMetaForExternalTable} updates exactly what is returned here, so the two can never disagree.
+     * <p>
+     * {@link PartitionUtil#getPartitionNames} is a remote metadata call, which is why this runs before the caller
+     * takes the mv's write lock rather than inside the critical section.
+     */
+    public Map<PCTTableSnapshotInfo, List<String>> collectExternalTablePartitionNames(
+            Map<Long, BaseTableSnapshotInfo> snapshotBaseTables, Set<Long> refBaseTableIds) {
+        Map<PCTTableSnapshotInfo, List<String>> partitionNames = Maps.newLinkedHashMap();
         boolean hasNextBatchPartition = mvTaskRunContext.hasNextBatchPartition();
-        // update version map of materialized view
-        for (BaseTableSnapshotInfo snapshotInfo : changedTablePartitionInfos) {
+        for (BaseTableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            Table snapshotTable = snapshotInfo.getBaseTable();
+            if (snapshotTable.isNativeTableOrMaterializedView()) {
+                continue;
+            }
             if (!(snapshotInfo instanceof PCTTableSnapshotInfo)) {
                 logger.warn("Skip update meta for base table {}, because it is not a PCTTableSnapshotInfo",
-                        snapshotInfo.getBaseTable().getName());
+                        snapshotTable.getName());
                 continue;
             }
             PCTTableSnapshotInfo pctTableSnapshotInfo = (PCTTableSnapshotInfo) snapshotInfo;
-            BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
-            Table snapshotTable = snapshotInfo.getBaseTable();
             // Non-ref-base-tables should be update meta at the last refresh, otherwise it may
             // cause wrong results for rewrite or refresh.
             // eg:
@@ -300,6 +309,26 @@ public class MVVersionManager {
                         snapshotTable.getName(), pctTableSnapshotInfo.getRefreshedPartitionInfos(), mv.getName());
                 continue;
             }
+            partitionNames.put(pctTableSnapshotInfo, PartitionUtil.getPartitionNames(snapshotTable));
+        }
+        return partitionNames;
+    }
+
+    private void updateMetaForExternalTable(MaterializedView.AsyncRefreshContext refreshContext,
+                                            Map<PCTTableSnapshotInfo, List<String>> externalTablePartitionNames) {
+        if (externalTablePartitionNames.isEmpty()) {
+            return;
+        }
+        logger.info("Update meta for mv {} with external tables:{}", mv.getName(),
+                externalTablePartitionNames.keySet());
+        Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> currentVersionMap =
+                refreshContext.getBaseTableInfoVisibleVersionMap();
+        // update version map of materialized view
+        for (Map.Entry<PCTTableSnapshotInfo, List<String>> entry : externalTablePartitionNames.entrySet()) {
+            PCTTableSnapshotInfo pctTableSnapshotInfo = entry.getKey();
+            List<String> partitionNamesList = entry.getValue();
+            BaseTableInfo baseTableInfo = pctTableSnapshotInfo.getBaseTableInfo();
+            Table snapshotTable = pctTableSnapshotInfo.getBaseTable();
 
             // Use computeIfAbsent to avoid unnecessary map creation
             Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
@@ -311,8 +340,7 @@ public class MVVersionManager {
             // overwrite old partition names
             currentTablePartitionInfo.putAll(partitionInfoMap);
 
-            // Remove partition info for partitions that no longer exist in the snapshot table
-            List<String> partitionNamesList = PartitionUtil.getPartitionNames(snapshotTable);
+            // Remove partition info for partitions that no longer exist in the snapshot table.
             if (!partitionNamesList.isEmpty()) {
                 Set<String> partitionNames = Sets.newHashSetWithExpectedSize(partitionNamesList.size());
                 partitionNames.addAll(partitionNamesList);
@@ -329,7 +357,6 @@ public class MVVersionManager {
                 currentTablePartitionInfo.clear();
             }
         }
-        return true;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVVersionManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVVersionManagerTest.java
@@ -20,8 +20,10 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.PartitionUtil;
 import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.WALApplier;
@@ -193,4 +195,129 @@ public class MVVersionManagerTest {
         Assertions.assertEquals(1000L, mv.getRefreshScheme().getLastFreshnessConfirmedAt());
         Assertions.assertEquals(0, editLogCount.get());
     }
+<<<<<<< HEAD
+=======
+
+    // A base table can be processed by a run without any of its partitions being refreshed: the run is not
+    // skipped (isOlapTableRefreshed is set unconditionally), but the derived max is 0.
+    @Test
+    public void updateMVVersionInfoKeepsLastRefreshTimeWhenNoPartitionWasRefreshed() {
+        long absorbedRefreshTime = 1767225600000L;
+        MaterializedView mv = buildMv(1000L);
+        mv.getRefreshScheme().setLastRefreshTime(absorbedRefreshTime);
+
+        OlapTable baseTable = mock(OlapTable.class);
+        when(baseTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        when(baseTable.isOlapOrCloudNativeTable()).thenReturn(true);
+        when(baseTable.getId()).thenReturn(2000L);
+        when(baseTable.getVisiblePartitionNames()).thenReturn(Set.of());
+        PCTTableSnapshotInfo snapshot = new PCTTableSnapshotInfo(mock(BaseTableInfo.class), baseTable);
+        Assertions.assertTrue(snapshot.getRefreshedPartitionInfos().isEmpty());
+
+        MVVersionManager manager = new MVVersionManager(mv, buildContext(null, statusWithProcessStartTime(2000L)),
+                MaterializedView.RefreshMode.PCT);
+        manager.updateMVVersionInfo(Map.of(2000L, snapshot), PCellSortedSet.of(), Set.of(2000L),
+                Map.of(), null, Map.of(), true);
+
+        Assertions.assertEquals(absorbedRefreshTime, mv.getRefreshScheme().getLastRefreshTime(),
+                "a run that refreshed no partition must not report the MV as never refreshed");
+    }
+
+    @Test
+    public void confirmFreshnessRecordsTheModeTheRunExecuted() {
+        MaterializedView mv = buildMv(1000L);
+        MVVersionManager manager = new MVVersionManager(mv,
+                buildContext(null, statusWithProcessStartTime(2000L)), MaterializedView.RefreshMode.PCT);
+
+        manager.confirmFreshness();
+
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT,
+                mv.getRefreshScheme().getLastExecutedRefreshMode());
+    }
+
+    @Test
+    public void confirmFreshnessLeavesTheExecutedModeWhenTheRunExecutedNothing() {
+        MaterializedView mv = buildMv(1000L);
+        mv.getRefreshScheme().setLastExecutedRefreshMode(MaterializedView.RefreshMode.PCT);
+        MVVersionManager manager = new MVVersionManager(mv,
+                buildContext(null, statusWithProcessStartTime(2000L)), null);
+
+        manager.confirmFreshness();
+
+        Assertions.assertEquals(2000L, mv.getRefreshScheme().getLastFreshnessConfirmedAt());
+        Assertions.assertEquals(MaterializedView.RefreshMode.PCT,
+                mv.getRefreshScheme().getLastExecutedRefreshMode());
+    }
+
+    // PartitionUtil.getPartitionNames reaches a connector table's remote metadata, so it must not run under the
+    // mv write lock: that lock is contended by other refresh runs and DDLs, which tryLock with a bounded timeout.
+    @Test
+    public void collectExternalTablePartitionNamesResolvesOnlyExternalBaseTables() {
+        AtomicInteger resolveCount = new AtomicInteger();
+        mockGetPartitionNames(resolveCount);
+
+        MaterializedView mv = buildMv(1000L);
+        OlapTable olapBaseTable = mock(OlapTable.class);
+        when(olapBaseTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        when(olapBaseTable.getId()).thenReturn(2000L);
+        Table externalBaseTable = mock(Table.class);
+        when(externalBaseTable.isNativeTableOrMaterializedView()).thenReturn(false);
+        when(externalBaseTable.getId()).thenReturn(3000L);
+
+        PCTTableSnapshotInfo olapSnapshot = new PCTTableSnapshotInfo(mock(BaseTableInfo.class), olapBaseTable);
+        PCTTableSnapshotInfo externalSnapshot = new PCTTableSnapshotInfo(mock(BaseTableInfo.class), externalBaseTable);
+
+        MVVersionManager manager = new MVVersionManager(mv, buildContext(null, statusWithProcessStartTime(2000L)),
+                MaterializedView.RefreshMode.PCT);
+        Map<PCTTableSnapshotInfo, List<String>> partitionNames = manager.collectExternalTablePartitionNames(
+                Map.of(2000L, olapSnapshot, 3000L, externalSnapshot), Set.of(2000L, 3000L));
+
+        Assertions.assertEquals(Set.of(externalSnapshot), partitionNames.keySet(),
+                "only external base tables need their partition names resolved from the connector");
+        Assertions.assertEquals(List.of("p1", "p2"), partitionNames.get(externalSnapshot));
+        Assertions.assertEquals(1, resolveCount.get());
+    }
+
+    @Test
+    public void updateMVVersionInfoPrunesExternalPartitionsWithoutCallingTheConnector() {
+        AtomicInteger resolveCount = new AtomicInteger();
+        mockGetPartitionNames(resolveCount);
+
+        MaterializedView mv = buildMv(1000L);
+        Table externalBaseTable = mock(Table.class);
+        when(externalBaseTable.isNativeTableOrMaterializedView()).thenReturn(false);
+        when(externalBaseTable.getId()).thenReturn(3000L);
+        BaseTableInfo baseTableInfo = mock(BaseTableInfo.class);
+        PCTTableSnapshotInfo snapshot = new PCTTableSnapshotInfo(baseTableInfo, externalBaseTable);
+        snapshot.getRefreshedPartitionInfos().put("p1", new MaterializedView.BasePartitionInfo(1L, 1L, 1L));
+
+        // p3 no longer exists in the base table, so the version map entry must be pruned.
+        Map<String, MaterializedView.BasePartitionInfo> versionMap = new HashMap<>();
+        versionMap.put("p3", new MaterializedView.BasePartitionInfo(1L, 1L, 1L));
+        mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap()
+                .put(baseTableInfo, versionMap);
+
+        MVVersionManager manager = new MVVersionManager(mv, buildContext(null, statusWithProcessStartTime(2000L)),
+                MaterializedView.RefreshMode.PCT);
+        manager.updateMVVersionInfo(Map.of(3000L, snapshot), PCellSortedSet.of(), Set.of(3000L),
+                Map.of(), null, Map.of(snapshot, List.of("p1", "p2")), true);
+
+        Assertions.assertEquals(Set.of("p1"), mv.getRefreshScheme().getAsyncRefreshContext()
+                        .getBaseTableInfoVisibleVersionMap().get(baseTableInfo).keySet(),
+                "the refreshed partition must be kept and the dropped one pruned");
+        Assertions.assertEquals(0, resolveCount.get(),
+                "the partition names were resolved before the lock, so the critical section must not call the "
+                        + "connector again");
+    }
+
+    private static void mockGetPartitionNames(AtomicInteger resolveCount) {
+        new MockUp<PartitionUtil>() {
+            @Mock
+            public List<String> getPartitionNames(Table table) {
+                resolveCount.incrementAndGet();
+                return List.of("p1", "p2");
+            }
+        };
+    }
+>>>>>>> 30c74b31ce0 ([BugFix] Resolve external base table partition names before taking the MV lock (#61528))
 }


### PR DESCRIPTION
## Conflict Info:  
UU fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java<br />UU fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVVersionManagerTest.java
## Why I'm doing:
At the end of an MV refresh, `MVVersionManager.updateMVVersionInfo()` runs inside the MV's write lock and calls `PartitionUtil.getPartitionNames()` for every external base table, in order to prune version-map entries for partitions that no longer exist.

That call reaches the remote metadata service (HMS / Iceberg / other connector catalogs). Holding the DB-intensive write lock across it means every millisecond of external-catalog latency is charged to everyone else contending for that MV: other refresh runs and DDLs acquire it with a `tryLock` bounded by `mv_refresh_try_lock_timeout_ms`, so a slow catalog makes *their* operations fail outright, not merely run slower.

```
before: after:
 tryLock(mv) resolve partition names <- remote I/O, unlocked
 | tryLock(mv)
 |-- getPartitionNames() <- remote I/O |
 | (external catalog latency, |-- re-check the mv still exists
 | blocking every other waiter) |-- update version map <- pure in-memory
 |-- update version map unlock
 unlock
```

## What I'm doing:
- Resolve the external base tables' partition names before taking the MV lock, and pass the result into `updateMVVersionInfo()`. The critical section becomes pure in-memory metadata work with no connector I/O.
- Make that pre-lock pass produce **both the decision and the data**: it returns the set of external base tables whose meta this run must update, mapped to their partition names. The locked path iterates exactly that set, so the "which tables are in scope" filter (including the non-ref-base-table deferral) now lives in exactly one place instead of two, and the locked path has no branching or lookup that could disagree with it. Net effect on `updateMetaForExternalTable` is a reduction, not an addition.
- Re-verify under the lock that the MV still exists. The existence check has always run before the lock and was never re-checked after it; that window is now long enough for a concurrent `DROP MATERIALIZED VIEW` to land in it, which would journal a refresh scheme and emit `MV_REFRESHED` for a detached MV. The re-check closes the widened window and the pre-existing narrow one.

Correctness note: resolving the partition names slightly earlier does not widen any race. That list is already newer than the refreshed-partition infos it is compared against, and pruning is best-effort by design — a partition dropped externally in between is simply pruned by the next refresh.

Behavior otherwise unchanged: the "any external base table counts as meta changed" return semantics and both skip-path log messages are preserved as-is.

Tests: two new cases in `MVVersionManagerTest` — one asserting only external base tables are resolved from the connector (native tables skipped), and one asserting the version map is still pruned correctly while the locked section makes zero connector calls.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5