### PR TITLE
[BugFix] Run onReload outside the db lock when replaying a create table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -742,7 +742,26 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     }
 
     /**
-     * onCreate is called when this table is created
+     * Called when this table's in-memory state has to be (re)derived from the rest of the catalog: from
+     * {@link #onCreate}, when replaying a create-table journal entry, when loading an image, and when an
+     * alter job swaps in a new schema. Implementations rebuild derived state only -- see
+     * {@link OlapTable#onReload} (partition info, rollup index meta, constraints) and
+     * {@link MaterializedView#onReload}, which resolves every base table and may reach external catalogs.
+     *
+     * <p>The lock context is caller-specific, so an implementation must not rely on any lock being held, and
+     * must not take the database lock itself:
+     * <ul>
+     *   <li>{@link com.starrocks.server.LocalMetastore#replayCreateTable} calls this with no lock held: the
+     *   table is not visible to anyone yet, and for an MV the reload is slow and remote, so holding the
+     *   database write lock across it would stall every query on that database.</li>
+     *   <li>The alter jobs (e.g. {@link com.starrocks.alter.SchemaChangeJobV2}) call this under the
+     *   database/table write lock and from inside the edit-log applier, because there the table is already
+     *   visible and the schema flip plus this reload must land as one atomic step.</li>
+     * </ul>
+     *
+     * <p>Where it does run unlocked, a reload can be observed half-done -- an MV is transiently inactive
+     * while reloading -- so a consumer that cannot tolerate that must wait for it explicitly, see
+     * {@link MaterializedView#waitForReloaded}.
      */
     public void onReload() {
         // Do nothing by default.

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2295,22 +2295,47 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     public void replayCreateTable(CreateTableInfo info) {
         Table table = info.getTable();
         Database db = this.fullNameToDb.get(info.getDbName());
-        Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.WRITE);
         try {
-            db.registerTableUnlocked(table);
-            if (table.isTemporaryTable()) {
-                TemporaryTableMgr temporaryTableMgr = GlobalStateMgr.getCurrentState().getTemporaryTableMgr();
-                UUID sessionId = ((OlapTable) table).getSessionId();
-                temporaryTableMgr.addTemporaryTable(sessionId, db.getId(), table.getName(), table.getId());
+            Locker locker = new Locker();
+            locker.lockDatabase(db.getId(), LockType.WRITE);
+            try {
+                db.registerTableUnlocked(table);
+                if (table.isTemporaryTable()) {
+                    TemporaryTableMgr temporaryTableMgr = GlobalStateMgr.getCurrentState().getTemporaryTableMgr();
+                    UUID sessionId = ((OlapTable) table).getSessionId();
+                    temporaryTableMgr.addTemporaryTable(sessionId, db.getId(), table.getName(), table.getId());
+                }
+            } finally {
+                locker.unLockDatabase(db.getId(), LockType.WRITE);
             }
+
+            // onReload runs outside the db lock. Registering the table and writing it to the catalog is what
+            // needs mutual exclusion; for an MV the reload is the single most expensive thing this thread
+            // does: onReload walks every base table through MetadataMgr.getTable, twice (analyzePartitionExprs
+            // and checkIsActiveOnLoadBlocking), and expands a hierarchical MV's whole dependency chain
+            // recursively. On a replaying follower the connector caches are cold, so those are real remote
+            // calls -- one slow external catalog used to hold this database's write lock for their entire
+            // duration, stalling every query against it as well as the replay thread.
+            //
+            // Safe here specifically because the table is *new*: before this journal entry nobody could see it
+            // at all, so the worst a reader can observe is a just-registered table whose derived state is not
+            // rebuilt yet, which for anything depending on it is indistinguishable from the entry not having
+            // been replayed. Nothing that was already correct is exposed half-updated -- which is exactly what
+            // would happen if an alter job moved its onReload out of the lock, since there the table is
+            // already serving queries.
+            //
+            // Note the register-then-reload order is unchanged, and Database.getTable is a plain map lookup,
+            // so a lock-free reader could already land between the two; releasing the lock first only widens
+            // that gap for readers that do take the lock, by the few instructions before
+            // MaterializedView.onReload marks itself inactive. From that point waitForReloaded (hierarchical
+            // reload, MVTaskRunProcessor) blocks whoever cannot tolerate a half-reloaded MV. Image loading
+            // leaves MVs in that same registered-but-not-reloaded state far longer and on purpose,
+            // asynchronously -- see GlobalStateMgr.processMvRelatedMeta.
             table.onReload();
         } catch (Throwable e) {
             LOG.error("replay create table failed: {}", table, e);
             // Rethrow, we should not eat the exception when replaying editlog.
             throw e;
-        } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
         }
 
         if (!isCheckpointThread()) {

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
@@ -111,6 +111,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -415,6 +416,138 @@ public class LocalMetastoreSimpleOpsEditLogTest {
         Table replayedTable = followerMetastore.getDb(DB_NAME).getTable(tableName);
         Assertions.assertNotNull(replayedTable);
         Assertions.assertEquals(table.getId(), replayedTable.getId());
+    }
+
+    // onReload reaches external systems for an MV with external base tables (twice per base table, and
+    // recursively through a hierarchical MV's whole dependency chain), so it must not run under the
+    // database's write lock: on a replaying follower the connector caches are cold, so those are real remote
+    // calls and every query against that database used to wait for them.
+    @Test
+    public void testReplayCreateTableRunsOnReloadOutsideDbLock() throws Exception {
+        AtomicReference<Boolean> lockHeldDuringReload = new AtomicReference<>();
+        new MockUp<OlapTable>() {
+            @Mock
+            public void onReload() {
+                lockHeldDuringReload.set(isDatabaseLocked(DB_ID));
+            }
+        };
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String tableName = "test_replay_create_table_onreload_lock";
+        OlapTable table = createOlapTable(GlobalStateMgr.getCurrentState().getNextId(), tableName);
+
+        LocalMetastore followerMetastore = new LocalMetastore(
+                GlobalStateMgr.getCurrentState(), new CatalogRecycleBin(),
+                new com.starrocks.catalog.ColocateTableIndex());
+        followerMetastore.unprotectCreateDb(new Database(db.getId(), db.getFullName()));
+        followerMetastore.replayCreateTable(new CreateTableInfoEPack(db, table, null, null, null));
+
+        Assertions.assertEquals(Boolean.FALSE, lockHeldDuringReload.get(),
+                "onReload must run after the database write lock is released");
+        Assertions.assertNotNull(followerMetastore.getDb(DB_NAME).getTable(tableName));
+    }
+
+    private static boolean isDatabaseLocked(long dbId) {
+        return GlobalStateMgr.getCurrentState().getLockManager().dumpLockManager().stream()
+                .anyMatch(lockInfo -> lockInfo.getRid() == dbId && !lockInfo.getOwners().isEmpty());
+    }
+
+    // Pins the ordering the lock-scope reasoning rests on: the table is registered inside the lock and
+    // reloaded only after it is released, so the worst a concurrent reader can observe is a just-registered
+    // table whose derived state is not rebuilt yet -- never a table that is missing after the entry replayed.
+    @Test
+    public void testReplayCreateTableRegistersTableBeforeReloadingIt() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String tableName = "test_replay_create_table_register_order";
+        OlapTable table = createOlapTable(GlobalStateMgr.getCurrentState().getNextId(), tableName);
+
+        LocalMetastore followerMetastore = new LocalMetastore(
+                GlobalStateMgr.getCurrentState(), new CatalogRecycleBin(),
+                new com.starrocks.catalog.ColocateTableIndex());
+        followerMetastore.unprotectCreateDb(new Database(db.getId(), db.getFullName()));
+
+        AtomicReference<Boolean> visibleDuringReload = new AtomicReference<>();
+        new MockUp<OlapTable>() {
+            @Mock
+            public void onReload() {
+                visibleDuringReload.set(followerMetastore.getDb(DB_NAME).getTable(tableName) != null);
+            }
+        };
+
+        followerMetastore.replayCreateTable(new CreateTableInfoEPack(db, table, null, null, null));
+
+        Assertions.assertEquals(Boolean.TRUE, visibleDuringReload.get(),
+                "the table must already be registered by the time onReload runs");
+    }
+
+    // Moving onReload out of the lock must not turn a reload failure into a leaked database write lock, and
+    // the failure must still propagate so that replay aborts instead of silently skipping the journal entry.
+    @Test
+    public void testReplayCreateTableRethrowsReloadFailureWithoutLeakingDbLock() throws Exception {
+        // Positive control for isDatabaseLocked: without it the "lock is not held" assertions here and in
+        // testReplayCreateTableRunsOnReloadOutsideDbLock would also pass if the helper never detected a lock.
+        Locker probe = new Locker();
+        probe.lockDatabase(DB_ID, LockType.WRITE);
+        try {
+            Assertions.assertTrue(isDatabaseLocked(DB_ID));
+        } finally {
+            probe.unLockDatabase(DB_ID, LockType.WRITE);
+        }
+        Assertions.assertFalse(isDatabaseLocked(DB_ID));
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public void onReload() {
+                throw new IllegalStateException("mocked reload failure");
+            }
+        };
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String tableName = "test_replay_create_table_reload_failure";
+        OlapTable table = createOlapTable(GlobalStateMgr.getCurrentState().getNextId(), tableName);
+
+        LocalMetastore followerMetastore = new LocalMetastore(
+                GlobalStateMgr.getCurrentState(), new CatalogRecycleBin(),
+                new com.starrocks.catalog.ColocateTableIndex());
+        followerMetastore.unprotectCreateDb(new Database(db.getId(), db.getFullName()));
+
+        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class,
+                () -> followerMetastore.replayCreateTable(new CreateTableInfoEPack(db, table, null, null, null)));
+        Assertions.assertEquals("mocked reload failure", e.getMessage());
+        Assertions.assertFalse(isDatabaseLocked(DB_ID),
+                "the database write lock must be released even when onReload fails");
+    }
+
+    // The temporary-table registration is the only other mutation of shared state in this method, so it must
+    // have stayed inside the lock instead of being dragged out together with onReload.
+    @Test
+    public void testReplayCreateTemporaryTableRegistersItInsideTheLock() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        String tableName = "test_replay_create_temp_table";
+        OlapTable table = createOlapTable(GlobalStateMgr.getCurrentState().getNextId(), tableName);
+        UUID sessionId = UUID.randomUUID();
+        table.setSessionId(sessionId);
+
+        LocalMetastore followerMetastore = new LocalMetastore(
+                GlobalStateMgr.getCurrentState(), new CatalogRecycleBin(),
+                new com.starrocks.catalog.ColocateTableIndex());
+        followerMetastore.unprotectCreateDb(new Database(db.getId(), db.getFullName()));
+
+        TemporaryTableMgr temporaryTableMgr = GlobalStateMgr.getCurrentState().getTemporaryTableMgr();
+        AtomicReference<Long> registeredDuringReload = new AtomicReference<>();
+        new MockUp<OlapTable>() {
+            @Mock
+            public void onReload() {
+                registeredDuringReload.set(temporaryTableMgr.getTable(sessionId, DB_ID, tableName));
+            }
+        };
+
+        followerMetastore.replayCreateTable(new CreateTableInfoEPack(db, table, null, null, null));
+
+        Assertions.assertEquals(Long.valueOf(table.getId()), registeredDuringReload.get(),
+                "the temporary table must be registered before the database lock is released");
+        Assertions.assertEquals(Long.valueOf(table.getId()),
+                temporaryTableMgr.getTable(sessionId, DB_ID, tableName));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

