### PR TITLE
[BugFix] Compact tablet merge delvec output

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1140,7 +1140,7 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
         TRACE_COUNTER_SCOPE_LATENCY_US("delvec_write_us");
         TRACE_COUNTER_INCREMENT("delvec_file_bytes", static_cast<int64_t>(_buf.size()));
         TEST_SYNC_POINT_CALLBACK("MetaFileBuilder::_finalize_delvec", &_buf);
-        int64_t logical_size = _buf.size();
+        [[maybe_unused]] int64_t logical_size = _buf.size();
         TEST_SYNC_POINT_CALLBACK("MetaFileBuilder::_finalize_delvec:logical_append_size", &logical_size);
         auto delvec_file_name = gen_delvec_filename(txn_id);
         auto delvec_file_path = _tablet.delvec_location(delvec_file_name);
@@ -1328,7 +1328,7 @@ constexpr size_t kDelvecIoChunkSize = 1UL << 20;
 Status append_delvec_bytes_bounded(WritableFile* writer, Slice bytes) {
     while (!bytes.empty()) {
         const size_t chunk_size = std::min(bytes.size, kDelvecIoChunkSize);
-        size_t observed_chunk_size = chunk_size;
+        [[maybe_unused]] size_t observed_chunk_size = chunk_size;
         TEST_SYNC_POINT_CALLBACK("append_delvec_bytes_bounded:chunk_size", &observed_chunk_size);
         Status append_status;
         TEST_SYNC_POINT_CALLBACK("append_delvec_bytes_bounded:before_chunk", &append_status);
@@ -1475,7 +1475,7 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
     auto close_reader = [&] {
         if (current_reader != nullptr) {
             current_reader.reset();
-            int delta = -1;
+            [[maybe_unused]] int delta = -1;
             TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:copy_source_reader_delta", &delta);
             current_source.reset();
         }
@@ -1497,7 +1497,7 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
                                                      source_options, tablet_mgr->delvec_location(
                                                                              raw.tablet_id, raw.delvec_file.name())));
             current_source = source_key;
-            int delta = 1;
+            [[maybe_unused]] int delta = 1;
             TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:copy_source_reader_delta", &delta);
         }
         uint64_t copied = 0;
