### PR TITLE
[BugFix] Observe cancel while waiting for fetch_data instead of blocking to the deadline

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -59,6 +59,9 @@ import java.util.concurrent.TimeoutException;
 
 public class ResultReceiver {
     private static final Logger LOG = LogManager.getLogger(ResultReceiver.class);
+    // Poll the in-flight fetch_data RPC in slices of this length so a cancel() is observed within this
+    // bound instead of blocking for the whole remaining query deadline. See getNext().
+    private static final long CANCEL_CHECK_INTERVAL_MS = 1000L;
     private volatile boolean isDone = false;
     private volatile boolean isCancel = false;
     private long packetIdx = 0;
@@ -90,12 +93,37 @@ public class ResultReceiver {
                 Future<PFetchDataResult> future = BackendServiceClient.getInstance().fetchDataAsync(address, request);
                 PFetchDataResult pResult = null;
                 while (pResult == null) {
+                    // cancel() only flips a flag; it cannot abort the RPC (jprotobuf's Future.cancel() is a
+                    // no-op) and the sink BE answers fetch_data only when it has rows. If that BE is gone
+                    // (crashed, node reclaimed, wedged in SHUTDOWN) no answer ever comes and its brpc talk
+                    // timeout is a day. Blocking here for the whole remaining deadline would keep this thread
+                    // parked until query_timeout, and because StmtExecutor.execute() releases the query's
+                    // admission slot only after getNext() returns, that slot (and every query waiting on it)
+                    // would stay stuck too. So check the cancel flag first, then wait in short slices.
+                    if (isCancel) {
+                        status.setStatus(Status.CANCELLED);
+                        return null;
+                    }
                     long currentTs = System.currentTimeMillis();
                     if (currentTs >= deadlineMs) {
                         throw new TimeoutException("query timeout");
                     }
+                    long waitMs = Math.min(deadlineMs - currentTs, CANCEL_CHECK_INTERVAL_MS);
                     try {
-                        pResult = future.get(deadlineMs - currentTs, TimeUnit.MILLISECONDS);
+                        pResult = future.get(waitMs, TimeUnit.MILLISECONDS);
+                    } catch (TimeoutException e) {
+                        // A poll slice elapsed with no answer (standard Future contract). Loop to re-check
+                        // the cancel flag and the real deadline. The brpc callback survives a timed-out
+                        // get(), so re-issuing get() on the same future simply keeps waiting.
+                    } catch (ExecutionException e) {
+                        // jprotobuf-rpc-core does not honor the Future contract: a slice timeout surfaces as
+                        // ExecutionException wrapping a TimeoutException rather than a bare TimeoutException.
+                        // Treat that as a slice expiry; propagate any genuine execution failure to the outer
+                        // handler. (Matching only the wrapped-TimeoutException cause avoids mistaking the
+                        // real query-deadline path, which we raise ourselves above, for a slice.)
+                        if (!(e.getCause() instanceof TimeoutException)) {
+                            throw e;
+                        }
                     } catch (InterruptedException e) {
                         // continue to get result
                         LOG.info("future get interrupted Exception");

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ResultReceiverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ResultReceiverTest.java
@@ -1,0 +1,208 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.Status;
+import com.starrocks.proto.PFetchDataResult;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.rpc.BackendServiceClient;
+import com.starrocks.rpc.PFetchDataRequest;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TUniqueId;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class ResultReceiverTest {
+
+    private static final TNetworkAddress ADDRESS = new TNetworkAddress("127.0.0.1", 8060);
+    private static final long BACKEND_ID = 10001L;
+
+    // A stand-in for the brpc fetch_data future that reproduces jprotobuf-rpc-core's real, non-standard
+    // behavior: get(timeout) does NOT throw a bare TimeoutException when a slice elapses; it throws
+    // ExecutionException wrapping a TimeoutException. A plain CompletableFuture (used by an earlier test)
+    // throws the standard TimeoutException and therefore hides the bug this class exists to guard against.
+    private static final class BrpcLikeFuture implements Future<PFetchDataResult> {
+        // Number of get() calls that report a slice timeout before the result is delivered.
+        // Integer.MAX_VALUE models a sink backend that is gone and will never answer.
+        private final int timeoutsBeforeResult;
+        private final PFetchDataResult result;
+        private int calls = 0;
+
+        private BrpcLikeFuture(int timeoutsBeforeResult, PFetchDataResult result) {
+            this.timeoutsBeforeResult = timeoutsBeforeResult;
+            this.result = result;
+        }
+
+        static BrpcLikeFuture neverAnswers() {
+            return new BrpcLikeFuture(Integer.MAX_VALUE, null);
+        }
+
+        static BrpcLikeFuture answersAfter(int timeouts, PFetchDataResult result) {
+            return new BrpcLikeFuture(timeouts, result);
+        }
+
+        @Override
+        public PFetchDataResult get(long timeout, TimeUnit unit) throws ExecutionException, TimeoutException {
+            if (calls < timeoutsBeforeResult) {
+                calls++;
+                // Sleep a bounded slice so the polling loop does not busy-spin, then fail the way the
+                // real client does: TimeoutException wrapped in ExecutionException.
+                try {
+                    Thread.sleep(Math.min(unit.toMillis(timeout), 50L));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                throw new ExecutionException("Ocurrs time out with specfied time " + timeout + " MILLISECONDS",
+                        new TimeoutException("timeout"));
+            }
+            return result;
+        }
+
+        @Override
+        public PFetchDataResult get() {
+            throw new UnsupportedOperationException();
+        }
+
+        // jprotobuf's future returns false here and does nothing — cancelling the future cannot unblock us.
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            return false;
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+
+        @Override
+        public boolean isDone() {
+            return calls >= timeoutsBeforeResult;
+        }
+    }
+
+    private static PFetchDataResult okEosResult() {
+        PFetchDataResult result = new PFetchDataResult();
+        result.status = new StatusPB();
+        result.status.statusCode = TStatusCode.OK.getValue();
+        result.packetSeq = 0L;
+        result.eos = true;
+        return result;
+    }
+
+    private static void mockFetchData(BackendServiceClient client, Future<PFetchDataResult> future) throws Exception {
+        new Expectations() {
+            {
+                BackendServiceClient.getInstance();
+                result = client;
+                minTimes = 0;
+
+                client.fetchDataAsync((TNetworkAddress) any, (PFetchDataRequest) any);
+                result = future;
+                minTimes = 0;
+            }
+        };
+    }
+
+    // The coordinator cancels the query (e.g. CoordinatorMonitor saw the result-sink backend die) while the
+    // query thread is blocked waiting for rows. cancel() only flips a flag, so the wait must observe it on
+    // its own — otherwise the thread, and the admission slot it holds, stay busy until query_timeout.
+    @Test
+    public void testCancelWakesUpGetNextDespiteBrpcTimeoutWrapping(@Mocked BackendServiceClient client)
+            throws Exception {
+        mockFetchData(client, BrpcLikeFuture.neverAnswers());
+
+        final int queryTimeoutMs = 600_000;
+        ResultReceiver receiver = new ResultReceiver(new TUniqueId(1L, 2L), BACKEND_ID, ADDRESS, queryTimeoutMs);
+        Status status = new Status();
+        AtomicReference<RowBatch> batch = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread queryThread = new Thread(() -> {
+            try {
+                batch.set(receiver.getNext(status));
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        }, "result-receiver-test-query");
+        queryThread.start();
+
+        // Let the query thread reach the wait on the RPC future.
+        Thread.sleep(500);
+        Assertions.assertTrue(queryThread.isAlive(), "getNext must block while the BE has not answered");
+
+        long cancelledAtMs = System.currentTimeMillis();
+        receiver.cancel();
+        queryThread.join(10_000);
+
+        Assertions.assertFalse(queryThread.isAlive(), "getNext must return once the receiver is cancelled");
+        Assertions.assertNull(failure.get(), "getNext must not throw on cancel: " + failure.get());
+        Assertions.assertTrue(status.isCancelled(), "status after cancel: " + status);
+        Assertions.assertNull(batch.get());
+        // Bounded by the cancel poll interval, nowhere near the query deadline.
+        long elapsedMs = System.currentTimeMillis() - cancelledAtMs;
+        Assertions.assertTrue(elapsedMs < 5_000, "took " + elapsedMs + "ms to observe cancel");
+    }
+
+    // Without a cancel the query deadline is still the bound: the receiver must not wait forever on a
+    // silent BE, and it must report TIMEOUT (not some wrapped RPC error) when the deadline passes.
+    @Test
+    public void testDeadlineEnforcedDespiteBrpcTimeoutWrapping(@Mocked BackendServiceClient client)
+            throws Exception {
+        mockFetchData(client, BrpcLikeFuture.neverAnswers());
+
+        final int queryTimeoutMs = 1_500;
+        ResultReceiver receiver = new ResultReceiver(new TUniqueId(1L, 2L), BACKEND_ID, ADDRESS, queryTimeoutMs);
+        Status status = new Status();
+
+        long startMs = System.currentTimeMillis();
+        RowBatch batch = receiver.getNext(status);
+        long elapsedMs = System.currentTimeMillis() - startMs;
+
+        Assertions.assertTrue(status.isTimeout(), "status after deadline: " + status);
+        Assertions.assertNotNull(batch);
+        Assertions.assertTrue(elapsedMs >= queryTimeoutMs - 100, "returned before the deadline: " + elapsedMs);
+        Assertions.assertTrue(elapsedMs < queryTimeoutMs + 5_000, "returned long after the deadline: " + elapsedMs);
+    }
+
+    // Regression guard for the earlier slicing bug: a query whose first fetch_data slices time out but then
+    // succeeds must NOT be reported as a query timeout. The bug was catching only the standard
+    // TimeoutException, so jprotobuf's ExecutionException("...time out...") escaped to the outer handler and
+    // any query taking longer than one slice failed with "Query reached its timeout".
+    @Test
+    public void testSlowFetchThatEventuallySucceedsIsNotAFalseTimeout(@Mocked BackendServiceClient client)
+            throws Exception {
+        // Three slice timeouts, then the result arrives — well within the deadline.
+        mockFetchData(client, BrpcLikeFuture.answersAfter(3, okEosResult()));
+
+        final int queryTimeoutMs = 600_000;
+        ResultReceiver receiver = new ResultReceiver(new TUniqueId(1L, 2L), BACKEND_ID, ADDRESS, queryTimeoutMs);
+        Status status = new Status();
+
+        RowBatch batch = receiver.getNext(status);
+
+        Assertions.assertFalse(status.isTimeout(), "must not be a false timeout: " + status);
+        Assertions.assertFalse(status.isCancelled(), "must not be cancelled: " + status);
+        Assertions.assertTrue(status.ok(), "status should be OK: " + status);
+        Assertions.assertNotNull(batch);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`ResultReceiver.getNext()` waits for the in-flight `fetch_data` RPC with a single `future.get(deadlineMs - now)`. `cancel()` only flips a flag -- it cannot abort the RPC (jprotobuf's `Future.cancel()` is a no-op) -- and the result-sink BE answers `fetch_data` only when it has rows. If that BE is gone (crashed, reclaimed, or wedged in `SHUTDOWN`) no answer ever comes and its brpc talk timeout is a day, so the coordinator thread stays parked until `query_timeout` even though the query was already cancelled, e.g. by `CoordinatorMonitor` once the node was declared dead. `StmtExecutor.execute()` releases the query's admission slot only after `getNext()` returns, so that slot -- and every query queued behind it -- stays stuck for the same duration.

## What I'm doing:

- Wait for the future in 1s slices and re-check the cancel flag between them, so a cancel is observed within a second instead of at the query deadline.
- Treat a slice expiry correctly for this client: jprotobuf-rpc-core does not honor the `Future` contract and surfaces a slice timeout as `ExecutionException` wrapping a `TimeoutException` rather than a bare `TimeoutException`. Only that wrapped case is treated as a slice expiry; every other `ExecutionException` still propagates to the outer handler unchanged.
- The query deadline is untouched: the existing `deadlineMs` check still bounds the wait, so a silent BE fails with `TIMEOUT` exactly as before.
- `ResultReceiverTest` reproduces jprotobuf's behavior with a stand-in future and covers cancel wake-up, deadline enforcement, and a slow fetch that must not be reported as a false timeout.

Fixes #78575

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
