### PR TITLE
[BugFix] Drop a delvec page's local cache and retry when its checksum fails (backport #78086)

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -23,6 +23,8 @@
 #include "storage/lake/metacache.h"
 #include "storage/lake/update_manager.h"
 #include "storage/protobuf_file.h"
+#include "storage/rowset/page_io.h"
+#include "testutil/sync_point.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
 #include "util/defer_op.h"
@@ -31,6 +33,18 @@
 #include "util/trace.h"
 
 namespace starrocks::lake {
+
+// Recovery hook for delvec files: drop the local data cache after a page's crc32c
+// failed to verify, so the retry reads through to the remote object.
+static Status drop_corrupted_delvec_file_cache(const std::string& path) {
+    Status drop_status = Status::NotSupported("clear corrupted cache is only supported in shared-data mode");
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    drop_status = drop_local_cache_data(path);
+#endif
+    // Outside the platform guard on purpose, so tests can drive the retry path on any build.
+    TEST_SYNC_POINT_CALLBACK("lake::drop_corrupted_delvec_file_cache", &drop_status);
+    return drop_status;
+}
 
 static std::string delvec_cache_key(int64_t tablet_id, const DelvecPagePB& page) {
     DelvecCacheKeyPB cache_key_pb;
@@ -696,10 +710,11 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, ui
     auto iter = metadata.delvec_meta().delvecs().find(segment_id);
     if (iter != metadata.delvec_meta().delvecs().end()) {
         VLOG(2) << fmt::format("get_del_vec {} segid {}", metadata.delvec_meta().ShortDebugString(), segment_id);
+        const DelvecPagePB& delvec_page = iter->second;
         std::string buf;
-        raw::stl_string_resize_uninitialized(&buf, iter->second.size());
+        raw::stl_string_resize_uninitialized(&buf, delvec_page.size());
         // find in cache
-        std::string cache_key = delvec_cache_key(metadata.id(), iter->second);
+        std::string cache_key = delvec_cache_key(metadata.id(), delvec_page);
         auto cached_delvec = tablet_mgr->metacache()->lookup_delvec(cache_key);
         if (cached_delvec != nullptr) {
             delvec->copy_from(*cached_delvec);
@@ -707,42 +722,67 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, ui
         }
 
         // lookup delvec file name and then read it
-        auto iter2 = metadata.delvec_meta().version_to_file().find(iter->second.version());
+        auto iter2 = metadata.delvec_meta().version_to_file().find(delvec_page.version());
         if (iter2 == metadata.delvec_meta().version_to_file().end()) {
             LOG(ERROR) << "Can't find delvec file name for tablet: " << metadata.id()
-                       << ", version: " << iter->second.version();
+                       << ", version: " << delvec_page.version();
             return Status::InternalError("Can't find delvec file name");
         }
         const auto& delvec_name = iter2->second.name();
         RandomAccessFileOptions opts{.skip_fill_local_cache = !lake_io_opts.fill_data_cache};
-        std::unique_ptr<RandomAccessFile> rf;
-        if (lake_io_opts.fs && lake_io_opts.location_provider) {
-            ASSIGN_OR_RETURN(
-                    rf, lake_io_opts.fs->new_random_access_file(
-                                opts, lake_io_opts.location_provider->delvec_location(metadata.id(), delvec_name)));
-        } else {
-            ASSIGN_OR_RETURN(rf,
-                             fs::new_random_access_file(opts, tablet_mgr->delvec_location(metadata.id(), delvec_name)));
-        }
-        RETURN_IF_ERROR(rf->read_at_fully(iter->second.offset(), buf.data(), iter->second.size()));
-        if (iter->second.has_crc32c() && iter->second.crc32c_gen_version() == iter->second.version()) {
-            // check crc32c
-            uint32_t crc32c = crc32c::Value(buf.data(), iter->second.size());
-            if (crc32c != crc32c::Unmask(iter->second.crc32c())) {
-                LOG(ERROR) << fmt::format(
-                        "delvec crc32c mismatch, tabletid {}, delvecfile {}, offset {}, size {}, expect crc32c {}, "
-                        "actual "
-                        "crc32c {}",
-                        metadata.id(), delvec_name, iter->second.offset(), iter->second.size(),
-                        crc32c::Unmask(iter->second.crc32c()), crc32c);
-                if (config::enable_strict_delvec_crc_check) {
-                    return Status::Corruption(fmt::format("delvec crc32c mismatch. expect crc32c {}, actual {}",
-                                                          crc32c::Unmask(iter->second.crc32c()), crc32c));
-                }
+        const std::string delvec_path =
+                (lake_io_opts.fs && lake_io_opts.location_provider)
+                        ? lake_io_opts.location_provider->delvec_location(metadata.id(), delvec_name)
+                        : tablet_mgr->delvec_location(metadata.id(), delvec_name);
+        auto read_page = [&]() -> Status {
+            std::unique_ptr<RandomAccessFile> rf;
+            if (lake_io_opts.fs && lake_io_opts.location_provider) {
+                ASSIGN_OR_RETURN(rf, lake_io_opts.fs->new_random_access_file(opts, delvec_path));
+            } else {
+                ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, delvec_path));
             }
+            return rf->read_at_fully(delvec_page.offset(), buf.data(), delvec_page.size());
+        };
+        // Returns Corruption only when strict checking is on; a mismatch is otherwise
+        // tolerated and the page is used as read.
+        auto verify_page = [&]() -> Status {
+            if (!delvec_page.has_crc32c() || delvec_page.crc32c_gen_version() != delvec_page.version()) {
+                return Status::OK();
+            }
+            uint32_t crc32c = crc32c::Value(buf.data(), delvec_page.size());
+            if (crc32c == crc32c::Unmask(delvec_page.crc32c())) {
+                return Status::OK();
+            }
+            LOG(ERROR) << fmt::format(
+                    "delvec crc32c mismatch, tabletid {}, delvecfile {}, offset {}, size {}, expect crc32c {}, actual "
+                    "crc32c {}",
+                    metadata.id(), delvec_name, delvec_page.offset(), delvec_page.size(),
+                    crc32c::Unmask(delvec_page.crc32c()), crc32c);
+            if (config::enable_strict_delvec_crc_check) {
+                return Status::Corruption(fmt::format("delvec crc32c mismatch. expect crc32c {}, actual {}",
+                                                      crc32c::Unmask(delvec_page.crc32c()), crc32c));
+            }
+            return Status::OK();
+        };
+        RETURN_IF_ERROR(read_page());
+        if (auto verify_st = verify_page(); !verify_st.ok()) {
+            // A delvec file is immutable once written, so bytes that do not match the
+            // recorded checksum are not the bytes that were written. The likeliest culprit
+            // is a corrupted block in the local data cache rather than in remote storage,
+            // so drop the cache and read once more -- the retry then reads through to the
+            // remote object. Segment pages (PageIO::read_and_decompress_page) and
+            // persistent-index sstables recover from cache corruption the same way.
+            auto drop_status = drop_corrupted_delvec_file_cache(delvec_path);
+            if (!drop_status.ok()) {
+                VLOG(2) << "skip clearing corrupted cache for " << delvec_path << ": " << drop_status;
+                return verify_st;
+            }
+            LOG(INFO) << "cleared corrupted cache for " << delvec_path << ", re-reading the delvec page";
+            RETURN_IF_ERROR(read_page());
+            RETURN_IF_ERROR(verify_page());
         }
         // parse delvec
-        RETURN_IF_ERROR(delvec->load(iter->second.version(), buf.data(), iter->second.size()));
+        RETURN_IF_ERROR(delvec->load(delvec_page.version(), buf.data(), delvec_page.size()));
         // put in cache
         if (fill_cache) {
             auto delvec_cache_ptr = std::make_shared<DelVector>();

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -26,12 +26,14 @@
 #include "storage/lake/column_mode_partial_update_handler.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
+#include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/update_manager.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
 #include "util/starrocks_metrics.h"
 #include "util/uid_util.h"
 
@@ -192,6 +194,97 @@ TEST_F(MetaFileTest, test_delvec_rw) {
 
     iter2 = version_to_file_map.find(new_version);
     EXPECT_TRUE(iter2 != version_to_file_map.end());
+}
+
+// A delvec page whose bytes fail the recorded crc32c is most plausibly a corrupted
+// block in the local data cache, so get_del_vec drops that cache and reads once
+// more. Simulate exactly that: corrupt the delvec file, then have the cache-drop
+// hook restore the original bytes -- standing in for the retry reading through to
+// an intact remote object -- and the read must then succeed. Without the hook the
+// drop reports NotSupported on this build, the retry is skipped, and the original
+// Corruption surfaces.
+TEST_F(MetaFileTest, test_get_del_vec_crc32c_retries_after_dropping_cache) {
+    const int64_t tablet_id = 10012;
+    const uint32_t segment_id = 5678;
+    const int64_t version = 11;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    metadata->set_next_rowset_id(110);
+    metadata->mutable_schema()->set_keys_type(PRIMARY_KEYS);
+
+    MetaFileBuilder builder(*tablet, metadata);
+    DelVector dv;
+    dv.set_empty();
+    std::shared_ptr<DelVector> ndv;
+    std::vector<uint32_t> dels = {1, 3, 5, 7, 90000};
+    dv.add_dels_as_new_version(dels, version, &ndv);
+    const std::string expected_delvec = ndv->save();
+    builder.append_delvec(ndv, segment_id);
+    ASSERT_OK(builder.finalize(next_id()));
+
+    ASSIGN_OR_ABORT(auto metadata2, _tablet_manager->get_tablet_metadata(tablet_id, version));
+    auto page_iter = metadata2->delvec_meta().delvecs().find(segment_id);
+    ASSERT_TRUE(page_iter != metadata2->delvec_meta().delvecs().end());
+    const auto& delvec_page = page_iter->second;
+    ASSERT_TRUE(delvec_page.has_crc32c());
+    auto file_iter = metadata2->delvec_meta().version_to_file().find(delvec_page.version());
+    ASSERT_TRUE(file_iter != metadata2->delvec_meta().version_to_file().end());
+    const std::string delvec_path = _tablet_manager->delvec_location(tablet_id, file_iter->second.name());
+
+    // Keep the good bytes, then corrupt one byte inside the page (length-preserving).
+    std::string good_bytes;
+    {
+        ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(delvec_path));
+        ASSIGN_OR_ABORT(good_bytes, rf->read_all());
+        ASSERT_GT(good_bytes.size(), delvec_page.offset());
+        auto corrupted = good_bytes;
+        corrupted[delvec_page.offset()] = static_cast<char>(corrupted[delvec_page.offset()] ^ 0xff);
+        WritableFileOptions wopts{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(wopts, delvec_path));
+        ASSERT_OK(wf->append(Slice(corrupted)));
+        ASSERT_OK(wf->close());
+    }
+    // Make sure the reads below hit the file, not a delvec primed into the metacache.
+    _tablet_manager->metacache()->prune();
+
+    bool old_strict = config::enable_strict_delvec_crc_check;
+    config::enable_strict_delvec_crc_check = true;
+    LakeIOOptions lake_io_opts;
+
+    // Without the hook: the drop is NotSupported here, so the original Corruption
+    // must surface.
+    {
+        DelVector read_delvec;
+        auto st = get_del_vec(_tablet_manager.get(), *metadata2, segment_id, false, lake_io_opts, &read_delvec);
+        ASSERT_TRUE(st.is_corruption()) << st;
+    }
+
+    // With the hook: force the drop to report success and restore the file at the
+    // same moment -- that is what dropping a corrupt cached block achieves in
+    // production -- and the retry must succeed.
+    int drop_calls = 0;
+    const std::string sync_point = "lake::drop_corrupted_delvec_file_cache";
+    SyncPoint::GetInstance()->SetCallBack(sync_point, [&](void* arg) {
+        ++drop_calls;
+        WritableFileOptions wopts{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(wopts, delvec_path));
+        CHECK_OK(wf->append(Slice(good_bytes)));
+        CHECK_OK(wf->close());
+        *(Status*)arg = Status::OK();
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    {
+        DelVector read_delvec;
+        auto st = get_del_vec(_tablet_manager.get(), *metadata2, segment_id, false, lake_io_opts, &read_delvec);
+        ASSERT_OK(st);
+        EXPECT_EQ(expected_delvec, read_delvec.save());
+    }
+    EXPECT_EQ(1, drop_calls);
+    SyncPoint::GetInstance()->ClearCallBack(sync_point);
+    SyncPoint::GetInstance()->DisableProcessing();
+    config::enable_strict_delvec_crc_check = old_strict;
 }
 
 TEST_F(MetaFileTest, test_delvec_read_loop) {


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #78086 to branch-4.0 (the Mergify backport #78603 hit a conflict in `meta_file.cpp` and was closed).

Delvec pages (`.delvec` files, read by `get_del_vec`) have no recovery from local-cache corruption: with `enable_strict_delvec_crc_check` (default true), a crc32c mismatch on a delvec page returns `Corruption` and leaves the corrupted local cache entry in place. Since the cache is persistent and the reader is pinned to the node, every retry (publish, compaction) re-reads the same bad bytes and fails forever — the same wedge #77481 (backported as #77998) fixed for PK index sstables.

## What I'm doing:

- #78086: in `get_del_vec` (`be/src/storage/lake/meta_file.cpp`), factor the page read and crc32c verification into `read_page` / `verify_page`; when strict verification fails with `Corruption`, drop the delvec file's local cache (`drop_corrupted_delvec_file_cache`, built on the existing `drop_local_cache_data`, with its own `lake::drop_corrupted_delvec_file_cache` sync point) and read the page once more so the retry reads through to the remote object. If the second verification still fails, the `Corruption` propagates as before. Behavior is unchanged for intact pages, non-strict mode, and builds without a local cache layer.

Deviations from the main commit, because branch-4.0 differs:
- `get_del_vec` on 4.0 has only the `segment_id` overload (main split out a `DelvecPagePB` overload), so the retry logic is applied inside the existing function with a `delvec_page` alias for `iter->second`.
- 4.0 has no del-file recovery (#78022 was not backported here), so the new helper stands alone instead of sitting next to `drop_corrupted_del_file_cache`; comments adjusted accordingly.
- UT `MetaFileTest.test_get_del_vec_crc32c_retries_after_dropping_cache` calls the `segment_id` overload and includes `testutil/sync_point.h`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