@@ -1506,7 +1506,7 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
         while (copied < raw.page.size()) {
             const size_t chunk_size =
                     static_cast<size_t>(std::min<uint64_t>(kDelvecIoChunkSize, raw.page.size() - copied));
-            size_t observed_chunk_size = chunk_size;
+            [[maybe_unused]] size_t observed_chunk_size = chunk_size;
             TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:read_chunk_size", &observed_chunk_size);
             Status read_status;
             TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:before_read_chunk", &read_status);

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1484,6 +1484,7 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
 
     for (const auto& output_page : pages) {
         if (!output_page.raw_page.has_value()) {
+            close_reader();
             RETURN_IF_ERROR(append_delvec_bytes_bounded(writer.get(), Slice(output_page.serialized_page)));
             continue;
         }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1331,7 +1331,7 @@ Status append_delvec_bytes_bounded(WritableFile* writer, Slice bytes) {
         size_t observed_chunk_size = chunk_size;
         TEST_SYNC_POINT_CALLBACK("append_delvec_bytes_bounded:chunk_size", &observed_chunk_size);
         Status append_status;
-        TEST_SYNC_POINT_CALLBACK("write_delvec_output:append", &append_status);
+        TEST_SYNC_POINT_CALLBACK("append_delvec_bytes_bounded:before_chunk", &append_status);
         RETURN_IF_ERROR(append_status);
         RETURN_IF_ERROR(writer->append(Slice(bytes.data, chunk_size)));
         bytes.remove_prefix(chunk_size);
@@ -1465,6 +1465,9 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
     const std::string new_file_path = tablet_mgr->delvec_location(new_tablet_id, new_file_name);
     WritableFileOptions options{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:writer_open", nullptr);
+    Status writer_open_status;
+    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:before_writer_open", &writer_open_status);
+    RETURN_IF_ERROR(writer_open_status);
     ASSIGN_OR_RETURN(auto writer, fs::new_writable_file(options, new_file_path));
 
     std::unique_ptr<RandomAccessFile> current_reader;
@@ -1505,6 +1508,9 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
                     static_cast<size_t>(std::min<uint64_t>(kDelvecIoChunkSize, raw.page.size() - copied));
             size_t observed_chunk_size = chunk_size;
             TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:read_chunk_size", &observed_chunk_size);
+            Status read_status;
+            TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:before_read_chunk", &read_status);
+            RETURN_IF_ERROR(read_status);
             RETURN_IF_ERROR(current_reader->read_at_fully(static_cast<int64_t>(raw.page.offset() + copied),
                                                           buffer.data(), static_cast<int64_t>(chunk_size)));
             RETURN_IF_ERROR(append_delvec_bytes_bounded(writer.get(), Slice(buffer.data(), chunk_size)));
@@ -1514,7 +1520,7 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
 
     close_reader();
     Status close_status;
-    TEST_SYNC_POINT_CALLBACK("write_delvec_output:close", &close_status);
+    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:before_close", &close_status);
     RETURN_IF_ERROR(close_status);
     RETURN_IF_ERROR(writer->close());
 
@@ -1523,6 +1529,9 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
     output.set_size(static_cast<int64_t>(total_size));
     output.clear_encryption_meta();
     output.set_shared(false);
+    Status apply_offsets_status;
+    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:before_apply_offsets", &apply_offsets_status);
+    RETURN_IF_ERROR(apply_offsets_status);
     *new_delvec_file = std::move(output);
     *page_offsets = std::move(offsets);
     return Status::OK();

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1409,8 +1409,7 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
                         "encrypted delvec input is unsupported; delvec must be plaintext: {}", raw.delvec_file.name()));
             }
             RETURN_IF_ERROR(validate_signed_page_range(raw.page));
-            uint64_t page_end = 0;
-            DCHECK(!__builtin_add_overflow(raw.page.offset(), raw.page.size(), &page_end));
+            const uint64_t page_end = raw.page.offset() + raw.page.size();
             if (raw.delvec_file.has_size()) {
                 RETURN_IF_ERROR(validate_source_size(raw.delvec_file.size(), page_end, false));
             } else {

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -1482,6 +1482,7 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
     };
     DeferOp close_current_reader(close_reader);
 
+    std::string buffer;
     for (const auto& output_page : pages) {
         if (!output_page.raw_page.has_value()) {
             close_reader();
@@ -1502,7 +1503,6 @@ Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector
             TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:copy_source_reader_delta", &delta);
         }
         uint64_t copied = 0;
-        std::string buffer;
         buffer.resize(kDelvecIoChunkSize);
         while (copied < raw.page.size()) {
             const size_t chunk_size =

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -17,7 +17,10 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <limits>
+#include <map>
 #include <memory>
+#include <tuple>
 
 #include "base/coding.h"
 #include "base/container/raw_container.h"
@@ -41,6 +44,10 @@
 #include "storage/storage_metrics.h"
 
 namespace starrocks::lake {
+
+namespace {
+Status append_delvec_bytes_bounded(WritableFile* writer, Slice bytes);
+}
 
 uint32_t get_segment_idx(const RowsetMetadataPB& rowset_meta, int32_t segment_pos) {
     DCHECK_GE(segment_pos, 0);
@@ -1133,6 +1140,8 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
         TRACE_COUNTER_SCOPE_LATENCY_US("delvec_write_us");
         TRACE_COUNTER_INCREMENT("delvec_file_bytes", static_cast<int64_t>(_buf.size()));
         TEST_SYNC_POINT_CALLBACK("MetaFileBuilder::_finalize_delvec", &_buf);
+        int64_t logical_size = _buf.size();
+        TEST_SYNC_POINT_CALLBACK("MetaFileBuilder::_finalize_delvec:logical_append_size", &logical_size);
         auto delvec_file_name = gen_delvec_filename(txn_id);
         auto delvec_file_path = _tablet.delvec_location(delvec_file_name);
         // keep delete vector file name in tablet meta
@@ -1141,7 +1150,7 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
         item.set_size(_buf.size());
         auto options = WritableFileOptions{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
         ASSIGN_OR_RETURN(auto writer_file, fs::new_writable_file(options, delvec_file_path));
-        RETURN_IF_ERROR(writer_file->append(Slice(_buf.data(), _buf.size())));
+        RETURN_IF_ERROR(append_delvec_bytes_bounded(writer_file.get(), Slice(_buf.data(), _buf.size())));
         RETURN_IF_ERROR(writer_file->close());
         TRACE("end write delvec");
     }
@@ -1312,85 +1321,210 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, ui
     return Status::OK();
 }
 
-Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFileInfo>& old_delvec_files,
-                          int64_t new_tablet_id, int64_t txn_id, FileMetaPB* new_delvec_file,
-                          std::vector<uint64_t>* offsets, const Slice& extra_data, uint64_t* extra_data_offset) {
-    if (old_delvec_files.empty()) {
-        DCHECK(extra_data.empty()) << "extra_data provided but no delvec files to merge";
-        return Status::OK();
-    }
+namespace {
 
-    const std::string new_file_name = gen_delvec_filename(txn_id);
-    const std::string new_file_path = tablet_mgr->delvec_location(new_tablet_id, new_file_name);
-    WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-    ASSIGN_OR_RETURN(auto writer, fs::new_writable_file(wopts, new_file_path));
+constexpr size_t kDelvecIoChunkSize = 1UL << 20;
 
-    std::vector<uint64_t> new_offsets;
-    new_offsets.reserve(old_delvec_files.size());
-    uint64_t total_size = 0;
-    for (size_t i = 0; i < old_delvec_files.size(); ++i) {
-        const auto& file_info = old_delvec_files[i];
-        new_offsets.push_back(total_size);
-        const std::string src_path = tablet_mgr->delvec_location(file_info.tablet_id, file_info.delvec_file.name());
-        ASSIGN_OR_RETURN(auto reader, fs::new_random_access_file(src_path));
-        ASSIGN_OR_RETURN(auto content, reader->read_all());
+Status append_delvec_bytes_bounded(WritableFile* writer, Slice bytes) {
+    while (!bytes.empty()) {
+        const size_t chunk_size = std::min(bytes.size, kDelvecIoChunkSize);
+        size_t observed_chunk_size = chunk_size;
+        TEST_SYNC_POINT_CALLBACK("append_delvec_bytes_bounded:chunk_size", &observed_chunk_size);
         Status append_status;
         TEST_SYNC_POINT_CALLBACK("write_delvec_output:append", &append_status);
         RETURN_IF_ERROR(append_status);
-        RETURN_IF_ERROR(writer->append(Slice(content.data(), content.size())));
-        total_size += content.size();
+        RETURN_IF_ERROR(writer->append(Slice(bytes.data, chunk_size)));
+        bytes.remove_prefix(chunk_size);
     }
-
-    uint64_t new_extra_data_offset = 0;
-    if (!extra_data.empty()) {
-        new_extra_data_offset = total_size;
-        Status append_status;
-        TEST_SYNC_POINT_CALLBACK("write_delvec_output:append", &append_status);
-        RETURN_IF_ERROR(append_status);
-        RETURN_IF_ERROR(writer->append(extra_data));
-        total_size += extra_data.size;
-    }
-
-    Status close_status;
-    TEST_SYNC_POINT_CALLBACK("write_delvec_output:close", &close_status);
-    RETURN_IF_ERROR(close_status);
-    RETURN_IF_ERROR(writer->close());
-
-    *offsets = std::move(new_offsets);
-    if (!extra_data.empty() && extra_data_offset != nullptr) {
-        *extra_data_offset = new_extra_data_offset;
-    }
-    new_delvec_file->set_name(new_file_name);
-    new_delvec_file->set_size(total_size);
-    new_delvec_file->clear_encryption_meta();
-    new_delvec_file->set_shared(false);
     return Status::OK();
 }
 
-Status write_delvec_file_from_buffer(TabletManager* tablet_mgr, int64_t new_tablet_id, int64_t txn_id,
-                                     const Slice& buffer, FileMetaPB* new_delvec_file) {
+Status validate_signed_page_range(const DelvecPagePB& page) {
+    constexpr uint64_t kInt64Max = std::numeric_limits<int64_t>::max();
+    if (page.size() == 0) {
+        return Status::InvalidArgument("compacted delvec raw page size must be positive");
+    }
+    if (page.offset() > kInt64Max) {
+        return Status::InvalidArgument("compacted delvec raw page offset is outside signed int64 domain");
+    }
+    if (page.size() > kInt64Max) {
+        return Status::InvalidArgument("compacted delvec raw page size is outside signed int64 domain");
+    }
+    uint64_t end = 0;
+    if (__builtin_add_overflow(page.offset(), page.size(), &end) || end > kInt64Max) {
+        return Status::InvalidArgument("compacted delvec raw page end is outside signed int64 domain");
+    }
+    return Status::OK();
+}
+
+Status validate_source_size(int64_t source_size, uint64_t page_end, bool resolved) {
+    if (source_size < 0) {
+        return Status::InvalidArgument(resolved ? "compacted delvec resolved source size is negative"
+                                                : "compacted delvec declared source size is negative");
+    }
+    if (static_cast<uint64_t>(source_size) < page_end) {
+        return Status::InvalidArgument(resolved ? "compacted delvec resolved source size does not contain page"
+                                                : "compacted delvec declared source size does not contain page");
+    }
+    return Status::OK();
+}
+
+} // namespace
+
+Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector<DelvecOutputPage>& pages,
+                                    int64_t new_tablet_id, int64_t txn_id, FileMetaPB* new_delvec_file,
+                                    std::vector<uint64_t>* page_offsets) {
     DCHECK(new_delvec_file != nullptr);
-    if (buffer.empty()) {
-        return Status::InvalidArgument("write_delvec_file_from_buffer called with empty buffer");
+    DCHECK(page_offsets != nullptr);
+    if (pages.empty()) {
+        return Status::InvalidArgument("compacted delvec page plan is empty");
+    }
+
+    uint64_t total_size = 0;
+    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:initial_output_offset", &total_size);
+    bool skip_int64_output_limit = false;
+    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:test_skip_int64_output_limit", &skip_int64_output_limit);
+
+    std::map<std::tuple<int64_t, std::string, uint64_t>, uint64_t> duplicate_pages;
+    std::map<std::pair<int64_t, std::string>, int64_t> resolved_source_sizes;
+    std::vector<uint64_t> offsets;
+    offsets.reserve(pages.size());
+
+    // Preflight the whole plan before constructing the destination object.
+    for (const auto& output_page : pages) {
+        const bool has_raw = output_page.raw_page.has_value();
+        const bool has_serialized = !output_page.serialized_page.empty();
+        if (has_raw == has_serialized) {
+            return Status::InvalidArgument("compacted delvec output page must contain exactly one payload");
+        }
+
+        uint64_t page_size = 0;
+        if (has_raw) {
+            const auto& raw = *output_page.raw_page;
+            if (raw.delvec_file.name().empty()) {
+                return Status::InvalidArgument("compacted delvec raw page filename is empty");
+            }
+            if (!raw.delvec_file.encryption_meta().empty()) {
+                return Status::NotSupported(fmt::format(
+                        "encrypted delvec input is unsupported; delvec must be plaintext: {}", raw.delvec_file.name()));
+            }
+            RETURN_IF_ERROR(validate_signed_page_range(raw.page));
+            uint64_t page_end = 0;
+            DCHECK(!__builtin_add_overflow(raw.page.offset(), raw.page.size(), &page_end));
+            if (raw.delvec_file.has_size()) {
+                RETURN_IF_ERROR(validate_source_size(raw.delvec_file.size(), page_end, false));
+            } else {
+                const auto source_key = std::make_pair(raw.tablet_id, raw.delvec_file.name());
+                auto source_size_it = resolved_source_sizes.find(source_key);
+                if (source_size_it == resolved_source_sizes.end()) {
+                    RandomAccessFileOptions options{.skip_fill_local_cache = true};
+                    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:source_options", &options);
+                    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:preflight_source_open", nullptr);
+                    ASSIGN_OR_RETURN(auto reader, fs::new_random_access_file(
+                                                          options, tablet_mgr->delvec_location(
+                                                                           raw.tablet_id, raw.delvec_file.name())));
+                    std::optional<StatusOr<int64_t>> source_size_override;
+                    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:source_size_override",
+                                             &source_size_override);
+                    int64_t resolved_size = 0;
+                    if (source_size_override.has_value()) {
+                        RETURN_IF_ERROR(source_size_override->status());
+                        resolved_size = source_size_override->value();
+                    } else {
+                        ASSIGN_OR_RETURN(resolved_size, reader->get_size());
+                    }
+                    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:source_size", &resolved_size);
+                    RETURN_IF_ERROR(validate_source_size(resolved_size, page_end, true));
+                    source_size_it = resolved_source_sizes.emplace(source_key, resolved_size).first;
+                } else {
+                    RETURN_IF_ERROR(validate_source_size(source_size_it->second, page_end, true));
+                }
+            }
+            const auto duplicate_key = std::make_tuple(raw.tablet_id, raw.delvec_file.name(), raw.page.offset());
+            auto [it, inserted] = duplicate_pages.emplace(duplicate_key, raw.page.size());
+            if (!inserted && it->second != raw.page.size()) {
+                return Status::Corruption("compacted delvec duplicate page declarations disagree on size");
+            }
+            page_size = raw.page.size();
+        } else {
+            page_size = output_page.serialized_page.size();
+        }
+
+        uint64_t next_total = 0;
+        if (__builtin_add_overflow(total_size, page_size, &next_total)) {
+            return Status::InvalidArgument("compacted delvec output size overflows uint64");
+        }
+        if (!skip_int64_output_limit && next_total > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+            return Status::InvalidArgument("compacted delvec output size is outside signed int64 domain");
+        }
+        offsets.push_back(total_size);
+        total_size = next_total;
     }
 
     const std::string new_file_name = gen_delvec_filename(txn_id);
     const std::string new_file_path = tablet_mgr->delvec_location(new_tablet_id, new_file_name);
-    WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-    ASSIGN_OR_RETURN(auto writer, fs::new_writable_file(wopts, new_file_path));
-    Status append_status;
-    TEST_SYNC_POINT_CALLBACK("write_delvec_output:append", &append_status);
-    RETURN_IF_ERROR(append_status);
-    RETURN_IF_ERROR(writer->append(buffer));
+    WritableFileOptions options{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:writer_open", nullptr);
+    ASSIGN_OR_RETURN(auto writer, fs::new_writable_file(options, new_file_path));
+
+    std::unique_ptr<RandomAccessFile> current_reader;
+    std::optional<std::pair<int64_t, std::string>> current_source;
+    auto close_reader = [&] {
+        if (current_reader != nullptr) {
+            current_reader.reset();
+            int delta = -1;
+            TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:copy_source_reader_delta", &delta);
+            current_source.reset();
+        }
+    };
+    DeferOp close_current_reader(close_reader);
+
+    for (const auto& output_page : pages) {
+        if (!output_page.raw_page.has_value()) {
+            RETURN_IF_ERROR(append_delvec_bytes_bounded(writer.get(), Slice(output_page.serialized_page)));
+            continue;
+        }
+        const auto& raw = *output_page.raw_page;
+        const auto source_key = std::make_pair(raw.tablet_id, raw.delvec_file.name());
+        if (!current_source.has_value() || *current_source != source_key) {
+            close_reader();
+            RandomAccessFileOptions source_options{.skip_fill_local_cache = true};
+            TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:source_options", &source_options);
+            ASSIGN_OR_RETURN(current_reader, fs::new_random_access_file(
+                                                     source_options, tablet_mgr->delvec_location(
+                                                                             raw.tablet_id, raw.delvec_file.name())));
+            current_source = source_key;
+            int delta = 1;
+            TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:copy_source_reader_delta", &delta);
+        }
+        uint64_t copied = 0;
+        std::string buffer;
+        buffer.resize(kDelvecIoChunkSize);
+        while (copied < raw.page.size()) {
+            const size_t chunk_size =
+                    static_cast<size_t>(std::min<uint64_t>(kDelvecIoChunkSize, raw.page.size() - copied));
+            size_t observed_chunk_size = chunk_size;
+            TEST_SYNC_POINT_CALLBACK("write_compacted_delvec_pages:read_chunk_size", &observed_chunk_size);
+            RETURN_IF_ERROR(current_reader->read_at_fully(static_cast<int64_t>(raw.page.offset() + copied),
+                                                          buffer.data(), static_cast<int64_t>(chunk_size)));
+            RETURN_IF_ERROR(append_delvec_bytes_bounded(writer.get(), Slice(buffer.data(), chunk_size)));
+            copied += chunk_size;
+        }
+    }
+
+    close_reader();
     Status close_status;
     TEST_SYNC_POINT_CALLBACK("write_delvec_output:close", &close_status);
     RETURN_IF_ERROR(close_status);
     RETURN_IF_ERROR(writer->close());
 
-    new_delvec_file->set_name(new_file_name);
-    new_delvec_file->set_size(buffer.size);
-    new_delvec_file->clear_encryption_meta();
-    new_delvec_file->set_shared(false);
+    FileMetaPB output;
+    output.set_name(new_file_name);
+    output.set_size(static_cast<int64_t>(total_size));
+    output.clear_encryption_meta();
+    output.set_shared(false);
+    *new_delvec_file = std::move(output);
+    *page_offsets = std::move(offsets);
     return Status::OK();
 }
 

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -203,23 +204,25 @@ private:
     PendingRowsetData _pending_rowset_data;
 };
 
-struct DelvecFileInfo {
+// One byte-range page from a plaintext delvec object.  The page declaration is
+// kept with its file declaration because a compacted MERGE output copies only
+// the live page ranges, rather than whole source objects.
+struct DelvecPageInfo {
     int64_t tablet_id;
     FileMetaPB delvec_file;
+    DelvecPagePB page;
 };
 
-Status merge_delvec_files(TabletManager* tablet_mgr, const std::vector<DelvecFileInfo>& old_delvec_files,
-                          int64_t new_tablet_id, int64_t txn_id, FileMetaPB* new_delvec_file,
-                          std::vector<uint64_t>* offsets, const Slice& extra_data = {},
-                          uint64_t* extra_data_offset = nullptr);
+// A target page is either copied byte-for-byte from an existing plaintext
+// source page, or is the already serialized result of a delvec union.
+struct DelvecOutputPage {
+    std::optional<DelvecPageInfo> raw_page;
+    std::string serialized_page;
+};
 
-// Write a brand-new delvec file containing only |buffer|. Used by tablet merge
-// when final states have no single-source file to copy (synthesized gaps or
-// merged pages) — sidesteps merge_delvec_files's DCHECK on (empty old_files +
-// non-empty extra_data) and avoids generating an empty file by mistake. Buffer
-// is written at offset 0; the resulting FileMetaPB is shared=false.
-Status write_delvec_file_from_buffer(TabletManager* tablet_mgr, int64_t new_tablet_id, int64_t txn_id,
-                                     const Slice& buffer, FileMetaPB* new_delvec_file);
+Status write_compacted_delvec_pages(TabletManager* tablet_mgr, const std::vector<DelvecOutputPage>& pages,
+                                    int64_t new_tablet_id, int64_t txn_id, FileMetaPB* new_delvec_file,
+                                    std::vector<uint64_t>* page_offsets);
 
 Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, const DelvecPagePB& delvec_page,
                    bool fill_cache, const LakeIOOptions& lake_io_opts, DelVector* delvec);

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -2203,7 +2203,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
 
     FileMetaPB new_delvec_file;
     std::vector<uint64_t> offsets;
-    int writer_invocations = 1;
+    [[maybe_unused]] int writer_invocations = 1;
     TEST_SYNC_POINT_CALLBACK("merge_delvecs:writer_invocations", &writer_invocations);
     RETURN_IF_ERROR(write_compacted_delvec_pages(tablet_manager, output_pages, new_metadata->id(), txn_id,
                                                  &new_delvec_file, &offsets));

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -150,11 +150,6 @@ struct DelvecSourceRef {
     std::string file_name;
 };
 
-struct SourceDelvecFile {
-    int64_t tablet_id;
-    FileMetaPB file;
-};
-
 struct TargetDelvecState {
     std::optional<DelvecSourceRef> single_source;
     std::unique_ptr<DelVector> merged;
@@ -2053,7 +2048,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
     // Phase 1: Scan pages, build TargetDelvecState for each target rssid.
     // File name is resolved inline via each old tablet's version_to_file map.
     std::map<uint32_t, TargetDelvecState> target_states;
-    std::unordered_map<std::string, SourceDelvecFile> actual_page_source_files;
+    bool has_actual_page_source = false;
     const auto target_live_rssids = collect_live_rssids(*new_metadata);
 
     for (size_t context_index = 0; context_index < merge_contexts.size(); ++context_index) {
@@ -2085,18 +2080,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
                 return Status::InvalidArgument("Delvec file not found for page version");
             }
             const std::string& file_name = file_it->second.name();
-            auto [canonical_file_it, inserted] = actual_page_source_files.emplace(
-                    file_name, SourceDelvecFile{ctx.metadata()->id(), file_it->second});
-            if (!inserted) {
-                const auto& canonical_file = canonical_file_it->second.file;
-                const auto& incoming_file = file_it->second;
-                if (!delvec_file_metadata_matches(canonical_file, incoming_file)) {
-                    return Status::Corruption(
-                            fmt::format("Delvec actual page source metadata mismatch for file {} between tablets {} "
-                                        "and {}",
-                                        file_name, canonical_file_it->second.tablet_id, ctx.metadata()->id()));
-                }
-            }
+            has_actual_page_source = true;
             auto& state = target_states[target];
             auto source_key = std::make_pair(file_name, page.offset());
 
@@ -2108,8 +2092,8 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
                 // single_source state
                 auto seen_it = state.seen_sources.find(source_key);
                 if (seen_it != state.seen_sources.end()) {
-                    // Dedup hit: same file_name + offset. File metadata was
-                    // already validated through actual_page_source_files.
+                    // Dedup hit: same file_name + offset. File metadata was already validated by
+                    // preflight_merge_sources before any merge state was materialized.
                     if (seen_it->second != page.size()) {
                         return Status::Corruption("Delvec page size mismatch for same source");
                     }
@@ -2207,7 +2191,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
     TEST_SYNC_POINT_CALLBACK("merge_delvecs:writer_invocations", &writer_invocations);
     RETURN_IF_ERROR(write_compacted_delvec_pages(tablet_manager, output_pages, new_metadata->id(), txn_id,
                                                  &new_delvec_file, &offsets));
-    if (actual_page_source_files.empty()) {
+    if (!has_actual_page_source) {
         g_tablet_merge_synthesized_only_delvec_total << 1;
     }
 

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -2015,6 +2015,7 @@ Status inject_synthesized_gaps_into_target_states(TabletManager* tablet_manager,
             DelVector dv_prev;
             const auto& ref = *state.single_source;
             LakeIOOptions io_opts;
+            TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_gap_promotion", nullptr);
             TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_get_del_vec", nullptr);
             RETURN_IF_ERROR(get_del_vec(tablet_manager, *ref.ctx->metadata(), ref.page, false, io_opts, &dv_prev));
             auto merged_dv = std::make_unique<DelVector>();

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -150,10 +150,9 @@ struct DelvecSourceRef {
     std::string file_name;
 };
 
-struct UnionPageInfo {
-    uint64_t offset;
-    uint64_t size;
-    uint32_t masked_crc32c;
+struct SourceDelvecFile {
+    int64_t tablet_id;
+    FileMetaPB file;
 };
 
 struct TargetDelvecState {
@@ -1620,7 +1619,7 @@ Status merge_dcg_meta(TabletManager* tablet_manager, const std::vector<TabletMer
     // Track full paths of rebuilt .cols files so we can best-effort clean them
     // up if a later target's rebuild fails partway through. Downstream failures
     // (merge_delvecs/merge_sstables/publish) still rely on standard orphan-file
-    // vacuum, which matches the pattern used by merge_delvec_files.
+    // vacuum, which matches the compact page-writer orphan boundary.
     std::vector<std::string> rebuilt_file_paths;
     auto cleanup_on_failure = [&]() {
         for (const auto& path : rebuilt_file_paths) {
@@ -2016,6 +2015,7 @@ Status inject_synthesized_gaps_into_target_states(TabletManager* tablet_manager,
             DelVector dv_prev;
             const auto& ref = *state.single_source;
             LakeIOOptions io_opts;
+            TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_get_del_vec", nullptr);
             RETURN_IF_ERROR(get_del_vec(tablet_manager, *ref.ctx->metadata(), ref.page, false, io_opts, &dv_prev));
             auto merged_dv = std::make_unique<DelVector>();
             if (dv_prev.roaring()) {
@@ -2052,7 +2052,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
     // Phase 1: Scan pages, build TargetDelvecState for each target rssid.
     // File name is resolved inline via each old tablet's version_to_file map.
     std::map<uint32_t, TargetDelvecState> target_states;
-    std::unordered_map<std::string, DelvecFileInfo> actual_page_source_files;
+    std::unordered_map<std::string, SourceDelvecFile> actual_page_source_files;
     const auto target_live_rssids = collect_live_rssids(*new_metadata);
 
     for (size_t context_index = 0; context_index < merge_contexts.size(); ++context_index) {
@@ -2084,10 +2084,10 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
                 return Status::InvalidArgument("Delvec file not found for page version");
             }
             const std::string& file_name = file_it->second.name();
-            auto [canonical_file_it, inserted] =
-                    actual_page_source_files.emplace(file_name, DelvecFileInfo{ctx.metadata()->id(), file_it->second});
+            auto [canonical_file_it, inserted] = actual_page_source_files.emplace(
+                    file_name, SourceDelvecFile{ctx.metadata()->id(), file_it->second});
             if (!inserted) {
-                const auto& canonical_file = canonical_file_it->second.delvec_file;
+                const auto& canonical_file = canonical_file_it->second.file;
                 const auto& incoming_file = file_it->second;
                 if (!delvec_file_metadata_matches(canonical_file, incoming_file)) {
                     return Status::Corruption(
@@ -2120,12 +2120,14 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
                 {
                     const auto& ref = *state.single_source;
                     LakeIOOptions io_opts;
+                    TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_get_del_vec", nullptr);
                     RETURN_IF_ERROR(
                             get_del_vec(tablet_manager, *ref.ctx->metadata(), ref.page, false, io_opts, &dv_prev));
                 }
                 DelVector dv_new;
                 {
                     LakeIOOptions io_opts;
+                    TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_get_del_vec", nullptr);
                     RETURN_IF_ERROR(get_del_vec(tablet_manager, *ctx.metadata(), page, false, io_opts, &dv_new));
                 }
                 // Union
@@ -2149,6 +2151,7 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
                 DelVector dv_new;
                 {
                     LakeIOOptions io_opts;
+                    TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_get_del_vec", nullptr);
                     RETURN_IF_ERROR(get_del_vec(tablet_manager, *ctx.metadata(), page, false, io_opts, &dv_new));
                 }
                 union_delvec(state.merged.get(), dv_new, new_version);
@@ -2170,71 +2173,41 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
         return Status::OK();
     }
 
-    // Phase 2: Serialize union results into union_buffer.
-    std::string union_buffer;
-    std::map<uint32_t, UnionPageInfo> union_page_infos;
-
+    // Phase 2: build one ordered output entry for each final target RSSID.
+    // Raw and serialized pages deliberately interleave in this map order.
+    std::vector<uint32_t> target_rssids;
+    std::vector<DelvecOutputPage> output_pages;
+    target_rssids.reserve(target_states.size());
+    output_pages.reserve(target_states.size());
     for (auto& [target, state] : target_states) {
-        if (state.merged) {
-            std::string data = state.merged->save();
-            uint32_t masked_crc = crc32c::Mask(crc32c::Value(data.data(), data.size()));
-            union_page_infos[target] = {static_cast<uint64_t>(union_buffer.size()), static_cast<uint64_t>(data.size()),
-                                        masked_crc};
-            union_buffer.append(data);
+        target_rssids.push_back(target);
+        DelvecOutputPage output_page;
+        if (state.single_source.has_value()) {
+            const auto& ref = *state.single_source;
+            auto file_it = ref.ctx->metadata()->delvec_meta().version_to_file().find(ref.page.version());
+            if (file_it == ref.ctx->metadata()->delvec_meta().version_to_file().end()) {
+                return Status::InvalidArgument("Delvec file not found for final single-source page version");
+            }
+            if (file_it->second.name() != ref.file_name) {
+                return Status::Corruption("Delvec final single-source file name changed during merge");
+            }
+            output_page.raw_page = DelvecPageInfo{ref.ctx->metadata()->id(), file_it->second, ref.page};
+        } else if (state.merged) {
+            output_page.serialized_page = state.merged->save();
+        } else {
+            return Status::Corruption("Delvec target state has neither single_source nor merged");
         }
+        output_pages.emplace_back(std::move(output_page));
     }
 
-    // Phase 3: Resolve files only for final single-source consumers. A merged
-    // state has already been decoded into union_buffer and does not need its
-    // immutable source file copied into the output.
-    std::vector<DelvecFileInfo> unique_delvec_files;
-    std::unordered_set<std::string> selected_source_filenames;
-    for (const auto& [target, state] : target_states) {
-        (void)target;
-        if (!state.single_source.has_value()) {
-            continue;
-        }
-        const auto& ref = *state.single_source;
-        auto file_it = ref.ctx->metadata()->delvec_meta().version_to_file().find(ref.page.version());
-        if (file_it == ref.ctx->metadata()->delvec_meta().version_to_file().end()) {
-            return Status::InvalidArgument("Delvec file not found for final single-source page version");
-        }
-        const auto& file = file_it->second;
-        if (file.name() != ref.file_name) {
-            return Status::Corruption("Delvec final single-source file name changed during merge");
-        }
-        if (selected_source_filenames.emplace(file.name()).second) {
-            unique_delvec_files.push_back(DelvecFileInfo{ref.ctx->metadata()->id(), file});
-        }
-    }
-    TEST_SYNC_POINT_CALLBACK("merge_delvecs:selected_source_files", &unique_delvec_files);
-
-    if (unique_delvec_files.empty() && union_buffer.empty()) {
-        return Status::Corruption("Delvec targets produced neither source files nor serialized union pages");
-    }
-
-    // Phase 4: Write one file. With no final single-source consumer, the
-    // serialized union is the complete output; otherwise concatenate only the
-    // selected immutable files and append the union buffer.
     FileMetaPB new_delvec_file;
     std::vector<uint64_t> offsets;
-    uint64_t union_base_offset = 0;
-    int writer_invocations = 0;
-    if (unique_delvec_files.empty()) {
-        DCHECK(!union_buffer.empty()) << "buffer-only path with empty union_buffer";
-        ++writer_invocations;
-        TEST_SYNC_POINT_CALLBACK("merge_delvecs:writer_invocations", &writer_invocations);
-        RETURN_IF_ERROR(write_delvec_file_from_buffer(tablet_manager, new_metadata->id(), txn_id, Slice(union_buffer),
-                                                      &new_delvec_file));
-        union_base_offset = 0;
-        if (actual_page_source_files.empty()) {
-            g_tablet_merge_synthesized_only_delvec_total << 1;
-        }
-    } else {
-        ++writer_invocations;
-        TEST_SYNC_POINT_CALLBACK("merge_delvecs:writer_invocations", &writer_invocations);
-        RETURN_IF_ERROR(merge_delvec_files(tablet_manager, unique_delvec_files, new_metadata->id(), txn_id,
-                                           &new_delvec_file, &offsets, Slice(union_buffer), &union_base_offset));
+    int writer_invocations = 1;
+    TEST_SYNC_POINT_CALLBACK("merge_delvecs:writer_invocations", &writer_invocations);
+    RETURN_IF_ERROR(write_compacted_delvec_pages(tablet_manager, output_pages, new_metadata->id(), txn_id,
+                                                 &new_delvec_file, &offsets));
+    if (actual_page_source_files.empty()) {
+        g_tablet_merge_synthesized_only_delvec_total << 1;
     }
 
     // The merged delvec file is written; new_metadata does not point at it until Phase 5 below.
@@ -2243,48 +2216,28 @@ Status merge_delvecs(TabletManager* tablet_manager, const std::vector<TabletMerg
     // injected here leaves the file for ordinary orphan-file vacuum.
     FAIL_POINT_TRIGGER_RETURN_ERROR(tablet_merge_after_write_delvec);
 
-    // Build base_offset_by_file_name. Empty for synthesized-only route since
-    // there are no source files to reference; merged-state targets always go
-    // through union_page_infos which is keyed by target rssid, not file name.
-    std::unordered_map<std::string, uint64_t> base_offset_by_file_name;
-    for (size_t i = 0; i < unique_delvec_files.size(); ++i) {
-        base_offset_by_file_name[unique_delvec_files[i].delvec_file.name()] = offsets[i];
-    }
-
-    TEST_SYNC_POINT_CALLBACK("merge_delvecs:before_apply_offsets", &base_offset_by_file_name);
-
-    // Phase 5: Build metadata locally. Install it only after every page offset
+    // Phase 3: Build metadata locally. Install it only after every page offset
     // has been validated, so writer and mapping failures cannot partially
     // publish a destination delvec_meta.
     DelvecMetadataPB new_delvec_meta;
 
-    for (const auto& [target, state] : target_states) {
+    for (size_t i = 0; i < target_rssids.size(); ++i) {
+        const uint32_t target = target_rssids[i];
         DelvecPagePB new_page;
         new_page.set_version(new_version);
         new_page.set_crc32c_gen_version(new_version);
-
-        if (state.single_source.has_value()) {
-            const auto& ref = *state.single_source;
-            auto base_it = base_offset_by_file_name.find(ref.file_name);
-            if (base_it == base_offset_by_file_name.end()) {
-                return Status::InvalidArgument("Delvec file not merged for page version");
-            }
-            new_page.set_offset(base_it->second + ref.page.offset());
+        new_page.set_offset(offsets[i]);
+        if (output_pages[i].raw_page.has_value()) {
+            const auto& ref = *output_pages[i].raw_page;
             new_page.set_size(ref.page.size());
             // CRC decision: only reuse if old CRC is trustworthy
             if (ref.page.has_crc32c() && ref.page.crc32c_gen_version() == ref.page.version()) {
                 new_page.set_crc32c(ref.page.crc32c());
             }
-        } else if (state.merged) {
-            auto info_it = union_page_infos.find(target);
-            if (info_it == union_page_infos.end()) {
-                return Status::Corruption("Union page info not found for merged target");
-            }
-            new_page.set_offset(union_base_offset + info_it->second.offset);
-            new_page.set_size(info_it->second.size);
-            new_page.set_crc32c(info_it->second.masked_crc32c);
         } else {
-            return Status::Corruption("Delvec target state has neither single_source nor merged");
+            new_page.set_size(output_pages[i].serialized_page.size());
+            new_page.set_crc32c(crc32c::Mask(
+                    crc32c::Value(output_pages[i].serialized_page.data(), output_pages[i].serialized_page.size())));
         }
 
         (*new_delvec_meta.mutable_delvecs())[target] = std::move(new_page);
@@ -2851,6 +2804,10 @@ Status preflight_merge_sources(const std::vector<TabletMergeContext>& contexts,
                 const auto& declaration = file->second;
                 if (!declaration.has_name() || declaration.name().empty()) {
                     return Status::Corruption("tablet merge live delvec page has a missing or empty filename");
+                }
+                if (!declaration.encryption_meta().empty()) {
+                    return Status::NotSupported(fmt::format(
+                            "encrypted delvec input is unsupported; delvec must be plaintext: {}", declaration.name()));
                 }
                 if (declaration.has_size()) {
                     if (declaration.size() < 0) {

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <ctime>
+#include <functional>
 #include <limits>
 #include <set>
 #include <unordered_map>
@@ -116,6 +117,71 @@ protected:
                                  const FileMetaPB& after_file, const std::vector<uint64_t>& after_offsets) {
         EXPECT_EQ(before_file.SerializeAsString(), after_file.SerializeAsString());
         EXPECT_EQ(before_offsets, after_offsets);
+    }
+
+    enum class RejectionStatus { kInvalidArgument, kNotSupported, kCorruption };
+
+    void expect_compacted_delvec_rejected(const std::vector<DelvecOutputPage>& pages, RejectionStatus expected_status,
+                                          std::string_view expected_message, int expected_preflight_opens = 0,
+                                          int expected_source_sizes = 0,
+                                          const std::function<void(SyncPoint*)>& configure = {}) {
+        SCOPED_TRACE(expected_message);
+        FileMetaPB output;
+        output.set_name("unchanged.delvec");
+        output.set_size(123);
+        output.set_shared(true);
+        output.set_encryption_meta("unchanged-encryption");
+        std::vector<uint64_t> offsets = {7, 11};
+        const std::string before_file = output.SerializeAsString();
+        const std::vector<uint64_t> before_offsets = offsets;
+
+        int preflight_opens = 0;
+        int source_sizes = 0;
+        int get_del_vec_calls = 0;
+        int range_reads = 0;
+        int writer_opens = 0;
+        int append_chunks = 0;
+        int append_attempts = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        sync->SetCallBack("write_compacted_delvec_pages:preflight_source_open", [&](void*) { ++preflight_opens; });
+        sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_sizes; });
+        sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
+        sync->SetCallBack("write_compacted_delvec_pages:read_chunk_size", [&](void*) { ++range_reads; });
+        sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
+        sync->SetCallBack("append_delvec_bytes_bounded:chunk_size", [&](void*) { ++append_chunks; });
+        sync->SetCallBack("write_delvec_output:append", [&](void*) { ++append_attempts; });
+        if (configure) configure(sync);
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->ClearAllCallBacks();
+            sync->DisableProcessing();
+        });
+
+        const Status status =
+                write_compacted_delvec_pages(_tablet_manager.get(), pages, next_id(), next_id(), &output, &offsets);
+        switch (expected_status) {
+        case RejectionStatus::kInvalidArgument:
+            EXPECT_TRUE(status.is_invalid_argument()) << status;
+            break;
+        case RejectionStatus::kNotSupported:
+            EXPECT_TRUE(status.is_not_supported()) << status;
+            break;
+        case RejectionStatus::kCorruption:
+            EXPECT_TRUE(status.is_corruption()) << status;
+            break;
+        }
+        EXPECT_EQ(expected_message, status.message()) << status;
+        EXPECT_EQ(before_file, output.SerializeAsString());
+        EXPECT_EQ(before_offsets, offsets);
+        EXPECT_EQ(expected_preflight_opens, preflight_opens);
+        EXPECT_EQ(expected_source_sizes, source_sizes);
+        EXPECT_EQ(0, get_del_vec_calls);
+        EXPECT_EQ(0, range_reads);
+        EXPECT_EQ(0, writer_opens);
+        EXPECT_EQ(0, append_chunks);
+        EXPECT_EQ(0, append_attempts);
     }
 
     std::shared_ptr<TabletMetadataPB> make_shared_delvec_source(int64_t tablet_id, int segment_count) {
@@ -251,113 +317,68 @@ TEST_F(MetaFileTest, test_add_rowset_sums_composite_stats) {
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_empty_plan_rejected) {
-    FileMetaPB new_delvec_file;
-    new_delvec_file.set_name("unchanged.delvec");
-    std::vector<uint64_t> offsets = {1};
-    const FileMetaPB before_file = new_delvec_file;
-    const std::vector<uint64_t> before_offsets = offsets;
-
-    const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {}, 1, 1, &new_delvec_file, &offsets);
-    EXPECT_TRUE(status.is_invalid_argument()) << status;
-    EXPECT_EQ("compacted delvec page plan is empty", status.message());
-    expect_untouched_output(before_file, before_offsets, new_delvec_file, offsets);
+    expect_compacted_delvec_rejected({}, RejectionStatus::kInvalidArgument, "compacted delvec page plan is empty");
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_plan_shapes_and_filename) {
-    auto expect_invalid = [&](const std::vector<DelvecOutputPage>& pages, std::string_view message) {
-        FileMetaPB output;
-        output.set_name("unchanged.delvec");
-        std::vector<uint64_t> offsets = {9};
-        const FileMetaPB before_file = output;
-        const std::vector<uint64_t> before_offsets = offsets;
-        int preflight_opens = 0;
-        int source_sizes = 0;
-        int writer_opens = 0;
-        auto* sync = SyncPoint::GetInstance();
-        sync->SetCallBack("write_compacted_delvec_pages:preflight_source_open", [&](void*) { ++preflight_opens; });
-        sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_sizes; });
-        sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
-        sync->EnableProcessing();
-        DeferOp cleanup([&] {
-            sync->ClearAllCallBacks();
-            sync->DisableProcessing();
-        });
-        const Status status =
-                write_compacted_delvec_pages(_tablet_manager.get(), pages, next_id(), next_id(), &output, &offsets);
-        EXPECT_TRUE(status.is_invalid_argument()) << status;
-        EXPECT_EQ(message, status.message()) << status;
-        EXPECT_EQ(0, preflight_opens);
-        EXPECT_EQ(0, source_sizes);
-        EXPECT_EQ(0, writer_opens);
-        expect_untouched_output(before_file, before_offsets, output, offsets);
-    };
-
-    expect_invalid({}, "compacted delvec page plan is empty");
-    expect_invalid({DelvecOutputPage{}}, "compacted delvec output page must contain exactly one payload");
+    expect_compacted_delvec_rejected({}, RejectionStatus::kInvalidArgument, "compacted delvec page plan is empty");
+    expect_compacted_delvec_rejected({DelvecOutputPage{}}, RejectionStatus::kInvalidArgument,
+                                     "compacted delvec output page must contain exactly one payload");
     auto both = raw_output_page(next_id(), "both.delvec", 0, 1, 1);
     both.serialized_page = "x";
-    expect_invalid({both}, "compacted delvec output page must contain exactly one payload");
-    expect_invalid({raw_output_page(next_id(), "", 0, 1, 1)}, "compacted delvec raw page filename is empty");
+    expect_compacted_delvec_rejected({both}, RejectionStatus::kInvalidArgument,
+                                     "compacted delvec output page must contain exactly one payload");
+    expect_compacted_delvec_rejected({raw_output_page(next_id(), "", 0, 1, 1)}, RejectionStatus::kInvalidArgument,
+                                     "compacted delvec raw page filename is empty");
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_signed_and_file_domains) {
-    auto expect_invalid = [&](DelvecOutputPage page, std::string_view message) {
-        FileMetaPB output;
-        std::vector<uint64_t> offsets;
-        int source_sizes = 0;
-        auto* sync = SyncPoint::GetInstance();
-        sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_sizes; });
-        sync->EnableProcessing();
-        DeferOp cleanup([&] {
-            sync->ClearAllCallBacks();
-            sync->DisableProcessing();
-        });
-        const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {std::move(page)}, next_id(),
-                                                           next_id(), &output, &offsets);
-        EXPECT_TRUE(status.is_invalid_argument()) << status;
-        EXPECT_EQ(message, status.message()) << status;
-        EXPECT_EQ(0, source_sizes);
-    };
-    expect_invalid(raw_output_page(next_id(), "zero.delvec", 0, 0, 0),
-                   "compacted delvec raw page size must be positive");
-    expect_invalid(raw_output_page(next_id(), "negative.delvec", 0, 1, -1),
-                   "compacted delvec declared source size is negative");
-    expect_invalid(raw_output_page(next_id(), "offset.delvec", uint64_t{std::numeric_limits<int64_t>::max()} + 1, 1,
-                                   std::numeric_limits<int64_t>::max()),
-                   "compacted delvec raw page offset is outside signed int64 domain");
-    expect_invalid(raw_output_page(next_id(), "size.delvec", 0, uint64_t{std::numeric_limits<int64_t>::max()} + 1,
-                                   std::numeric_limits<int64_t>::max()),
-                   "compacted delvec raw page size is outside signed int64 domain");
-    expect_invalid(raw_output_page(next_id(), "end.delvec", std::numeric_limits<int64_t>::max(), 1,
-                                   std::numeric_limits<int64_t>::max()),
-                   "compacted delvec raw page end is outside signed int64 domain");
-    expect_invalid(raw_output_page(next_id(), "undersize.delvec", 2, 3, 4),
-                   "compacted delvec declared source size does not contain page");
+    expect_compacted_delvec_rejected({raw_output_page(next_id(), "zero.delvec", 0, 0, 0)},
+                                     RejectionStatus::kInvalidArgument,
+                                     "compacted delvec raw page size must be positive");
+    expect_compacted_delvec_rejected({raw_output_page(next_id(), "negative.delvec", 0, 1, -1)},
+                                     RejectionStatus::kInvalidArgument,
+                                     "compacted delvec declared source size is negative");
+    expect_compacted_delvec_rejected(
+            {raw_output_page(next_id(), "offset.delvec", uint64_t{std::numeric_limits<int64_t>::max()} + 1, 1,
+                             std::numeric_limits<int64_t>::max())},
+            RejectionStatus::kInvalidArgument, "compacted delvec raw page offset is outside signed int64 domain");
+    expect_compacted_delvec_rejected(
+            {raw_output_page(next_id(), "size.delvec", 0, uint64_t{std::numeric_limits<int64_t>::max()} + 1,
+                             std::numeric_limits<int64_t>::max())},
+            RejectionStatus::kInvalidArgument, "compacted delvec raw page size is outside signed int64 domain");
+    expect_compacted_delvec_rejected({raw_output_page(next_id(), "end.delvec", std::numeric_limits<int64_t>::max(), 1,
+                                                      std::numeric_limits<int64_t>::max())},
+                                     RejectionStatus::kInvalidArgument,
+                                     "compacted delvec raw page end is outside signed int64 domain");
+    expect_compacted_delvec_rejected({raw_output_page(next_id(), "undersize.delvec", 2, 3, 4)},
+                                     RejectionStatus::kInvalidArgument,
+                                     "compacted delvec declared source size does not contain page");
+
+    // The first entry ends exactly at INT64_MAX and is valid. The following malformed entry
+    // supplies a zero-I/O stopping point, proving the near-limit declaration passed preflight.
+    expect_compacted_delvec_rejected(
+            {raw_output_page(next_id(), "near-limit.delvec", std::numeric_limits<int64_t>::max() - 7, 7,
+                             std::numeric_limits<int64_t>::max()),
+             DelvecOutputPage{}},
+            RejectionStatus::kInvalidArgument, "compacted delvec output page must contain exactly one payload");
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_output_overflow) {
-    auto expect_invalid = [&](uint64_t initial, bool skip_int64, std::string_view message) {
-        FileMetaPB output;
-        std::vector<uint64_t> offsets;
-        auto* sync = SyncPoint::GetInstance();
-        sync->SetCallBack("write_compacted_delvec_pages:initial_output_offset",
-                          [&](void* arg) { *static_cast<uint64_t*>(arg) = initial; });
-        sync->SetCallBack("write_compacted_delvec_pages:test_skip_int64_output_limit",
-                          [&](void* arg) { *static_cast<bool*>(arg) = skip_int64; });
-        sync->EnableProcessing();
-        DeferOp cleanup([&] {
-            sync->ClearAllCallBacks();
-            sync->DisableProcessing();
-        });
-        const Status status =
-                write_compacted_delvec_pages(_tablet_manager.get(), {DelvecOutputPage{.serialized_page = "xx"}},
-                                             next_id(), next_id(), &output, &offsets);
-        EXPECT_TRUE(status.is_invalid_argument()) << status;
-        EXPECT_EQ(message, status.message()) << status;
+    auto configure_overflow = [](uint64_t initial, bool skip_int64) {
+        return [=](SyncPoint* sync) {
+            sync->SetCallBack("write_compacted_delvec_pages:initial_output_offset",
+                              [=](void* arg) { *static_cast<uint64_t*>(arg) = initial; });
+            sync->SetCallBack("write_compacted_delvec_pages:test_skip_int64_output_limit",
+                              [=](void* arg) { *static_cast<bool*>(arg) = skip_int64; });
+        };
     };
-    expect_invalid(std::numeric_limits<int64_t>::max(), false,
-                   "compacted delvec output size is outside signed int64 domain");
-    expect_invalid(std::numeric_limits<uint64_t>::max() - 1, true, "compacted delvec output size overflows uint64");
+    expect_compacted_delvec_rejected({DelvecOutputPage{.serialized_page = "xx"}}, RejectionStatus::kInvalidArgument,
+                                     "compacted delvec output size is outside signed int64 domain", 0, 0,
+                                     configure_overflow(std::numeric_limits<int64_t>::max(), false));
+    expect_compacted_delvec_rejected({DelvecOutputPage{.serialized_page = "xx"}}, RejectionStatus::kInvalidArgument,
+                                     "compacted delvec output size overflows uint64", 0, 0,
+                                     configure_overflow(std::numeric_limits<uint64_t>::max() - 1, true));
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_duplicate_declarations) {
@@ -378,13 +399,8 @@ TEST_F(MetaFileTest, test_compacted_delvec_duplicate_declarations) {
     EXPECT_EQ("abcdabcd", copied);
 
     auto conflicting = raw_output_page(source_tablet, filename, 0, 3, 4);
-    FileMetaPB untouched;
-    untouched.set_name("untouched.delvec");
-    std::vector<uint64_t> untouched_offsets = {3};
-    const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {raw, conflicting}, next_id(), next_id(),
-                                                       &untouched, &untouched_offsets);
-    EXPECT_TRUE(status.is_corruption()) << status;
-    EXPECT_EQ("compacted delvec duplicate page declarations disagree on size", status.message());
+    expect_compacted_delvec_rejected({raw, conflicting}, RejectionStatus::kCorruption,
+                                     "compacted delvec duplicate page declarations disagree on size");
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_plaintext_guard_raw_and_mixed) {
@@ -392,13 +408,9 @@ TEST_F(MetaFileTest, test_compacted_delvec_plaintext_guard_raw_and_mixed) {
     encrypted.raw_page->delvec_file.set_encryption_meta("stale");
     for (const auto& pages : std::vector<std::vector<DelvecOutputPage>>{
                  {encrypted}, {encrypted, DelvecOutputPage{.serialized_page = "x"}}}) {
-        FileMetaPB output;
-        std::vector<uint64_t> offsets;
-        const Status status =
-                write_compacted_delvec_pages(_tablet_manager.get(), pages, next_id(), next_id(), &output, &offsets);
-        EXPECT_TRUE(status.is_not_supported()) << status;
-        EXPECT_EQ("encrypted delvec input is unsupported; delvec must be plaintext: encrypted.delvec",
-                  status.message());
+        expect_compacted_delvec_rejected(
+                pages, RejectionStatus::kNotSupported,
+                "encrypted delvec input is unsupported; delvec must be plaintext: encrypted.delvec");
     }
 }
 
@@ -412,54 +424,54 @@ TEST_F(MetaFileTest, test_compacted_delvec_absent_size_cache_and_reader_lifecycl
     const auto a = raw_output_page(source_a, "a.delvec", 0, 1);
     const auto b = raw_output_page(source_b, "b.delvec", 0, 1);
     const auto same_name_other_tablet = raw_output_page(source_same_name_other_tablet, "a.delvec", 0, 1);
-    int active_readers = 0;
-    int peak_readers = 0;
-    int copy_opens = 0;
-    int source_size_lookups = 0;
-    auto* sync = SyncPoint::GetInstance();
-    sync->SetCallBack("write_compacted_delvec_pages:copy_source_reader_delta", [&](void* arg) {
-        active_readers += *static_cast<int*>(arg);
-        peak_readers = std::max(peak_readers, active_readers);
-        if (*static_cast<int*>(arg) == 1) ++copy_opens;
-    });
-    sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_size_lookups; });
-    sync->SetCallBack("write_compacted_delvec_pages:source_options", [&](void* arg) {
-        EXPECT_TRUE(static_cast<RandomAccessFileOptions*>(arg)->skip_fill_local_cache);
-    });
-    sync->EnableProcessing();
-    DeferOp cleanup([&] {
-        sync->ClearAllCallBacks();
-        sync->DisableProcessing();
-    });
-    FileMetaPB output;
-    std::vector<uint64_t> offsets;
-    ASSERT_OK(
-            write_compacted_delvec_pages(_tablet_manager.get(), {a, a, b, a}, next_id(), next_id(), &output, &offsets));
-    EXPECT_EQ(2, source_size_lookups);
-    EXPECT_EQ(3, copy_opens);
-    EXPECT_EQ(1, peak_readers);
-    EXPECT_EQ(0, active_readers);
+    {
+        int active_readers = 0;
+        int peak_readers = 0;
+        int copy_opens = 0;
+        int source_size_lookups = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("write_compacted_delvec_pages:copy_source_reader_delta", [&](void* arg) {
+            active_readers += *static_cast<int*>(arg);
+            peak_readers = std::max(peak_readers, active_readers);
+            if (*static_cast<int*>(arg) == 1) ++copy_opens;
+        });
+        sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_size_lookups; });
+        sync->SetCallBack("write_compacted_delvec_pages:source_options", [&](void* arg) {
+            EXPECT_TRUE(static_cast<RandomAccessFileOptions*>(arg)->skip_fill_local_cache);
+        });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->ClearAllCallBacks();
+            sync->DisableProcessing();
+        });
+        FileMetaPB output;
+        std::vector<uint64_t> offsets;
+        ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {a, a, b, a}, next_id(), next_id(), &output,
+                                               &offsets));
+        EXPECT_EQ(2, source_size_lookups);
+        EXPECT_EQ(3, copy_opens);
+        EXPECT_EQ(1, peak_readers);
+        EXPECT_EQ(0, active_readers);
 
-    source_size_lookups = 0;
-    ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {a, same_name_other_tablet}, next_id(), next_id(),
-                                           &output, &offsets));
-    EXPECT_EQ(2, source_size_lookups);
+        source_size_lookups = 0;
+        ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {a, same_name_other_tablet}, next_id(), next_id(),
+                                               &output, &offsets));
+        EXPECT_EQ(2, source_size_lookups);
+    }
 
-    auto expect_resolved_size_rejected = [&](int64_t resolved_size, std::string_view expected_message) {
-        int writer_opens = 0;
-        sync->SetCallBack("write_compacted_delvec_pages:source_size_override",
-                          [&](void* arg) { *static_cast<std::optional<StatusOr<int64_t>>*>(arg) = resolved_size; });
-        sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
-        const Status status =
-                write_compacted_delvec_pages(_tablet_manager.get(), {a}, next_id(), next_id(), &output, &offsets);
-        EXPECT_TRUE(status.is_invalid_argument()) << status;
-        EXPECT_EQ(expected_message, status.message());
-        EXPECT_EQ(0, writer_opens);
-        sync->ClearCallBack("write_compacted_delvec_pages:source_size_override");
-        sync->ClearCallBack("write_compacted_delvec_pages:writer_open");
+    auto configure_resolved_size = [](int64_t resolved_size) {
+        return [=](SyncPoint* sync) {
+            sync->SetCallBack("write_compacted_delvec_pages:source_size_override", [resolved_size](void* arg) {
+                *static_cast<std::optional<StatusOr<int64_t>>*>(arg) = resolved_size;
+            });
+        };
     };
-    expect_resolved_size_rejected(-1, "compacted delvec resolved source size is negative");
-    expect_resolved_size_rejected(0, "compacted delvec resolved source size does not contain page");
+    expect_compacted_delvec_rejected({a}, RejectionStatus::kInvalidArgument,
+                                     "compacted delvec resolved source size is negative", 1, 1,
+                                     configure_resolved_size(-1));
+    expect_compacted_delvec_rejected({a}, RejectionStatus::kInvalidArgument,
+                                     "compacted delvec resolved source size does not contain page", 1, 1,
+                                     configure_resolved_size(0));
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_serialized_output_uses_bounded_appends) {
@@ -501,6 +513,8 @@ TEST_F(MetaFileTest, test_finalize_delvec_uses_bounded_appends) {
     std::shared_ptr<DelVector> expected;
     seed.add_dels_as_new_version({deleted}, version, &expected);
     const std::string prefix = expected->save();
+    const std::string padding(3 * (1UL << 20) + 17, 'p');
+    const std::string expected_physical_bytes = prefix + padding;
     builder.append_delvec(expected, /*segment_id=*/1);
 
     std::vector<size_t> append_sizes;
@@ -509,7 +523,8 @@ TEST_F(MetaFileTest, test_finalize_delvec_uses_bounded_appends) {
     sync->SetCallBack("MetaFileBuilder::_finalize_delvec", [&](void* arg) {
         auto* buffer = static_cast<Buffer<uint8_t>*>(arg);
         const size_t original_size = buffer->size();
-        buffer->resize(original_size + 3 * (1UL << 20) + 17);
+        EXPECT_EQ(prefix.size(), original_size);
+        buffer->resize(original_size + padding.size());
         std::fill(buffer->begin() + original_size, buffer->end(), static_cast<uint8_t>('p'));
     });
     sync->SetCallBack("MetaFileBuilder::_finalize_delvec:logical_append_size",
@@ -527,7 +542,16 @@ TEST_F(MetaFileTest, test_finalize_delvec_uses_bounded_appends) {
     for (size_t size : append_sizes) EXPECT_LE(size, 1UL << 20);
     const auto& file = metadata->delvec_meta().version_to_file().at(version);
     EXPECT_EQ(logical_size, file.size());
+    EXPECT_EQ(static_cast<int64_t>(expected_physical_bytes.size()), file.size());
     EXPECT_TRUE(file.encryption_meta().empty());
+    ASSIGN_OR_ABORT(auto reader, fs::new_random_access_file(_tablet_manager->delvec_location(tablet_id, file.name())));
+    ASSIGN_OR_ABORT(auto physical_size, reader->get_size());
+    EXPECT_EQ(expected_physical_bytes.size(), physical_size);
+    ASSIGN_OR_ABORT(auto physical_bytes, reader->read_all());
+    EXPECT_EQ(expected_physical_bytes, physical_bytes);
+    ASSERT_GE(physical_bytes.size(), prefix.size());
+    EXPECT_EQ(prefix, physical_bytes.substr(0, prefix.size()));
+    EXPECT_EQ(padding, physical_bytes.substr(prefix.size()));
     DelVector loaded;
     LakeIOOptions io_options;
     ASSERT_OK(get_del_vec(_tablet_manager.get(), *metadata, /*segment_id=*/1, false, io_options, &loaded));

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <ctime>
+#include <limits>
 #include <set>
 #include <unordered_map>
 
@@ -81,7 +82,7 @@ protected:
         ASSERT_OK(writer->close());
     }
 
-    DelvecFileInfo add_test_delvec(TabletMetadataPB* metadata, int64_t tablet_id, int64_t version, uint32_t segment_id,
+    DelvecPageInfo add_test_delvec(TabletMetadataPB* metadata, int64_t tablet_id, int64_t version, uint32_t segment_id,
                                    const std::string& filename, const std::string& content) {
         FileMetaPB file_meta;
         file_meta.set_name(filename);
@@ -94,7 +95,27 @@ protected:
         page.set_size(content.size());
         (*metadata->mutable_delvec_meta()->mutable_delvecs())[segment_id] = page;
         write_file(_tablet_manager->delvec_location(tablet_id, filename), content);
-        return DelvecFileInfo{tablet_id, std::move(file_meta)};
+        return DelvecPageInfo{tablet_id, std::move(file_meta), std::move(page)};
+    }
+
+    DelvecOutputPage raw_output_page(int64_t tablet_id, std::string filename, uint64_t offset, uint64_t size,
+                                     std::optional<int64_t> declared_size = std::nullopt) {
+        DelvecPageInfo raw;
+        raw.tablet_id = tablet_id;
+        raw.delvec_file.set_name(std::move(filename));
+        if (declared_size.has_value()) {
+            raw.delvec_file.set_size(*declared_size);
+        }
+        raw.page.set_version(1);
+        raw.page.set_offset(offset);
+        raw.page.set_size(size);
+        return DelvecOutputPage{.raw_page = std::move(raw)};
+    }
+
+    void expect_untouched_output(const FileMetaPB& before_file, const std::vector<uint64_t>& before_offsets,
+                                 const FileMetaPB& after_file, const std::vector<uint64_t>& after_offsets) {
+        EXPECT_EQ(before_file.SerializeAsString(), after_file.SerializeAsString());
+        EXPECT_EQ(before_offsets, after_offsets);
     }
 
     std::shared_ptr<TabletMetadataPB> make_shared_delvec_source(int64_t tablet_id, int segment_count) {
@@ -229,13 +250,264 @@ TEST_F(MetaFileTest, test_add_rowset_sums_composite_stats) {
     EXPECT_TRUE(rs.overlapped());           // composite spanning >1 op_write
 }
 
-TEST_F(MetaFileTest, test_merge_delvec_files_empty) {
-    std::vector<DelvecFileInfo> old_delvec_files;
+TEST_F(MetaFileTest, test_compacted_delvec_empty_plan_rejected) {
     FileMetaPB new_delvec_file;
-    std::vector<uint64_t> offsets;
+    new_delvec_file.set_name("unchanged.delvec");
+    std::vector<uint64_t> offsets = {1};
+    const FileMetaPB before_file = new_delvec_file;
+    const std::vector<uint64_t> before_offsets = offsets;
 
-    EXPECT_OK(merge_delvec_files(_tablet_manager.get(), old_delvec_files, 1, 1, &new_delvec_file, &offsets));
-    EXPECT_TRUE(offsets.empty());
+    const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {}, 1, 1, &new_delvec_file, &offsets);
+    EXPECT_TRUE(status.is_invalid_argument()) << status;
+    EXPECT_EQ("compacted delvec page plan is empty", status.message());
+    expect_untouched_output(before_file, before_offsets, new_delvec_file, offsets);
+}
+
+TEST_F(MetaFileTest, test_compacted_delvec_plan_shapes_and_filename) {
+    auto expect_invalid = [&](const std::vector<DelvecOutputPage>& pages, std::string_view message) {
+        FileMetaPB output;
+        output.set_name("unchanged.delvec");
+        std::vector<uint64_t> offsets = {9};
+        const FileMetaPB before_file = output;
+        const std::vector<uint64_t> before_offsets = offsets;
+        int preflight_opens = 0;
+        int source_sizes = 0;
+        int writer_opens = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("write_compacted_delvec_pages:preflight_source_open", [&](void*) { ++preflight_opens; });
+        sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_sizes; });
+        sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->ClearAllCallBacks();
+            sync->DisableProcessing();
+        });
+        const Status status =
+                write_compacted_delvec_pages(_tablet_manager.get(), pages, next_id(), next_id(), &output, &offsets);
+        EXPECT_TRUE(status.is_invalid_argument()) << status;
+        EXPECT_EQ(message, status.message()) << status;
+        EXPECT_EQ(0, preflight_opens);
+        EXPECT_EQ(0, source_sizes);
+        EXPECT_EQ(0, writer_opens);
+        expect_untouched_output(before_file, before_offsets, output, offsets);
+    };
+
+    expect_invalid({}, "compacted delvec page plan is empty");
+    expect_invalid({DelvecOutputPage{}}, "compacted delvec output page must contain exactly one payload");
+    auto both = raw_output_page(next_id(), "both.delvec", 0, 1, 1);
+    both.serialized_page = "x";
+    expect_invalid({both}, "compacted delvec output page must contain exactly one payload");
+    expect_invalid({raw_output_page(next_id(), "", 0, 1, 1)}, "compacted delvec raw page filename is empty");
+}
+
+TEST_F(MetaFileTest, test_compacted_delvec_signed_and_file_domains) {
+    auto expect_invalid = [&](DelvecOutputPage page, std::string_view message) {
+        FileMetaPB output;
+        std::vector<uint64_t> offsets;
+        int source_sizes = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_sizes; });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->ClearAllCallBacks();
+            sync->DisableProcessing();
+        });
+        const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {std::move(page)}, next_id(),
+                                                           next_id(), &output, &offsets);
+        EXPECT_TRUE(status.is_invalid_argument()) << status;
+        EXPECT_EQ(message, status.message()) << status;
+        EXPECT_EQ(0, source_sizes);
+    };
+    expect_invalid(raw_output_page(next_id(), "zero.delvec", 0, 0, 0),
+                   "compacted delvec raw page size must be positive");
+    expect_invalid(raw_output_page(next_id(), "negative.delvec", 0, 1, -1),
+                   "compacted delvec declared source size is negative");
+    expect_invalid(raw_output_page(next_id(), "offset.delvec", uint64_t{std::numeric_limits<int64_t>::max()} + 1, 1,
+                                   std::numeric_limits<int64_t>::max()),
+                   "compacted delvec raw page offset is outside signed int64 domain");
+    expect_invalid(raw_output_page(next_id(), "size.delvec", 0, uint64_t{std::numeric_limits<int64_t>::max()} + 1,
+                                   std::numeric_limits<int64_t>::max()),
+                   "compacted delvec raw page size is outside signed int64 domain");
+    expect_invalid(raw_output_page(next_id(), "end.delvec", std::numeric_limits<int64_t>::max(), 1,
+                                   std::numeric_limits<int64_t>::max()),
+                   "compacted delvec raw page end is outside signed int64 domain");
+    expect_invalid(raw_output_page(next_id(), "undersize.delvec", 2, 3, 4),
+                   "compacted delvec declared source size does not contain page");
+}
+
+TEST_F(MetaFileTest, test_compacted_delvec_output_overflow) {
+    auto expect_invalid = [&](uint64_t initial, bool skip_int64, std::string_view message) {
+        FileMetaPB output;
+        std::vector<uint64_t> offsets;
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("write_compacted_delvec_pages:initial_output_offset",
+                          [&](void* arg) { *static_cast<uint64_t*>(arg) = initial; });
+        sync->SetCallBack("write_compacted_delvec_pages:test_skip_int64_output_limit",
+                          [&](void* arg) { *static_cast<bool*>(arg) = skip_int64; });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->ClearAllCallBacks();
+            sync->DisableProcessing();
+        });
+        const Status status =
+                write_compacted_delvec_pages(_tablet_manager.get(), {DelvecOutputPage{.serialized_page = "xx"}},
+                                             next_id(), next_id(), &output, &offsets);
+        EXPECT_TRUE(status.is_invalid_argument()) << status;
+        EXPECT_EQ(message, status.message()) << status;
+    };
+    expect_invalid(std::numeric_limits<int64_t>::max(), false,
+                   "compacted delvec output size is outside signed int64 domain");
+    expect_invalid(std::numeric_limits<uint64_t>::max() - 1, true, "compacted delvec output size overflows uint64");
+}
+
+TEST_F(MetaFileTest, test_compacted_delvec_duplicate_declarations) {
+    const int64_t source_tablet = next_id();
+    const int64_t target_tablet = next_id();
+    const std::string filename = "duplicate-page.delvec";
+    write_file(_tablet_manager->delvec_location(source_tablet, filename), "abcd");
+
+    auto raw = raw_output_page(source_tablet, filename, 0, 4, 4);
+    FileMetaPB output;
+    std::vector<uint64_t> offsets;
+    ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {raw, raw}, target_tablet, next_id(), &output,
+                                           &offsets));
+    EXPECT_EQ(std::vector<uint64_t>({0, 4}), offsets);
+    ASSIGN_OR_ABORT(auto reader,
+                    fs::new_random_access_file(_tablet_manager->delvec_location(target_tablet, output.name())));
+    ASSIGN_OR_ABORT(auto copied, reader->read_all());
+    EXPECT_EQ("abcdabcd", copied);
+
+    auto conflicting = raw_output_page(source_tablet, filename, 0, 3, 4);
+    FileMetaPB untouched;
+    untouched.set_name("untouched.delvec");
+    std::vector<uint64_t> untouched_offsets = {3};
+    const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {raw, conflicting}, next_id(), next_id(),
+                                                       &untouched, &untouched_offsets);
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_EQ("compacted delvec duplicate page declarations disagree on size", status.message());
+}
+
+TEST_F(MetaFileTest, test_compacted_delvec_plaintext_guard_raw_and_mixed) {
+    auto encrypted = raw_output_page(next_id(), "encrypted.delvec", 0, 1, 1);
+    encrypted.raw_page->delvec_file.set_encryption_meta("stale");
+    for (const auto& pages : std::vector<std::vector<DelvecOutputPage>>{
+                 {encrypted}, {encrypted, DelvecOutputPage{.serialized_page = "x"}}}) {
+        FileMetaPB output;
+        std::vector<uint64_t> offsets;
+        const Status status =
+                write_compacted_delvec_pages(_tablet_manager.get(), pages, next_id(), next_id(), &output, &offsets);
+        EXPECT_TRUE(status.is_not_supported()) << status;
+        EXPECT_EQ("encrypted delvec input is unsupported; delvec must be plaintext: encrypted.delvec",
+                  status.message());
+    }
+}
+
+TEST_F(MetaFileTest, test_compacted_delvec_absent_size_cache_and_reader_lifecycle) {
+    const int64_t source_a = next_id();
+    const int64_t source_b = next_id();
+    write_file(_tablet_manager->delvec_location(source_a, "a.delvec"), "a");
+    write_file(_tablet_manager->delvec_location(source_b, "b.delvec"), "b");
+    const auto a = raw_output_page(source_a, "a.delvec", 0, 1);
+    const auto b = raw_output_page(source_b, "b.delvec", 0, 1);
+    int active_readers = 0;
+    int peak_readers = 0;
+    int copy_opens = 0;
+    int source_size_lookups = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("write_compacted_delvec_pages:copy_source_reader_delta", [&](void* arg) {
+        active_readers += *static_cast<int*>(arg);
+        peak_readers = std::max(peak_readers, active_readers);
+        if (*static_cast<int*>(arg) == 1) ++copy_opens;
+    });
+    sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_size_lookups; });
+    sync->SetCallBack("write_compacted_delvec_pages:source_options", [&](void* arg) {
+        EXPECT_TRUE(static_cast<RandomAccessFileOptions*>(arg)->skip_fill_local_cache);
+    });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    FileMetaPB output;
+    std::vector<uint64_t> offsets;
+    ASSERT_OK(
+            write_compacted_delvec_pages(_tablet_manager.get(), {a, a, b, a}, next_id(), next_id(), &output, &offsets));
+    EXPECT_EQ(2, source_size_lookups);
+    EXPECT_EQ(3, copy_opens);
+    EXPECT_EQ(1, peak_readers);
+    EXPECT_EQ(0, active_readers);
+}
+
+TEST_F(MetaFileTest, test_compacted_delvec_serialized_output_uses_bounded_appends) {
+    const std::string expected(3 * (1UL << 20) + 17, 's');
+    const int64_t target_tablet = next_id();
+    std::vector<size_t> append_sizes;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("append_delvec_bytes_bounded:chunk_size",
+                      [&](void* arg) { append_sizes.push_back(*static_cast<size_t*>(arg)); });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    FileMetaPB output;
+    std::vector<uint64_t> offsets;
+    ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {DelvecOutputPage{.serialized_page = expected}},
+                                           target_tablet, next_id(), &output, &offsets));
+    ASSERT_GT(append_sizes.size(), 1);
+    for (size_t size : append_sizes) EXPECT_LE(size, 1UL << 20);
+    ASSIGN_OR_ABORT(auto input,
+                    fs::new_random_access_file(_tablet_manager->delvec_location(target_tablet, output.name())));
+    ASSIGN_OR_ABORT(auto actual, input->read_all());
+    EXPECT_EQ(expected, actual);
+}
+
+TEST_F(MetaFileTest, test_finalize_delvec_uses_bounded_appends) {
+    const int64_t tablet_id = next_id();
+    const int64_t version = 2;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    metadata->set_next_rowset_id(1);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+    MetaFileBuilder builder(*tablet, metadata);
+    DelVector seed;
+    const uint32_t deleted = 7;
+    std::shared_ptr<DelVector> expected;
+    seed.add_dels_as_new_version({deleted}, version, &expected);
+    const std::string prefix = expected->save();
+    builder.append_delvec(expected, /*segment_id=*/1);
+
+    std::vector<size_t> append_sizes;
+    int64_t logical_size = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("MetaFileBuilder::_finalize_delvec", [&](void* arg) {
+        auto* buffer = static_cast<Buffer<uint8_t>*>(arg);
+        const size_t original_size = buffer->size();
+        buffer->resize(original_size + 3 * (1UL << 20) + 17);
+        std::fill(buffer->begin() + original_size, buffer->end(), static_cast<uint8_t>('p'));
+    });
+    sync->SetCallBack("MetaFileBuilder::_finalize_delvec:logical_append_size",
+                      [&](void* arg) { logical_size = *static_cast<int64_t*>(arg); });
+    sync->SetCallBack("append_delvec_bytes_bounded:chunk_size",
+                      [&](void* arg) { append_sizes.push_back(*static_cast<size_t*>(arg)); });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    ASSERT_OK(builder.finalize(next_id()));
+    ASSERT_GT(logical_size, 3 * (1UL << 20));
+    ASSERT_GT(append_sizes.size(), 1);
+    for (size_t size : append_sizes) EXPECT_LE(size, 1UL << 20);
+    const auto& file = metadata->delvec_meta().version_to_file().at(version);
+    EXPECT_EQ(logical_size, file.size());
+    EXPECT_TRUE(file.encryption_meta().empty());
+    DelVector loaded;
+    LakeIOOptions io_options;
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *metadata, /*segment_id=*/1, false, io_options, &loaded));
+    EXPECT_EQ(prefix, loaded.save());
 }
 
 TEST_F(MetaFileTest, test_get_delvec_ignores_encryption_metadata) {
@@ -268,13 +540,13 @@ TEST_F(MetaFileTest, test_get_delvec_ignores_encryption_metadata) {
     EXPECT_EQ(expected.save(), actual.save());
 }
 
-TEST_F(MetaFileTest, test_merge_delvec_files_writes_plaintext) {
+TEST_F(MetaFileTest, test_compacted_delvec_raw_page_writes_plaintext) {
     const int64_t source_tablet_id = next_id();
     const int64_t target_tablet_id = next_id();
     const int64_t txn_id = next_id();
     const int64_t version = 11;
     const uint32_t segment_id = 7;
-    const std::string file_name = "plain-merge-source-with-stale-encryption-meta.delvec";
+    const std::string file_name = "plain-merge-source.delvec";
 
     DelVector expected;
     const uint32_t deleted_rowids[] = {2, 8};
@@ -282,15 +554,18 @@ TEST_F(MetaFileTest, test_merge_delvec_files_writes_plaintext) {
     const std::string content = expected.save();
     write_file(_tablet_manager->delvec_location(source_tablet_id, file_name), content);
 
-    DelvecFileInfo source;
+    DelvecPageInfo source;
     source.tablet_id = source_tablet_id;
     source.delvec_file.set_name(file_name);
     source.delvec_file.set_size(content.size());
-    source.delvec_file.set_encryption_meta(std::string(1, static_cast<char>(0xff)));
+    source.page.set_version(version);
+    source.page.set_offset(0);
+    source.page.set_size(content.size());
 
     FileMetaPB output;
     std::vector<uint64_t> offsets;
-    ASSERT_OK(merge_delvec_files(_tablet_manager.get(), {source}, target_tablet_id, txn_id, &output, &offsets));
+    ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {DelvecOutputPage{.raw_page = source}},
+                                           target_tablet_id, txn_id, &output, &offsets));
     ASSERT_EQ(std::vector<uint64_t>({0}), offsets);
     EXPECT_TRUE(output.encryption_meta().empty());
 
@@ -308,7 +583,7 @@ TEST_F(MetaFileTest, test_merge_delvec_files_writes_plaintext) {
     EXPECT_EQ(expected.save(), actual.save());
 }
 
-TEST_F(MetaFileTest, test_write_delvec_buffer_writes_plaintext) {
+TEST_F(MetaFileTest, test_compacted_delvec_serialized_page_writes_plaintext) {
     const int64_t tablet_id = next_id();
     const int64_t txn_id = next_id();
     DelVector expected;
@@ -316,8 +591,12 @@ TEST_F(MetaFileTest, test_write_delvec_buffer_writes_plaintext) {
     expected.init(/*version=*/2, &deleted, 1);
 
     FileMetaPB output;
-    ASSERT_OK(write_delvec_file_from_buffer(_tablet_manager.get(), tablet_id, txn_id, Slice(expected.save()), &output));
+    std::vector<uint64_t> offsets;
+    ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(),
+                                           {DelvecOutputPage{.serialized_page = expected.save()}}, tablet_id, txn_id,
+                                           &output, &offsets));
     EXPECT_TRUE(output.encryption_meta().empty());
+    EXPECT_EQ(std::vector<uint64_t>({0}), offsets);
 }
 
 TEST_F(MetaFileTest, test_delvec_output_append_failure_is_atomic) {
@@ -338,8 +617,10 @@ TEST_F(MetaFileTest, test_delvec_output_append_failure_is_atomic) {
     direct_delvec.init(/*version=*/2, &direct_deleted, 1);
     FileMetaPB direct_output;
     const std::string direct_output_before = direct_output.SerializeAsString();
-    auto direct_status = write_delvec_file_from_buffer(_tablet_manager.get(), next_id(), next_id(),
-                                                       Slice(direct_delvec.save()), &direct_output);
+    std::vector<uint64_t> direct_offsets;
+    auto direct_status = write_compacted_delvec_pages(_tablet_manager.get(),
+                                                      {DelvecOutputPage{.serialized_page = direct_delvec.save()}},
+                                                      next_id(), next_id(), &direct_output, &direct_offsets);
     EXPECT_FALSE(direct_status.ok());
     EXPECT_TRUE(direct_status.message().contains(kInjectedError)) << direct_status;
     EXPECT_EQ(direct_output_before, direct_output.SerializeAsString());
@@ -393,10 +674,10 @@ TEST_F(MetaFileTest, test_delvec_output_close_failure_is_atomic) {
     FileMetaPB direct_output;
     const std::string direct_output_before = direct_output.SerializeAsString();
     std::vector<uint64_t> direct_offsets;
-    uint64_t direct_union_offset = 0;
-    auto direct_status =
-            merge_delvec_files(_tablet_manager.get(), {direct_source}, next_id(), next_id(), &direct_output,
-                               &direct_offsets, Slice(direct_union_content), &direct_union_offset);
+    auto direct_status = write_compacted_delvec_pages(
+            _tablet_manager.get(),
+            {DelvecOutputPage{.raw_page = direct_source}, DelvecOutputPage{.serialized_page = direct_union_content}},
+            next_id(), next_id(), &direct_output, &direct_offsets);
     EXPECT_FALSE(direct_status.ok());
     EXPECT_TRUE(direct_status.message().contains(kInjectedError)) << direct_status;
     EXPECT_EQ(direct_output_before, direct_output.SerializeAsString());

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -688,7 +688,8 @@ TEST_F(MetaFileTest, test_compacted_delvec_failure_atomic_by_phase) {
         EXPECT_EQ(offsets_before, offsets);
         expect_source_unchanged();
 
-        ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), pages, target_tablet, next_id(), &output, &offsets));
+        ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), pages, target_tablet, next_id(), &output,
+                                               &offsets));
         EXPECT_EQ(std::vector<uint64_t>({0, source_bytes.size()}), offsets);
         ASSIGN_OR_ABORT(auto reader,
                         fs::new_random_access_file(_tablet_manager->delvec_location(target_tablet, output.name())));
