### PR TITLE
[BugFix] Correct the misspelled ZoneMapIndexFilter counter

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -578,7 +578,7 @@ void LakeDataSource::init_counter(RuntimeState* state) {
             ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyRangeNumber", TUnit::UNIT, segment_init_name);
     _column_iterator_init_timer = ADD_CHILD_TIMER(_runtime_profile, "ColumnIteratorInit", segment_init_name);
     _bitmap_index_iterator_init_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexIteratorInit", segment_init_name);
-    _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFiter", segment_init_name);
+    _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", segment_init_name);
     _rows_key_range_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", segment_init_name);
     _bf_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BloomFilterFilter", segment_init_name);
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -180,7 +180,7 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
             ADD_CHILD_COUNTER(_runtime_profile, "RemainingRowsAfterShortKeyFilter", TUnit::UNIT, segment_init_name);
     _column_iterator_init_timer = ADD_CHILD_TIMER(_runtime_profile, "ColumnIteratorInit", segment_init_name);
     _bitmap_index_iterator_init_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexIteratorInit", segment_init_name);
-    _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFiter", segment_init_name);
+    _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", segment_init_name);
     _rows_key_range_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", segment_init_name);
     _rows_key_range_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyRangeNumber", TUnit::UNIT, segment_init_name);

--- a/docs/en/table_design/indexes/Bitmap_index.md
+++ b/docs/en/table_design/indexes/Bitmap_index.md
@@ -290,7 +290,7 @@ IOTaskExecTime: 2s77ms // Total time for scanning data, longer than without bitm
     DictDecode: 329.696ms // Time for decoding dictionary for low cardinality optimization is similar since the output row count is the same.
     BitmapIndexFilter: 419.308ms // Time for filtering data with the bitmap index.
     BitmapIndexFilterRows: 123.433M (123432975) // Number of rows filtered by the bitmap index.
-    ZoneMapIndexFiter: 171.580ms // Time for filtering data with ZoneMap Index.
+    ZoneMapIndexFilter: 171.580ms // Time for filtering data with ZoneMap Index.
 ```
 
 ##### Determine whether to use bitmap index based on StarRocks default configuration

--- a/docs/ja/table_design/indexes/Bitmap_index.md
+++ b/docs/ja/table_design/indexes/Bitmap_index.md
@@ -289,7 +289,7 @@ IOTaskExecTime: 2s77ms // データスキャンの合計時間。ビットマッ
     DictDecode: 329.696ms // 出力行数が同じであるため、低基数最適化のための辞書デコード時間は同様です。
     BitmapIndexFilter: 419.308ms // ビットマップインデックスによるデータフィルタリングの時間。
     BitmapIndexFilterRows: 123.433M (123432975) // ビットマップインデックスによってフィルタリングされた行数。
-    ZoneMapIndexFiter: 171.580ms // ZoneMapインデックスによるデータフィルタリングの時間。
+    ZoneMapIndexFilter: 171.580ms // ZoneMapインデックスによるデータフィルタリングの時間。
 ```
 
 ##### StarRocksのデフォルト設定に基づいてビットマップインデックスを使用するかどうかを決定

--- a/docs/zh/table_design/indexes/Bitmap_index.md
+++ b/docs/zh/table_design/indexes/Bitmap_index.md
@@ -290,7 +290,7 @@ IOTaskExecTime: 2s77ms // Scan 数据总时间，相对于没创建 Bitmap 索�
     DictDecode: 329.696ms // 因为输出的行数是一样的，所以低基数优化字典解码的时间所花时间差不多
     BitmapIndexFilter: 419.308ms // Bitmap 索引过滤数据的时间。
     BitmapIndexFilterRows: 123.433M (123432975) // Bitmap 索引过滤掉的数据行数。
-    ZoneMapIndexFiter: 171.580ms // ZoneMap 索引过滤数据花了 0.17 秒。
+    ZoneMapIndexFilter: 171.580ms // ZoneMap 索引过滤数据花了 0.17 秒。
 ```
 
 ##### 由 StarRocks 默认配置决定是否使用 Bitmap 索引


### PR DESCRIPTION
The segment-init zone map timer was registered as "ZoneMapIndexFiter", missing the l, in both the OLAP and the lake scan profile, and the bitmap index docs printed the same misspelling in a sample profile. The row counter beside it is spelled "ZoneMapIndexFilterRows", so the timer/rows pair did not match and the timer did not appear where readers looked for it.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
