### PR TITLE
[BugFix] Bound the data-driven allocations in the parquet/orc/csv read path against the query memory limit

### DIFF
--- a/be/src/cache/scan/shared_buffered_input_stream.cpp
+++ b/be/src/cache/scan/shared_buffered_input_stream.cpp
@@ -225,7 +225,11 @@ Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offse
             // we will count how many extra bytes we read because of alignment.
             _shared_align_io_bytes += sb.size - sb.raw_size;
         }
-        sb.buffer.reserve(sb.size);
+        // A range larger than max_buffer_size gets a shared buffer of its own size, so sb.size is
+        // the size of a whole column chunk and is bounded only by the file. check_mem_limit() above
+        // only reports a tracker that is already over its limit; it does not account for the bytes
+        // about to be reserved here, which is what this scope adds.
+        TRY_CATCH_BAD_ALLOC(sb.buffer.reserve(sb.size));
         RETURN_IF_ERROR(_stream->read_at_fully(sb.offset, sb.buffer.data(), sb.size));
     }
     *buffer = sb.buffer.data() + offset - sb.offset;

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -555,12 +555,29 @@ bool BinaryColumnBase<T>::append_strings_overflow(const Slice* data, size_t size
     } else if (max_length <= 128) {
         append_fixed_length<T, 128>(data, size, &bytes, &_offsets);
     } else {
+        // Values wider than the largest fixed-length specialization are copied at their
+        // exact length, so we cannot reuse append_fixed_length here. Size the destination
+        // up front anyway: appending one value at a time lets the byte buffer grow
+        // geometrically, which re-copies the whole buffer on every doubling and leaves the
+        // final capacity at up to twice the bytes actually held. That is what turns a chunk
+        // of large strings into a multi-hundred-MB allocation spike in the scan path.
+        uint64_t total_length = 0;
         for (size_t i = 0; i < size; i++) {
-            const auto& s = data[i];
-            const auto* const p = reinterpret_cast<const Bytes::value_type*>(s.data);
-            bytes.insert(bytes.end(), p, p + s.size);
-            _offsets.emplace_back(bytes.size());
+            total_length += data[i].size;
         }
+
+        const uint64_t old_bytes_size = bytes.size();
+        const uint64_t new_bytes_size = old_bytes_size + total_length;
+        bytes.resize(new_bytes_size);
+
+        auto* __restrict dst_bytes = bytes.data();
+        uint64_t offset = old_bytes_size;
+        for (size_t i = 0; i < size; i++) {
+            memcpy(dst_bytes + offset, data[i].data, data[i].size);
+            offset += data[i].size;
+            _offsets.emplace_back(offset);
+        }
+        DCHECK_EQ(offset, new_bytes_size);
     }
     invalidate_slice_cache();
     return true;

--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -17,6 +17,7 @@
 #include <unordered_set>
 
 #include "base/string/trim.h"