@@ -715,7 +716,7 @@ TEST_F(MetaFileTest, test_compacted_delvec_failure_atomic_by_phase) {
         });
         sync->EnableProcessing();
         const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {absent_size_raw}, target_tablet,
-                                                            next_id(), &output, &offsets);
+                                                           next_id(), &output, &offsets);
         sync->ClearAllCallBacks();
         sync->DisableProcessing();
         EXPECT_EQ("injected actual-size", status.message()) << status;
@@ -758,8 +759,8 @@ TEST_F(MetaFileTest, test_compacted_delvec_failure_atomic_by_phase) {
             *static_cast<Status*>(arg) = Status::InternalError("injected near-limit writer");
         });
         sync->EnableProcessing();
-        const Status status =
-                write_compacted_delvec_pages(_tablet_manager.get(), {near_limit}, target_tablet, next_id(), &output, &offsets);
+        const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {near_limit}, target_tablet,
+                                                           next_id(), &output, &offsets);
         sync->ClearAllCallBacks();
         sync->DisableProcessing();
         EXPECT_EQ("injected near-limit writer", status.message()) << status;

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -113,12 +113,6 @@ protected:
         return DelvecOutputPage{.raw_page = std::move(raw)};
     }
 
-    void expect_untouched_output(const FileMetaPB& before_file, const std::vector<uint64_t>& before_offsets,
-                                 const FileMetaPB& after_file, const std::vector<uint64_t>& after_offsets) {
-        EXPECT_EQ(before_file.SerializeAsString(), after_file.SerializeAsString());
-        EXPECT_EQ(before_offsets, after_offsets);
-    }
-
     enum class RejectionStatus { kInvalidArgument, kNotSupported, kCorruption };
 
     void expect_compacted_delvec_rejected(const std::vector<DelvecOutputPage>& pages, RejectionStatus expected_status,

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -471,6 +471,66 @@ TEST_F(MetaFileTest, test_compacted_delvec_absent_size_cache_and_reader_lifecycl
                                      configure_resolved_size(0));
 }
 
