### PR TITLE
[BugFix] Invalidate global dict after fast schema evolution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -130,6 +130,7 @@ import com.starrocks.sql.ast.OptimizeClause;
 import com.starrocks.sql.ast.ReorderColumnsClause;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTaskExecutor;
 import com.starrocks.task.AgentTaskQueue;
@@ -4531,6 +4532,21 @@ public class SchemaChangeHandler extends AlterHandler {
             }
             olapTable.setIndexes(indexes);
             olapTable.rebuildFullSchema();
+
+            // A schema change does not bump the partition visible version, which is what a global
+            // dict's validity is checked against, so the collected dicts stay "valid" while the new
+            // rowsets this change produces are encoded independently -- a query would then decode
+            // them against a stale dict and fail with "Dict Decode failed". SchemaChangeJobV2#onFinished
+            // invalidates every varchar column's dict for the same reason. Do it here, on the shared
+            // catalog-update path while the table write lock is held, so BOTH the leader (WAL callback)
+            // and a follower (replayFastSchemaEvolutionMetaChange, which calls this method directly and
+            // never enters the leader wrapper) invalidate the dict -- otherwise a follower that replayed
+            // the change keeps serving the stale dict and hits the same decode failure.
+            for (Column column : olapTable.getColumns()) {
+                if (column.getType().isVarchar()) {
+                    IDictManager.getInstance().removeGlobalDict(olapTable, column.getColumnId());
+                }
+            }
 
             // If modified columns are already done, inactive related mv
             AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable, modifiedColumns);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerVarcharWidenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerVarcharWidenTest.java
@@ -16,20 +16,28 @@ package com.starrocks.alter;
 
 import com.starrocks.catalog.ColocateTableIndex;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.TableColumnAlterInfo;
+import com.starrocks.persist.WALApplier;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.ModifyColumnClause;
 import com.starrocks.sql.ast.expression.TypeDef;
