### PR TITLE
[BugFix] Fix dump-tablet-metadata SQL test discovery and docs version

### DIFF
--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -93,7 +93,7 @@ This topic introduces the following types of BE configurations:
 - Unit: Bytes
 - Is mutable: Yes
 - Description: The tracked memory budget for synchronous allocations made while processing one `/api/cloudnative/dump_tablet_metadata` request on a CN. It uses the standard MemTracker accounting granularity rather than enforcing a byte-exact ceiling. It covers metadata inspection, sensitive-field redaction, and JSON serialization, but not the metadata already stored in the CN metadata cache or the asynchronous HTTP output buffer. Each request uses the value captured when it is admitted. If this value is less than or equal to `0`, new requests fail closed.
-- Introduced in: v26.2
+- Introduced in: v4.2
 
 ### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
 
@@ -102,7 +102,7 @@ This topic introduces the following types of BE configurations:
 - Unit: Bytes
 - Is mutable: Yes
 - Description: The maximum size of the complete JSON response for one `/api/cloudnative/dump_tablet_metadata` request. The size is checked before the response is handed to the HTTP output buffer. Each request uses the value captured when it is admitted. If this value is less than or equal to `0`, new requests fail closed.
-- Introduced in: v26.2
+- Introduced in: v4.2
 
 ### lake_dump_tablet_metadata_max_concurrency
 
@@ -111,7 +111,7 @@ This topic introduces the following types of BE configurations:
 - Unit: Requests
 - Is mutable: Yes
 - Description: The maximum number of `/api/cloudnative/dump_tablet_metadata` requests admitted concurrently on one CN. A request continues to occupy one slot until its HTTP request is released. Increasing the value applies immediately to new requests. Decreasing it does not cancel admitted requests, and new requests are rejected until the active count is below the new limit. If this value is less than or equal to `0`, new requests fail closed.
-- Introduced in: v26.2
+- Introduced in: v4.2
 
 ### lake_enable_del_file_crc_check
 

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -93,7 +93,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: バイト
 - 変更可能: はい
 - 説明: CN が 1 件の `/api/cloudnative/dump_tablet_metadata` リクエストを同期処理するときの追跡対象メモリ予算です。バイト単位の厳密な上限ではなく、標準の MemTracker の集計粒度を使用します。メタデータの検査、機密フィールドのマスキング、JSON シリアライズを対象としますが、CN のメタデータキャッシュに既に格納されているメタデータと非同期 HTTP 出力バッファは対象外です。各リクエストは受付時に取得した値を使用します。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
-- 導入バージョン: v26.2
+- 導入バージョン: v4.2
 
 ### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
 
@@ -102,7 +102,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: バイト
 - 変更可能: はい
 - 説明: 1 件の `/api/cloudnative/dump_tablet_metadata` リクエストが返す完全な JSON レスポンスの最大バイト数です。HTTP 出力バッファへ渡す前にサイズを検査します。各リクエストは受付時に取得した値を使用します。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
-- 導入バージョン: v26.2
+- 導入バージョン: v4.2
 
 ### lake_dump_tablet_metadata_max_concurrency
 
@@ -111,7 +111,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 単位: リクエスト
 - 変更可能: はい
 - 説明: 1 台の CN で同時に受け付ける `/api/cloudnative/dump_tablet_metadata` リクエスト数の上限です。各リクエストは HTTP request が解放されるまで 1 スロットを使用します。値を増やすと新しいリクエストに直ちに反映されます。値を減らしても受付済みのリクエストはキャンセルされず、アクティブ数が新しい上限未満になるまで新しいリクエストは拒否されます。この値が `0` 以下の場合、新しいリクエストは fail-closed で拒否されます。
-- 導入バージョン: v26.2
+- 導入バージョン: v4.2
 
 ### lake_enable_del_file_crc_check
 

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -90,7 +90,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：Bytes
 - 是否动态：是
 - 描述：CN 同步处理单个 `/api/cloudnative/dump_tablet_metadata` 请求时的受跟踪内存预算。该预算使用标准 MemTracker 统计粒度，并非精确到字节的硬上限。该限制覆盖元数据检查、敏感字段脱敏和 JSON 序列化，但不包含 CN 元数据缓存中已存在的元数据，也不包含异步 HTTP 输出缓冲区。每个请求使用其被接纳时读取到的配置值。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
-- 引入版本：v26.2
+- 引入版本：v4.2
 
 ### lake_dump_tablet_metadata_per_request_json_size_limit_bytes
 
@@ -99,7 +99,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：Bytes
 - 是否动态：是
 - 描述：单个 `/api/cloudnative/dump_tablet_metadata` 请求完整 JSON 响应的最大字节数。响应交给 HTTP 输出缓冲区之前会检查该限制。每个请求使用其被接纳时读取到的配置值。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
-- 引入版本：v26.2
+- 引入版本：v4.2
 
 ### lake_dump_tablet_metadata_max_concurrency
 
@@ -108,7 +108,7 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 单位：请求
 - 是否动态：是
 - 描述：单个 CN 上可同时接纳的 `/api/cloudnative/dump_tablet_metadata` 请求数上限。请求在其 HTTP request 被释放之前一直占用一个并发名额。调大配置会立即影响新请求；调小配置不会取消已接纳的请求，在活跃请求数降到新上限以下之前会拒绝新请求。如果该值小于或等于 `0`，新请求将以 fail-closed 方式被拒绝。
