### PR TITLE
[BugFix] Keep one stuck query from blocking cancellation of the others when a node dies

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorMonitor.java
@@ -17,6 +17,7 @@ package com.starrocks.qe;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.proto.PPlanFragmentCancelReason;
 import com.starrocks.qe.scheduler.Coordinator;
@@ -25,6 +26,10 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -42,11 +47,20 @@ public class CoordinatorMonitor {
     private final BlockingQueue<Long> comingDeadBackendIDQueue;
     private final AtomicBoolean started;
     private final DeadBackendAndComputeNodeChecker checker;
+    private final ExecutorService cancelExecutor;
 
     public CoordinatorMonitor() {
         comingDeadBackendIDQueue = Queues.newLinkedBlockingDeque(COMING_DEAD_BACKEND_QUEUE_CAPACITY);
         started = new AtomicBoolean(false);
         checker = new DeadBackendAndComputeNodeChecker();
+        // Coordinator.cancel() takes the coordinator lock, and deliverExecFragments() holds that same lock for
+        // the whole deployment RPC round-trip — up to query_delivery_timeout when the target node is the one
+        // that just died. Cancelling coordinators one after another on the checker thread would let a single
+        // query stuck in deployment delay the cancellation of every other query. Give each cancel its own
+        // thread; the pool is unbounded so a cancel is never dropped, and idle threads go away after a minute.
+        cancelExecutor = ThreadPoolManager.newDaemonThreadPool(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS,
+                new SynchronousQueue<>(), new ThreadPoolExecutor.AbortPolicy(), "coordinator-monitor-cancel",
+                false);
     }
 
     public static CoordinatorMonitor getInstance() {
@@ -83,20 +97,48 @@ public class CoordinatorMonitor {
                     deadBackendIDs.add(backendID);
                 }
 
-                final List<Coordinator> coordinators = QeProcessorImpl.INSTANCE.getCoordinators();
-                for (Coordinator coord : coordinators) {
-                    boolean isUsingDeadBackend = deadBackendIDs.stream().anyMatch(coord::isUsingBackend);
-                    if (isUsingDeadBackend) {
-                        if (LOG.isWarnEnabled()) {
-                            LOG.warn("Cancel query [{}], because some related backend is not alive",
-                                    DebugUtil.printId(coord.getQueryId()));
-                        }
-                        coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR,
-                                FeConstants.BACKEND_NODE_NOT_FOUND_ERROR);
-                    }
+                try {
+                    cancelCoordinatorsUsing(deadBackendIDs);
+                } catch (Throwable e) {
+                    // This thread is the only thing that cancels queries on dead nodes and nothing restarts it.
+                    // Whatever one sweep throws must not take it down for the rest of the process lifetime.
+                    LOG.warn("failed to cancel queries on dead backends {}", deadBackendIDs, e);
                 }
 
                 deadBackendIDs.clear();
+            }
+        }
+
+        private void cancelCoordinatorsUsing(List<Long> deadBackendIDs) {
+            final List<Coordinator> coordinators = QeProcessorImpl.INSTANCE.getCoordinators();
+            for (Coordinator coord : coordinators) {
+                if (coord == null) {
+                    continue;
+                }
+                final boolean isUsingDeadBackend;
+                try {
+                    isUsingDeadBackend = deadBackendIDs.stream().anyMatch(coord::isUsingBackend);
+                } catch (Throwable e) {
+                    LOG.warn("failed to check whether query [{}] uses a dead backend, skip it",
+                            DebugUtil.printId(coord.getQueryId()), e);
+                    continue;
+                }
+                if (!isUsingDeadBackend) {
+                    continue;
+                }
+                if (LOG.isWarnEnabled()) {
+                    LOG.warn("Cancel query [{}], because some related backend is not alive",
+                            DebugUtil.printId(coord.getQueryId()));
+                }
+                cancelExecutor.execute(() -> {
+                    try {
+                        coord.cancel(PPlanFragmentCancelReason.INTERNAL_ERROR,
+                                FeConstants.BACKEND_NODE_NOT_FOUND_ERROR);
+                    } catch (Throwable e) {
+                        LOG.warn("failed to cancel query [{}] whose backend is not alive",
+                                DebugUtil.printId(coord.getQueryId()), e);
+                    }
+                });
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorMonitorTest.java
@@ -16,10 +16,12 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.thrift.TUniqueId;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -29,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class CoordinatorMonitorTest {
 
@@ -141,5 +144,92 @@ public class CoordinatorMonitorTest {
         } finally {
             Config.heartbeat_timeout_second = prevHeartbeatTimeout;
         }
+    }
+
+    // The checker is the only thing that cancels queries on dead nodes and it is never restarted, so it has to
+    // survive whatever a single coordinator does: a QueryInfo registered without a coordinator (MV maintenance
+    // jobs do that), a coordinator whose check throws, and a coordinator whose cancel() blocks on the coordinator
+    // lock because it is stuck deploying to the very node that just died. None of these may delay or prevent
+    // the cancellation of the other queries, and the checker must still process the next dead node afterwards.
+    @Test
+    public void testCheckerSurvivesBrokenCoordinatorsAndBlockedCancel(@Mocked DefaultCoordinator throwing,
+                                                                     @Mocked DefaultCoordinator blocking,
+                                                                     @Mocked DefaultCoordinator healthy)
+            throws InterruptedException {
+        final QeProcessor qeProcessor = QeProcessorImpl.INSTANCE;
+        List<Coordinator> coordinators = Lists.newArrayList(null, throwing, blocking, healthy);
+
+        CountDownLatch blockingEntered = new CountDownLatch(1);
+        CountDownLatch releaseBlocking = new CountDownLatch(1);
+        AtomicInteger healthyCancels = new AtomicInteger();
+        CountDownLatch healthyCancelledOnce = new CountDownLatch(1);
+
+        new Expectations(qeProcessor, throwing, blocking, healthy) {
+            {
+                qeProcessor.getCoordinators();
+                result = coordinators;
+                minTimes = 0;
+
+                throwing.getQueryId();
+                result = new TUniqueId(1L, 1L);
+                minTimes = 0;
+                blocking.getQueryId();
+                result = new TUniqueId(2L, 2L);
+                minTimes = 0;
+                healthy.getQueryId();
+                result = new TUniqueId(3L, 3L);
+                minTimes = 0;
+
+                throwing.isUsingBackend(anyLong);
+                result = new RuntimeException("isUsingBackend blew up");
+                minTimes = 0;
+                blocking.isUsingBackend(anyLong);
+                result = true;
+                minTimes = 0;
+                healthy.isUsingBackend(anyLong);
+                result = true;
+                minTimes = 0;
+
+                // Holds "the coordinator lock" until the test releases it, like deliverExecFragments() waiting
+                // on an exec_plan_fragment RPC to a node that is gone.
+                blocking.cancel((PPlanFragmentCancelReason) any, anyString);
+                result = new mockit.Delegate<Void>() {
+                    void cancel(PPlanFragmentCancelReason cancelReason, String cancelledMessage)
+                            throws InterruptedException {
+                        blockingEntered.countDown();
+                        releaseBlocking.await(30, TimeUnit.SECONDS);
+                    }
+                };
+                minTimes = 0;
+
+                healthy.cancel((PPlanFragmentCancelReason) any, anyString);
+                result = new mockit.Delegate<Void>() {
+                    void cancel(PPlanFragmentCancelReason cancelReason, String cancelledMessage) {
+                        healthyCancels.incrementAndGet();
+                        healthyCancelledOnce.countDown();
+                    }
+                };
+                minTimes = 0;
+            }
+        };
+
+        CoordinatorMonitor.getInstance().start();
+        CoordinatorMonitor.getInstance().addDeadBackend(42L);
+
+        Assertions.assertTrue(blockingEntered.await(5, TimeUnit.SECONDS), "blocking coordinator never cancelled");
+        // Still blocked in cancel(); the healthy coordinator must be cancelled regardless, and soon.
+        Assertions.assertTrue(healthyCancelledOnce.await(5, TimeUnit.SECONDS),
+                "a blocked cancel() delayed cancelling the other queries");
+
+        // The checker thread must have survived the null and the throwing coordinator: another dead node gets
+        // processed too.
+        CoordinatorMonitor.getInstance().addDeadBackend(43L);
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (healthyCancels.get() < 2 && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50);
+        }
+        Assertions.assertTrue(healthyCancels.get() >= 2, "checker stopped processing dead nodes");
+
+        releaseBlocking.countDown();
     }
 }