+#include "runtime/current_thread.h"
 
 namespace starrocks {
 
@@ -544,7 +545,9 @@ Status CSVReader::_expand_buffer() {
     }
     size_t new_capacity = std::min(_storage.size() * 2, kMaxBufferSize);
     DCHECK_EQ(_storage.data(), _buff.position()) << "should compact buffer before expand";
-    _storage.resize(new_capacity);
+    // The buffer doubles up to kMaxBufferSize, so a single record without a row delimiter can make
+    // this ask for gigabytes at once.
+    TRY_CATCH_BAD_ALLOC(_storage.resize(new_capacity));
     CSVBuffer new_buff(_storage.data(), _storage.size());
     new_buff.add_limit(_buff.available());
     DCHECK_EQ(_storage.data(), new_buff.position());
@@ -560,7 +563,7 @@ Status CSVReader::_expand_buffer_loosely() {
         return Status::InternalError("CSV line length exceed limit " + std::to_string(kMaxBufferSize));
     }
     size_t new_capacity = std::min(_storage.size() * 2, kMaxBufferSize);
-    _storage.resize(new_capacity);
+    TRY_CATCH_BAD_ALLOC(_storage.resize(new_capacity));
     CSVBuffer new_buff(_storage.data(), _storage.size());
     new_buff.set_position_offset(_buff.position_offset());
     new_buff.set_limit_offset(_buff.limit_offset());

--- a/be/src/formats/orc/column_reader.cpp
+++ b/be/src/formats/orc/column_reader.cpp
@@ -17,6 +17,7 @@
 #include "common/statusor.h"
 #include "formats/orc/orc_chunk_reader.h"
 #include "formats/orc/utils.h"
+#include "runtime/current_thread.h"
 
 namespace starrocks {
 
@@ -519,7 +520,7 @@ Status StringColumnReader::get_next(orc::ColumnVectorBatch* cvb, Column* col, si
 
     auto& vb = values->get_bytes();
     // Need to resize after insert, because of padding char existed
-    vb.reserve(vb.size() + len);
+    TRY_CATCH_BAD_ALLOC(vb.reserve(vb.size() + len));
 
     auto& vo = values->get_offset();
     // We can resize directly
@@ -671,7 +672,7 @@ Status VarbinaryColumnReader::get_next(orc::ColumnVectorBatch* cvb, Column* col,
     size_t write_pos = vb.size();
 
     // vb is using RawVectorPad16, resize will not initialize vector
-    vb.resize(vb.size() + len);
+    TRY_CATCH_BAD_ALLOC(vb.resize(vb.size() + len));
     vo.resize_uninitialized(vo.size() + size, vb.size());
 
     if (cvb->hasNulls) {

--- a/be/src/formats/parquet/encoding_delta.h
+++ b/be/src/formats/parquet/encoding_delta.h
@@ -27,6 +27,7 @@
 #include "column/raw_data_visitor.h"
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
+#include "runtime/current_thread.h"
 
 namespace starrocks::parquet {
 
@@ -613,7 +614,7 @@ public:
             down_cast<NullableColumn*>(dst)->null_column_raw_ptr()->append_default(count);
         }
         auto* binary_column = ColumnHelper::get_binary_column(dst);
-        binary_column->append_continuous_strings(slice_buffer_.data(), count);
+        TRY_CATCH_BAD_ALLOC(binary_column->append_continuous_strings(slice_buffer_.data(), count));
         return Status::OK();
     }
 
@@ -883,7 +884,7 @@ public:
             down_cast<NullableColumn*>(dst)->null_column_raw_ptr()->append_default(count);
         }
         auto* binary_column = ColumnHelper::get_binary_column(dst);
-        binary_column->append_continuous_strings(slice_buffer_.data(), count);
+        TRY_CATCH_BAD_ALLOC(binary_column->append_continuous_strings(slice_buffer_.data(), count));
         return Status::OK();
     }
 

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -32,6 +32,7 @@
 #include "common/status.h"
 #include "common/system/cpu_info.h"
 #include "formats/parquet/encoding.h"
+#include "runtime/current_thread.h"
 
 namespace {
 // Single-pass min/max bounds check for dictionary indices. Reads the unsigned
@@ -384,7 +385,8 @@ public:
         _dict.resize(num_values);
 
         // reserve enough memory to use append_strings_overflow
-        raw::stl_vector_resize_uninitialized(&_dict_data, total_length + Column::APPEND_OVERFLOW_MAX_SIZE);
+        TRY_CATCH_BAD_ALLOC(
+                raw::stl_vector_resize_uninitialized(&_dict_data, total_length + Column::APPEND_OVERFLOW_MAX_SIZE));
 
         size_t offset = 0;
         _max_value_length = 0;
@@ -400,7 +402,8 @@ public:
     }
 
     Status get_dict_values(Column* column) override {
-        auto ret = column->append_strings_overflow(_dict.data(), _dict.size(), _max_value_length);
+        bool ret = false;
+        TRY_CATCH_BAD_ALLOC(ret = column->append_strings_overflow(_dict.data(), _dict.size(), _max_value_length));
         if (UNLIKELY(!ret)) {
             return Status::InternalError("DictDecoder append strings to column failed");
         }
@@ -441,7 +444,8 @@ public:
             }
         }
 
-        bool ret = column->append_strings_overflow(slices.data(), slices.size(), _max_value_length);
+        bool ret = false;
+        TRY_CATCH_BAD_ALLOC(ret = column->append_strings_overflow(slices.data(), slices.size(), _max_value_length));
 
         if (UNLIKELY(!ret)) {
             return Status::InternalError("DictDecoder append strings to column failed");
@@ -577,7 +581,7 @@ private:
             if (read_count == 0) {
                 return Status::OK();
             }
-            binary_column->append_bytes_overflow(datas, lengths, read_count, _max_value_length);
+            TRY_CATCH_BAD_ALLOC(binary_column->append_bytes_overflow(datas, lengths, read_count, _max_value_length));
             DCHECK_EQ(binary_column->get_bytes().size(), binary_column->get_offset().back());
         }
 
@@ -602,20 +606,22 @@ private:
                 return Status::InternalError("DictDecoder<Slice> expected a binary destination column");
             }
             auto* binary_column = down_cast<BinaryColumn*>(data_column);