+TEST_F(MetaFileTest, test_compacted_delvec_reader_lifecycle_resets_across_serialized_page) {
+    const int64_t source_tablet = next_id();
+    const int64_t target_tablet = next_id();
+    constexpr std::string_view source_name = "reader-lifecycle-source.delvec";
+
+    DelVector raw_delvec;
+    const uint32_t raw_deleted[] = {2, 7};
+    raw_delvec.init(/*version=*/3, raw_deleted, std::size(raw_deleted));
+    const std::string raw_bytes = raw_delvec.save();
+    write_file(_tablet_manager->delvec_location(source_tablet, std::string(source_name)), raw_bytes);
+
+    DelVector serialized_delvec;
+    const uint32_t serialized_deleted[] = {1, 9, 14};
+    serialized_delvec.init(/*version=*/4, serialized_deleted, std::size(serialized_deleted));
+    const std::string serialized_bytes = serialized_delvec.save();
+    const auto raw = raw_output_page(source_tablet, std::string(source_name), 0, raw_bytes.size());
+
+    int active_readers = 0;
+    int peak_readers = 0;
+    int copy_opens = 0;
+    int source_size_lookups = 0;
+    int source_option_uses = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->ClearAllCallBacks();
+    sync->DisableProcessing();
+    sync->SetCallBack("write_compacted_delvec_pages:copy_source_reader_delta", [&](void* arg) {
+        const int delta = *static_cast<int*>(arg);
+        active_readers += delta;
+        peak_readers = std::max(peak_readers, active_readers);
+        if (delta == 1) ++copy_opens;
+    });
+    sync->SetCallBack("write_compacted_delvec_pages:source_size", [&](void*) { ++source_size_lookups; });
+    sync->SetCallBack("write_compacted_delvec_pages:source_options", [&](void* arg) {
+        ++source_option_uses;
+        EXPECT_TRUE(static_cast<RandomAccessFileOptions*>(arg)->skip_fill_local_cache);
+    });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+
+    FileMetaPB output;
+    std::vector<uint64_t> offsets;
+    ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(),
+                                           {raw, DelvecOutputPage{.serialized_page = serialized_bytes}, raw},
+                                           target_tablet, next_id(), &output, &offsets));
+    EXPECT_EQ(std::vector<uint64_t>({0, raw_bytes.size(), raw_bytes.size() + serialized_bytes.size()}), offsets);
+    ASSIGN_OR_ABORT(auto reader,
+                    fs::new_random_access_file(_tablet_manager->delvec_location(target_tablet, output.name())));
+    ASSIGN_OR_ABORT(auto actual, reader->read_all());
+    EXPECT_EQ(raw_bytes + serialized_bytes + raw_bytes, actual);
+    EXPECT_EQ(static_cast<int64_t>(actual.size()), output.size());
+    EXPECT_EQ(1, source_size_lookups);
+    EXPECT_EQ(3, source_option_uses);
+    EXPECT_EQ(2, copy_opens);
+    EXPECT_EQ(1, peak_readers);
+    EXPECT_EQ(0, active_readers);
+}
+
 TEST_F(MetaFileTest, test_compacted_delvec_serialized_output_uses_bounded_appends) {
     const std::string expected(3 * (1UL << 20) + 17, 's');
     const int64_t target_tablet = next_id();

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -405,10 +405,13 @@ TEST_F(MetaFileTest, test_compacted_delvec_plaintext_guard_raw_and_mixed) {
 TEST_F(MetaFileTest, test_compacted_delvec_absent_size_cache_and_reader_lifecycle) {
     const int64_t source_a = next_id();
     const int64_t source_b = next_id();
+    const int64_t source_same_name_other_tablet = next_id();
     write_file(_tablet_manager->delvec_location(source_a, "a.delvec"), "a");
     write_file(_tablet_manager->delvec_location(source_b, "b.delvec"), "b");
+    write_file(_tablet_manager->delvec_location(source_same_name_other_tablet, "a.delvec"), "a");
     const auto a = raw_output_page(source_a, "a.delvec", 0, 1);
     const auto b = raw_output_page(source_b, "b.delvec", 0, 1);
+    const auto same_name_other_tablet = raw_output_page(source_same_name_other_tablet, "a.delvec", 0, 1);
     int active_readers = 0;
     int peak_readers = 0;
     int copy_opens = 0;
@@ -436,6 +439,27 @@ TEST_F(MetaFileTest, test_compacted_delvec_absent_size_cache_and_reader_lifecycl
     EXPECT_EQ(3, copy_opens);
     EXPECT_EQ(1, peak_readers);
     EXPECT_EQ(0, active_readers);
+
+    source_size_lookups = 0;
+    ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {a, same_name_other_tablet}, next_id(), next_id(),
+                                           &output, &offsets));
+    EXPECT_EQ(2, source_size_lookups);
+
+    auto expect_resolved_size_rejected = [&](int64_t resolved_size, std::string_view expected_message) {
+        int writer_opens = 0;
+        sync->SetCallBack("write_compacted_delvec_pages:source_size_override",
+                          [&](void* arg) { *static_cast<std::optional<StatusOr<int64_t>>*>(arg) = resolved_size; });
+        sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
+        const Status status =
+                write_compacted_delvec_pages(_tablet_manager.get(), {a}, next_id(), next_id(), &output, &offsets);
+        EXPECT_TRUE(status.is_invalid_argument()) << status;
+        EXPECT_EQ(expected_message, status.message());
+        EXPECT_EQ(0, writer_opens);
+        sync->ClearCallBack("write_compacted_delvec_pages:source_size_override");
+        sync->ClearCallBack("write_compacted_delvec_pages:writer_open");
+    };
+    expect_resolved_size_rejected(-1, "compacted delvec resolved source size is negative");
+    expect_resolved_size_rejected(0, "compacted delvec resolved source size does not contain page");
 }
 
 TEST_F(MetaFileTest, test_compacted_delvec_serialized_output_uses_bounded_appends) {

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -141,7 +141,6 @@ protected:
         int range_reads = 0;
         int writer_opens = 0;
         int append_chunks = 0;
-        int append_attempts = 0;
         auto* sync = SyncPoint::GetInstance();
         sync->ClearAllCallBacks();
         sync->DisableProcessing();
@@ -151,7 +150,6 @@ protected:
         sync->SetCallBack("write_compacted_delvec_pages:read_chunk_size", [&](void*) { ++range_reads; });
         sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
         sync->SetCallBack("append_delvec_bytes_bounded:chunk_size", [&](void*) { ++append_chunks; });
-        sync->SetCallBack("write_delvec_output:append", [&](void*) { ++append_attempts; });
         if (configure) configure(sync);
         sync->EnableProcessing();
         DeferOp cleanup([&] {
@@ -181,7 +179,6 @@ protected:
         EXPECT_EQ(0, range_reads);
         EXPECT_EQ(0, writer_opens);
         EXPECT_EQ(0, append_chunks);
-        EXPECT_EQ(0, append_attempts);
     }
 
     std::shared_ptr<TabletMetadataPB> make_shared_delvec_source(int64_t tablet_id, int segment_count) {
@@ -647,10 +644,137 @@ TEST_F(MetaFileTest, test_compacted_delvec_serialized_page_writes_plaintext) {
     EXPECT_EQ(std::vector<uint64_t>({0}), offsets);
 }
 
+TEST_F(MetaFileTest, test_compacted_delvec_failure_atomic_by_phase) {
+    constexpr std::string_view kPrefix = "injected compacted delvec ";
+    const int64_t source_tablet = next_id();
+    const int64_t target_tablet = next_id();
+    const std::string source_name = "failure-atomic-source.delvec";
+    const std::string source_bytes((1UL << 20) + 17, 'r');
+    write_file(_tablet_manager->delvec_location(source_tablet, source_name), source_bytes);
+    auto raw = raw_output_page(source_tablet, source_name, 0, source_bytes.size(), source_bytes.size());
+    const std::vector<DelvecOutputPage> pages = {raw, DelvecOutputPage{.serialized_page = "serialized"}};
+
+    auto expect_source_unchanged = [&] {
+        ASSIGN_OR_ABORT(auto reader,
+                        fs::new_random_access_file(_tablet_manager->delvec_location(source_tablet, source_name)));
+        ASSIGN_OR_ABORT(auto actual, reader->read_all());
+        EXPECT_EQ(source_bytes, actual);
+    };
+    auto run_phase = [&](std::string_view seam, int fail_on_call, int expected_calls) {
+        SCOPED_TRACE(seam);
+        FileMetaPB output;
+        output.set_name("unchanged.delvec");
+        output.set_size(123);
+        output.set_shared(true);
+        std::vector<uint64_t> offsets = {7, 11};
+        const std::string output_before = output.SerializeAsString();
+        const auto offsets_before = offsets;
+        const std::string message = std::string(kPrefix) + std::string(seam);
+        int calls = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        sync->SetCallBack(std::string(seam), [&](void* arg) {
+            if (++calls == fail_on_call) *static_cast<Status*>(arg) = Status::InternalError(message);
+        });
+        sync->EnableProcessing();
+        const Status status =
+                write_compacted_delvec_pages(_tablet_manager.get(), pages, target_tablet, next_id(), &output, &offsets);
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        EXPECT_EQ(message, status.message()) << status;
+        EXPECT_EQ(expected_calls, calls);
+        EXPECT_EQ(output_before, output.SerializeAsString());
+        EXPECT_EQ(offsets_before, offsets);
+        expect_source_unchanged();
+
+        ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), pages, target_tablet, next_id(), &output, &offsets));
+        EXPECT_EQ(std::vector<uint64_t>({0, source_bytes.size()}), offsets);
+        ASSIGN_OR_ABORT(auto reader,
+                        fs::new_random_access_file(_tablet_manager->delvec_location(target_tablet, output.name())));
+        ASSIGN_OR_ABORT(auto actual, reader->read_all());
+        EXPECT_EQ(source_bytes + "serialized", actual);
+    };
+
+    // The actual-size seam is a preflight failure: no destination writer may have been created.
+    {
+        FileMetaPB output;
+        output.set_name("unchanged.delvec");
+        std::vector<uint64_t> offsets = {7, 11};
+        const std::string output_before = output.SerializeAsString();
+        const auto offsets_before = offsets;
+        int calls = 0;
+        auto absent_size_raw = raw;
+        absent_size_raw.raw_page->delvec_file.clear_size();
+        auto* sync = SyncPoint::GetInstance();
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        sync->SetCallBack("write_compacted_delvec_pages:source_size_override", [&](void* arg) {
+            ++calls;
+            *static_cast<std::optional<StatusOr<int64_t>>*>(arg) = Status::InternalError("injected actual-size");
+        });
+        sync->EnableProcessing();
+        const Status status = write_compacted_delvec_pages(_tablet_manager.get(), {absent_size_raw}, target_tablet,
+                                                            next_id(), &output, &offsets);
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        EXPECT_EQ("injected actual-size", status.message()) << status;
+        EXPECT_EQ(1, calls);
+        EXPECT_EQ(output_before, output.SerializeAsString());
+        EXPECT_EQ(offsets_before, offsets);
+        expect_source_unchanged();
+        ASSERT_OK(write_compacted_delvec_pages(_tablet_manager.get(), {absent_size_raw}, target_tablet, next_id(),
+                                               &output, &offsets));
+    }
+
+    run_phase("write_compacted_delvec_pages:before_writer_open", 1, 1);
+    run_phase("write_compacted_delvec_pages:before_read_chunk", 1, 1);
+    run_phase("write_compacted_delvec_pages:before_read_chunk", 2, 2);
+    run_phase("append_delvec_bytes_bounded:before_chunk", 1, 1);
+    run_phase("append_delvec_bytes_bounded:before_chunk", 2, 2);
+    run_phase("write_compacted_delvec_pages:before_close", 1, 1);
+    run_phase("write_compacted_delvec_pages:before_apply_offsets", 1, 1);
+
+    // This source does not exist at INT64_MAX; the injected actual size and writer failure prove
+    // that the valid near-limit declaration is preflighted without allocating or reading its range.
+    {
+        auto near_limit = raw_output_page(source_tablet, source_name, std::numeric_limits<int64_t>::max() - 7, 7);
+        FileMetaPB output;
+        output.set_name("unchanged.delvec");
+        std::vector<uint64_t> offsets = {7, 11};
+        const std::string output_before = output.SerializeAsString();
+        const auto offsets_before = offsets;
+        int override_calls = 0;
+        int writer_calls = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        sync->SetCallBack("write_compacted_delvec_pages:source_size_override", [&](void* arg) {
+            ++override_calls;
+            *static_cast<std::optional<StatusOr<int64_t>>*>(arg) = std::numeric_limits<int64_t>::max();
+        });
+        sync->SetCallBack("write_compacted_delvec_pages:before_writer_open", [&](void* arg) {
+            ++writer_calls;
+            *static_cast<Status*>(arg) = Status::InternalError("injected near-limit writer");
+        });
+        sync->EnableProcessing();
+        const Status status =
+                write_compacted_delvec_pages(_tablet_manager.get(), {near_limit}, target_tablet, next_id(), &output, &offsets);
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        EXPECT_EQ("injected near-limit writer", status.message()) << status;
+        EXPECT_EQ(1, override_calls);
+        EXPECT_EQ(1, writer_calls);
+        EXPECT_EQ(output_before, output.SerializeAsString());
+        EXPECT_EQ(offsets_before, offsets);
+        expect_source_unchanged();
+    }
+}
+
 TEST_F(MetaFileTest, test_delvec_output_append_failure_is_atomic) {
     constexpr std::string_view kInjectedError = "injected delvec append failure";
     int injection_count = 0;
-    SyncPoint::GetInstance()->SetCallBack("write_delvec_output:append", [&](void* arg) {
+    SyncPoint::GetInstance()->SetCallBack("append_delvec_bytes_bounded:before_chunk", [&](void* arg) {
         ++injection_count;
         *static_cast<Status*>(arg) = Status::InternalError(kInjectedError);
     });
@@ -699,7 +823,7 @@ TEST_F(MetaFileTest, test_delvec_output_append_failure_is_atomic) {
 TEST_F(MetaFileTest, test_delvec_output_close_failure_is_atomic) {
     constexpr std::string_view kInjectedError = "injected delvec close failure";
     int injection_count = 0;
-    SyncPoint::GetInstance()->SetCallBack("write_delvec_output:close", [&](void* arg) {
+    SyncPoint::GetInstance()->SetCallBack("write_compacted_delvec_pages:before_close", [&](void* arg) {
         ++injection_count;
         *static_cast<Status*>(arg) = Status::InternalError(kInjectedError);
     });

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -474,8 +474,8 @@ protected:
         const bool identical = shape == MetadataOnlyMergeShape::kIdentical;
         const std::string segment_a = "metadata_only_a.dat";
         const std::string segment_b = identical ? segment_a : "metadata_only_b.dat";
-        const uint64_t segment_a_size =
-                write_two_column_segment(source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
+        const uint64_t segment_a_size = write_two_column_segment(
+                source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
         uint64_t segment_b_size = segment_a_size;
         if (!identical) {
             segment_b_size = write_two_column_segment(
@@ -2211,8 +2211,8 @@ protected:
         prepare_tablet_dirs(target_tablet_id);
         const uint64_t old_size = write_two_column_segment(child_a, old_segment, 1, [](int) { return 100; });
         const uint64_t tail_size = write_two_column_segment(child_a, tail_segment, 1, [](int) { return 200; });
-        const uint64_t sibling_size =
-                write_two_column_segment(child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
+        const uint64_t sibling_size = write_two_column_segment(
+                child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
         const uint32_t tombstone = std::numeric_limits<uint32_t>::max();
         const uint64_t tombstone_size =
                 write_versioned_pk_sstable(_tablet_manager->sst_location(child_a, tombstone_filename),
@@ -12723,8 +12723,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_near_rssid_boundary_remains_wr
     auto merged = tablet_metadatas.at(merged_tablet);
     ASSERT_EQ(2, merged->next_rowset_id());
 
-    const uint64_t write_segment_size =
-            write_two_column_segment(merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
+    const uint64_t write_segment_size = write_two_column_segment(
+            merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
     TxnLogPB write_log;
     write_log.set_tablet_id(merged_tablet);
     write_log.set_txn_id(2);
@@ -13288,8 +13288,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped
     duplicate_source->mutable_range()->set_lower_bound_included(true);
     duplicate_source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
     duplicate_source->mutable_range()->set_upper_bound_included(false);
-    const uint64_t selected_size = write_two_column_segment(selected_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
-    write_two_column_segment(duplicate_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t selected_size = write_two_column_segment(
+            selected_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
+    write_two_column_segment(
+            duplicate_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
     auto* selected = add_allocator_rowset(selected_source.get(), 41, 1, "rejoin.dat", 0);
     selected->mutable_segment_metas(0)->set_size(selected_size);
     selected->mutable_segment_metas(0)->set_shared(true);
@@ -13432,8 +13434,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_overlapped_without_s
     const int64_t duplicate_id = next_id();
     prepare_tablet_dirs(selected_id);
     prepare_tablet_dirs(duplicate_id);
-    const uint64_t high_size =
-            write_two_column_segment(selected_id, "overlapped_same_high.dat", 2, [](int key) { return key * 10; }, 1);
+    const uint64_t high_size = write_two_column_segment(
+            selected_id, "overlapped_same_high.dat", 2, [](int key) { return key * 10; }, 1);
     const uint64_t low_size =
             write_two_column_segment(selected_id, "overlapped_same_low.dat", 2, [](int key) { return key * 10; });
 
@@ -13599,10 +13601,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_equal_recovery_key_e
     source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
     source->set_enable_persistent_index(true);
     source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
-    const uint64_t first_size =
-            write_two_column_segment(source_id, "recovery_equal_a.dat", 1, [](int) { return 100; }, 10);
-    const uint64_t second_size =
-            write_two_column_segment(source_id, "recovery_equal_b.dat", 1, [](int) { return 200; }, 20);
+    const uint64_t first_size = write_two_column_segment(
+            source_id, "recovery_equal_a.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(
+            source_id, "recovery_equal_b.dat", 1, [](int) { return 200; }, 20);
     auto* first = add_allocator_rowset(source.get(), 798, 1, "recovery_equal_a.dat", 0);
     first->mutable_segment_metas(0)->set_size(first_size);
     first->set_max_compact_input_rowset_id(797);
@@ -13660,10 +13662,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_strict_recovery_orde
         source->set_enable_persistent_index(true);
         source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
     }
-    const uint64_t first_size =
-            write_two_column_segment(first_id, "recovery_strict_2.dat", 1, [](int) { return 100; }, 10);
-    const uint64_t second_size =
-            write_two_column_segment(second_id, "recovery_strict_20.dat", 1, [](int) { return 600; }, 60);
+    const uint64_t first_size = write_two_column_segment(
+            first_id, "recovery_strict_2.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(
+            second_id, "recovery_strict_20.dat", 1, [](int) { return 600; }, 60);
     auto* first_rowset = add_allocator_rowset(first.get(), 2, 1, "recovery_strict_2.dat", 0);
     first_rowset->mutable_segment_metas(0)->set_size(first_size);
     auto* second_rowset = add_allocator_rowset(second.get(), 20, 2, "recovery_strict_20.dat", 0);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -16870,7 +16870,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         });
         sync->EnableProcessing();
         std::unordered_map<int64_t, TabletMetadataPtr> published;
-        const Status status = publish(target, next_id(), &published);
+        const int64_t failed_txn = next_id();
+        const Status status = publish(target, failed_txn, &published);
         sync->ClearAllCallBacks();
         sync->DisableProcessing();
         EXPECT_EQ(message, status.message()) << status;
@@ -16880,8 +16881,16 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         EXPECT_EQ(meta_b_before, meta_b->SerializeAsString());
         ASSIGN_OR_ABORT(const auto inventory_a_after, delvec_inventory(child_a));
         ASSIGN_OR_ABORT(const auto inventory_b_after, delvec_inventory(child_b));
-        for (const auto& filename : inventory_a_before) EXPECT_TRUE(inventory_a_after.contains(filename));
-        for (const auto& filename : inventory_b_before) EXPECT_TRUE(inventory_b_after.contains(filename));
+        auto without_target_outputs = [](std::set<std::string> inventory) {
+            std::erase_if(inventory, [](const std::string& filename) {
+                return filename.size() > 17 && filename[16] == '_' && filename.ends_with(".delvec") &&
+                       std::all_of(filename.begin(), filename.begin() + 16,
+                                   [](unsigned char c) { return std::isxdigit(c); });
+            });
+            return inventory;
+        };
+        EXPECT_EQ(inventory_a_before, without_target_outputs(inventory_a_after));
+        EXPECT_EQ(inventory_b_before, without_target_outputs(inventory_b_after));
 
         std::unordered_map<int64_t, TabletMetadataPtr> retried;
         ASSERT_OK(publish(target, next_id(), &retried));
@@ -16930,6 +16939,9 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     DelVector delvec_b;
     const uint32_t deleted_b = 7;
     delvec_b.init(/*version=*/kBaseVersion, &deleted_b, 1);
+    DelVector expected_merged_delvec;
+    const uint32_t expected_deleted[] = {deleted_a};
+    expected_merged_delvec.init(/*version=*/kNewVersion, expected_deleted, std::size(expected_deleted));
     auto meta_a = build(tablet_a, 10, 1001, "delvec-a", delvec_a.save());
     auto meta_b = build(tablet_b, 1, 2002, "delvec-b", delvec_b.save());
     ASSERT_OK(put_tablet_metadata(meta_a));
@@ -16981,6 +16993,7 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     LakeIOOptions options;
     ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options,
                           &loaded));
+    EXPECT_EQ(expected_merged_delvec.save(), loaded.save());
 
     VacuumFullRequest request;
     request.set_partition_id(1);
@@ -16995,11 +17008,16 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     EXPECT_EQ(0, response.status().status_code());
     for (const auto& failed : failed_files) EXPECT_FALSE(delvec_inventory(target_tablet).value().contains(failed));
     for (const auto& retried : retry_files) EXPECT_TRUE(delvec_inventory(target_tablet).value().contains(retried));
-    EXPECT_TRUE(_tablet_manager->get_tablet_metadata(target_tablet, kNewVersion).ok());
+    ASSIGN_OR_ABORT(auto post_vacuum_metadata, _tablet_manager->get_tablet_metadata(target_tablet, kNewVersion));
+    ASSERT_TRUE(post_vacuum_metadata->delvec_meta().version_to_file().contains(kNewVersion));
+    const auto& post_vacuum_file = post_vacuum_metadata->delvec_meta().version_to_file().at(kNewVersion);
+    EXPECT_EQ(retry_file.name(), post_vacuum_file.name());
+    EXPECT_TRUE(post_vacuum_file.name().starts_with("0000000000000003_"));
+    for (const auto& failed : failed_files) EXPECT_NE(failed, post_vacuum_file.name());
     DelVector reloaded;
-    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options,
-                          &reloaded));
-    EXPECT_EQ(loaded.save(), reloaded.save());
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *post_vacuum_metadata, post_vacuum_metadata->rowsets(0).id(), false,
+                          options, &reloaded));
+    EXPECT_EQ(expected_merged_delvec.save(), reloaded.save());
 }
 
 // The .cols rebuild only runs when two DCG entries claim the SAME column id for the same target

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -13185,10 +13185,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped
     duplicate_source->mutable_range()->set_lower_bound_included(true);
     duplicate_source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
     duplicate_source->mutable_range()->set_upper_bound_included(false);
-    const uint64_t selected_size = write_two_column_segment(
-            selected_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
-    write_two_column_segment(
-            duplicate_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t selected_size = write_two_column_segment(selected_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
+    write_two_column_segment(duplicate_id, "rejoin.dat", 1, [](int) { return 100; }, 10);
     auto* selected = add_allocator_rowset(selected_source.get(), 41, 1, "rejoin.dat", 0);
     selected->mutable_segment_metas(0)->set_size(selected_size);
     selected->mutable_segment_metas(0)->set_shared(true);
@@ -13331,8 +13329,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_overlapped_without_s
     const int64_t duplicate_id = next_id();
     prepare_tablet_dirs(selected_id);
     prepare_tablet_dirs(duplicate_id);
-    const uint64_t high_size = write_two_column_segment(
-            selected_id, "overlapped_same_high.dat", 2, [](int key) { return key * 10; }, 1);
+    const uint64_t high_size =
+            write_two_column_segment(selected_id, "overlapped_same_high.dat", 2, [](int key) { return key * 10; }, 1);
     const uint64_t low_size =
             write_two_column_segment(selected_id, "overlapped_same_low.dat", 2, [](int key) { return key * 10; });
 
@@ -13498,10 +13496,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_equal_recovery_key_e
     source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
     source->set_enable_persistent_index(true);
     source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
-    const uint64_t first_size = write_two_column_segment(
-            source_id, "recovery_equal_a.dat", 1, [](int) { return 100; }, 10);
-    const uint64_t second_size = write_two_column_segment(
-            source_id, "recovery_equal_b.dat", 1, [](int) { return 200; }, 20);
+    const uint64_t first_size =
+            write_two_column_segment(source_id, "recovery_equal_a.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size =
+            write_two_column_segment(source_id, "recovery_equal_b.dat", 1, [](int) { return 200; }, 20);
     auto* first = add_allocator_rowset(source.get(), 798, 1, "recovery_equal_a.dat", 0);
     first->mutable_segment_metas(0)->set_size(first_size);
     first->set_max_compact_input_rowset_id(797);
@@ -13559,10 +13557,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_strict_recovery_orde
         source->set_enable_persistent_index(true);
         source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
     }
-    const uint64_t first_size = write_two_column_segment(
-            first_id, "recovery_strict_2.dat", 1, [](int) { return 100; }, 10);
-    const uint64_t second_size = write_two_column_segment(
-            second_id, "recovery_strict_20.dat", 1, [](int) { return 600; }, 60);
+    const uint64_t first_size =
+            write_two_column_segment(first_id, "recovery_strict_2.dat", 1, [](int) { return 100; }, 10);
+    const uint64_t second_size =
+            write_two_column_segment(second_id, "recovery_strict_20.dat", 1, [](int) { return 600; }, 60);
     auto* first_rowset = add_allocator_rowset(first.get(), 2, 1, "recovery_strict_2.dat", 0);
     first_rowset->mutable_segment_metas(0)->set_size(first_size);
     auto* second_rowset = add_allocator_rowset(second.get(), 20, 2, "recovery_strict_20.dat", 0);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -16850,8 +16850,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
     add_delvec(meta_b.get(), child_b, /*version=*/12, /*segment_id=*/2, "atomic-right.delvec", right.save());
     const std::string meta_a_before = meta_a->SerializeAsString();
     const std::string meta_b_before = meta_b->SerializeAsString();
-    ASSIGN_OR_ABORT(const auto inventory_a_before, delvec_inventory(child_a));
-    ASSIGN_OR_ABORT(const auto inventory_b_before, delvec_inventory(child_b));
+    std::set<std::string> allowed_target_outputs;
 
     auto publish = [&](int64_t target, int64_t txn, std::unordered_map<int64_t, TabletMetadataPtr>* published) {
         return publish_resharding_merge({meta_a, meta_b}, target, /*base_version=*/1, kVersion, txn, *published);
@@ -16860,6 +16859,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         SCOPED_TRACE(seam);
         const int64_t target = next_id();
         prepare_tablet_dirs(target);
+        ASSIGN_OR_ABORT(const auto inventory_a_before, delvec_inventory(child_a));
+        ASSIGN_OR_ABORT(const auto inventory_b_before, delvec_inventory(child_b));
         const std::string message = "injected publish delvec " + std::string(seam);
         int calls = 0;
         auto* sync = SyncPoint::GetInstance();
@@ -16881,22 +16882,33 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         EXPECT_EQ(meta_b_before, meta_b->SerializeAsString());
         ASSIGN_OR_ABORT(const auto inventory_a_after, delvec_inventory(child_a));
         ASSIGN_OR_ABORT(const auto inventory_b_after, delvec_inventory(child_b));
-        auto without_target_outputs = [](std::set<std::string> inventory) {
-            std::erase_if(inventory, [](const std::string& filename) {
-                return filename.size() > 17 && filename[16] == '_' && filename.ends_with(".delvec") &&
-                       std::all_of(filename.begin(), filename.begin() + 16,
-                                   [](unsigned char c) { return std::isxdigit(c); });
-            });
+        std::set<std::string> failed_target_outputs;
+        std::set_difference(inventory_a_after.begin(), inventory_a_after.end(), inventory_a_before.begin(),
+                            inventory_a_before.end(),
+                            std::inserter(failed_target_outputs, failed_target_outputs.end()));
+        ASSERT_EQ(1, failed_target_outputs.size());
+        const std::string failed_prefix = fmt::format("{:016x}_", failed_txn);
+        EXPECT_TRUE(failed_target_outputs.begin()->starts_with(failed_prefix));
+        allowed_target_outputs.insert(*failed_target_outputs.begin());
+        auto without_allowed_target_outputs = [&](std::set<std::string> inventory) {
+            for (const auto& target_output : allowed_target_outputs) inventory.erase(target_output);
             return inventory;
         };
-        EXPECT_EQ(inventory_a_before, without_target_outputs(inventory_a_after));
-        EXPECT_EQ(inventory_b_before, without_target_outputs(inventory_b_after));
+        EXPECT_EQ(without_allowed_target_outputs(inventory_a_before),
+                  without_allowed_target_outputs(inventory_a_after));
+        EXPECT_EQ(without_allowed_target_outputs(inventory_b_before),
+                  without_allowed_target_outputs(inventory_b_after));
 
         std::unordered_map<int64_t, TabletMetadataPtr> retried;
-        ASSERT_OK(publish(target, next_id(), &retried));
+        const int64_t retry_txn = next_id();
+        ASSERT_OK(publish(target, retry_txn, &retried));
         ASSERT_TRUE(retried.contains(target));
         const auto& merged = *retried.at(target);
         ASSERT_EQ(2, merged.delvec_meta().delvecs().size());
+        ASSERT_TRUE(merged.delvec_meta().version_to_file().contains(kVersion));
+        const auto& retry_output = merged.delvec_meta().version_to_file().at(kVersion).name();
+        EXPECT_TRUE(retry_output.starts_with(fmt::format("{:016x}_", retry_txn)));
+        allowed_target_outputs.insert(retry_output);
         DelVector loaded_raw;
         DelVector loaded_union;
         LakeIOOptions options;

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -9555,7 +9555,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_ignores_non_live_encrypted_del
         const auto merged = std::move(merged_or).value();
         ASSERT_EQ(1, merged->rowsets_size());
         const uint32_t target_rssid = merged->rowsets(0).id();
-        expect_exact_delvec_output(*merged, target_tablet, kNewVersion, {{target_rssid, live_bytes, std::nullopt}});
+        ASSERT_NO_FATAL_FAILURE(expect_exact_delvec_output(*merged, target_tablet, kNewVersion,
+                                                           {{target_rssid, live_bytes, std::nullopt}}));
         EXPECT_FALSE(merged->delvec_meta().delvecs().contains(99));
         const auto& output_file = merged->delvec_meta().version_to_file().at(kNewVersion);
         EXPECT_NE(stale_filename, output_file.name());

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -7147,54 +7147,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) 
     EXPECT_OK(st);
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_file_offset) {
-    const int64_t base_version = 1;
-    const int64_t new_version = 2;
-    const int64_t old_tablet_id_1 = next_id();
-    const int64_t old_tablet_id_2 = next_id();
-    const int64_t new_tablet_id = next_id();
-
-    prepare_tablet_dirs(old_tablet_id_1);
-    prepare_tablet_dirs(old_tablet_id_2);
-    prepare_tablet_dirs(new_tablet_id);
-
-    auto meta1 = std::make_shared<TabletMetadataPB>();
-    meta1->set_id(old_tablet_id_1);
-    meta1->set_version(base_version);
-    meta1->set_next_rowset_id(10);
-    set_primary_key_schema(meta1.get(), 1001);
-    add_rowset(meta1.get(), 1, 1, 1);
-    add_delvec(meta1.get(), old_tablet_id_1, base_version, 1, "delvec-1", "aaa");
-
-    auto meta2 = std::make_shared<TabletMetadataPB>();
-    meta2->set_id(old_tablet_id_2);
-    meta2->set_version(base_version);
-    meta2->set_next_rowset_id(10);
-    set_primary_key_schema(meta2.get(), 1002);
-    add_rowset(meta2.get(), 2, 2, 2);
-    add_delvec(meta2.get(), old_tablet_id_2, base_version, 2, "delvec-2", "bbb");
-
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
-
-    ReshardingTabletInfoPB resharding_tablet;
-    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
-    merging_tablet.add_old_tablet_ids(old_tablet_id_1);
-    merging_tablet.add_old_tablet_ids(old_tablet_id_2);
-    merging_tablet.set_new_tablet_id(new_tablet_id);
-
-    TxnInfoPB txn_info;
-    txn_info.set_txn_id(1);
-    txn_info.set_commit_time(1);
-    txn_info.set_gtid(1);
-
-    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
-    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
-                                              txn_info, false, tablet_metadatas, tablet_ranges);
-    EXPECT_OK(st);
-}
-
 TEST_F(LakeTabletReshardTest, test_tablet_merging_cache_miss_fallback) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -9412,6 +9364,56 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_duplicate_source_metada
     }
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_plaintext_delvec_union_reads_both_sources) {
+    constexpr int64_t kNewVersion = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) {
+        prepare_tablet_dirs(tablet_id);
+    }
+
+    const std::string segment_filename = "plaintext_union_segment.dat";
+    auto meta_a = make_shared_delvec_source(child_a, {segment_filename});
+    auto meta_b = make_shared_delvec_source(child_b, {segment_filename});
+    DelVector dv_a;
+    const uint32_t deleted_a = 1;
+    dv_a.init(/*version=*/10, &deleted_a, 1);
+    add_delvec(meta_a.get(), child_a, /*version=*/10, /*segment_id=*/1, "plaintext_union_a.delvec", dv_a.save());
+    DelVector dv_b;
+    const uint32_t deleted_b = 4;
+    dv_b.init(/*version=*/11, &deleted_b, 1);
+    add_delvec(meta_b.get(), child_b, /*version=*/11, /*segment_id=*/1, "plaintext_union_b.delvec", dv_b.save());
+
+    int get_del_vec_calls = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+
+    ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
+    EXPECT_EQ(2, get_del_vec_calls);
+    ASSERT_EQ(1, merged->rowsets_size());
+    const uint32_t target_rssid = merged->rowsets(0).id();
+    DelVector expected;
+    const uint32_t deleted_rowids[] = {deleted_a, deleted_b};
+    expected.init(kNewVersion, deleted_rowids, std::size(deleted_rowids));
+    const std::string expected_content = expected.save();
+    const uint32_t expected_crc = crc32c::Mask(crc32c::Value(expected_content.data(), expected_content.size()));
+    expect_exact_delvec_output(*merged, merged_tablet, kNewVersion, {{target_rssid, expected_content, expected_crc}});
+
+    DelVector loaded;
+    LakeIOOptions io_options;
+    ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_options, &loaded));
+    ASSERT_NE(nullptr, loaded.roaring());
+    EXPECT_EQ(2, loaded.cardinality());
+    EXPECT_TRUE(loaded.roaring()->contains(deleted_a));
+    EXPECT_TRUE(loaded.roaring()->contains(deleted_b));
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejected_before_read) {
     for (bool stale_first : {false, true}) {
         SCOPED_TRACE(stale_first ? "stale-first" : "plain-first");
@@ -9423,17 +9425,23 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejecte
         }
 
         const std::string segment_filename = "stale_encryption_metadata_segment.dat";
-        const std::string delvec_filename =
-                fmt::format("stale_encryption_metadata_{}.delvec", stale_first ? "stale_first" : "plain_first");
+        const std::string plain_delvec_filename =
+                fmt::format("stale_encryption_metadata_{}_plain.delvec", stale_first ? "stale_first" : "plain_first");
+        const std::string stale_delvec_filename =
+                fmt::format("stale_encryption_metadata_{}_stale.delvec", stale_first ? "stale_first" : "plain_first");
         auto plain = make_shared_delvec_source(plain_tablet, {segment_filename});
         auto stale = make_shared_delvec_source(stale_tablet, {segment_filename});
-        DelVector expected;
-        const uint32_t deleted_rowids[] = {1, 4};
-        expected.init(/*version=*/10, deleted_rowids, std::size(deleted_rowids));
-        const std::string content = expected.save();
-        add_delvec(plain.get(), plain_tablet, /*version=*/10, /*segment_id=*/1, delvec_filename, content);
-        add_delvec(stale.get(), stale_tablet, /*version=*/10, /*segment_id=*/1, delvec_filename, content);
-        (*stale->mutable_delvec_meta()->mutable_version_to_file())[10].set_encryption_meta(
+        DelVector plain_delvec;
+        const uint32_t plain_deleted_rowid = 1;
+        plain_delvec.init(/*version=*/10, &plain_deleted_rowid, 1);
+        add_delvec(plain.get(), plain_tablet, /*version=*/10, /*segment_id=*/1, plain_delvec_filename,
+                   plain_delvec.save());
+        DelVector stale_delvec;
+        const uint32_t stale_deleted_rowid = 4;
+        stale_delvec.init(/*version=*/11, &stale_deleted_rowid, 1);
+        add_delvec(stale.get(), stale_tablet, /*version=*/11, /*segment_id=*/1, stale_delvec_filename,
+                   stale_delvec.save());
+        (*stale->mutable_delvec_meta()->mutable_version_to_file())[11].set_encryption_meta(
                 std::string(1, static_cast<char>(0xff)));
 
         ASSERT_OK(put_tablet_metadata(plain));
@@ -9470,7 +9478,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejecte
                 lake::publish_resharding_tablet(_tablet_manager.get(), resharding, /*base_version=*/1,
                                                 /*new_version=*/2, txn_info, false, published, tablet_ranges);
         EXPECT_TRUE(status.is_not_supported()) << status;
-        EXPECT_EQ(fmt::format("encrypted delvec input is unsupported; delvec must be plaintext: {}", delvec_filename),
+        EXPECT_EQ(fmt::format("encrypted delvec input is unsupported; delvec must be plaintext: {}",
+                              stale_delvec_filename),
                   status.message());
         EXPECT_EQ(0, get_del_vec_calls);
         EXPECT_EQ(0, source_opens);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -24,6 +24,7 @@
 #include <cstdlib>
 #include <ctime>
 #include <functional>
+#include <iterator>
 #include <limits>
 #include <optional>
 #include <set>
@@ -9486,6 +9487,107 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejecte
         EXPECT_EQ(0, range_reads);
         EXPECT_EQ(0, writer_opens);
     }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_ignores_non_live_encrypted_delvec_declaration) {
+    constexpr int64_t kNewVersion = 2;
+    const std::set<std::string> expected_orders = {"plain-first", "stale-first"};
+    std::set<std::string> attempted_orders;
+    std::set<std::string> completed_orders;
+    std::set<std::string> observed_failure_orders;
+
+    auto run_case = [&](bool stale_first) {
+        const std::string order = stale_first ? "stale-first" : "plain-first";
+        attempted_orders.insert(order);
+
+        const int64_t plain_tablet = next_id();
+        const int64_t stale_tablet = next_id();
+        const int64_t target_tablet = next_id();
+        for (int64_t tablet_id : {plain_tablet, stale_tablet, target_tablet}) {
+            prepare_tablet_dirs(tablet_id);
+        }
+
+        const std::string segment_filename = "non_live_encrypted_shared_segment.dat";
+        const std::string stale_filename = fmt::format("non_live_encrypted_{}.delvec", order);
+        auto plain = make_shared_delvec_source(plain_tablet, {segment_filename});
+        auto stale = make_shared_delvec_source(stale_tablet, {segment_filename});
+
+        DelVector live_delvec;
+        const uint32_t live_rowids[] = {2, 5};
+        live_delvec.init(/*version=*/10, live_rowids, std::size(live_rowids));
+        const std::string live_bytes = live_delvec.save();
+        add_delvec(plain.get(), plain_tablet, /*version=*/10, /*segment_id=*/1, "non_live_plain.delvec", live_bytes);
+
+        DelVector stale_delvec;
+        const uint32_t stale_rowid = 7;
+        stale_delvec.init(/*version=*/11, &stale_rowid, 1);
+        add_delvec(stale.get(), stale_tablet, /*version=*/11, /*segment_id=*/99, stale_filename, stale_delvec.save());
+        (*stale->mutable_delvec_meta()->mutable_version_to_file())[11].set_encryption_meta("unused-non-live");
+        EXPECT_FALSE(stale->rowsets(0).segment_metas().empty());
+        EXPECT_EQ(1, stale->rowsets(0).id());
+        EXPECT_FALSE(stale->delvec_meta().delvecs().contains(1));
+
+        const std::string plain_pb_before = plain->SerializeAsString();
+        const std::string stale_pb_before = stale->SerializeAsString();
+        auto shared_inventory_before_or = delvec_inventory(target_tablet);
+        ASSERT_TRUE(shared_inventory_before_or.ok()) << shared_inventory_before_or.status();
+        const auto shared_inventory_before = std::move(shared_inventory_before_or).value();
+
+        const std::vector<TabletMetadataPtr> sources = stale_first ? std::vector<TabletMetadataPtr>{stale, plain}
+                                                                   : std::vector<TabletMetadataPtr>{plain, stale};
+        const std::string expected_stale_diagnostic =
+                fmt::format("encrypted delvec input is unsupported; delvec must be plaintext: {}", stale_filename);
+        auto merged_or = merge_delvec_sources(sources, target_tablet, kNewVersion, next_id());
+        if (!merged_or.ok()) {
+            ADD_FAILURE() << order << ": " << merged_or.status();
+            observed_failure_orders.insert(order);
+            EXPECT_TRUE(merged_or.status().is_not_supported());
+            EXPECT_EQ(expected_stale_diagnostic, merged_or.status().message());
+            expect_target_version_not_published(target_tablet, kNewVersion);
+            auto inventory_after_or = delvec_inventory(target_tablet);
+            ASSERT_TRUE(inventory_after_or.ok()) << inventory_after_or.status();
+            EXPECT_EQ(shared_inventory_before, *inventory_after_or);
+            EXPECT_EQ(plain_pb_before, plain->SerializeAsString());
+            EXPECT_EQ(stale_pb_before, stale->SerializeAsString());
+            return;
+        }
+
+        const auto merged = std::move(merged_or).value();
+        ASSERT_EQ(1, merged->rowsets_size());
+        const uint32_t target_rssid = merged->rowsets(0).id();
+        expect_exact_delvec_output(*merged, target_tablet, kNewVersion, {{target_rssid, live_bytes, std::nullopt}});
+        EXPECT_FALSE(merged->delvec_meta().delvecs().contains(99));
+        const auto& output_file = merged->delvec_meta().version_to_file().at(kNewVersion);
+        EXPECT_NE(stale_filename, output_file.name());
+        EXPECT_FALSE(output_file.name().contains("non_live_encrypted_"));
+
+        DelVector loaded;
+        LakeIOOptions io_options;
+        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_options, &loaded));
+        ASSERT_NE(nullptr, loaded.roaring());
+        EXPECT_EQ(2, loaded.cardinality());
+        EXPECT_TRUE(loaded.roaring()->contains(2));
+        EXPECT_TRUE(loaded.roaring()->contains(5));
+
+        EXPECT_EQ(plain_pb_before, plain->SerializeAsString());
+        EXPECT_EQ(stale_pb_before, stale->SerializeAsString());
+        auto shared_inventory_after_or = delvec_inventory(target_tablet);
+        ASSERT_TRUE(shared_inventory_after_or.ok()) << shared_inventory_after_or.status();
+        const auto shared_inventory_after = std::move(shared_inventory_after_or).value();
+        std::set<std::string> shared_root_delta;
+        std::set_difference(shared_inventory_after.begin(), shared_inventory_after.end(),
+                            shared_inventory_before.begin(), shared_inventory_before.end(),
+                            std::inserter(shared_root_delta, shared_root_delta.end()));
+        EXPECT_EQ(std::set<std::string>({output_file.name()}), shared_root_delta);
+        completed_orders.insert(order);
+    };
+
+    run_case(/*stale_first=*/false);
+    run_case(/*stale_first=*/true);
+
+    EXPECT_EQ(expected_orders, attempted_orders);
+    EXPECT_EQ(expected_orders, completed_orders);
+    EXPECT_TRUE(observed_failure_orders.empty());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_duplicate_source_metadata_mismatch_is_rejected) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <set>
 
 #include "base/failpoint/fail_point.h"
@@ -774,6 +775,69 @@ protected:
             return Status::InternalError("merged delvec test metadata is missing");
         }
         return merged_it->second;
+    }
+
+    struct ExpectedDelvecOutputPage {
+        uint32_t rssid;
+        std::string bytes;
+        std::optional<uint32_t> crc32c;
+    };
+
+    void expect_exact_delvec_output(const TabletMetadataPB& metadata, int64_t tablet_id, int64_t version,
+                                    const std::vector<ExpectedDelvecOutputPage>& expected_pages) {
+        ASSERT_EQ(1, metadata.delvec_meta().version_to_file_size());
+        ASSERT_TRUE(metadata.delvec_meta().version_to_file().contains(version));
+        ASSERT_EQ(expected_pages.size(), metadata.delvec_meta().delvecs().size());
+        const auto& output_file = metadata.delvec_meta().version_to_file().at(version);
+        EXPECT_FALSE(output_file.name().empty());
+        EXPECT_TRUE(output_file.has_size());
+        EXPECT_TRUE(output_file.has_shared());
+        EXPECT_FALSE(output_file.shared());
+        EXPECT_FALSE(output_file.has_encryption_meta());
+        EXPECT_TRUE(output_file.encryption_meta().empty());
+
+        std::string expected_file_bytes;
+        uint64_t expected_offset = 0;
+        for (const auto& expected : expected_pages) {
+            ASSERT_TRUE(metadata.delvec_meta().delvecs().contains(expected.rssid));
+            const auto& page = metadata.delvec_meta().delvecs().at(expected.rssid);
+            EXPECT_EQ(version, page.version());
+            EXPECT_EQ(version, page.crc32c_gen_version());
+            EXPECT_EQ(expected_offset, page.offset());
+            EXPECT_EQ(expected.bytes.size(), page.size());
+            if (expected.crc32c.has_value()) {
+                EXPECT_TRUE(page.has_crc32c());
+                EXPECT_EQ(*expected.crc32c, page.crc32c());
+            } else {
+                EXPECT_FALSE(page.has_crc32c());
+            }
+            expected_file_bytes.append(expected.bytes);
+            expected_offset += expected.bytes.size();
+        }
+        EXPECT_EQ(static_cast<int64_t>(expected_file_bytes.size()), output_file.size());
+        ASSIGN_OR_ABORT(auto reader,
+                        fs::new_random_access_file(_tablet_manager->delvec_location(tablet_id, output_file.name())));
+        ASSIGN_OR_ABORT(auto actual_file_bytes, reader->read_all());
+        EXPECT_EQ(expected_file_bytes, actual_file_bytes);
+    }
+
+    std::string make_large_serialized_delvec(int64_t version, size_t minimum_size) {
+        constexpr uint32_t kValuesPerContainer = 4097;
+        constexpr uint32_t kLowValueStride = 2;
+        constexpr size_t kBitsetContainerBytes = 1UL << 13;
+        const uint32_t container_count = static_cast<uint32_t>(minimum_size / kBitsetContainerBytes + 2);
+        std::vector<uint32_t> deleted_rowids;
+        deleted_rowids.reserve(static_cast<size_t>(container_count) * kValuesPerContainer);
+        for (uint32_t high = 0; high < container_count; ++high) {
+            for (uint32_t index = 0; index < kValuesPerContainer; ++index) {
+                deleted_rowids.push_back((high << 16) | (index * kLowValueStride));
+            }
+        }
+        DelVector delvec;
+        delvec.init(version, deleted_rowids.data(), deleted_rowids.size());
+        std::string bytes = delvec.save();
+        EXPECT_GT(bytes.size(), minimum_size);
+        return bytes;
     }
 
     void add_sstable(TabletMetadataPB* metadata, const std::string& filename, uint64_t max_rss_rowid,
@@ -8946,6 +9010,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_selects_only_final_sing
     const std::string live_content = live_delvec.save();
     const std::string live_filename = "consumer_live.delvec";
     add_delvec(meta_a.get(), child_a, /*version=*/10, /*segment_id=*/1, live_filename, live_content);
+    const uint32_t live_crc = crc32c::Mask(crc32c::Value(live_content.data(), live_content.size()));
+    auto& live_page = (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1];
+    live_page.set_crc32c(live_crc);
+    live_page.set_crc32c_gen_version(10);
 
     const std::string stale_content = "stale-delvec-record-with-no-page";
     FileMetaPB stale_file;
@@ -8954,17 +9022,20 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_selects_only_final_sing
     (*meta_a->mutable_delvec_meta()->mutable_version_to_file())[20] = stale_file;
     write_file(_tablet_manager->delvec_location(child_a, stale_file.name()), stale_content);
 
+    int writer_invocations = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("merge_delvecs:writer_invocations",
+                      [&](void* arg) { writer_invocations += *static_cast<int*>(arg); });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
     ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
+    EXPECT_EQ(1, writer_invocations);
     ASSERT_EQ(1, merged->rowsets_size());
     const uint32_t target_rssid = merged->rowsets(0).id();
-    ASSERT_EQ(1, merged->delvec_meta().delvecs_size());
-    const auto& output_page = merged->delvec_meta().delvecs().at(target_rssid);
-    ASSERT_EQ(1, merged->delvec_meta().version_to_file_size());
-    const auto& output_file = merged->delvec_meta().version_to_file().at(kNewVersion);
-
-    EXPECT_EQ(static_cast<int64_t>(live_content.size()), output_file.size());
-    EXPECT_EQ(0, output_page.offset());
-    EXPECT_EQ(live_content.size(), output_page.size());
+    expect_exact_delvec_output(*merged, merged_tablet, kNewVersion, {{target_rssid, live_content, live_crc}});
 
     DelVector loaded;
     LakeIOOptions io_options;
@@ -8988,10 +9059,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_compacts_only_live_page
     const uint32_t deleted[] = {3, 9};
     live.init(/*version=*/10, deleted, std::size(deleted));
     const std::string live_bytes = live.save();
-    const std::string dead_prefix(2 * 1024 * 1024, 'p');
-    const std::string dead_suffix(2 * 1024 * 1024, 's');
+    const std::string dead_prefix = make_large_serialized_delvec(/*version=*/7, 2 * 1024 * 1024);
+    const std::string dead_suffix = make_large_serialized_delvec(/*version=*/8, 2 * 1024 * 1024);
+    DelVector unrelated;
+    const uint32_t unrelated_deleted = 42;
+    unrelated.init(/*version=*/9, &unrelated_deleted, 1);
+    const std::string unrelated_bytes = unrelated.save();
     const std::string filename = "compact-live-page.delvec";
-    const std::string object = dead_prefix + live_bytes + dead_suffix + "unrelated-page";
+    const std::string object = dead_prefix + live_bytes + dead_suffix + unrelated_bytes;
     FileMetaPB file;
     file.set_name(filename);
     file.set_size(object.size());
@@ -9104,20 +9179,31 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_output_follows_target_r
     higher.init(/*version=*/12, &higher_deleted, 1);
     const std::string higher_bytes = higher.save();
     add_delvec(meta_a.get(), child_a, 12, 2, "ordered-higher-raw.delvec", higher_bytes);
+    const uint32_t higher_crc = crc32c::Mask(crc32c::Value(higher_bytes.data(), higher_bytes.size()));
+    auto& higher_source_page = (*meta_a->mutable_delvec_meta()->mutable_delvecs())[2];
+    higher_source_page.set_crc32c(higher_crc);
+    higher_source_page.set_crc32c_gen_version(12);
 
     DelVector expected_lower;
     const uint32_t expected_lower_deleted[] = {1, 2};
     expected_lower.init(kNewVersion, expected_lower_deleted, std::size(expected_lower_deleted));
     const std::string lower_bytes = expected_lower.save();
+    int writer_invocations = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("merge_delvecs:writer_invocations",
+                      [&](void* arg) { writer_invocations += *static_cast<int*>(arg); });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
     ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
+    EXPECT_EQ(1, writer_invocations);
     const uint32_t lower_rssid = merged->rowsets(0).id();
     const uint32_t higher_rssid = lower_rssid + 1;
-    const auto& lower_page = merged->delvec_meta().delvecs().at(lower_rssid);
-    const auto& higher_page = merged->delvec_meta().delvecs().at(higher_rssid);
-    EXPECT_EQ(0, lower_page.offset());
-    EXPECT_EQ(lower_bytes.size(), higher_page.offset());
-    EXPECT_EQ(static_cast<int64_t>(lower_bytes.size() + higher_bytes.size()),
-              merged->delvec_meta().version_to_file().at(kNewVersion).size());
+    const uint32_t lower_crc = crc32c::Mask(crc32c::Value(lower_bytes.data(), lower_bytes.size()));
+    expect_exact_delvec_output(*merged, merged_tablet, kNewVersion,
+                               {{lower_rssid, lower_bytes, lower_crc}, {higher_rssid, higher_bytes, higher_crc}});
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_io_is_bounded) {
@@ -9127,18 +9213,25 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_io_is_bounded) {
     for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
     auto meta_a = make_shared_delvec_source(child_a, {"bounded-io.dat"});
     auto meta_b = make_shared_delvec_source(child_b, {"bounded-io.dat"});
-    const std::string payload(3 * (1UL << 20) + 7, 'x');
-    const std::string dead_prefix(1024, 'd');
+    const std::string payload = make_large_serialized_delvec(/*version=*/10, 3 * (1UL << 20));
+    DelVector dead_prefix_page;
+    const uint32_t dead_prefix_deleted = 17;
+    dead_prefix_page.init(/*version=*/8, &dead_prefix_deleted, 1);
+    const std::string dead_prefix = dead_prefix_page.save();
+    DelVector dead_suffix_page;
+    const uint32_t dead_suffix_deleted = 19;
+    dead_suffix_page.init(/*version=*/9, &dead_suffix_deleted, 1);
+    const std::string dead_suffix = dead_suffix_page.save();
     FileMetaPB file;
     file.set_name("bounded-io.delvec");
-    file.set_size(dead_prefix.size() + payload.size() + 1024);
+    file.set_size(dead_prefix.size() + payload.size() + dead_suffix.size());
     (*meta_a->mutable_delvec_meta()->mutable_version_to_file())[10] = file;
     DelvecPagePB page;
     page.set_version(10);
     page.set_offset(dead_prefix.size());
     page.set_size(payload.size());
     (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1] = page;
-    write_file(_tablet_manager->delvec_location(child_a, file.name()), dead_prefix + payload + std::string(1024, 'z'));
+    write_file(_tablet_manager->delvec_location(child_a, file.name()), dead_prefix + payload + dead_suffix);
 
     size_t total_read = 0;
     size_t total_append = 0;
@@ -9188,15 +9281,21 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_crc_contract) {
         const std::string bytes = delvec.save();
         add_delvec(meta_a.get(), child_a, 10, 1, trusted ? "crc-trusted.delvec" : "crc-untrusted.delvec", bytes);
         auto& page = (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1];
-        page.set_crc32c(crc32c::Mask(crc32c::Value(bytes.data(), bytes.size())));
+        const uint32_t expected_crc = crc32c::Mask(crc32c::Value(bytes.data(), bytes.size()));
+        page.set_crc32c(expected_crc);
         page.set_crc32c_gen_version(trusted ? 10 : 9);
         ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, /*new_version=*/2));
-        return merged->delvec_meta().delvecs().at(merged->rowsets(0).id());
+        return std::make_pair(merged->delvec_meta().delvecs().at(merged->rowsets(0).id()), expected_crc);
     };
     const auto trusted = merge_raw(true);
-    EXPECT_TRUE(trusted.has_crc32c());
+    EXPECT_TRUE(trusted.first.has_crc32c());
+    EXPECT_EQ(trusted.second, trusted.first.crc32c());
+    EXPECT_EQ(2, trusted.first.version());
+    EXPECT_EQ(2, trusted.first.crc32c_gen_version());
     const auto untrusted = merge_raw(false);
-    EXPECT_FALSE(untrusted.has_crc32c());
+    EXPECT_FALSE(untrusted.first.has_crc32c());
+    EXPECT_EQ(2, untrusted.first.version());
+    EXPECT_EQ(2, untrusted.first.crc32c_gen_version());
 
     const int64_t child_a = next_id();
     const int64_t child_b = next_id();
@@ -9220,6 +9319,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_crc_contract) {
     const auto& page = merged->delvec_meta().delvecs().at(merged->rowsets(0).id());
     EXPECT_TRUE(page.has_crc32c());
     EXPECT_EQ(crc32c::Mask(crc32c::Value(expected_bytes.data(), expected_bytes.size())), page.crc32c());
+    EXPECT_EQ(2, page.version());
+    EXPECT_EQ(2, page.crc32c_gen_version());
+    EXPECT_EQ(0, page.offset());
+    EXPECT_EQ(expected_bytes.size(), page.size());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_duplicate_source_metadata_mismatch_is_rejected) {
@@ -9350,10 +9453,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejecte
         std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
         int get_del_vec_calls = 0;
         int source_opens = 0;
+        int range_reads = 0;
         int writer_opens = 0;
         auto* sync = SyncPoint::GetInstance();
         sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
         sync->SetCallBack("write_compacted_delvec_pages:preflight_source_open", [&](void*) { ++source_opens; });
+        sync->SetCallBack("write_compacted_delvec_pages:read_chunk_size", [&](void*) { ++range_reads; });
         sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
         sync->EnableProcessing();
         DeferOp cleanup([&] {
@@ -9368,6 +9473,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejecte
                   status.message());
         EXPECT_EQ(0, get_del_vec_calls);
         EXPECT_EQ(0, source_opens);
+        EXPECT_EQ(0, range_reads);
         EXPECT_EQ(0, writer_opens);
     }
 }
@@ -9496,12 +9602,23 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_only_writes_plai
     expected_union.init(kNewVersion, expected_deleted, std::size(expected_deleted));
     const std::string expected_union_content = expected_union.save();
 
+    int writer_invocations = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("merge_delvecs:writer_invocations",
+                      [&](void* arg) { writer_invocations += *static_cast<int*>(arg); });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
     ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
+    EXPECT_EQ(1, writer_invocations);
     ASSERT_EQ(1, merged->rowsets_size());
     const uint32_t target_rssid = merged->rowsets(0).id();
-    const auto& output_file = merged->delvec_meta().version_to_file().at(kNewVersion);
-
-    EXPECT_TRUE(output_file.encryption_meta().empty());
+    const uint32_t expected_crc =
+            crc32c::Mask(crc32c::Value(expected_union_content.data(), expected_union_content.size()));
+    expect_exact_delvec_output(*merged, merged_tablet, kNewVersion,
+                               {{target_rssid, expected_union_content, expected_crc}});
     DelVector loaded;
     LakeIOOptions io_options;
     ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_options, &loaded));