When a follower FE replays a `CreateTable` journal entry, `replayCreateTable` held the database write lock across the whole operation, including `table.onReload()`.

For an ordinary OLAP table that is cheap. For a materialized view it is not: `onReload()` walks every base table through `MetadataMgr.getTable()` twice (once in `analyzePartitionExprs`, once in `checkIsActiveOnLoadBlocking`), and for a hierarchical MV it expands the entire dependency chain recursively. On a replaying follower the connector caches are cold, so those lookups are real remote calls to the external catalog.

The result is that one slow external catalog holds a database's write lock for the full duration of the reload — stalling every query against that database as well as the replay thread itself: 

```
replayCreateTable
 ├── lockDatabase(WRITE) ───────────────────────────────────┐
 │ registerTableUnlocked(table) (fast, in-memory) │ every query on
 │ onReload() │ this db blocks
 │ └── per base table: MetadataMgr.getTable() x2 │ here
 │ └── cold connector cache -> remote RPC │
 │ └── hierarchical MV: recurse whole chain │
 └── unLockDatabase(WRITE) ─────────────────────────────────┘
```

## What I'm doing:

Narrow the lock scope: the database write lock now covers only the mutation of shared state — `registerTableUnlocked` plus the temporary-table registration — and `onReload()` runs after the lock is released.

```
lockDatabase(WRITE)
 registerTableUnlocked(table) / addTemporaryTable(...)
unLockDatabase(WRITE)

table.onReload() <-- expensive, now lock-free
```

This is safe specifically because the table is brand new: before this journal entry nobody could observe it at all, so a reader that catches it mid-reload (an MV is transiently inactive while reloading, see `MaterializedView.onReload`) sees exactly the same state as if the entry had not been replayed yet. The consumers that must not observe a half-reloaded MV already wait explicitly via `MaterializedView.waitForReloaded` — from the hierarchical reload path and from `MVTaskRunProcessor`.

Error handling is unchanged: failures are still logged and rethrown so replay does not silently swallow them.

Adds a unit test that mocks `OlapTable.onReload` to record whether the database lock is held at that moment, asserting it is not, and that the table is still registered afterwards.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5