### PR DESCRIPTION
## Why I'm doing:

`CoordinatorMonitor.DeadBackendAndComputeNodeChecker` is the only thread that cancels the queries running on a node that just died, and nothing restarts it. It cancels coordinators one after another on that single thread and runs the whole sweep unguarded:

- `Coordinator.cancel()` takes the coordinator lock, and `deliverExecFragments()` holds that same lock for the whole deployment RPC round trip -- up to `query_delivery_timeout` when the target node is exactly the one that just died. A single query stuck in deployment therefore delays cancelling every other query on that node, and the next dead node waits behind it.
- Anything one coordinator throws escapes the run loop and kills the checker thread for the rest of the process lifetime, after which no query is ever cancelled on a dead node again. A `null` entry in the list returned by `QeProcessorImpl.getCoordinators()` is enough: the NPE raised while logging the failing coordinator's query id aborts the sweep.

## What I'm doing:

- Cancel each coordinator on its own thread from an unbounded cached pool (`coordinator-monitor-cancel`, idle threads reaped after 60s), so a blocked `cancel()` cannot delay the others.
- Skip `null` coordinators, and contain both per-coordinator and per-sweep failures so the checker thread always survives.
- `CoordinatorMonitorTest` adds a case with a null entry, a coordinator whose `isUsingBackend()` throws, and a coordinator whose `cancel()` blocks: the healthy query must still be cancelled promptly and the checker must still process the next dead node.

Fixes #78576

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