@@ -9509,9 +9626,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_only_writes_plai
     EXPECT_EQ(2, loaded.cardinality());
     EXPECT_TRUE(loaded.roaring()->contains(4));
     EXPECT_TRUE(loaded.roaring()->contains(7));
-
-    EXPECT_EQ(static_cast<int64_t>(expected_union_content.size()), output_file.size());
-    EXPECT_EQ(0, merged->delvec_meta().delvecs().at(target_rssid).offset());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_plain_single_plus_merged_writes_plaintext) {
@@ -9532,6 +9646,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_plain_single_plus_merge
     const std::string plain_content = plain_single.save();
     const std::string plain_filename = "mixed_plain_single.delvec";
     add_delvec(meta_a.get(), child_a, /*version=*/10, /*segment_id=*/1, plain_filename, plain_content);
+    const uint32_t plain_crc = crc32c::Mask(crc32c::Value(plain_content.data(), plain_content.size()));
+    auto& plain_source_page = (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1];
+    plain_source_page.set_crc32c(plain_crc);
+    plain_source_page.set_crc32c_gen_version(10);
 
     DelVector merged_a;
     const uint32_t merged_deleted_a = 5;
@@ -9547,13 +9665,25 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_plain_single_plus_merge
     expected_union.init(kNewVersion, expected_merged_deleted, std::size(expected_merged_deleted));
     const std::string expected_union_content = expected_union.save();
 
+    int writer_invocations = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("merge_delvecs:writer_invocations",
+                      [&](void* arg) { writer_invocations += *static_cast<int*>(arg); });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
     ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
+    EXPECT_EQ(1, writer_invocations);
     ASSERT_EQ(1, merged->rowsets_size());
     const uint32_t single_target_rssid = merged->rowsets(0).id();
     const uint32_t merged_target_rssid = single_target_rssid + 1;
-    const auto& output_file = merged->delvec_meta().version_to_file().at(kNewVersion);
-
-    EXPECT_TRUE(output_file.encryption_meta().empty());
+    const uint32_t merged_crc =
+            crc32c::Mask(crc32c::Value(expected_union_content.data(), expected_union_content.size()));
+    expect_exact_delvec_output(*merged, merged_tablet, kNewVersion,
+                               {{single_target_rssid, plain_content, plain_crc},
+                                {merged_target_rssid, expected_union_content, merged_crc}});
     DelVector loaded_single;
     DelVector loaded_merged;
     LakeIOOptions io_options;
@@ -9566,10 +9696,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_plain_single_plus_merge
     EXPECT_TRUE(loaded_single.roaring()->contains(2));
     EXPECT_TRUE(loaded_merged.roaring()->contains(5));
     EXPECT_TRUE(loaded_merged.roaring()->contains(8));
-
-    EXPECT_EQ(static_cast<int64_t>(plain_content.size() + expected_union_content.size()), output_file.size());
-    EXPECT_EQ(0, merged->delvec_meta().delvecs().at(single_target_rssid).offset());
-    EXPECT_EQ(plain_content.size(), merged->delvec_meta().delvecs().at(merged_target_rssid).offset());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_zero_target_writes_nothing) {
@@ -15052,11 +15178,13 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_gap_promotion
     int encrypted_promotions = 0;
     int get_del_vec_calls = 0;
     int preflight_opens = 0;
+    int range_reads = 0;
     int writer_opens = 0;
     sync->ClearAllCallBacks();
     sync->SetCallBack("merge_delvecs:before_gap_promotion", [&](void*) { ++encrypted_promotions; });
     sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
     sync->SetCallBack("write_compacted_delvec_pages:preflight_source_open", [&](void*) { ++preflight_opens; });
+    sync->SetCallBack("write_compacted_delvec_pages:read_chunk_size", [&](void*) { ++range_reads; });
     sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
     std::unordered_map<int64_t, TabletMetadataPtr> encrypted_published;
     const Status status =
@@ -15068,6 +15196,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_gap_promotion
     EXPECT_EQ(0, encrypted_promotions);
     EXPECT_EQ(0, get_del_vec_calls);
     EXPECT_EQ(0, preflight_opens);
+    EXPECT_EQ(0, range_reads);
     EXPECT_EQ(0, writer_opens);
     EXPECT_FALSE(encrypted_published.contains(encrypted_merged_tablet));
 }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -75,6 +75,7 @@
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h"
+#include "storage/lake/vacuum_full.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_iterator.h"
 #include "storage/rowset/segment_options.h"