-            for (int i = 0; i < count; ++i) {
-                if (filter[i]) {
-                    binary_column->append(_dict[_indexes[i]]);
-                } else {
-                    binary_column->append_default();
+            TRY_CATCH_BAD_ALLOC({
+                for (int i = 0; i < count; ++i) {
+                    if (filter[i]) {
+                        binary_column->append(_dict[_indexes[i]]);
+                    } else {
+                        binary_column->append_default();
+                    }
                 }
-            }
+            });
         } else {
             _slices.resize(count);
             auto ret = _rle_batch_reader.GetBatchWithDict(_dict.data(), _dict.size(), _slices.data(), count);
             if (UNLIKELY(ret <= 0)) {
                 return Status::InternalError("DictDecoder<Slice> GetBatchWithDict failed");
             }
-            ret = dst->append_strings_overflow(_slices.data(), _slices.size(), _max_value_length);
+            TRY_CATCH_BAD_ALLOC(ret = dst->append_strings_overflow(_slices.data(), _slices.size(), _max_value_length));
             if (UNLIKELY(!ret)) {
                 return Status::InternalError("DictDecoder append strings to column failed");
             }

--- a/be/src/formats/parquet/encoding_plain.h
+++ b/be/src/formats/parquet/encoding_plain.h
@@ -32,6 +32,7 @@
 #include "common/status.h"
 #include "formats/parquet/encoding.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 
 #ifdef __AVX2__
 #include <immintrin.h>
@@ -263,13 +264,14 @@ public:
         // fill bytes data
         max_size = std::max<decltype(max_size)>(static_cast<decltype(max_size)>(BitUtil::next_power_of_two(max_size)),
                                                 static_cast<decltype(max_size)>(8));
-        if (datas[read_count - 1] - _data.data + max_size <= _data.size) {
-            binary_column->append_bytes_overflow(datas, lengths, read_count, max_size);
-            DCHECK_EQ(binary_column->get_bytes().size(), binary_column->get_offset().back());
-        } else {
-            binary_column->append_bytes(datas, lengths, read_count);
-            DCHECK_EQ(binary_column->get_bytes().size(), binary_column->get_offset().back());
-        }
+        TRY_CATCH_BAD_ALLOC({
+            if (datas[read_count - 1] - _data.data + max_size <= _data.size) {
+                binary_column->append_bytes_overflow(datas, lengths, read_count, max_size);
+            } else {
+                binary_column->append_bytes(datas, lengths, read_count);
+            }
+        });
+        DCHECK_EQ(binary_column->get_bytes().size(), binary_column->get_offset().back());
 
         return Status::OK();
     }
@@ -318,11 +320,13 @@ public:
             max_size =
                     std::max<decltype(max_size)>(static_cast<decltype(max_size)>(BitUtil::next_power_of_two(max_size)),
                                                  static_cast<decltype(max_size)>(8));