-- 引入版本：v26.2
+- 引入版本：v4.2
 
 ### lake_enable_del_file_crc_check
 

--- a/test/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
+++ b/test/sql/test_dump_tablet_metadata/T/check_dump_tablet_metadata.sh
@@ -1,8 +1,31 @@
 #!/usr/bin/env bash
 
+# Shared-data CI workers may appear in SHOW BACKENDS, SHOW COMPUTE NODES, or both.
+# Match test/lib/sr_sql_lib.py::_get_backend_http_endpoints and identify columns by
+# header name so added SHOW columns do not shift IP/HttpPort/Alive.
+collect_endpoints() {
+    {
+        ${mysql_cmd} -e "SHOW BACKENDS"
+        ${mysql_cmd} -e "SHOW COMPUTE NODES"
+    } | awk -F '\t' '
+        $1 == "BackendId" || $1 == "ComputeNodeId" {
+            ip = http = alive = 0
+            for (i = 1; i <= NF; i++) {
+                if ($i == "IP") ip = i
+                if ($i == "HttpPort") http = i
+                if ($i == "Alive") alive = i
+            }
+            next
+        }
+        ip && http && alive && $alive == "true" && $ip != "" && $http != "" {
+            print $ip ":" $http
+        }
+    ' | sort -u
+}
+
 check_table() {
     local table=$1
-    local tablet_id version endpoints endpoint attempt
+    local tablet_id version endpoints endpoint attempt body
 
     tablet_id=$(${mysql_cmd} -D"${database}" -e "SHOW TABLETS FROM ${table} LIMIT 1" | awk -F '\t' '
         NR == 1 {
@@ -21,16 +44,34 @@ check_table() {
         }
     ')
     version=$(${mysql_cmd} -Ne "SELECT VISIBLE_VERSION FROM information_schema.partitions_meta WHERE DB_NAME='${database}' AND TABLE_NAME='${table}' LIMIT 1")
-    [ -n "${tablet_id}" ] && [ -n "${version}" ] || return 1
+    tablet_id=${tablet_id//$'\r'/}
+    version=${version//$'\r'/}
+    if [ -z "${tablet_id}" ] || [ -z "${version}" ]; then
+        echo "failed to resolve tablet metadata identity: table=${table} tablet_id='${tablet_id}' version='${version}'" >&2
+        return 1
+    fi
 
     for attempt in $(seq 1 10); do
-        ${mysql_cmd} -D"${database}" -Ne "SELECT COUNT(*) FROM ${table}" >/dev/null || return 1
-        endpoints=$(${mysql_cmd} -Ne "SHOW COMPUTE NODES" | awk -F '\t' '$9 == "true" { print $2 ":" $5 }')
+        # A real predicate scan loads lake tablet metadata into the CN metacache.
+        # COUNT(*) can be rewritten to a meta-scan/FE stats path and may not cache
+        # the versioned key this API looks up. Parallel CI can also evict the cache
+        # left behind by INSERT, so refresh it immediately before the dump.
+        ${mysql_cmd} -D"${database}" -Ne "SELECT k FROM ${table} WHERE k = 1" >/dev/null || return 1
+        endpoints=$(collect_endpoints)
         for endpoint in ${endpoints}; do
-            curl -fsS --connect-timeout 1 --max-time 3 -u root: "http://${endpoint}/api/cloudnative/dump_tablet_metadata/${tablet_id}?version=${version}" |
-                jq -e '.status == "OK"' >/dev/null && return 0
+            body=$(curl -sS --connect-timeout 2 --max-time 10 -u root: \
+                "http://${endpoint}/api/cloudnative/dump_tablet_metadata/${tablet_id}?version=${version}" || true)
+            echo "${body}" | jq -e '.status == "OK"' >/dev/null && return 0
         done
         [ "${attempt}" -eq 10 ] || sleep 1
+    done
+
+    echo "dump_tablet_metadata cache miss: table=${table} tablet_id=${tablet_id} version=${version} endpoints=${endpoints:-<none>}" >&2
+    for endpoint in ${endpoints}; do
+        echo "response from ${endpoint}:" >&2
+        curl -sS --connect-timeout 2 --max-time 10 -u root: \
+            "http://${endpoint}/api/cloudnative/dump_tablet_metadata/${tablet_id}?version=${version}" >&2 || true
+        echo >&2
     done
     return 1
 }


### PR DESCRIPTION
## Why I'm doing:

Follow-up for https://github.com/StarRocks/starrocks/pull/78449. SQL-Tester failed on the new `test_dump_tablet_metadata_cache_local_reads` case, and Codex asked to replace the nonexistent `v26.2` introduction version.

## What I'm doing:

- Discover CN/BE HTTP endpoints from both `SHOW BACKENDS` and `SHOW COMPUTE NODES`, identifying `IP` / `HttpPort` / `Alive` by header name (same approach as `test/lib/sr_sql_lib.py`).
- Warm the lake metacache with `SELECT k FROM table WHERE k = 1` instead of `COUNT(*)`, which can be rewritten away from a versioned metadata load.
- Print dump-API diagnostics on failure so the next CI miss is not silent.
- Change EN/ZH/JA docs from `v26.2` to `v4.2`.

Please merge this into the sync branch `main-cd-contributed-pr-60607` so PR 78449 picks up the fix.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5


Made with [Cursor](https://cursor.com)