### PR TITLE
[BugFix] Preserve 64-bit ordinals in collection sparse reads

### DIFF
--- a/be/src/storage/rowset/array_column_iterator.cpp
+++ b/be/src/storage/rowset/array_column_iterator.cpp
@@ -119,7 +119,7 @@ Status ArrayColumnIterator::next_batch(size_t* n, Column* dst) {
 }
 
 Status ArrayColumnIterator::next_batch_null_offsets(const SparseRange<>& range, UInt32Column* offsets,
-                                                    UInt8Column* nulls, SparseRange<>* element_range,
+                                                    UInt8Column* nulls, OrdinalSparseRange* element_range,
                                                     size_t* element_rows) {
     // 1. Read null column
     if (_null_iterator != nullptr) {
@@ -161,7 +161,7 @@ Status ArrayColumnIterator::next_batch_null_offsets(const SparseRange<>& range, 
         num_to_read = end_offset - num_to_read;
         *element_rows += num_to_read;
 
-        element_range->add(Range<>(element_ordinal, element_ordinal + num_to_read));
+        element_range->add(OrdinalRange(element_ordinal, element_ordinal + num_to_read));
     }
 
     return Status::OK();
@@ -173,7 +173,7 @@ Status ArrayColumnIterator::next_batch(const SparseRange<>& range, Column* dst) 
     CHECK((_null_iterator == nullptr && null_column == nullptr) ||
           (_null_iterator != nullptr && null_column != nullptr));
 
-    SparseRange element_read_range;
+    OrdinalSparseRange element_read_range;
     size_t read_rows = 0;
     RETURN_IF_ERROR(next_batch_null_offsets(range, array_column->offsets_column_raw_ptr(), null_column,
                                             &element_read_range, &read_rows));
@@ -185,7 +185,8 @@ Status ArrayColumnIterator::next_batch(const SparseRange<>& range, Column* dst) 
     if (_access_values) {
         // if array column is nullable, element_read_range may be empty
         DCHECK(element_read_range.empty() || (element_read_range.begin() == _element_iterator->get_current_ordinal()));
-        RETURN_IF_ERROR(_element_iterator->next_batch(element_read_range, array_column->elements_column_raw_ptr()));
+        RETURN_IF_ERROR(
+                _element_iterator->next_batch_by_ordinal(element_read_range, array_column->elements_column_raw_ptr()));
     } else {
         if (!array_column->elements_column()->is_constant()) {
             array_column->elements_column_raw_ptr()->append_default(1);
@@ -296,7 +297,7 @@ Status ArrayColumnIterator::next_dict_codes(const SparseRange<>& range, Column* 
     CHECK((_null_iterator == nullptr && null_column == nullptr) ||
           (_null_iterator != nullptr && null_column != nullptr));
 
-    SparseRange element_read_range;
+    OrdinalSparseRange element_read_range;
     size_t read_rows = 0;
     RETURN_IF_ERROR(next_batch_null_offsets(range, array_column->offsets_column_raw_ptr(), null_column,
                                             &element_read_range, &read_rows));
@@ -307,7 +308,8 @@ Status ArrayColumnIterator::next_dict_codes(const SparseRange<>& range, Column* 
 
     // if array column is nullable, element_read_range may be empty
     DCHECK(element_read_range.empty() || (element_read_range.begin() == _element_iterator->get_current_ordinal()));
-    RETURN_IF_ERROR(_element_iterator->next_dict_codes(element_read_range, array_column->elements_column_raw_ptr()));
+    RETURN_IF_ERROR(
+            _element_iterator->next_dict_codes_by_ordinal(element_read_range, array_column->elements_column_raw_ptr()));
 
     return Status::OK();
 }
@@ -351,20 +353,29 @@ Status ArrayColumnIterator::decode_dict_codes(const int32_t* codes, size_t size,
 
 StatusOr<std::vector<std::pair<int64_t, int64_t>>> ArrayColumnIterator::get_io_range_vec(const SparseRange<>& range,
                                                                                          Column* dst) {
+    OrdinalSparseRange ordinal_range;
+    for (size_t i = 0; i < range.size(); ++i) {
+        ordinal_range.add(OrdinalRange(range[i].begin(), range[i].end()));
+    }
+    return get_io_range_vec_by_ordinal(ordinal_range, dst);
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> ArrayColumnIterator::get_io_range_vec_by_ordinal(
+        const OrdinalSparseRange& range, Column* dst) {
     auto [array_column, null_column] = unpack_array_column(dst);
     CHECK((_null_iterator == nullptr && null_column == nullptr) ||
           (_null_iterator != nullptr && null_column != nullptr));
 
-    SparseRange element_range;
+    OrdinalSparseRange element_range;
 
-    SparseRangeIterator<> iter = range.new_iterator();
+    auto iter = range.new_iterator();
     size_t to_read = range.span_size();
 
     UInt32Column* offsets = array_column->offsets_column_raw_ptr();
     // array column can be nested, range may be empty
     DCHECK(range.empty() || (range.begin() == _array_size_iterator->get_current_ordinal()));
     while (iter.has_more()) {
-        Range<> r = iter.next(to_read);
+        auto r = iter.next(to_read);
 
         RETURN_IF_ERROR(_array_size_iterator->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
         size_t element_ordinal = _array_size_iterator->element_ordinal();
@@ -381,8 +392,8 @@ StatusOr<std::vector<std::pair<int64_t, int64_t>>> ArrayColumnIterator::get_io_r
         size_t end_offset = data.back();
 
         size_t prev_array_size = offsets->size();
-        SparseRange<> size_read_range(r);
-        RETURN_IF_ERROR(_array_size_iterator->next_batch(size_read_range, offsets));
+        OrdinalSparseRange size_read_range(r);
+        RETURN_IF_ERROR(_array_size_iterator->next_batch_by_ordinal(size_read_range, offsets));
         size_t curr_array_size = offsets->size();
 
         size_t num_to_read = end_offset;
@@ -392,16 +403,16 @@ StatusOr<std::vector<std::pair<int64_t, int64_t>>> ArrayColumnIterator::get_io_r
         }
         num_to_read = end_offset - num_to_read;
 
-        element_range.add(Range<>(element_ordinal, element_ordinal + num_to_read));
+        element_range.add(OrdinalRange(element_ordinal, element_ordinal + num_to_read));
     }
 
     std::vector<std::pair<int64_t, int64_t>> res;
     if (_null_iterator != nullptr) {
-        ASSIGN_OR_RETURN(auto vec, _null_iterator->get_io_range_vec(range, dst));
+        ASSIGN_OR_RETURN(auto vec, _null_iterator->get_io_range_vec_by_ordinal(range, dst));
         res.insert(res.end(), vec.begin(), vec.end());
     }
     if (_access_values) {
-        ASSIGN_OR_RETURN(auto vec, _element_iterator->get_io_range_vec(element_range, dst));
+        ASSIGN_OR_RETURN(auto vec, _element_iterator->get_io_range_vec_by_ordinal(element_range, dst));
         res.insert(res.end(), vec.begin(), vec.end());
     }
     return res;

--- a/be/src/storage/rowset/array_column_iterator.h
+++ b/be/src/storage/rowset/array_column_iterator.h
@@ -67,12 +67,15 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec_by_ordinal(const OrdinalSparseRange& range,
+                                                                                   Column* dst) override;
+
     std::string name() const override { return "ArrayColumnIterator"; }
 
 private:
     Status next_batch_null_offsets(size_t* n, UInt32Column* offsets, UInt8Column* nulls, size_t* element_rows);
     Status next_batch_null_offsets(const SparseRange<>& range, UInt32Column* offsets, UInt8Column* nulls,
-                                   SparseRange<>* element_range, size_t* element_rows);
+                                   OrdinalSparseRange* element_range, size_t* element_rows);
 
 private:
     ColumnReader* _reader;

--- a/be/src/storage/rowset/column_iterator.cpp
+++ b/be/src/storage/rowset/column_iterator.cpp
@@ -82,6 +82,34 @@ Status ColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
     return Status::OK();
 }
 
+Status ColumnIterator::next_batch_by_ordinal(const OrdinalSparseRange& range, Column* dst) {
+    auto iter = range.new_iterator();
+    auto to_read = range.span_size();
+    while (to_read > 0) {
+        RETURN_IF_ERROR(seek_to_ordinal(iter.begin()));
+        auto r = iter.next(to_read);
+        auto n = size_t{r.span_size()};
+        RETURN_IF_ERROR(next_batch(&n, dst));
+        CHECK_EQ(r.span_size(), n);
+        to_read -= n;
+    }
+    return Status::OK();
+}
+
+Status ColumnIterator::next_dict_codes_by_ordinal(const OrdinalSparseRange& range, Column* dst) {
+    auto iter = range.new_iterator();
+    auto to_read = range.span_size();
+    while (to_read > 0) {
+        RETURN_IF_ERROR(seek_to_ordinal(iter.begin()));
+        auto r = iter.next(to_read);
+        auto n = size_t{r.span_size()};
+        RETURN_IF_ERROR(next_dict_codes(&n, dst));
+        CHECK_EQ(r.span_size(), n);
+        to_read -= n;
+    }
+    return Status::OK();
+}
+
 Status ColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
     auto n = size_t{1};
     for (auto i = size_t{0}; i < size; i++) {

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -133,8 +133,17 @@ public:
 
     virtual Status next_batch(const SparseRange<>& range, Column* dst);
 
+    // Collection child columns can contain more than UINT32_MAX values even though
+    // the parent segment has at most UINT32_MAX rows.
+    virtual Status next_batch_by_ordinal(const OrdinalSparseRange& range, Column* dst);
+
     virtual StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                                 Column* dst) {
+        return Status::NotSupported("Not Implemented");
+    }
+
+    virtual StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec_by_ordinal(
+            const OrdinalSparseRange& range, Column* dst) {
         return Status::NotSupported("Not Implemented");
     }
 
@@ -220,6 +229,8 @@ public:
     virtual Status next_dict_codes(size_t* n, Column* dst) { return Status::NotSupported(""); }
 
     virtual Status next_dict_codes(const SparseRange<>& range, Column* dst) { return Status::NotSupported(""); }
+
+    virtual Status next_dict_codes_by_ordinal(const OrdinalSparseRange& range, Column* dst);
 
     // given a list of dictionary codes, fill |dst| column with the decoded values.
     // |codes| pointer to the array of dictionary codes.

--- a/be/src/storage/rowset/column_iterator_decorator.h
+++ b/be/src/storage/rowset/column_iterator_decorator.h
@@ -43,6 +43,10 @@ public:
 
     Status next_batch(const SparseRange<>& range, Column* dst) override { return _parent->next_batch(range, dst); }
 
+    Status next_batch_by_ordinal(const OrdinalSparseRange& range, Column* dst) override {
+        return _parent->next_batch_by_ordinal(range, dst);
+    }
+
     ordinal_t get_current_ordinal() const override { return _parent->get_current_ordinal(); }
 
     Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
@@ -74,6 +78,10 @@ public:
         return _parent->next_dict_codes(range, dst);
     }
 
+    Status next_dict_codes_by_ordinal(const OrdinalSparseRange& range, Column* dst) override {
+        return _parent->next_dict_codes_by_ordinal(range, dst);
+    }
+
     Status decode_dict_codes(const int32_t* codes, size_t size, Column* words) override {
         return _parent->decode_dict_codes(codes, size, words);
     }
@@ -94,6 +102,11 @@ public:
 
     Status fetch_dict_codes_by_rowid(const rowid_t* rowids, size_t size, Column* values) override {
         return _parent->fetch_dict_codes_by_rowid(rowids, size, values);
+    }
+
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec_by_ordinal(const OrdinalSparseRange& range,
+                                                                                   Column* dst) override {
+        return _parent->get_io_range_vec_by_ordinal(range, dst);
     }
 
     Status next_batch(size_t* n, Column* dst, ColumnAccessPath* path) override {

--- a/be/src/storage/rowset/map_column_iterator.cpp
+++ b/be/src/storage/rowset/map_column_iterator.cpp
@@ -149,14 +149,18 @@ Status MapColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
         down_cast<NullableColumn*>(dst)->update_has_null();
     }
 
-    SparseRange element_read_range;
+    OrdinalSparseRange ordinal_range;
+    for (size_t i = 0; i < range.size(); ++i) {
+        ordinal_range.add(OrdinalRange(range[i].begin(), range[i].end()));
+    }
+    OrdinalSparseRange element_read_range;
     size_t read_rows = 0;
-    RETURN_IF_ERROR(get_element_range_vec(range, map_column, true /* seek */, element_read_range, read_rows));
+    RETURN_IF_ERROR(get_element_range_vec(ordinal_range, map_column, true /* seek */, element_read_range, read_rows));
 
     // if array column is nullable, element_read_range may be empty
     DCHECK(element_read_range.empty() || (element_read_range.begin() == _keys->get_current_ordinal()));
     if (_access_keys) {
-        RETURN_IF_ERROR(_keys->next_batch(element_read_range, map_column->keys_column_raw_ptr()));
+        RETURN_IF_ERROR(_keys->next_batch_by_ordinal(element_read_range, map_column->keys_column_raw_ptr()));
     } else {
         if (!map_column->keys_column()->is_constant()) {
             map_column->keys_column_raw_ptr()->append_default(1);
@@ -167,7 +171,7 @@ Status MapColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
     }
 
     if (_access_values) {
-        RETURN_IF_ERROR(_values->next_batch(element_read_range, map_column->values_column_raw_ptr()));
+        RETURN_IF_ERROR(_values->next_batch_by_ordinal(element_read_range, map_column->values_column_raw_ptr()));
     } else {
         if (!map_column->values_column()->is_constant()) {
             map_column->values_column_raw_ptr()->append_default(1);
@@ -270,9 +274,9 @@ Status MapColumnIterator::seek_to_ordinal(ordinal_t ord) {
     return Status::OK();
 }
 
-Status MapColumnIterator::get_element_range_vec(const SparseRange<>& range, MapColumn* map_column, bool seek,
-                                                SparseRange<>& element_read_range, size_t& read_rows) {
-    SparseRangeIterator<> iter = range.new_iterator();
+Status MapColumnIterator::get_element_range_vec(const OrdinalSparseRange& range, MapColumn* map_column, bool seek,
+                                                OrdinalSparseRange& element_read_range, size_t& read_rows) {
+    auto iter = range.new_iterator();
     size_t to_read = range.span_size();
 
     // array column can be nested, range may be empty
@@ -280,7 +284,7 @@ Status MapColumnIterator::get_element_range_vec(const SparseRange<>& range, MapC
     element_read_range.clear();
     read_rows = 0;
     while (iter.has_more()) {
-        Range<> r = iter.next(to_read);
+        auto r = iter.next(to_read);
 
         RETURN_IF_ERROR(_offsets->seek_to_ordinal_and_calc_element_ordinal(r.begin()));
         size_t element_ordinal = _offsets->element_ordinal();
@@ -299,8 +303,8 @@ Status MapColumnIterator::get_element_range_vec(const SparseRange<>& range, MapC
         size_t end_offset = data.back();
 
         size_t prev_array_size = offsets->size();
-        SparseRange<> size_read_range(r);
-        RETURN_IF_ERROR(_offsets->next_batch(size_read_range, offsets));
+        OrdinalSparseRange size_read_range(r);
+        RETURN_IF_ERROR(_offsets->next_batch_by_ordinal(size_read_range, offsets));
         size_t curr_array_size = offsets->size();
 
         size_t num_to_read = end_offset;
@@ -311,7 +315,7 @@ Status MapColumnIterator::get_element_range_vec(const SparseRange<>& range, MapC
         num_to_read = end_offset - num_to_read;
         read_rows += num_to_read;
 
-        element_read_range.add(Range<>(element_ordinal, element_ordinal + num_to_read));
+        element_read_range.add(OrdinalRange(element_ordinal, element_ordinal + num_to_read));
     }
 
     return Status::OK();
@@ -319,6 +323,15 @@ Status MapColumnIterator::get_element_range_vec(const SparseRange<>& range, MapC
 
 StatusOr<std::vector<std::pair<int64_t, int64_t>>> MapColumnIterator::get_io_range_vec(const SparseRange<>& range,
                                                                                        Column* dst) {
+    OrdinalSparseRange ordinal_range;
+    for (size_t i = 0; i < range.size(); ++i) {
+        ordinal_range.add(OrdinalRange(range[i].begin(), range[i].end()));
+    }
+    return get_io_range_vec_by_ordinal(ordinal_range, dst);
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> MapColumnIterator::get_io_range_vec_by_ordinal(
+        const OrdinalSparseRange& range, Column* dst) {
     MapColumn* map_column = nullptr;
     if (dst->is_nullable()) {
         auto* nullable_column = down_cast<NullableColumn*>(dst);
@@ -329,19 +342,19 @@ StatusOr<std::vector<std::pair<int64_t, int64_t>>> MapColumnIterator::get_io_ran
 
     std::vector<std::pair<int64_t, int64_t>> res;
     if (_nulls != nullptr) {
-        ASSIGN_OR_RETURN(auto vec, _nulls->get_io_range_vec(range, dst));
+        ASSIGN_OR_RETURN(auto vec, _nulls->get_io_range_vec_by_ordinal(range, dst));
         res.insert(res.end(), vec.begin(), vec.end());
     }
 
-    SparseRange element_read_range;
+    OrdinalSparseRange element_read_range;
     size_t read_rows = 0;
     RETURN_IF_ERROR(get_element_range_vec(range, map_column, false /* seek */, element_read_range, read_rows));
     if (_access_keys) {
-        ASSIGN_OR_RETURN(auto vec, _keys->get_io_range_vec(element_read_range, dst));
+        ASSIGN_OR_RETURN(auto vec, _keys->get_io_range_vec_by_ordinal(element_read_range, dst));
         res.insert(res.end(), vec.begin(), vec.end());
     }
     if (_access_values) {
-        ASSIGN_OR_RETURN(auto vec, _values->get_io_range_vec(element_read_range, dst));
+        ASSIGN_OR_RETURN(auto vec, _values->get_io_range_vec_by_ordinal(element_read_range, dst));
         res.insert(res.end(), vec.begin(), vec.end());
     }
     return res;

--- a/be/src/storage/rowset/map_column_iterator.h
+++ b/be/src/storage/rowset/map_column_iterator.h
@@ -49,11 +49,14 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec_by_ordinal(const OrdinalSparseRange& range,
+                                                                                   Column* dst) override;
+
     std::string name() const override { return "MapColumnIterator"; }
 
 private:
-    Status get_element_range_vec(const SparseRange<>& range, MapColumn* map_column, bool seek,
-                                 SparseRange<>& element_read_range, size_t& read_rows);
+    Status get_element_range_vec(const OrdinalSparseRange& range, MapColumn* map_column, bool seek,
+                                 OrdinalSparseRange& element_read_range, size_t& read_rows);
 
     ColumnReader* _reader;
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -889,8 +889,9 @@ bool ScalarColumnIterator::_contains_deleted_row(uint32_t page_index) const {
     return true;
 }
 
-StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::get_io_range_vec(const SparseRange<>& range,
-                                                                                          Column* dst) {
+template <typename RangeType>
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::_get_io_range_vec(const RangeType& range,
+                                                                                           Column* dst) {
     (void)dst;
     std::vector<std::pair<int64_t, int64_t>> res;
     auto reader = get_column_reader();
@@ -930,6 +931,16 @@ StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::get_io_
     }
 
     return res;
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::get_io_range_vec(const SparseRange<>& range,
+                                                                                          Column* dst) {
+    return _get_io_range_vec(range, dst);
+}
+
+StatusOr<std::vector<std::pair<int64_t, int64_t>>> ScalarColumnIterator::get_io_range_vec_by_ordinal(
+        const OrdinalSparseRange& range, Column* dst) {
+    return _get_io_range_vec(range, dst);
 }
 
 bool ScalarColumnIterator::support_push_down_predicate(

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -118,6 +118,9 @@ public:
     StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec(const SparseRange<>& range,
                                                                         Column* dst) override;
 
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> get_io_range_vec_by_ordinal(const OrdinalSparseRange& range,
+                                                                                   Column* dst) override;
+
     std::string name() const override { return "ScalarColumnIterator"; }
 
     void reserve_col(size_t n, Column* column) override {
@@ -131,6 +134,9 @@ public:
     bool support_push_down_predicate(const std::vector<const ColumnPredicate*>& compound_and_predicates) override;
 
 private:
+    template <typename RangeType>
+    StatusOr<std::vector<std::pair<int64_t, int64_t>>> _get_io_range_vec(const RangeType& range, Column* dst);
+
     static Status _seek_to_pos_in_page(ParsedPage* page, ordinal_t offset_in_page);
     Status _load_next_page(bool* eos);
     Status _read_data_page(const OrdinalPageIndexIterator& iter);

--- a/be/src/storage_primitive/range.h
+++ b/be/src/storage_primitive/range.h
@@ -524,11 +524,13 @@ template class Range<>;
 template class Range<ordinal_t>;
 using RowIdRange = Range<rowid_t>;
 using OridinalRange = Range<ordinal_t>;
+using OrdinalRange = Range<ordinal_t>;
 
 template class SparseRange<>;
 template class SparseRange<ordinal_t>;
 using RowIdSparseRange = SparseRange<rowid_t>;
 using OridinalSparseRange = SparseRange<ordinal_t>;
+using OrdinalSparseRange = SparseRange<ordinal_t>;
 
 template class SparseRangeIterator<>;
 template class SparseRangeIterator<ordinal_t>;

--- a/be/test/storage/rowset/column_iterator_decorator_test.cpp
+++ b/be/test/storage/rowset/column_iterator_decorator_test.cpp
@@ -16,12 +16,88 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
+
 #include "base/testutil/assert.h"
+#include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/fixed_length_column.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "storage/rowset/array_column_iterator.h"
+#include "storage/rowset/map_column_iterator.h"
 #include "storage/rowset/series_column_iterator.h"
 
 namespace starrocks {
+
+namespace {
+
+constexpr ordinal_t kLargeElementOrdinal = static_cast<ordinal_t>(std::numeric_limits<rowid_t>::max()) + 17;
+
+class CollectionSizeIterator final : public ColumnIterator {
+public:
+    Status seek_to_first() override {
+        _ordinal = 0;
+        return Status::OK();
+    }
+
+    Status seek_to_ordinal(ordinal_t ordinal) override {
+        _ordinal = ordinal;
+        return Status::OK();
+    }
+
+    Status seek_to_ordinal_and_calc_element_ordinal(ordinal_t ordinal) override {
+        _ordinal = ordinal;
+        _element_ordinal = kLargeElementOrdinal + ordinal * kElementsPerRow;
+        return Status::OK();
+    }
+
+    int64_t element_ordinal() const override { return _element_ordinal; }
+
+    Status next_batch(size_t* n, Column* dst) override {
+        for (size_t i = 0; i < *n; ++i) {
+            dst->append_datum(static_cast<uint32_t>(kElementsPerRow));
+        }
+        _ordinal += *n;
+        return Status::OK();
+    }
+
+    ordinal_t get_current_ordinal() const override { return _ordinal; }
+    ordinal_t num_rows() const override { return 2; }
+
+private:
+    static constexpr ordinal_t kElementsPerRow = 3;
+    ordinal_t _ordinal = 0;
+    ordinal_t _element_ordinal = 0;
+};
+
+class OrdinalEchoIterator final : public ColumnIterator {
+public:
+    Status seek_to_first() override {
+        _ordinal = 0;
+        return Status::OK();
+    }
+
+    Status seek_to_ordinal(ordinal_t ordinal) override {
+        _ordinal = ordinal;
+        return Status::OK();
+    }
+
+    Status next_batch(size_t* n, Column* dst) override {
+        for (size_t i = 0; i < *n; ++i) {
+            dst->append_datum(static_cast<int64_t>(_ordinal++));
+        }
+        return Status::OK();
+    }
+
+    ordinal_t get_current_ordinal() const override { return _ordinal; }
+    ordinal_t num_rows() const override { return kLargeElementOrdinal + 16; }
+
+private:
+    ordinal_t _ordinal = 0;
+};
+
+} // namespace
 
 TEST(ColumnIteratorDecoratorTest, test) {
     auto iter = SeriesColumnIterator<int32_t>{0, 100};
@@ -73,6 +149,43 @@ TEST(ColumnIteratorDecoratorTest, test) {
     ASSERT_EQ(2, column.size());
     ASSERT_EQ(1, column.get(0).get_int32());
     ASSERT_EQ(2, column.get(1).get_int32());
+}
+
+TEST(ColumnIteratorDecoratorTest, ArraySparseReadPreservesLargeElementOrdinal) {
+    auto iterator = ArrayColumnIterator(nullptr, nullptr, std::make_unique<CollectionSizeIterator>(),
+                                        std::make_unique<OrdinalEchoIterator>(), nullptr);
+    ASSERT_OK(iterator.init(ColumnIteratorOptions{}));
+
+    auto elements = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    auto array = ArrayColumn::create(std::move(elements), UInt32Column::create());
+    auto range = SparseRange<>({0, 1});
+
+    ASSERT_OK(iterator.next_batch(range, array.get()));
+    ASSERT_EQ(1, array->size());
+    ASSERT_EQ(3, array->elements_column()->size());
+    EXPECT_EQ(kLargeElementOrdinal, array->elements_column()->get(0).get_int64());
+    EXPECT_EQ(kLargeElementOrdinal + 1, array->elements_column()->get(1).get_int64());
+    EXPECT_EQ(kLargeElementOrdinal + 2, array->elements_column()->get(2).get_int64());
+}
+
+TEST(ColumnIteratorDecoratorTest, MapSparseReadPreservesLargeElementOrdinal) {
+    auto iterator = MapColumnIterator(nullptr, nullptr, std::make_unique<CollectionSizeIterator>(),
+                                      std::make_unique<OrdinalEchoIterator>(), std::make_unique<OrdinalEchoIterator>(),
+                                      nullptr);
+    ASSERT_OK(iterator.init(ColumnIteratorOptions{}));
+
+    auto keys = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    auto values = NullableColumn::create(Int64Column::create(), NullColumn::create());
+    auto map = MapColumn::create(std::move(keys), std::move(values), UInt32Column::create());
+    auto range = SparseRange<>({0, 1});
+
+    ASSERT_OK(iterator.next_batch(range, map.get()));
+    ASSERT_EQ(1, map->size());
+    ASSERT_EQ(3, map->keys_column()->size());
+    EXPECT_EQ(kLargeElementOrdinal, map->keys_column()->get(0).get_int64());
+    EXPECT_EQ(kLargeElementOrdinal + 2, map->keys_column()->get(2).get_int64());
+    EXPECT_EQ(kLargeElementOrdinal, map->values_column()->get(0).get_int64());
+    EXPECT_EQ(kLargeElementOrdinal + 2, map->values_column()->get(2).get_int64());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

ARRAY and MAP child columns are stored as flattened values. Although the number
of parent rows in a segment is bounded by `UINT32_MAX`, the number of flattened
child values can exceed that limit.

The collection sparse-read path currently represents child ordinals with the
default `SparseRange<>`, whose range type is `rowid_t` (`uint32_t`). Child
ordinals above `UINT32_MAX` are therefore truncated before being passed to the
child column iterator.

For example, for an `ARRAY<FLOAT>` column containing 768-dimensional vectors,
the flattened child ordinal can exceed `UINT32_MAX` when a segment contains
approximately 5.59 million rows. The truncated ordinal can cause incorrect
reads or prevent schema-change and vector-index-build jobs from making
progress.

PR #77819 fixed the vector exact-search fallback call site by replacing its
sparse read with a contiguous size-based read. However, the reusable ARRAY and
MAP sparse-read paths still truncate flattened child ordinals. This PR fixes
the underlying collection-reader issue.

## What I'm doing:

- Add ordinal-width sparse-read APIs to `ColumnIterator`.
- Forward the new APIs through `ColumnIteratorDecorator`.
- Keep parent row ranges as 32-bit `rowid_t` ranges.
- Represent flattened ARRAY and MAP child ranges using 64-bit `ordinal_t`.
- Use the ordinal-width APIs when reading ARRAY elements and MAP keys/values.
- Preserve 64-bit child ordinals in dictionary reads and I/O range collection.
- Add synthetic ARRAY and MAP tests that exercise child ordinals above
  `UINT32_MAX` without allocating a multi-billion-row test segment.

Related to #77819.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

The behavior change is a correctness fix: flattened ARRAY and MAP child
ordinals no longer wrap at the 32-bit row-id boundary.

## Testing:

Added the following unit tests:

- `ArraySparseReadPreservesLargeElementOrdinal`
- `MapSparseReadPreservesLargeElementOrdinal`

Both tests use a synthetic child ordinal greater than `UINT32_MAX` and exercise
the real ARRAY and MAP sparse-read paths.

Local checks passed:

- `git diff --check`
- Changed-module boundary check
- Full BE module-boundary check
- BE AGENTS rendering check

The focused BE unit-test build was not completed locally because the clean
worktree did not contain the prebuilt StarRocks third-party Boost and AWS SDK
dependencies. Compilation and execution of the added tests are covered by the
community CI.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5