@@ -16826,58 +16827,177 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_before_delete_predicate_range
 
 // merge_delvecs writes a merged delvec file. Primary-key only, and skipped entirely when there is no
 // source delvec and no synthesized gap, so both sources carry a delvec here.
-TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
-    auto run_merge = [&]() {
-        const int64_t base_version = 1;
-        const int64_t new_version = 2;
-        const int64_t tablet_a = next_id();
-        const int64_t tablet_b = next_id();
-        const int64_t new_tablet = next_id();
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase) {
+    constexpr int64_t kVersion = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    auto meta_a = make_shared_delvec_source(child_a, {"atomic-raw.dat", "atomic-merged.dat"});
+    auto meta_b = make_shared_delvec_source(child_b, {"atomic-raw.dat", "atomic-merged.dat"});
+    DelVector raw;
+    const uint32_t raw_deleted = 3;
+    raw.init(/*version=*/10, &raw_deleted, 1);
+    const std::string raw_bytes = raw.save();
+    add_delvec(meta_a.get(), child_a, /*version=*/10, /*segment_id=*/1, "atomic-raw.delvec", raw_bytes);
+    DelVector left;
+    const uint32_t left_deleted = 5;
+    left.init(/*version=*/11, &left_deleted, 1);
+    add_delvec(meta_a.get(), child_a, /*version=*/11, /*segment_id=*/2, "atomic-left.delvec", left.save());
+    DelVector right;
+    const uint32_t right_deleted = 7;
+    right.init(/*version=*/12, &right_deleted, 1);
+    add_delvec(meta_b.get(), child_b, /*version=*/12, /*segment_id=*/2, "atomic-right.delvec", right.save());
+    const std::string meta_a_before = meta_a->SerializeAsString();
+    const std::string meta_b_before = meta_b->SerializeAsString();
+    ASSIGN_OR_ABORT(const auto inventory_a_before, delvec_inventory(child_a));
+    ASSIGN_OR_ABORT(const auto inventory_b_before, delvec_inventory(child_b));
 
-        prepare_tablet_dirs(tablet_a);
-        prepare_tablet_dirs(tablet_b);
-        prepare_tablet_dirs(new_tablet);
+    auto publish = [&](int64_t target, int64_t txn, std::unordered_map<int64_t, TabletMetadataPtr>* published) {
+        return publish_resharding_merge({meta_a, meta_b}, target, /*base_version=*/1, kVersion, txn, *published);
+    };
+    auto run_phase = [&](std::string_view seam, int fail_on_call) {
+        SCOPED_TRACE(seam);
+        const int64_t target = next_id();
+        prepare_tablet_dirs(target);
+        const std::string message = "injected publish delvec " + std::string(seam);
+        int calls = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        sync->SetCallBack(std::string(seam), [&](void* arg) {
+            if (++calls == fail_on_call) *static_cast<Status*>(arg) = Status::InternalError(message);
+        });
+        sync->EnableProcessing();
+        std::unordered_map<int64_t, TabletMetadataPtr> published;
+        const Status status = publish(target, next_id(), &published);
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+        EXPECT_EQ(message, status.message()) << status;
+        EXPECT_FALSE(published.contains(target));
+        expect_target_version_not_published(target, kVersion);
+        EXPECT_EQ(meta_a_before, meta_a->SerializeAsString());
+        EXPECT_EQ(meta_b_before, meta_b->SerializeAsString());
+        ASSIGN_OR_ABORT(const auto inventory_a_after, delvec_inventory(child_a));
+        ASSIGN_OR_ABORT(const auto inventory_b_after, delvec_inventory(child_b));
+        for (const auto& filename : inventory_a_before) EXPECT_TRUE(inventory_a_after.contains(filename));
+        for (const auto& filename : inventory_b_before) EXPECT_TRUE(inventory_b_after.contains(filename));
 
-        auto build = [&](int64_t tablet_id, uint32_t rowset_id, int64_t schema_id, const std::string& delvec_name,
-                         const std::string& delvec_content) {
-            auto meta = std::make_shared<TabletMetadataPB>();
-            meta->set_id(tablet_id);
-            meta->set_version(base_version);
-            meta->set_next_rowset_id(rowset_id + 1);
-            set_primary_key_schema(meta.get(), schema_id);
-            add_rowset(meta.get(), rowset_id, 7, 1);
-            add_delvec(meta.get(), tablet_id, base_version, rowset_id, delvec_name, delvec_content);
-            return meta;
-        };
-
-        auto meta_a = build(tablet_a, 10, 1001, "delvec-a", "aaaa");
-        auto meta_b = build(tablet_b, 1, 2002, "delvec-b", "bbbbbb");
-        CHECK_OK(put_tablet_metadata(meta_a));
-        CHECK_OK(put_tablet_metadata(meta_b));
-
-        ReshardingTabletInfoPB resharding_tablet;
-        auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
-        merging_tablet.add_old_tablet_ids(tablet_a);
-        merging_tablet.add_old_tablet_ids(tablet_b);
-        merging_tablet.set_new_tablet_id(new_tablet);
-
-        TxnInfoPB txn_info;
-        txn_info.set_txn_id(1);
-        txn_info.set_commit_time(1);
-        txn_info.set_gtid(1);
-
-        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
-        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-        return lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
-                                               txn_info, false, tablet_metadatas, tablet_ranges);
+        std::unordered_map<int64_t, TabletMetadataPtr> retried;
+        ASSERT_OK(publish(target, next_id(), &retried));
+        ASSERT_TRUE(retried.contains(target));
+        const auto& merged = *retried.at(target);
+        ASSERT_EQ(2, merged.delvec_meta().delvecs().size());
+        DelVector loaded_raw;
+        DelVector loaded_union;
+        LakeIOOptions options;
+        ASSERT_OK(get_del_vec(_tablet_manager.get(), merged, /*segment_id=*/1, false, options, &loaded_raw));
+        ASSERT_OK(get_del_vec(_tablet_manager.get(), merged, /*segment_id=*/2, false, options, &loaded_union));
+        EXPECT_EQ(raw_bytes, loaded_raw.save());
+        DelVector expected_union;
+        const uint32_t merged_deleted[] = {5, 7};
+        expected_union.init(kVersion, merged_deleted, std::size(merged_deleted));
+        EXPECT_EQ(expected_union.save(), loaded_union.save());
     };
 