-            if (slices[count - 1].data - _data.data + max_size <= _data.size) {
-                ret = ColumnHelper::get_binary_column(dst)->append_strings_overflow(slices, num_decoded, max_size);
-            } else {
-                ret = ColumnHelper::get_binary_column(dst)->append_strings(slices, num_decoded);
-            }
+            TRY_CATCH_BAD_ALLOC({
+                if (slices[count - 1].data - _data.data + max_size <= _data.size) {
+                    ret = ColumnHelper::get_binary_column(dst)->append_strings_overflow(slices, num_decoded, max_size);
+                } else {
+                    ret = ColumnHelper::get_binary_column(dst)->append_strings(slices, num_decoded);
+                }
+            });
 
             if (UNLIKELY(!ret)) {
                 return Status::InternalError("PlainDecoder append strings to column failed");

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include "base/testutil/parallel_test.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
@@ -176,6 +178,92 @@ PARALLEL_TEST(BinaryColumnTest, test_append_strings) {
     auto* c = reinterpret_cast<BinaryColumn*>(c2->data_column_raw_ptr());
     for (size_t i = 0; i < values.size(); i++) {
         ASSERT_EQ(values[i], c->immutable_data()[i]);
+    }
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(BinaryColumnTest, test_append_strings_overflow_long_values) {
+    // Values longer than 128 bytes take the branch that copies each value at its exact
+    // length. Build the sources in one padded buffer, the way the parquet dict decoder
+    // and binary dict page do, so the fixed-length branches would be legal here too.
+    const std::vector<size_t> lengths{200, 0, 129, 1, 4096};
+    size_t total_length = 0;
+    for (size_t len : lengths) {
+        total_length += len;
+    }
+
+    std::string backing(total_length + Column::APPEND_OVERFLOW_MAX_SIZE, '\0');
+    std::vector<Slice> values;
+    size_t offset = 0;
+    for (size_t i = 0; i < lengths.size(); i++) {
+        for (size_t j = 0; j < lengths[i]; j++) {
+            backing[offset + j] = static_cast<char>('a' + (i * 7 + j) % 26);
+        }
+        values.emplace_back(backing.data() + offset, lengths[i]);
+        offset += lengths[i];
+    }
+    const size_t max_length = *std::max_element(lengths.begin(), lengths.end());
+
+    auto c1 = BinaryColumn::create();
+    ASSERT_TRUE(c1->append_strings_overflow(values.data(), values.size(), max_length));
+    ASSERT_EQ(values.size(), c1->size());
+    for (size_t i = 0; i < values.size(); i++) {
+        ASSERT_EQ(values[i], c1->immutable_data()[i]);
+    }
+    ASSERT_EQ(total_length, c1->get_bytes().size());
+    // The byte buffer is sized from the total up front. Appending value by value would
+    // grow it geometrically and leave the capacity at up to twice the bytes held.
+    ASSERT_EQ(total_length, c1->get_bytes().capacity());
+
+    // Appending onto a non-empty column keeps the existing prefix intact.
+    ASSERT_TRUE(c1->append_strings_overflow(values.data(), values.size(), max_length));
+    ASSERT_EQ(values.size() * 2, c1->size());
+    ASSERT_EQ(total_length * 2, c1->get_bytes().size());
+    for (size_t i = 0; i < values.size(); i++) {
+        ASSERT_EQ(values[i], c1->immutable_data()[i]);
+        ASSERT_EQ(values[i], c1->immutable_data()[i + values.size()]);
+    }
+
+    // Appending nothing is a no-op.
+    ASSERT_TRUE(c1->append_strings_overflow(values.data(), 0, max_length));
+    ASSERT_EQ(values.size() * 2, c1->size());
+    ASSERT_EQ(total_length * 2, c1->get_bytes().size());
+
+    // Nullable BinaryColumn forwards to the same path.
+    auto c2 = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    ASSERT_TRUE(c2->append_strings_overflow(values.data(), values.size(), max_length));
+    ASSERT_EQ(values.size(), c2->size());
+    auto* c = reinterpret_cast<BinaryColumn*>(c2->data_column_raw_ptr());
+    for (size_t i = 0; i < values.size(); i++) {
+        ASSERT_FALSE(c2->is_null(i));
+        ASSERT_EQ(values[i], c->immutable_data()[i]);
+    }
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(BinaryColumnTest, test_append_strings_overflow_short_values) {
+    // Guard the fixed-length specializations against the long-value branch: both must
+    // produce identical columns.
+    for (size_t max_length : {8, 16, 32, 64, 128}) {
+        std::string backing(max_length * 4 + Column::APPEND_OVERFLOW_MAX_SIZE, '\0');
+        std::vector<Slice> values;
+        size_t offset = 0;
+        for (size_t i = 0; i < 4; i++) {
+            const size_t len = max_length - i;
+            for (size_t j = 0; j < len; j++) {
+                backing[offset + j] = static_cast<char>('a' + (i * 3 + j) % 26);
+            }
+            values.emplace_back(backing.data() + offset, len);
+            offset += len;
+        }
+
+        auto column = BinaryColumn::create();
+        ASSERT_TRUE(column->append_strings_overflow(values.data(), values.size(), max_length));
+        ASSERT_EQ(values.size(), column->size());
+        for (size_t i = 0; i < values.size(); i++) {
+            ASSERT_EQ(values[i], column->immutable_data()[i]);
+        }
+        ASSERT_EQ(offset, column->get_bytes().size());
     }
 }
 


### PR DESCRIPTION
## Why I'm doing:

A production BE reported a single 1.2 GiB allocation from the Hive/Parquet scan path:

```
mem_hook.cpp:117 large memory alloc... acquire:1287348634 bytes, is_bad_alloc_caught: 0
 BinaryColumnBase<uint32_t>::append_strings_overflow
 parquet::DictDecoder<Slice>::_next_batch_value
 parquet::GroupReader::get_next
 connector::HiveDataSource::get_next
 workgroup::ScanExecutor::worker_thread
```

Two problems on that one stack.

**1. `is_bad_alloc_caught: 0` — the query memory limit is not consulted while an external-table scan materializes a chunk.**

The mem hook has two modes, selected by the thread-local `tls_is_catched` flag that `TRY_CATCH_BAD_ALLOC` sets:

```
 flag set flag clear (this path today)
 -------------------------- ----------------------------
 order check tracker -> malloc malloc -> account afterwards
 over the limit returns nullptr not checked, allocation proceeds
 malloc fails bad_alloc -> MemoryLimitExceeded bad_alloc escapes
```

Nothing on `ScanExecutor::worker_thread` catches an escaping `std::bad_alloc`, so the process terminates. Column materialization runs entirely with the flag clear, which is where the 1.2 GiB request came from.

The obvious fix — one scope around `HiveDataSource::get_next` — is the wrong shape, and not only because every scanner underneath would have to be exception-safe. While the flag is set, **every** allocation in its dynamic extent gets `nullptr` on overrun, including allocations made inside liborc, libhdfs and the compression codecs. Third-party C code that does not check `malloc` would then segfault. That trades an OOM crash for a null-deref crash inside a library we do not control, so the scope has to be narrow enough that no third-party code ever executes inside it.

**2. The long-string append path grows its byte buffer one value at a time.**

`append_strings_overflow` sizes the destination up front for values up to 128 bytes but falls back to appending value by value above that, so the buffer is re-copied on every doubling. This is what turned a chunk of large strings into a 1.2 GiB request: dictionary-encoded values expand by orders of magnitude over their on-disk size, and the buffer doubled its way there instead of being sized once.

## What I'm doing:

Wrapping the individual allocating statements whose size is decided by the data, so the mem hook checks the query's tracker before calling the allocator and the failure becomes a `MemoryLimitExceeded` status for that query alone. This follows the pattern `parquet/page_reader.cpp` already uses for page buffers, and keeps each scope down to a single container resize — no third-party code ever runs with the flag set.

Fifteen sites, all in our own code (nothing under `apache-orc/`, and no third-party source is touched):

| Area | What is now bounded |
|---|---|
| `parquet/encoding_dict.h` | dictionary page expansion, whole-dictionary appends, and both branches of the batch decode — including the one on the reported stack |
| `parquet/encoding_plain.h` | PLAIN variable-length appends |
| `parquet/encoding_delta.h` | DELTA_BYTE_ARRAY / DELTA_LENGTH_BYTE_ARRAY appends |
| `orc/column_reader.cpp` | string and varbinary byte buffers in our ORC-to-column conversion |
| `cache/scan/shared_buffered_input_stream.cpp` | the coalesced IO buffer — a range above `max_buffer_size` gets a buffer of its own size, so this is a whole column chunk and is bounded only by the file |
| `formats/csv/csv_reader.cpp` | the record buffer, which doubles from 8 MB up to 2.1 GB, so one malformed line can ask for gigabytes at once |

Separately, `append_strings_overflow` now computes the total length first and sizes the byte buffer once before copying, instead of appending value by value. Offset handling is unchanged. Unit tests cover both branch families, including empty values, appending onto a non-empty column, and a zero-length batch.

Deliberately left alone:

- **Allocations inside third-party libraries** (simdjson, liborc, zlib/zstd/snappy). Keeping them outside these scopes is the point, not an oversight.
- **The JSON reader.** Its buffer is a fixed 8 MB allocated through `ByteBuffer::allocate_with_tracker`, which already carries this protection, and it never grows — a record larger than the buffer is an explicit error, not a realloc.
- **The per-row column appends in the CSV and JSON scanners.** They have no batch total to precompute, and the only loop that could hold a scope also performs IO, which would put the HDFS/S3 client back inside it. The upstream bound is the record buffer, which is now covered.

Coverage here is enumerated rather than exhaustive: an allocation that is not on this list still escapes the limit. That is the deliberate trade for never letting third-party code see a failing `malloc`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5