### PR TITLE
[BugFix] Make CancelableAnalyzeTask.cancel pick a single winner

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/CancelableAnalyzeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/CancelableAnalyzeTask.java
@@ -25,6 +25,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CancelableAnalyzeTask implements RunnableFuture<Void> {
     private static final Logger LOG = LogManager.getLogger(CancelableAnalyzeTask.class);
@@ -33,6 +34,7 @@ public class CancelableAnalyzeTask implements RunnableFuture<Void> {
     private final AnalyzeStatus analyzeStatus;
     private volatile boolean cancelled = false;
     private volatile boolean done = false;
+    private final AtomicBoolean cancelRequested = new AtomicBoolean(false);
     private volatile Throwable exception = null;
     private final CountDownLatch latch = new CountDownLatch(1);
     private volatile Thread runningThread = null;
@@ -72,17 +74,23 @@ public class CancelableAnalyzeTask implements RunnableFuture<Void> {
             return false;
         }
 
+        // Only the caller that claims the request owns the cancellation; the rest get false, as
+        // Future#cancel requires. The claim is a separate flag so that the terminal state is still
+        // published in the order an observer expects: cancelled, then done, then the latch.
+        if (!cancelRequested.compareAndSet(false, true)) {
+            return false;
+        }
+
         cancelled = true;
         analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);
 
-        if (mayInterruptIfRunning && runningThread != null) {
-            runningThread.interrupt();
+        Thread thread = runningThread;
+        if (mayInterruptIfRunning && thread != null) {
+            thread.interrupt();
         }
 
-        if (!done) {
-            done = true;
-            latch.countDown();
-        }
+        done = true;
+        latch.countDown();
 
         return true;
     }


### PR DESCRIPTION
## Why I'm doing:

`CancelableAnalyzeTask.cancel()` decided whether it had won the cancellation by reading a
volatile flag and then writing it:

```java
if (done) {
 return false;
}

cancelled = true;
analyzeStatus.setStatus(StatsConstants.ScheduleStatus.FAILED);

if (mayInterruptIfRunning && runningThread!= null) {
 runningThread.interrupt();
}

if (!done) {
 done = true;
 latch.countDown();
}

return true;
```

Concurrent callers can all read `done` as false before any of them writes it, so more than
one returns `true`. `Future#cancel` promises the opposite, and
`CancelableAnalyzeTaskTest.shouldHandleConcurrentCancellationAttempts` asserts it directly:

```
Only one cancellation should succeed ==> expected: <1> but was: <2>
```

That is why the case fails intermittently, taking FE UT red on unrelated PRs. A 5-thread
stress of the extracted old logic reproduces multiple winners in about 1 run in 2000; the
same stress of the new logic is clean over 20000 runs.

## What I'm doing:

- Hold `done` in an `AtomicBoolean` and let `compareAndSet(false, true)` name the single
 owner of the not-done to done transition, in `cancel()` and in the two places `run()`
 completes the task. The status update and the interrupt now run only for the winner.

- Snapshot `runningThread` before the null check. The field is volatile, so the guard and
 the `interrupt()` call could read different values, and the call could hit a null.

Behaviour for existing callers is unchanged. `AnalyzeMgr.killAllPendingTasks()` cancels
tasks still queued, and `shouldNotCancelCompletedTask` already asserts the semantics this
change makes race-free: a caller arriving after the task finished gets `false`, the task is
not marked cancelled, and its status stays `FINISH`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

The existing `shouldHandleConcurrentCancellationAttempts` already covers this; it was
failing against the old implementation rather than missing.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5