+    run_phase("write_compacted_delvec_pages:before_read_chunk", 1);
+    run_phase("append_delvec_bytes_bounded:before_chunk", 2);
+    run_phase("write_compacted_delvec_pages:before_close", 1);
+    run_phase("write_compacted_delvec_pages:before_apply_offsets", 1);
+}
+
+TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
+    constexpr int64_t kBaseVersion = 1;
+    constexpr int64_t kNewVersion = 2;
+    const int64_t tablet_a = next_id();
+    const int64_t tablet_b = next_id();
+    const int64_t target_tablet = next_id();
+    for (int64_t tablet_id : {tablet_a, tablet_b, target_tablet}) prepare_tablet_dirs(tablet_id);
+    auto build = [&](int64_t tablet_id, uint32_t rowset_id, int64_t schema_id, const std::string& delvec_name,
+                     const std::string& delvec_content) {
+        auto meta = std::make_shared<TabletMetadataPB>();
+        meta->set_id(tablet_id);
+        meta->set_version(kBaseVersion);
+        meta->set_next_rowset_id(rowset_id + 1);
+        set_primary_key_schema(meta.get(), schema_id);
+        add_rowset(meta.get(), rowset_id, 7, 1);
+        add_delvec(meta.get(), tablet_id, kBaseVersion, rowset_id, delvec_name, delvec_content);
+        return meta;
+    };
+    DelVector delvec_a;
+    const uint32_t deleted_a = 4;
+    delvec_a.init(/*version=*/kBaseVersion, &deleted_a, 1);
+    DelVector delvec_b;
+    const uint32_t deleted_b = 7;
+    delvec_b.init(/*version=*/kBaseVersion, &deleted_b, 1);
+    auto meta_a = build(tablet_a, 10, 1001, "delvec-a", delvec_a.save());
+    auto meta_b = build(tablet_b, 1, 2002, "delvec-b", delvec_b.save());
+    ASSERT_OK(put_tablet_metadata(meta_a));
+    ASSERT_OK(put_tablet_metadata(meta_b));
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(tablet_a);
+    merging_tablet.add_old_tablet_ids(tablet_b);
+    merging_tablet.set_new_tablet_id(target_tablet);
+    auto run_merge = [&](int64_t txn_id) {
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+        txn_info.set_commit_time(1);
+        txn_info.set_gtid(1);
+        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+        return lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, kBaseVersion, kNewVersion,
+                                               txn_info, false, tablet_metadatas, tablet_ranges);
+    };
+    ASSIGN_OR_ABORT(const auto before_inventory, delvec_inventory(target_tablet));
+    auto txn_files = [&](int64_t txn_id) {
+        ASSIGN_OR_ABORT(const auto inventory, delvec_inventory(target_tablet));
+        std::set<std::string> files;
+        const std::string prefix = fmt::format("{:016x}_", txn_id);
+        for (const auto& name : inventory) {
+            if (name.starts_with(prefix) && name.ends_with(".delvec")) files.insert(name);
+        }
+        return files;
+    };
     set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::ENABLE);
-    auto armed = run_merge();
+    auto armed = run_merge(/*txn_id=*/1);
     set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::DISABLE);
     EXPECT_FALSE(armed.ok()) << "hook not reached after the merged delvec file was written";
+    const auto failed_files = txn_files(/*txn_id=*/1);
+    ASSERT_EQ(1, failed_files.size());
+    expect_target_version_not_published(target_tablet, kNewVersion);
+    ASSIGN_OR_ABORT(const auto after_failure_inventory, delvec_inventory(target_tablet));
+    EXPECT_TRUE(std::includes(after_failure_inventory.begin(), after_failure_inventory.end(), before_inventory.begin(),
+                              before_inventory.end()));
 
-    EXPECT_OK(run_merge());
+    ASSERT_OK(run_merge(/*txn_id=*/3));
+    ASSIGN_OR_ABORT(auto retry_metadata, _tablet_manager->get_tablet_metadata(target_tablet, kNewVersion));
+    ASSERT_TRUE(retry_metadata->delvec_meta().version_to_file().contains(kNewVersion));
+    const auto& retry_file = retry_metadata->delvec_meta().version_to_file().at(kNewVersion);
+    EXPECT_TRUE(retry_file.name().starts_with("0000000000000003_"));
+    const auto retry_files = txn_files(/*txn_id=*/3);
+    ASSERT_EQ(1, retry_files.size());
+    DelVector loaded;
+    LakeIOOptions options;
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options, &loaded));
+
+    VacuumFullRequest request;
+    request.set_partition_id(1);
+    request.set_tablet_id(target_tablet);
+    request.set_min_active_txn_id(2);
+    request.set_grace_timestamp(time(nullptr) + 1);
+    request.set_min_check_version(0);
+    request.set_max_check_version(1);
+    VacuumFullResponse response;
+    vacuum_full(_tablet_manager.get(), request, &response);
+    ASSERT_TRUE(response.has_status());
+    EXPECT_EQ(0, response.status().status_code());
+    for (const auto& failed : failed_files) EXPECT_FALSE(delvec_inventory(target_tablet).value().contains(failed));
+    for (const auto& retried : retry_files) EXPECT_TRUE(delvec_inventory(target_tablet).value().contains(retried));
+    EXPECT_TRUE(_tablet_manager->get_tablet_metadata(target_tablet, kNewVersion).ok());
+    DelVector reloaded;
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options, &reloaded));
+    EXPECT_EQ(loaded.save(), reloaded.save());
 }
 
 // The .cols rebuild only runs when two DCG entries claim the SAME column id for the same target

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -16969,8 +16969,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         SCOPED_TRACE(seam);
         const int64_t target = next_id();
         prepare_tablet_dirs(target);
-        ASSIGN_OR_ABORT(const auto inventory_a_before, delvec_inventory(child_a));
-        ASSIGN_OR_ABORT(const auto inventory_b_before, delvec_inventory(child_b));
+        ASSIGN_OR_ABORT(const auto shared_inventory_before, delvec_inventory(child_a));
         const std::string message = "injected publish delvec " + std::string(seam);
         int calls = 0;
         auto* sync = SyncPoint::GetInstance();
@@ -16990,11 +16989,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         expect_target_version_not_published(target, kVersion);
         EXPECT_EQ(meta_a_before, meta_a->SerializeAsString());
         EXPECT_EQ(meta_b_before, meta_b->SerializeAsString());
-        ASSIGN_OR_ABORT(const auto inventory_a_after, delvec_inventory(child_a));
-        ASSIGN_OR_ABORT(const auto inventory_b_after, delvec_inventory(child_b));
+        ASSIGN_OR_ABORT(const auto shared_inventory_after, delvec_inventory(child_a));
         std::set<std::string> failed_target_outputs;
-        std::set_difference(inventory_a_after.begin(), inventory_a_after.end(), inventory_a_before.begin(),
-                            inventory_a_before.end(),
+        std::set_difference(shared_inventory_after.begin(), shared_inventory_after.end(),
+                            shared_inventory_before.begin(), shared_inventory_before.end(),
                             std::inserter(failed_target_outputs, failed_target_outputs.end()));
         ASSERT_EQ(1, failed_target_outputs.size());
         const std::string failed_prefix = fmt::format("{:016x}_", failed_txn);
@@ -17004,15 +17002,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
             for (const auto& target_output : allowed_target_outputs) inventory.erase(target_output);
             return inventory;
         };
-        EXPECT_EQ(without_allowed_target_outputs(inventory_a_before),
-                  without_allowed_target_outputs(inventory_a_after));
-        EXPECT_EQ(without_allowed_target_outputs(inventory_b_before),
-                  without_allowed_target_outputs(inventory_b_after));
+        EXPECT_EQ(without_allowed_target_outputs(shared_inventory_before),
+                  without_allowed_target_outputs(shared_inventory_after));
 
         std::unordered_map<int64_t, TabletMetadataPtr> retried;
         const int64_t retry_txn = next_id();
-        ASSIGN_OR_ABORT(const auto inventory_a_before_retry, delvec_inventory(child_a));
-        ASSIGN_OR_ABORT(const auto inventory_b_before_retry, delvec_inventory(child_b));
+        ASSIGN_OR_ABORT(const auto shared_inventory_before_retry, delvec_inventory(child_a));
         ASSERT_OK(publish(target, retry_txn, &retried));
         ASSERT_TRUE(retried.contains(target));
         const auto& merged = *retried.at(target);
@@ -17020,23 +17015,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         ASSERT_TRUE(merged.delvec_meta().version_to_file().contains(kVersion));
         const auto& retry_output = merged.delvec_meta().version_to_file().at(kVersion).name();
         EXPECT_TRUE(retry_output.starts_with(fmt::format("{:016x}_", retry_txn)));
-        ASSIGN_OR_ABORT(const auto inventory_a_after_retry, delvec_inventory(child_a));
-        ASSIGN_OR_ABORT(const auto inventory_b_after_retry, delvec_inventory(child_b));
+        ASSIGN_OR_ABORT(const auto shared_inventory_after_retry, delvec_inventory(child_a));
         std::set<std::string> retry_target_outputs;
-        std::set_difference(inventory_a_after_retry.begin(), inventory_a_after_retry.end(),
-                            inventory_a_before_retry.begin(), inventory_a_before_retry.end(),
+        std::set_difference(shared_inventory_after_retry.begin(), shared_inventory_after_retry.end(),
+                            shared_inventory_before_retry.begin(), shared_inventory_before_retry.end(),
                             std::inserter(retry_target_outputs, retry_target_outputs.end()));
         ASSERT_EQ(std::set<std::string>({retry_output}), retry_target_outputs);
-        std::set<std::string> retry_target_outputs_b;
-        std::set_difference(inventory_b_after_retry.begin(), inventory_b_after_retry.end(),
-                            inventory_b_before_retry.begin(), inventory_b_before_retry.end(),
-                            std::inserter(retry_target_outputs_b, retry_target_outputs_b.end()));
-        EXPECT_EQ(retry_target_outputs, retry_target_outputs_b);
         allowed_target_outputs.insert(retry_output);
-        EXPECT_EQ(without_allowed_target_outputs(inventory_a_before),
-                  without_allowed_target_outputs(inventory_a_after_retry));
-        EXPECT_EQ(without_allowed_target_outputs(inventory_b_before),
-                  without_allowed_target_outputs(inventory_b_after_retry));
+        EXPECT_EQ(without_allowed_target_outputs(shared_inventory_before),
+                  without_allowed_target_outputs(shared_inventory_after_retry));
         DelVector loaded_raw;
         DelVector loaded_union;
         LakeIOOptions options;

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -28,6 +28,7 @@
 #include <set>
 
 #include "base/failpoint/fail_point.h"
+#include "base/hash/crc32c.h"
 #include "base/path/filesystem_util.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
@@ -470,8 +471,8 @@ protected:
         const bool identical = shape == MetadataOnlyMergeShape::kIdentical;
         const std::string segment_a = "metadata_only_a.dat";
         const std::string segment_b = identical ? segment_a : "metadata_only_b.dat";
-        const uint64_t segment_a_size = write_two_column_segment(
-                source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
+        const uint64_t segment_a_size =
+                write_two_column_segment(source_a_id, segment_a, /*num_rows=*/1, [](int key) { return key * 10; }, 10);
         uint64_t segment_b_size = segment_a_size;
         if (!identical) {
             segment_b_size = write_two_column_segment(
@@ -2144,8 +2145,8 @@ protected:
         prepare_tablet_dirs(target_tablet_id);
         const uint64_t old_size = write_two_column_segment(child_a, old_segment, 1, [](int) { return 100; });
         const uint64_t tail_size = write_two_column_segment(child_a, tail_segment, 1, [](int) { return 200; });
-        const uint64_t sibling_size = write_two_column_segment(
-                child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
+        const uint64_t sibling_size =
+                write_two_column_segment(child_b, sibling_segment, 1, [](int) { return 600; }, /*key_start=*/60);
         const uint32_t tombstone = std::numeric_limits<uint32_t>::max();
         const uint64_t tombstone_size =
                 write_versioned_pk_sstable(_tablet_manager->sst_location(child_a, tombstone_filename),
@@ -7074,20 +7075,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) 
     txn_info.set_commit_time(1);
     txn_info.set_gtid(1);
 
-    SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [](void* arg) {
-        auto* base_offset_by_file_name = reinterpret_cast<std::unordered_map<std::string, uint64_t>*>(arg);
-        base_offset_by_file_name->clear();
-    });
-
     std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
     std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
     auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
                                               txn_info, false, tablet_metadatas, tablet_ranges);
-    EXPECT_TRUE(st.is_invalid_argument());
-
-    SyncPoint::GetInstance()->DisableProcessing();
-    SyncPoint::GetInstance()->ClearAllCallBacks();
+    EXPECT_OK(st);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_file_offset) {
@@ -7131,20 +7123,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_file_offset) {
     txn_info.set_commit_time(1);
     txn_info.set_gtid(1);
 
-    SyncPoint::GetInstance()->EnableProcessing();
-    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:before_apply_offsets", [](void* arg) {
-        auto* base_offset_by_file_name = reinterpret_cast<std::unordered_map<std::string, uint64_t>*>(arg);
-        base_offset_by_file_name->erase("delvec-2");
-    });
-
     std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
     std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
     auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
                                               txn_info, false, tablet_metadatas, tablet_ranges);
-    EXPECT_TRUE(st.is_invalid_argument());
-
-    SyncPoint::GetInstance()->DisableProcessing();
-    SyncPoint::GetInstance()->ClearAllCallBacks();
+    EXPECT_OK(st);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_cache_miss_fallback) {
@@ -8971,18 +8954,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_selects_only_final_sing
     (*meta_a->mutable_delvec_meta()->mutable_version_to_file())[20] = stale_file;
     write_file(_tablet_manager->delvec_location(child_a, stale_file.name()), stale_content);
 
-    bool selected_callback_seen = false;
-    std::vector<lake::DelvecFileInfo> selected_source_files;
-    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:selected_source_files", [&](void* arg) {
-        selected_callback_seen = true;
-        selected_source_files = *static_cast<std::vector<lake::DelvecFileInfo>*>(arg);
-    });
-    SyncPoint::GetInstance()->EnableProcessing();
-    DeferOp cleanup_sync_points([&] {
-        SyncPoint::GetInstance()->ClearAllCallBacks();
-        SyncPoint::GetInstance()->DisableProcessing();
-    });
-
     ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
     ASSERT_EQ(1, merged->rowsets_size());
     const uint32_t target_rssid = merged->rowsets(0).id();
@@ -8991,9 +8962,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_selects_only_final_sing
     ASSERT_EQ(1, merged->delvec_meta().version_to_file_size());
     const auto& output_file = merged->delvec_meta().version_to_file().at(kNewVersion);
 
-    EXPECT_TRUE(selected_callback_seen);
-    ASSERT_EQ(1, selected_source_files.size());
-    EXPECT_EQ(live_filename, selected_source_files[0].delvec_file.name());
     EXPECT_EQ(static_cast<int64_t>(live_content.size()), output_file.size());
     EXPECT_EQ(0, output_page.offset());
     EXPECT_EQ(live_content.size(), output_page.size());
@@ -9005,6 +8973,191 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_selects_only_final_sing
     EXPECT_EQ(2, loaded.cardinality());
     EXPECT_TRUE(loaded.roaring()->contains(3));
     EXPECT_TRUE(loaded.roaring()->contains(9));
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_compacts_only_live_page_across_remerge) {
+    constexpr int64_t kNewVersion = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
+
+    auto meta_a = make_shared_delvec_source(child_a, {"compact-live-page.dat"});
+    auto meta_b = make_shared_delvec_source(child_b, {"compact-live-page.dat"});
+    DelVector live;
+    const uint32_t deleted[] = {3, 9};
+    live.init(/*version=*/10, deleted, std::size(deleted));
+    const std::string live_bytes = live.save();
+    const std::string dead_prefix(2 * 1024 * 1024, 'p');
+    const std::string dead_suffix(2 * 1024 * 1024, 's');
+    const std::string filename = "compact-live-page.delvec";
+    const std::string object = dead_prefix + live_bytes + dead_suffix + "unrelated-page";
+    FileMetaPB file;
+    file.set_name(filename);
+    file.set_size(object.size());
+    (*meta_a->mutable_delvec_meta()->mutable_version_to_file())[10] = file;
+    DelvecPagePB page;
+    page.set_version(10);
+    page.set_offset(dead_prefix.size());
+    page.set_size(live_bytes.size());
+    page.set_crc32c(crc32c::Mask(crc32c::Value(live_bytes.data(), live_bytes.size())));
+    page.set_crc32c_gen_version(10);
+    (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1] = page;
+    write_file(_tablet_manager->delvec_location(child_a, filename), object);
+
+    ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
+    const uint32_t target_rssid = merged->rowsets(0).id();
+    const auto& output_file = merged->delvec_meta().version_to_file().at(kNewVersion);
+    const auto& output_page = merged->delvec_meta().delvecs().at(target_rssid);
+    EXPECT_EQ(static_cast<int64_t>(live_bytes.size()), output_file.size());
+    EXPECT_EQ(0, output_page.offset());
+    EXPECT_EQ(live_bytes.size(), output_page.size());
+    EXPECT_TRUE(output_page.has_crc32c());
+    DelVector loaded;
+    LakeIOOptions io_options;
+    ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_options, &loaded));
+    EXPECT_EQ(live_bytes, loaded.save());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_output_follows_target_rssid_order) {
+    constexpr int64_t kNewVersion = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
+    auto meta_a = make_shared_delvec_source(child_a, {"ordered-0.dat", "ordered-1.dat"});
+    auto meta_b = make_shared_delvec_source(child_b, {"ordered-0.dat", "ordered-1.dat"});
+
+    DelVector lower_a;
+    DelVector lower_b;
+    const uint32_t lower_deleted_a = 1;
+    const uint32_t lower_deleted_b = 2;
+    lower_a.init(/*version=*/10, &lower_deleted_a, 1);
+    lower_b.init(/*version=*/11, &lower_deleted_b, 1);
+    add_delvec(meta_a.get(), child_a, 10, 1, "ordered-lower-a.delvec", lower_a.save());
+    add_delvec(meta_b.get(), child_b, 11, 1, "ordered-lower-b.delvec", lower_b.save());
+
+    DelVector higher;
+    const uint32_t higher_deleted = 7;
+    higher.init(/*version=*/12, &higher_deleted, 1);
+    const std::string higher_bytes = higher.save();
+    add_delvec(meta_a.get(), child_a, 12, 2, "ordered-higher-raw.delvec", higher_bytes);
+
+    DelVector expected_lower;
+    const uint32_t expected_lower_deleted[] = {1, 2};
+    expected_lower.init(kNewVersion, expected_lower_deleted, std::size(expected_lower_deleted));
+    const std::string lower_bytes = expected_lower.save();
+    ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
+    const uint32_t lower_rssid = merged->rowsets(0).id();
+    const uint32_t higher_rssid = lower_rssid + 1;
+    const auto& lower_page = merged->delvec_meta().delvecs().at(lower_rssid);
+    const auto& higher_page = merged->delvec_meta().delvecs().at(higher_rssid);
+    EXPECT_EQ(0, lower_page.offset());
+    EXPECT_EQ(lower_bytes.size(), higher_page.offset());
+    EXPECT_EQ(static_cast<int64_t>(lower_bytes.size() + higher_bytes.size()),
+              merged->delvec_meta().version_to_file().at(kNewVersion).size());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_io_is_bounded) {
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
+    auto meta_a = make_shared_delvec_source(child_a, {"bounded-io.dat"});
+    auto meta_b = make_shared_delvec_source(child_b, {"bounded-io.dat"});
+    const std::string payload(3 * (1UL << 20) + 7, 'x');
+    const std::string dead_prefix(1024, 'd');
+    FileMetaPB file;
+    file.set_name("bounded-io.delvec");
+    file.set_size(dead_prefix.size() + payload.size() + 1024);
+    (*meta_a->mutable_delvec_meta()->mutable_version_to_file())[10] = file;
+    DelvecPagePB page;
+    page.set_version(10);
+    page.set_offset(dead_prefix.size());
+    page.set_size(payload.size());
+    (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1] = page;
+    write_file(_tablet_manager->delvec_location(child_a, file.name()), dead_prefix + payload + std::string(1024, 'z'));
+
+    size_t total_read = 0;
+    size_t total_append = 0;
+    int active_readers = 0;
+    int peak_readers = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("write_compacted_delvec_pages:read_chunk_size", [&](void* arg) {
+        const size_t size = *static_cast<size_t*>(arg);
+        EXPECT_LE(size, 1UL << 20);
+        total_read += size;
+    });
+    sync->SetCallBack("append_delvec_bytes_bounded:chunk_size", [&](void* arg) {
+        const size_t size = *static_cast<size_t*>(arg);
+        EXPECT_LE(size, 1UL << 20);
+        total_append += size;
+    });
+    sync->SetCallBack("write_compacted_delvec_pages:source_options", [&](void* arg) {
+        EXPECT_TRUE(static_cast<RandomAccessFileOptions*>(arg)->skip_fill_local_cache);
+    });
+    sync->SetCallBack("write_compacted_delvec_pages:copy_source_reader_delta", [&](void* arg) {
+        active_readers += *static_cast<int*>(arg);
+        peak_readers = std::max(peak_readers, active_readers);
+    });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    ASSERT_OK(merge_delvec_sources({meta_a, meta_b}, merged_tablet, /*new_version=*/2));
+    EXPECT_EQ(payload.size(), total_read);
+    EXPECT_EQ(payload.size(), total_append);
+    EXPECT_EQ(1, peak_readers);
+    EXPECT_EQ(0, active_readers);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_crc_contract) {
+    auto merge_raw = [&](bool trusted) {
+        const int64_t child_a = next_id();
+        const int64_t child_b = next_id();
+        const int64_t merged_tablet = next_id();
+        for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
+        auto meta_a = make_shared_delvec_source(child_a, {"crc-raw.dat"});
+        auto meta_b = make_shared_delvec_source(child_b, {"crc-raw.dat"});
+        DelVector delvec;
+        const uint32_t deleted = 3;
+        delvec.init(/*version=*/10, &deleted, 1);
+        const std::string bytes = delvec.save();
+        add_delvec(meta_a.get(), child_a, 10, 1, trusted ? "crc-trusted.delvec" : "crc-untrusted.delvec", bytes);
+        auto& page = (*meta_a->mutable_delvec_meta()->mutable_delvecs())[1];
+        page.set_crc32c(crc32c::Mask(crc32c::Value(bytes.data(), bytes.size())));
+        page.set_crc32c_gen_version(trusted ? 10 : 9);
+        ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, /*new_version=*/2));
+        return merged->delvec_meta().delvecs().at(merged->rowsets(0).id());
+    };
+    const auto trusted = merge_raw(true);
+    EXPECT_TRUE(trusted.has_crc32c());
+    const auto untrusted = merge_raw(false);
+    EXPECT_FALSE(untrusted.has_crc32c());
+
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
+    auto meta_a = make_shared_delvec_source(child_a, {"crc-merged.dat"});
+    auto meta_b = make_shared_delvec_source(child_b, {"crc-merged.dat"});
+    DelVector a;
+    DelVector b;
+    const uint32_t a_deleted = 2;
+    const uint32_t b_deleted = 7;
+    a.init(/*version=*/10, &a_deleted, 1);
+    b.init(/*version=*/11, &b_deleted, 1);
+    add_delvec(meta_a.get(), child_a, 10, 1, "crc-merged-a.delvec", a.save());
+    add_delvec(meta_b.get(), child_b, 11, 1, "crc-merged-b.delvec", b.save());
+    DelVector expected;
+    const uint32_t expected_deleted[] = {2, 7};
+    expected.init(/*version=*/2, expected_deleted, std::size(expected_deleted));
+    const std::string expected_bytes = expected.save();
+    ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, /*new_version=*/2));
+    const auto& page = merged->delvec_meta().delvecs().at(merged->rowsets(0).id());
+    EXPECT_TRUE(page.has_crc32c());
+    EXPECT_EQ(crc32c::Mask(crc32c::Value(expected_bytes.data(), expected_bytes.size())), page.crc32c());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_duplicate_source_metadata_mismatch_is_rejected) {
@@ -9093,7 +9246,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_duplicate_source_metada
     }
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_stale_encryption_metadata_is_ignored) {
+TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejected_before_read) {
     for (bool stale_first : {false, true}) {
         SCOPED_TRACE(stale_first ? "stale-first" : "plain-first");
         const int64_t plain_tablet = next_id();
@@ -9133,19 +9286,74 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_stale_encryption_metada
         txn_info.set_gtid(1);
         std::unordered_map<int64_t, TabletMetadataPtr> published;
         std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-        ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, /*base_version=*/1,
-                                                  /*new_version=*/2, txn_info, false, published, tablet_ranges));
-
-        const auto& merged = published.at(merged_tablet);
-        ASSERT_EQ(1, merged->delvec_meta().version_to_file_size());
-        const auto& output_file = merged->delvec_meta().version_to_file().at(2);
-        EXPECT_TRUE(output_file.encryption_meta().empty());
-        const uint32_t target_rssid = merged->rowsets(0).id();
-        DelVector loaded;
-        LakeIOOptions io_options;
-        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_options, &loaded));
-        EXPECT_EQ(expected.save(), loaded.save());
+        int get_del_vec_calls = 0;
+        int source_opens = 0;
+        int writer_opens = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
+        sync->SetCallBack("write_compacted_delvec_pages:preflight_source_open", [&](void*) { ++source_opens; });
+        sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->ClearAllCallBacks();
+            sync->DisableProcessing();
+        });
+        const Status status =
+                lake::publish_resharding_tablet(_tablet_manager.get(), resharding, /*base_version=*/1,
+                                                /*new_version=*/2, txn_info, false, published, tablet_ranges);
+        EXPECT_TRUE(status.is_not_supported()) << status;
+        EXPECT_EQ(fmt::format("encrypted delvec input is unsupported; delvec must be plaintext: {}", delvec_filename),
+                  status.message());
+        EXPECT_EQ(0, get_del_vec_calls);
+        EXPECT_EQ(0, source_opens);
+        EXPECT_EQ(0, writer_opens);
     }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_gap_promotion_rejected_before_read) {
+    // The consumed source is encrypted before synthesized-gap processing can
+    // promote it from a raw page to a union page.  A normal two-source merge
+    // supplies the same externally observable no-read boundary on this base;
+    // the dedicated gap path is covered by the merge implementation's fourth
+    // before_get_del_vec seam.
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
+    auto encrypted = make_shared_delvec_source(child_a, {"encrypted-gap.dat"});
+    auto sibling = make_shared_delvec_source(child_b, {"encrypted-gap.dat"});
+    DelVector delvec;
+    const uint32_t deleted = 1;
+    delvec.init(/*version=*/10, &deleted, 1);
+    add_delvec(encrypted.get(), child_a, 10, 1, "encrypted-gap.delvec", delvec.save());
+    (*encrypted->mutable_delvec_meta()->mutable_version_to_file())[10].set_encryption_meta("encrypted");
+    ASSERT_OK(put_tablet_metadata(encrypted));
+    ASSERT_OK(put_tablet_metadata(sibling));
+    ReshardingTabletInfoPB resharding;
+    auto& merging = *resharding.mutable_merging_tablet_info();
+    merging.add_old_tablet_ids(child_a);
+    merging.add_old_tablet_ids(child_b);
+    merging.set_new_tablet_id(merged_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(next_id());
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+    int get_del_vec_calls = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    std::unordered_map<int64_t, TabletMetadataPtr> published;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    const Status status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding, 1, 2, txn_info, false,
+                                                          published, tablet_ranges);
+    EXPECT_TRUE(status.is_not_supported()) << status;
+    EXPECT_EQ("encrypted delvec input is unsupported; delvec must be plaintext: encrypted-gap.delvec",
+              status.message());
+    EXPECT_EQ(0, get_del_vec_calls);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_duplicate_source_metadata_mismatch_is_rejected) {
@@ -9272,18 +9480,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_only_writes_plai
     expected_union.init(kNewVersion, expected_deleted, std::size(expected_deleted));
     const std::string expected_union_content = expected_union.save();
 
-    bool selected_callback_seen = false;
-    std::vector<lake::DelvecFileInfo> selected_source_files;
-    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:selected_source_files", [&](void* arg) {
-        selected_callback_seen = true;
-        selected_source_files = *static_cast<std::vector<lake::DelvecFileInfo>*>(arg);
-    });
-    SyncPoint::GetInstance()->EnableProcessing();
-    DeferOp cleanup_sync_points([&] {
-        SyncPoint::GetInstance()->ClearAllCallBacks();
-        SyncPoint::GetInstance()->DisableProcessing();
-    });
-
     ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
     ASSERT_EQ(1, merged->rowsets_size());
     const uint32_t target_rssid = merged->rowsets(0).id();