+import com.starrocks.sql.optimizer.statistics.CacheDictManager;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.TestWithFeService;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -302,6 +310,104 @@ public class SchemaChangeHandlerVarcharWidenTest extends TestWithFeService {
         Assertions.assertTrue(exception.getMessage().contains("primary key column[k1] cannot be nullable"),
                 exception.getMessage());
         assertColumnType(tableName, tableName, "k1", PrimitiveType.VARCHAR, 10);
+    }
+
+    @Test
+    public void testFastSchemaEvolutionInvalidatesGlobalDictForAllVarcharColumns() throws Exception {
+        // A schema change does not bump the partition visible version that a global dict's validity is
+        // checked against, so the fast-schema-evolution path must invalidate every varchar column's
+        // dict -- not just the altered one -- or a query would decode a new rowset against a stale dict
+        // and fail with "Dict Decode failed". Regression for the fuzz-found mut_286 crash.
+        String tableName = "t_fast_dict_invalidate";
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  name VARCHAR(50),\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+
+        List<String> invalidated = new ArrayList<>();
+        new MockUp<CacheDictManager>() {
+            @Mock
+            public void removeGlobalDict(OlapTable table, ColumnId columnName) {
+                invalidated.add(columnName.getId());
+            }
+        };
+
+        // Widening the key column takes the fast path (updateCatalogForFastSchemaEvolution).
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL",
+                tableName);
+        Assertions.assertNull(job);
+
+        String k1Id = getColumn(tableName, tableName, "k1").getColumnId().getId();
+        String nameId = getColumn(tableName, tableName, "name").getColumnId().getId();
+        String v1Id = getColumn(tableName, tableName, "v1").getColumnId().getId();
+        Assertions.assertTrue(invalidated.contains(k1Id), "altered varchar column must be invalidated");
+        Assertions.assertTrue(invalidated.contains(nameId),
+                "varchar column not participating in the alter must still be invalidated");
+        Assertions.assertFalse(invalidated.contains(v1Id), "non-varchar column must not be invalidated");
+    }
+
+    @Test
+    public void testReplayFastSchemaEvolutionInvalidatesGlobalDict() throws Exception {
+        // A follower applies OP_FAST_ALTER_TABLE_COLUMNS through replayFastSchemaEvolutionMetaChange,
+        // which calls applyFastSchemaEvolutionMetaChangeInternal directly and never enters the leader
+        // wrapper (updateCatalogForFastSchemaEvolution). The dict invalidation must therefore live on
+        // that shared internal path, or a follower that replayed the change keeps serving a stale dict
+        // and hits the same "Dict Decode failed" failure the leader fix was meant to prevent.
+        String tableName = "t_fast_dict_invalidate_replay";
+        createTable("CREATE TABLE test." + tableName + " (\n"
+                + "  k1 VARCHAR(10) NOT NULL,\n"
+                + "  name VARCHAR(50),\n"
+                + "  v1 INT\n"
+                + ") ENGINE=OLAP\n"
+                + "DUPLICATE KEY(k1)\n"
+                + "DISTRIBUTED BY HASH(k1) BUCKETS 1\n"
+                + "PROPERTIES (\n"
+                + "  \"replication_num\" = \"1\",\n"
+                + "  \"fast_schema_evolution\" = \"true\"\n"
+                + ");");
+
+        List<String> invalidated = new ArrayList<>();
+        new MockUp<CacheDictManager>() {
+            @Mock
+            public void removeGlobalDict(OlapTable table, ColumnId columnName) {
+                invalidated.add(columnName.getId());
+            }
+        };
+
+        // Capture the WAL record the leader journals WITHOUT applying it on the leader, so the
+        // invalidations we observe below come solely from the replay path -- exactly a follower that
+        // sees only the journal entry.
+        final TableColumnAlterInfo[] captured = new TableColumnAlterInfo[1];
+        new MockUp<EditLog>() {
+            @Mock
+            public void logModifyTableAddOrDrop(TableColumnAlterInfo info, WALApplier walApplier) {
+                captured[0] = info;
+            }
+        };
+
+        AlterJobV2 job = analyzeAndCreateJob(
+                "ALTER TABLE test." + tableName + " MODIFY COLUMN k1 VARCHAR(30) KEY NOT NULL",
+                tableName);
+        Assertions.assertNull(job);
+        Assertions.assertNotNull(captured[0], "leader must journal the fast schema evolution");
+        Assertions.assertTrue(invalidated.isEmpty(), "leader apply was suppressed, so nothing invalidated yet");
+
+        // Follower path: apply the journaled change through replay and assert it invalidates the dict.
+        GlobalStateMgr.getCurrentState().getSchemaChangeHandler()
+                .replayFastSchemaEvolutionMetaChange(captured[0]);
+
+        Assertions.assertTrue(invalidated.contains("k1"), "altered varchar column must be invalidated on replay");
+        Assertions.assertTrue(invalidated.contains("name"),
+                "other varchar column must also be invalidated on replay");
+        Assertions.assertFalse(invalidated.contains("v1"), "non-varchar column must not be invalidated");
     }
 
     private AlterJobV2 analyzeAndCreateJob(String sql, String tableName) throws Exception {


### PR DESCRIPTION
## Why I'm doing:

A global dictionary's validity is checked against the partition visible version, which a schema change does not bump. SchemaChangeJobV2#onFinished therefore invalidates every varchar column's dict when a full schema change completes, with a comment spelling out exactly why. The fast-schema-evolution path (updateCatalogForFastSchemaEvolution, taken by ADD/DROP value column, widen varchar, etc. in shared-nothing mode) changes the table metadata but never invalidated the dict.

So after a fast schema change the stale dict stays "valid" while the new rowsets the change produces are encoded independently, and a query then decodes those rowsets against the stale dict and fails at runtime with "Dict Decode failed, Dict can't take cover all key". The failing column need not be the altered one -- any varchar column is affected -- which is why the full path invalidates all of them.

Mirror onFinished in updateCatalogForFastSchemaEvolution: after the metadata change, invalidate the global dict of every varchar column.

Note: the shared-data fast path (LakeTableAsyncFastSchemaChangeJob) also lacks this invalidation and should be audited separately.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
