### PR TITLE
[BugFix] Keep the inner cast when reducing a lossy float to integral cast (backport #78238)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRule.java
@@ -52,6 +52,10 @@ import java.util.Optional;
 //   a(String)
 //
 public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
+    // IEEE-754 significand widths: binary32 is exact up to 2^24, binary64 up to 2^53
+    private static final int FLOAT_MANTISSA_BITS = 24;
+    private static final int DOUBLE_MANTISSA_BITS = 53;
+
     @Override
     public ScalarOperator visitCastOperator(CastOperator operator, ScalarOperatorRewriteContext context) {
         if (SPMFunctions.isSPMFunctions(operator.getChild(0))) {
@@ -157,6 +161,11 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
             return false;
         }
 
+        // the size check below misses this: getTypeSize() reports 8 bytes for FLOAT, DOUBLE and BIGINT
+        if (isValueChangingCast(grandChild, child)) {
+            return false;
+        }
+
         // cascaded cast cannot be reduced if middle type's size is smaller than two sides
         // e.g. cast(cast(smallint as tinyint) as int)
         if (parentSlotSize > childSlotSize && childSlotSize < grandChildSlotSize) {
@@ -166,6 +175,32 @@ public class ReduceCastRule extends TopDownScalarOperatorRewriteRule {
         Type childCompatibleType = Type.getAssignmentCompatibleType(grandChild, child, true);
         Type parentCompatibleType = Type.getAssignmentCompatibleType(child, parent, true);
         return childCompatibleType != Type.INVALID && parentCompatibleType != Type.INVALID;
+    }
+
+    // float -> integral truncates; integral -> float and double -> float round.
+    // e.g. cast(cast(100 / 3 as bigint) as varchar) must stay '33', not '33.333333333333336'
+    private static boolean isValueChangingCast(Type from, Type to) {
+        if (from.isFloatingPointType()) {
+            return !to.isFloatingPointType() || mantissaBits(from) > mantissaBits(to);
+        }
+        if (to.isFloatingPointType()) {
+            return exactValueBits(from) > mantissaBits(to);
+        }
+        return false;
+    }
+
+    private static int mantissaBits(Type type) {
+        return type.isFloat() ? FLOAT_MANTISSA_BITS : DOUBLE_MANTISSA_BITS;
+    }
+
+    // value bits from the stored width, minus the sign bit: BIGINT is 8 bytes, so 63
+    private static int exactValueBits(Type type) {
+        int slotSize = type.getPrimitiveType().getSlotSize();
+        if (slotSize <= 0) {
+            // no width to compare, assume lossy
+            return Integer.MAX_VALUE;
+        }
+        return (slotSize << 3) - 1;
     }
 
     private ScalarOperator inheritVarcharLengthAfterReduceCast(CastOperator operator) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rewrite.scalar;
 
+import com.google.common.collect.Lists;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
@@ -26,6 +27,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -94,6 +96,151 @@ public class ReduceCastRuleTest {
         assertTrue(child instanceof CastOperator);
         ScalarOperator grandChild = child.getChild(0);
         assertEquals(OperatorType.CONSTANT, grandChild.getOpType());
+    }
+
+    @Test
+    public void testFloatToIntegralCastIsNotReduced() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+        ScalarOperator doubleColumn = new ColumnRefOperator(0, Type.DOUBLE, "id_double", false);
+        ScalarOperator floatColumn = new ColumnRefOperator(1, Type.FLOAT, "id_float", false);
+
+        // cast(cast(id_double as bigint) as varchar) keeps the truncating cast
+        {
+            ScalarOperator operator =
+                    new CastOperator(Type.VARCHAR, new CastOperator(Type.BIGINT, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isVarchar());
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBigint());
+            Assertions.assertSame(doubleColumn, result.getChild(0).getChild(0));
+        }
+        // cast(cast(id_double as bigint) as double) keeps the truncating cast
+        {
+            ScalarOperator operator =
+                    new CastOperator(Type.DOUBLE, new CastOperator(Type.BIGINT, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isDouble());
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBigint());
+        }
+        // float needs the same guard
+        {
+            ScalarOperator operator =
+                    new CastOperator(Type.VARCHAR, new CastOperator(Type.BIGINT, floatColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBigint());
+        }
+        // float -> boolean changes the value the same way
+        {
+            ScalarOperator operator =
+                    new CastOperator(Type.TINYINT, new CastOperator(Type.BOOLEAN, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isBoolean());
+        }
+    }
+
+    @Test
+    public void testFloatToIntegralCastFoldsToTruncatedValue() {
+        // cast(cast(100 / 3 as bigint) as varchar) -> '33', not '33.333333333333336'
+        ScalarOperator operator = new CastOperator(Type.VARCHAR,
+                new CastOperator(Type.BIGINT, ConstantOperator.createDouble(100.0 / 3)));
+
+        ScalarOperator result = new ScalarOperatorRewriter().rewrite(operator,
+                Lists.newArrayList(new ReduceCastRule(), new FoldConstantsRule()));
+
+        assertTrue(result instanceof ConstantOperator);
+        assertEquals("33", ((ConstantOperator) result).getVarchar());
+    }
+
+    @Test
+    public void testIntegralToFloatCastIsNotReducedWhenItRounds() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+
+        // bigint above 2^53 is rounded by the cast to double
+        {
+            ScalarOperator bigintColumn = new ColumnRefOperator(0, Type.BIGINT, "id_bigint", false);
+            ScalarOperator operator =
+                    new CastOperator(Type.VARCHAR, new CastOperator(Type.DOUBLE, bigintColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isDouble());
+        }
+        // int does not fit the 24 bit float mantissa either
+        {
+            ScalarOperator intColumn = new ColumnRefOperator(0, Type.INT, "id_int", false);
+            ScalarOperator operator =
+                    new CastOperator(Type.VARCHAR, new CastOperator(Type.FLOAT, intColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isFloat());
+        }
+        // double -> float rounds as well
+        {
+            ScalarOperator doubleColumn = new ColumnRefOperator(0, Type.DOUBLE, "id_double", false);
+            ScalarOperator operator =
+                    new CastOperator(Type.VARCHAR, new CastOperator(Type.FLOAT, doubleColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getChild(0) instanceof CastOperator);
+            assertTrue(result.getChild(0).getType().isFloat());
+        }
+    }
+
+    @Test
+    public void testValuePreservingCastIsStillReduced() {
+        ScalarOperatorRewriteRule rule = new ReduceCastRule();
+
+        // cast(cast(id_int as bigint) as varchar) -> cast(id_int as varchar)
+        {
+            ScalarOperator intColumn = new ColumnRefOperator(0, Type.INT, "id_int", false);
+            ScalarOperator operator =
+                    new CastOperator(Type.VARCHAR, new CastOperator(Type.BIGINT, intColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isVarchar());
+            assertTrue(result.getChild(0) instanceof ColumnRefOperator);
+            assertTrue(result.getChild(0).getType().isInt());
+        }
+        // int fits the 53 bit double mantissa exactly
+        {
+            ScalarOperator intColumn = new ColumnRefOperator(0, Type.INT, "id_int", false);
+            ScalarOperator operator =
+                    new CastOperator(Type.DOUBLE, new CastOperator(Type.DOUBLE, intColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isDouble());
+            assertTrue(result.getChild(0) instanceof ColumnRefOperator);
+            assertTrue(result.getChild(0).getType().isInt());
+        }
+        // smallint fits the 24 bit float mantissa
+        {
+            ScalarOperator smallintColumn = new ColumnRefOperator(0, Type.SMALLINT, "id_smallint", false);
+            ScalarOperator operator =
+                    new CastOperator(Type.FLOAT, new CastOperator(Type.FLOAT, smallintColumn));
+
+            ScalarOperator result = rule.apply(operator, null);
+
+            assertTrue(result.getType().isFloat());
+            assertTrue(result.getChild(0) instanceof ColumnRefOperator);
+            assertTrue(result.getChild(0).getType().isSmallint());
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1434,6 +1434,28 @@ public class ExpressionTest extends PlanTestBase {
         sql = "select cast(cast(id_bool as boolean) as string) from test_bool;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "CAST(11: id_bool AS VARCHAR(65533))");
+
+        // float -> integral truncates, so the inner cast must survive
+        sql = "select cast(cast(t1f as bigint) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(6: t1f AS BIGINT) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(t1e as bigint) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(5: t1e AS BIGINT) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(t1f as bigint) as double) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(6: t1f AS BIGINT) AS DOUBLE)");
+
+        // integral -> float rounds, so the inner cast must survive
+        sql = "select cast(cast(t1d as double) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(4: t1d AS DOUBLE) AS VARCHAR(65533))");
+
+        sql = "select cast(cast(t1c as float) as string) from test_all_type;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "CAST(CAST(3: t1c AS FLOAT) AS VARCHAR(65533))");
     }
 
     @Test


### PR DESCRIPTION
Backport of #78238 to `branch-3.5-cc`.

## Why I'm doing:

`ReduceCastRule` collapses nested casts and drops the inner one when `checkCastTypeReduceAble()`
returns true. Its only narrowing guard compares byte width, and `PrimitiveType.getTypeSize()`
reports 8 bytes for FLOAT, DOUBLE and BIGINT alike, so the guard never fires for `double -> bigint`
and `cast(cast(<float expr> as bigint) as varchar)` is reduced to `cast(<float expr> as varchar)`.
The truncation is silently lost, with no error raised:

```sql
select cast(100/3 as bigint);                    -- 33                   correct
select cast(cast(100/3 as bigint) as varchar);   -- 33.333333333333336   wrong, expected '33'
```

This also breaks histogram collection: `HistogramStatisticsCollectJob` emits
`cast(cast(<count expr> as bigint) as varchar)` to get an integer bucket count. With the inner cast
dropped, a fractional count reaches the JSON, `Long.parseLong` in `HistogramUtils.convertBuckets`
throws, and the bucket is dropped - leaving the column with no histogram.

## What I'm doing:

Cherry-pick of f9d4d76bb8efc9d0ce753847dc0b48bb9ad3f693 - reject the reduction in
`checkCastTypeReduceAble` when the cast changes the value: float -> integral truncates, and
integral -> float or double -> float rounds when the source does not fit the target mantissa.

`ReduceCastRule.java` and `ExpressionTest.java` applied unchanged. `ReduceCastRuleTest.java`
conflicted only on the FE type-package refactor, which `branch-3.5-cc` predates: the new test code
was translated from upstream's per-type classes (`FloatType.DOUBLE`, `IntegerType.BIGINT`,
`VarcharType.VARCHAR`, `BooleanType.BOOLEAN`) to this branch's `com.starrocks.catalog.Type`
constants. No test logic or assertion was changed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