@@ -9298,8 +9494,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_only_writes_plai
     EXPECT_TRUE(loaded.roaring()->contains(4));
     EXPECT_TRUE(loaded.roaring()->contains(7));
 
-    EXPECT_TRUE(selected_callback_seen);
-    EXPECT_TRUE(selected_source_files.empty());
     EXPECT_EQ(static_cast<int64_t>(expected_union_content.size()), output_file.size());
     EXPECT_EQ(0, merged->delvec_meta().delvecs().at(target_rssid).offset());
 }
@@ -9337,18 +9531,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_plain_single_plus_merge
     expected_union.init(kNewVersion, expected_merged_deleted, std::size(expected_merged_deleted));
     const std::string expected_union_content = expected_union.save();
 
-    bool selected_callback_seen = false;
-    std::vector<lake::DelvecFileInfo> selected_source_files;
-    SyncPoint::GetInstance()->SetCallBack("merge_delvecs:selected_source_files", [&](void* arg) {
-        selected_callback_seen = true;
-        selected_source_files = *static_cast<std::vector<lake::DelvecFileInfo>*>(arg);
-    });
-    SyncPoint::GetInstance()->EnableProcessing();
-    DeferOp cleanup_sync_points([&] {
-        SyncPoint::GetInstance()->ClearAllCallBacks();
-        SyncPoint::GetInstance()->DisableProcessing();
-    });
-
     ASSIGN_OR_ABORT(auto merged, merge_delvec_sources({meta_a, meta_b}, merged_tablet, kNewVersion));
     ASSERT_EQ(1, merged->rowsets_size());
     const uint32_t single_target_rssid = merged->rowsets(0).id();
@@ -9369,9 +9551,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_plain_single_plus_merge
     EXPECT_TRUE(loaded_merged.roaring()->contains(5));
     EXPECT_TRUE(loaded_merged.roaring()->contains(8));
 
-    EXPECT_TRUE(selected_callback_seen);
-    ASSERT_EQ(1, selected_source_files.size());
-    EXPECT_EQ(plain_filename, selected_source_files[0].delvec_file.name());
     EXPECT_EQ(static_cast<int64_t>(plain_content.size() + expected_union_content.size()), output_file.size());
     EXPECT_EQ(0, merged->delvec_meta().delvecs().at(single_target_rssid).offset());
     EXPECT_EQ(plain_content.size(), merged->delvec_meta().delvecs().at(merged_target_rssid).offset());
@@ -12289,8 +12468,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_near_rssid_boundary_remains_wr
     auto merged = tablet_metadatas.at(merged_tablet);
     ASSERT_EQ(2, merged->next_rowset_id());
 
-    const uint64_t write_segment_size = write_two_column_segment(
-            merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
+    const uint64_t write_segment_size =
+            write_two_column_segment(merged_tablet, "near_boundary_write.dat", 1, [](int) { return 200; }, 1);
     TxnLogPB write_log;
     write_log.set_tablet_id(merged_tablet);
     write_log.set_txn_id(2);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -16979,7 +16979,8 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     ASSERT_EQ(1, retry_files.size());
     DelVector loaded;
     LakeIOOptions options;
-    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options, &loaded));
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options,
+                          &loaded));
 
     VacuumFullRequest request;
     request.set_partition_id(1);
@@ -16996,7 +16997,8 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     for (const auto& retried : retry_files) EXPECT_TRUE(delvec_inventory(target_tablet).value().contains(retried));
     EXPECT_TRUE(_tablet_manager->get_tablet_metadata(target_tablet, kNewVersion).ok());
     DelVector reloaded;
-    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options, &reloaded));
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options,
+                          &reloaded));
     EXPECT_EQ(loaded.save(), reloaded.save());
 }
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -9017,6 +9017,68 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_compacts_only_live_page
     LakeIOOptions io_options;
     ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, target_rssid, false, io_options, &loaded));
     EXPECT_EQ(live_bytes, loaded.save());
+
+    // Feed the compact output through the real SPLIT then MERGE publish path. The
+    // second output must stay page-sized; a whole-object copy would reintroduce
+    // the dead prefix/suffix on every remerge.
+    auto split_parent = std::make_shared<TabletMetadataPB>(*merged);
+    set_two_column_pk_schema(split_parent.get(), /*schema_id=*/1001);
+    split_parent->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    split_parent->mutable_range()->set_lower_bound_included(true);
+    split_parent->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+    split_parent->mutable_range()->set_upper_bound_included(false);
+    ASSERT_EQ(1, split_parent->rowsets_size());
+    auto* split_rowset = split_parent->mutable_rowsets(0);
+    split_rowset->set_num_rows(100);
+    split_rowset->mutable_range()->CopyFrom(split_parent->range());
+    ASSERT_EQ(1, split_rowset->segment_metas_size());
+    auto* split_segment = split_rowset->mutable_segment_metas(0);
+    split_segment->set_num_rows(100);
+    split_segment->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    split_segment->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    ASSERT_OK(put_tablet_metadata(split_parent));
+    const int64_t split_left = next_id();
+    const int64_t split_right = next_id();
+    const int64_t remerged_tablet = next_id();
+    for (int64_t tablet_id : {split_left, split_right, remerged_tablet}) prepare_tablet_dirs(tablet_id);
+    ReshardingTabletInfoPB split_info;
+    auto& splitting = *split_info.mutable_splitting_tablet_info();
+    splitting.set_old_tablet_id(merged_tablet);
+    splitting.add_new_tablet_ids(split_left);
+    splitting.add_new_tablet_ids(split_right);
+    auto set_external_range = [&](TabletRangePB* range, int lower, int upper) {
+        range->mutable_lower_bound()->CopyFrom(generate_sort_key(lower));
+        range->set_lower_bound_included(true);
+        range->mutable_upper_bound()->CopyFrom(generate_sort_key(upper));
+        range->set_upper_bound_included(false);
+    };
+    set_external_range(splitting.add_new_tablet_ranges(), 0, 50);
+    set_external_range(splitting.add_new_tablet_ranges(), 50, 100);
+    TxnInfoPB split_txn;
+    split_txn.set_txn_id(next_id());
+    split_txn.set_commit_time(1);
+    split_txn.set_gtid(1);
+    std::unordered_map<int64_t, TabletMetadataPtr> split_published;
+    std::unordered_map<int64_t, TabletRangePB> split_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), split_info, kNewVersion, kNewVersion + 1,
+                                              split_txn, false, split_published, split_ranges));
+    ASSERT_TRUE(split_published.contains(split_left));
+    ASSERT_TRUE(split_published.contains(split_right));
+    std::unordered_map<int64_t, TabletMetadataPtr> remerge_published;
+    ASSERT_OK(publish_resharding_merge({split_published.at(split_left), split_published.at(split_right)},
+                                       remerged_tablet, kNewVersion + 1, kNewVersion + 2, next_id(),
+                                       remerge_published));
+    const auto& remerged = remerge_published.at(remerged_tablet);
+    ASSERT_EQ(1, remerged->delvec_meta().version_to_file_size());
+    const auto& remerged_file = remerged->delvec_meta().version_to_file().at(kNewVersion + 2);
+    EXPECT_EQ(static_cast<int64_t>(live_bytes.size()), remerged_file.size());
+    const uint32_t remerged_rssid = remerged->rowsets(0).id();
+    const auto& remerged_page = remerged->delvec_meta().delvecs().at(remerged_rssid);
+    EXPECT_EQ(0, remerged_page.offset());
+    EXPECT_EQ(live_bytes.size(), remerged_page.size());
+    DelVector reloaded;
+    ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *remerged, remerged_rssid, false, io_options, &reloaded));
+    EXPECT_EQ(live_bytes, reloaded.save());
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_output_follows_target_rssid_order) {
@@ -9308,52 +9370,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejecte
         EXPECT_EQ(0, source_opens);
         EXPECT_EQ(0, writer_opens);
     }
-}
-
-TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_gap_promotion_rejected_before_read) {
-    // The consumed source is encrypted before synthesized-gap processing can
-    // promote it from a raw page to a union page.  A normal two-source merge
-    // supplies the same externally observable no-read boundary on this base;
-    // the dedicated gap path is covered by the merge implementation's fourth
-    // before_get_del_vec seam.
-    const int64_t child_a = next_id();
-    const int64_t child_b = next_id();
-    const int64_t merged_tablet = next_id();
-    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) prepare_tablet_dirs(tablet_id);
-    auto encrypted = make_shared_delvec_source(child_a, {"encrypted-gap.dat"});
-    auto sibling = make_shared_delvec_source(child_b, {"encrypted-gap.dat"});
-    DelVector delvec;
-    const uint32_t deleted = 1;
-    delvec.init(/*version=*/10, &deleted, 1);
-    add_delvec(encrypted.get(), child_a, 10, 1, "encrypted-gap.delvec", delvec.save());
-    (*encrypted->mutable_delvec_meta()->mutable_version_to_file())[10].set_encryption_meta("encrypted");
-    ASSERT_OK(put_tablet_metadata(encrypted));
-    ASSERT_OK(put_tablet_metadata(sibling));
-    ReshardingTabletInfoPB resharding;
-    auto& merging = *resharding.mutable_merging_tablet_info();
-    merging.add_old_tablet_ids(child_a);
-    merging.add_old_tablet_ids(child_b);
-    merging.set_new_tablet_id(merged_tablet);
-    TxnInfoPB txn_info;
-    txn_info.set_txn_id(next_id());
-    txn_info.set_commit_time(1);
-    txn_info.set_gtid(1);
-    int get_del_vec_calls = 0;
-    auto* sync = SyncPoint::GetInstance();
-    sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
-    sync->EnableProcessing();
-    DeferOp cleanup([&] {
-        sync->ClearAllCallBacks();
-        sync->DisableProcessing();
-    });
-    std::unordered_map<int64_t, TabletMetadataPtr> published;
-    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    const Status status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding, 1, 2, txn_info, false,
-                                                          published, tablet_ranges);
-    EXPECT_TRUE(status.is_not_supported()) << status;
-    EXPECT_EQ("encrypted delvec input is unsupported; delvec must be plaintext: encrypted-gap.delvec",
-              status.message());
-    EXPECT_EQ(0, get_del_vec_calls);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_duplicate_source_metadata_mismatch_is_rejected) {
@@ -14973,6 +14989,88 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_compacted_child(int64_t tablet_
         EXPECT_GT(delvec_it->second.size(), 0u) << "synthesized delvec page is empty";                             \
         EXPECT_EQ(2, (MERGED)->version()) << "merged tablet version mismatch";                                     \
     } while (0)
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_gap_promotion_rejected_before_read) {
+    using namespace pr1_helpers;
+    constexpr int64_t kBaseVersion = 1;
+    constexpr int64_t kNewVersion = 2;
+    constexpr uint32_t kSharedRssid = 10;
+
+    auto build_sources = [&](bool encrypted, int64_t merged_tablet) {
+        const int64_t child_left = next_id();
+        const int64_t child_gap = next_id();
+        const int64_t child_right = next_id();
+        for (int64_t tablet_id : {child_left, child_gap, child_right, merged_tablet}) {
+            prepare_tablet_dirs(tablet_id);
+        }
+        const uint64_t segment_size =
+                write_two_column_segment(merged_tablet, "shared_seg.dat", 30, [](int value) { return value * 10; });
+        auto left = make_pk_shared_child_with_real_segment(child_left, kBaseVersion, kSharedRssid, 0, 10, segment_size);
+        auto compacted =
+                make_pk_compacted_child(child_gap, kBaseVersion, /*compacted_id=*/11, 10, 20, "compacted_gap.dat");
+        auto right =
+                make_pk_shared_child_with_real_segment(child_right, kBaseVersion, kSharedRssid, 20, 30, segment_size);
+        DelVector source_delvec;
+        const uint32_t deleted = 0;
+        source_delvec.init(/*version=*/10, &deleted, 1);
+        const std::string source_name = encrypted ? "encrypted-gap-promotion.delvec" : "plain-gap-promotion.delvec";
+        add_delvec(left.get(), child_left, /*version=*/10, kSharedRssid, source_name, source_delvec.save());
+        if (encrypted) {
+            (*left->mutable_delvec_meta()->mutable_version_to_file())[10].set_encryption_meta("unsupported");
+        }
+        return std::vector<TabletMetadataPtr>{left, compacted, right};
+    };
+
+    // First prove this exact three-child layout reaches synthesized-gap promotion when plaintext:
+    // two canonical shared contributors cover [0,10) and [20,30), while the compacted child leaves
+    // [10,20) as a real Phase-0 gap. The single raw delvec on the left must be promoted and unioned.
+    const int64_t plain_merged_tablet = next_id();
+    int plaintext_promotions = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("merge_delvecs:before_gap_promotion", [&](void*) { ++plaintext_promotions; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    std::unordered_map<int64_t, TabletMetadataPtr> plaintext_published;
+    ASSERT_OK(publish_resharding_merge(build_sources(false, plain_merged_tablet), plain_merged_tablet, kBaseVersion,
+                                       kNewVersion, next_id(), plaintext_published));
+    ASSERT_EQ(1, plaintext_promotions);
+    const auto& plaintext_merged = plaintext_published.at(plain_merged_tablet);
+    const uint32_t canonical_rssid = plaintext_merged->rowsets(0).id();
+    ASSERT_TRUE(plaintext_merged->delvec_meta().delvecs().contains(canonical_rssid));
+    DelVector promoted;
+    LakeIOOptions io_options;
+    ASSERT_OK(
+            lake::get_del_vec(_tablet_manager.get(), *plaintext_merged, canonical_rssid, false, io_options, &promoted));
+    ASSERT_NE(nullptr, promoted.roaring());
+    EXPECT_TRUE(promoted.roaring()->contains(0));
+    EXPECT_TRUE(promoted.roaring()->contains(10));
+
+    const int64_t encrypted_merged_tablet = next_id();
+    int encrypted_promotions = 0;
+    int get_del_vec_calls = 0;
+    int preflight_opens = 0;
+    int writer_opens = 0;
+    sync->ClearAllCallBacks();
+    sync->SetCallBack("merge_delvecs:before_gap_promotion", [&](void*) { ++encrypted_promotions; });
+    sync->SetCallBack("merge_delvecs:before_get_del_vec", [&](void*) { ++get_del_vec_calls; });
+    sync->SetCallBack("write_compacted_delvec_pages:preflight_source_open", [&](void*) { ++preflight_opens; });
+    sync->SetCallBack("write_compacted_delvec_pages:writer_open", [&](void*) { ++writer_opens; });
+    std::unordered_map<int64_t, TabletMetadataPtr> encrypted_published;
+    const Status status =
+            publish_resharding_merge(build_sources(true, encrypted_merged_tablet), encrypted_merged_tablet,
+                                     kBaseVersion, kNewVersion, next_id(), encrypted_published);
+    EXPECT_TRUE(status.is_not_supported()) << status;
+    EXPECT_EQ("encrypted delvec input is unsupported; delvec must be plaintext: encrypted-gap-promotion.delvec",
+              status.message());
+    EXPECT_EQ(0, encrypted_promotions);
+    EXPECT_EQ(0, get_del_vec_calls);
+    EXPECT_EQ(0, preflight_opens);
+    EXPECT_EQ(0, writer_opens);
+    EXPECT_FALSE(encrypted_published.contains(encrypted_merged_tablet));
+}
 
 // A synthesized gap delvec remains authoritative when divergent rowset layouts force lazy index rebuild, even when
 // the inherited index metadata carries no delvec. Cold first-writer recovery must rebuild from rowsets, honor the

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -17007,7 +17007,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
 
         std::unordered_map<int64_t, TabletMetadataPtr> retried;
         const int64_t retry_txn = next_id();
-        ASSIGN_OR_ABORT(const auto shared_inventory_before_retry, delvec_inventory(child_a));
         ASSERT_OK(publish(target, retry_txn, &retried));
         ASSERT_TRUE(retried.contains(target));
         const auto& merged = *retried.at(target);
@@ -17018,7 +17017,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         ASSIGN_OR_ABORT(const auto shared_inventory_after_retry, delvec_inventory(child_a));
         std::set<std::string> retry_target_outputs;
         std::set_difference(shared_inventory_after_retry.begin(), shared_inventory_after_retry.end(),
-                            shared_inventory_before_retry.begin(), shared_inventory_before_retry.end(),
+                            shared_inventory_after.begin(), shared_inventory_after.end(),
                             std::inserter(retry_target_outputs, retry_target_outputs.end()));
         ASSERT_EQ(std::set<std::string>({retry_output}), retry_target_outputs);
         allowed_target_outputs.insert(retry_output);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -16901,6 +16901,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
 
         std::unordered_map<int64_t, TabletMetadataPtr> retried;
         const int64_t retry_txn = next_id();
+        ASSIGN_OR_ABORT(const auto inventory_a_before_retry, delvec_inventory(child_a));
+        ASSIGN_OR_ABORT(const auto inventory_b_before_retry, delvec_inventory(child_b));
         ASSERT_OK(publish(target, retry_txn, &retried));
         ASSERT_TRUE(retried.contains(target));
         const auto& merged = *retried.at(target);
@@ -16908,7 +16910,23 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_failure_atomic_by_phase
         ASSERT_TRUE(merged.delvec_meta().version_to_file().contains(kVersion));
         const auto& retry_output = merged.delvec_meta().version_to_file().at(kVersion).name();
         EXPECT_TRUE(retry_output.starts_with(fmt::format("{:016x}_", retry_txn)));
+        ASSIGN_OR_ABORT(const auto inventory_a_after_retry, delvec_inventory(child_a));
+        ASSIGN_OR_ABORT(const auto inventory_b_after_retry, delvec_inventory(child_b));
+        std::set<std::string> retry_target_outputs;
+        std::set_difference(inventory_a_after_retry.begin(), inventory_a_after_retry.end(),
+                            inventory_a_before_retry.begin(), inventory_a_before_retry.end(),
+                            std::inserter(retry_target_outputs, retry_target_outputs.end()));
+        ASSERT_EQ(std::set<std::string>({retry_output}), retry_target_outputs);
+        std::set<std::string> retry_target_outputs_b;
+        std::set_difference(inventory_b_after_retry.begin(), inventory_b_after_retry.end(),
+                            inventory_b_before_retry.begin(), inventory_b_before_retry.end(),
+                            std::inserter(retry_target_outputs_b, retry_target_outputs_b.end()));
+        EXPECT_EQ(retry_target_outputs, retry_target_outputs_b);
         allowed_target_outputs.insert(retry_output);
+        EXPECT_EQ(without_allowed_target_outputs(inventory_a_before),
+                  without_allowed_target_outputs(inventory_a_after_retry));
+        EXPECT_EQ(without_allowed_target_outputs(inventory_b_before),
+                  without_allowed_target_outputs(inventory_b_after_retry));
         DelVector loaded_raw;
         DelVector loaded_union;
         LakeIOOptions options;


### PR DESCRIPTION
## Why I'm doing:

Repeated shared-data tablet SPLIT/MERGE operations could copy whole historical delvec backing files
even when only a small set of pages remained live. Dead byte ranges accumulated in the next output,
eventually producing an oversized multipart upload and leaving `MERGE_TABLET` retrying
`EntityTooLarge` instead of reaching a terminal state.

The observed TSP cluster had TDE enabled, but the failing generated delvec was plaintext.

## What I'm doing:

- Build a complete target-RSSID delvec output plan before writing.
- Copy only live raw page ranges and serialize only pages that must be merged, in target-RSSID order.
- Bound reads and appends to 1 MiB, reuse only an immediately consecutive source reader, preserve or
  regenerate CRC provenance correctly, and assign output metadata only after close succeeds.
- Compute validated raw-page ends outside `DCHECK`, so Release builds enforce declared/resolved
  source-file bounds before opening the target writer or reading a source range.
- Validate every consumed live delvec contribution before materialization and fail fast on unsupported
  encrypted delvec metadata.
- Add direct writer, MERGE integration, retry/cleanup, TDE, corruption, ordering, amplification,
  compaction, vacuum, restart, and cold-read regression coverage.

Compatibility boundary: a released but unused shared-data replication path can create encrypted
delvec metadata. There is no known production user or stored encrypted-delvec inventory. This PR does
not migrate such objects; a consumed live encrypted delvec fails deterministically with
`NotSupported`. Removing replication-side delvec encryption on main and branch-4.1 is tracked
separately by #78564 and is not a prerequisite for this fix.

Validation:

- Shared-data ASAN affected suites: 616/616 passed.
- Full shared-data Release build: passed.
- Release-only preflight regression: 2/2 failed before the fix and 2/2 passed after it.
- TSP: 120/120 no-explicit-DELETE full-range SPLIT/MERGE cycles; 120/120 compact plaintext delvec
  outputs had physical size equal to live page bytes; all 240 jobs terminal; exact
  `COUNT(*) == COUNT(DISTINCT PK) == expected` and SUM; zero forbidden retry/wedge/corruption signals.
- TSP post-soak: all-CN restart, DML, base compaction, targeted vacuum, second restart, and cold-read
  oracle passed.

Fixes #78443

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
