### PR TITLE
[BugFix] Stop registering JSON extended columns on the shared catalog table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -208,23 +208,14 @@ public class JsonPathRewriteRule extends TransformationRule {
         }
 
         private Column createExtendedColumn(Table table, String path, ColumnAccessPath jsonPath) {
-            if (!table.containColumn(path)) {
-                Preconditions.checkState(table instanceof OlapTable, "Only support OlapTable");
-                // NOTE: The safety of adding a column dynamically is ensured by the fact that
-                // this rule is only applied during query planning, thus the Table here is already copied for the
-                // query. So this change would not affect the original table schema.
-                Column extendedColumn = new Column(path, jsonPath.getValueType(), true);
-
-                // Allocate the unique id for extended column
-                OlapTable olapTable = (OlapTable) table;
-                int nextUniqueId = olapTable.incAndGetMaxColUniqueId();
-                extendedColumn.setUniqueId(nextUniqueId);
-
-                table.addColumn(extendedColumn);
-                return extendedColumn;
-            } else {
-                return table.getColumn(path);
-            }
+            Preconditions.checkState(table instanceof OlapTable, "Only support OlapTable");
+            // The extended column is a per-query artifact: it only ever travels through the scan operator's
+            // colRefToColumnMetaMap and the ColumnAccessPath list, both of which are rebuilt for every scan.
+            // It must NOT be registered on the Table object. Doing so mutates the shared catalog instance for
+            // any statement whose source table is not copied (INSERT ... SELECT and MV refresh both reuse the
+            // live OlapTable), which leaks the column into InsertPlanner's sink schema and pins the path to
+            // whichever type happened to be resolved first.
+            return new Column(path, jsonPath.getValueType(), true);
         }
 
         public static ColumnAccessPath pathFromColumn(Column column) {
@@ -273,8 +264,7 @@ public class JsonPathRewriteRule extends TransformationRule {
 
             // Skip the JSON-path pushdown when two subfields of the same JSON column collide
             // case-insensitively (e.g. 'Campaign' vs 'campaign'); see hasCaseCollidingJsonSubfields.
-            if (hasCaseCollidingJsonSubfields(new ArrayList<>(project.getColumnRefMap().values()), columnRefFactory,
-                    null)) {
+            if (hasCaseCollidingJsonSubfields(new ArrayList<>(project.getColumnRefMap().values()), columnRefFactory)) {
                 return optExpr;
             }
 
@@ -348,7 +338,7 @@ public class JsonPathRewriteRule extends TransformationRule {
             if (scanOperator.getProjection() != null) {
                 jsonRoots.addAll(scanOperator.getProjection().getColumnRefMap().values());
             }
-            if (hasCaseCollidingJsonSubfields(jsonRoots, columnRefFactory, scanOperator.getTable())) {
+            if (hasCaseCollidingJsonSubfields(jsonRoots, columnRefFactory)) {
                 return optExpr;
             }
 
@@ -427,20 +417,18 @@ public class JsonPathRewriteRule extends TransformationRule {
      *
      * <p>JSON object keys are case-sensitive, so these are two distinct fields with distinct values.
      * The pushdown, however, materializes each as an extended {@link Column} whose name is the
-     * subfield path; those names collide in {@code Table.nameToColumn} (a case-insensitive map) and
-     * in every downstream name-keyed lookup (global-dict, min/max statistics). The result is a scan
-     * chunk with mismatched column row counts (BE crash) or a wrong global-dict mapping ("Dict Decode
-     * failed"). When such a collision is present we skip the rewrite for that scan entirely and let
+     * subfield path; those names collide in every downstream name-keyed lookup (global-dict, min/max
+     * statistics). The result is a scan chunk with mismatched column row counts (BE crash) or a wrong
+     * global-dict mapping ("Dict Decode failed"). When such a collision is present we skip the rewrite
+     * for that scan entirely and let
      * the query read the JSON column whole (identical to running with cbo_json_v2_rewrite=false),
      * which is correct — only the (rare) colliding query loses the subfield-pushdown optimization.
      *
      * <p>This is a side-effect-free pre-pass: it must run before any extended column is created,
      * because a partially-applied rewrite leaves dangling column refs that break later stages.
      */
-    private static boolean hasCaseCollidingJsonSubfields(List<ScalarOperator> roots, ColumnRefFactory factory,
-                                                         Table scanTable) {
+    private static boolean hasCaseCollidingJsonSubfields(List<ScalarOperator> roots, ColumnRefFactory factory) {
         // key: case-folded extended-column name -> the actual (case-sensitive) name that first claimed it.
-        // Used for collisions WITHIN this scan; cross-scan collisions are caught against the table below.
         Map<String, String> claimed = Maps.newHashMap();
         Deque<ScalarOperator> stack = new ArrayDeque<>();
         for (ScalarOperator root : roots) {
@@ -481,18 +469,12 @@ public class JsonPathRewriteRule extends TransformationRule {
             fullPath.addAll(fields);
             String name = ColumnAccessPath.createLinearPath(fullPath, call.getType()).getLinearPath();
 
-            // (a) collision within this scan: two subfields whose extended-column names differ only by case.
+            // Collision within this scan: two subfields whose extended-column names differ only by case.
+            // The cross-scan branch that used to live here is gone together with createExtendedColumn()'s
+            // table-backed reuse: extended columns are no longer registered on the shared table, so aliases
+            // of the same table can no longer pick up each other's case-differing column.
             String prior = claimed.putIfAbsent(name.toLowerCase(Locale.ROOT), name);
             if (prior != null && !prior.equals(name)) {
-                return true;
-            }
-            // (b) cross-scan collision: aliases of the same table share one analyzer table copy
-            // (AnalyzerUtils.copyTable), so another scan may already have added a case-differing extended
-            // column (e.g. t1 read j->'Campaign', t2 reads j->'campaign'). createExtendedColumn() would then
-            // reuse that column case-insensitively and emit the wrong path for this scan.
-            Table targetTable = scanTable != null ? scanTable : tableAndColumn.first;
-            Column existing = targetTable.getColumn(name);
-            if (existing != null && !existing.getName().equals(name)) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -1236,7 +1236,15 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
             }
 
             // Condition 3: the varchar column has collected global dict
-            Column columnObj = table.getColumn(column.getName());
+            // Extended json subfield columns are per-query artifacts and are not part of the table schema,
+            // so resolve them through the scan's own map first -- the same source checkExtendedColumn() uses.
+            Column columnObj = scan.getColRefToColumnMetaMap().get(column);
+            if (columnObj == null) {
+                columnObj = table.getColumn(column.getName());
+            }
+            if (columnObj == null) {
+                continue;
+            }
             if (!IDictManager.getInstance().hasGlobalDict(table.getId(), columnObj.getColumnId(), version)) {
                 LOG.debug("{} doesn't have global dict", column.getName());
                 continue;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -14,7 +14,9 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -455,5 +457,132 @@ public class JsonPathRewriteTest extends PlanTestBase {
         }
     }
 
-}
+    /**
+     * The extended column synthesized for a JSON subfield is a per-query artifact: it only ever travels
+     * through the scan's colRefToColumnMetaMap and the ColumnAccessPath list. It must not be registered on
+     * the OlapTable, because statements whose source table is not copied (INSERT ... SELECT and MV refresh
+     * both reuse the live catalog instance) would then mutate the shared table -- that is POST-1773.
+     */
+    @Test
+    public void testExtendedColumnNotRegisteredOnTable() throws Exception {
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        starRocksAssert.withTable(
+                "create table json_no_pollute (k int, j json) properties('replication_num'='1')");
+        try {
+            OlapTable table = (OlapTable) starRocksAssert.getTable("test", "json_no_pollute");
+            int schemaSizeBefore = table.getFullSchema().size();
+            int maxColUniqueIdBefore = table.getMaxColUniqueId();
 
+            // A plain SELECT plans against AnalyzerUtils.copyTable's copy, so it cannot show the leak.
+            // DML does not copy its source table -- that is the path that mutates the live catalog object.
+            String plan = getFragmentPlan(
+                    "insert into json_no_pollute select k, j from json_no_pollute "
+                            + "where get_json_int(j, '$.a') = 1");
+            // the rewrite did happen ...
+            assertContains(plan, "j.a");
+
+            // ... and yet the shared catalog object is untouched.
+            Assertions.assertEquals(schemaSizeBefore, table.getFullSchema().size(),
+                    "json path rewrite must not grow the shared table schema");
+            Assertions.assertNull(table.getColumn("j.a"),
+                    "extended column must not be resolvable through the table");
+            Assertions.assertEquals(maxColUniqueIdBefore, table.getMaxColUniqueId(),
+                    "json path rewrite must not consume column unique ids (maxColUniqueId is persisted)");
+
+            // Planning it again must not accumulate anything either.
+            getFragmentPlan("insert into json_no_pollute select k, j from json_no_pollute "
+                    + "where get_json_string(j, '$.b') = 'x'");
+            Assertions.assertEquals(schemaSizeBefore, table.getFullSchema().size(),
+                    "repeated planning must not accumulate extended columns");
+            Assertions.assertEquals(maxColUniqueIdBefore, table.getMaxColUniqueId(),
+                    "repeated planning must not consume column unique ids");
+        } finally {
+            starRocksAssert.dropTable("json_no_pollute");
+        }
+    }
+
+    /**
+     * POST-1773: `insert into t select ... from t where <json subfield predicate>` used to fail with
+     * "number of exprs is not same with slots". InsertPlanner takes outputFullSchema from
+     * targetTable.getFullSchema() (a live reference) before optimizing; the rewrite then grew that list
+     * mid-flight, so the sink tuple got one more slot than there were output exprs. On the second attempt
+     * the counts matched again -- at the cost of shipping a phantom always-NULL column on every load.
+     */
+    @Test
+    public void testSelfReferencingInsertHasNoPhantomColumn() throws Exception {
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        starRocksAssert.withTable(
+                "create table json_self_insert (k int, j json) properties('replication_num'='1')");
+        try {
+            String sql = "insert into json_self_insert select k, j from json_self_insert "
+                    + "where get_json_int(j, '$.a') = 1";
+            String plan = getFragmentPlan(sql);
+            assertContains(plan, "OLAP TABLE SINK");
+            // Two real columns in, two out -- no synthesized third slot.
+            assertContains(plan, "OUTPUT EXPRS:1: k | 2: j\n");
+            assertNotContains(plan, "3: expr");
+
+            // Planning it twice must produce the very same sink shape; the old behaviour differed between
+            // the first and the following runs because the first one left the extra column behind.
+            Assertions.assertEquals(plan, getFragmentPlan(sql),
+                    "the insert plan must be stable across repeated planning");
+        } finally {
+            starRocksAssert.dropTable("json_self_insert");
+        }
+    }
+
+    /**
+     * Two scans over the same table that read the same path with different types must each get their own
+     * extended column. While the columns were registered on the shared table, the second scan reused the
+     * first one's column and inherited its type, which pinned the slot to the wrong type and produced
+     * wrong results (a self-join filtering on both int and string form of $.x returned 0 rows).
+     */
+    @Test
+    public void testCrossScanSamePathDifferentTypes() throws Exception {
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+        starRocksAssert.withTable(
+                "create table json_cross_scan (k int, j json) properties('replication_num'='1')");
+        try {
+            String plan = getVerboseExplain(
+                    "select count(*) from json_cross_scan a join json_cross_scan b on a.k = b.k "
+                            + "where get_json_int(a.j, '$.x') = 1 and get_json_string(b.j, '$.x') = '2'");
+            // Each side keeps the type its own expression asked for.
+            assertContains(plan, "ExtendedColumnAccessPath: [/j(bigint(20))/x(bigint(20))]");
+            assertContains(plan, "ExtendedColumnAccessPath: [/j(varchar)/x(varchar)]");
+        } finally {
+            starRocksAssert.dropTable("json_cross_scan");
+            connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+            connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        }
+    }
+
+    /**
+     * Same as above but reached through an inlined CTE, which is how it shows up in real workloads:
+     * the two consumers become two scans of the same table.
+     */
+    @Test
+    public void testInlinedCteSamePathDifferentTypes() throws Exception {
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+        boolean cteReuse = connectContext.getSessionVariable().isCboCteReuse();
+        connectContext.getSessionVariable().setCboCteReuse(false);
+        starRocksAssert.withTable(
+                "create table json_cte_scan (k int, j json) properties('replication_num'='1')");
+        try {
+            String plan = getVerboseExplain(
+                    "with c as (select k, j from json_cte_scan where k < 100) "
+                            + "select count(*) from c c1 join c c2 on c1.k = c2.k "
+                            + "where get_json_int(c1.j, '$.x') = 1 and get_json_string(c2.j, '$.x') = '2'");
+            assertContains(plan, "ExtendedColumnAccessPath: [/j(bigint(20))/x(bigint(20))]");
+            assertContains(plan, "ExtendedColumnAccessPath: [/j(varchar)/x(varchar)]");
+        } finally {
+            starRocksAssert.dropTable("json_cte_scan");
+            connectContext.getSessionVariable().setCboCteReuse(cteReuse);
+            connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+            connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        }
+    }
+}

--- a/test/sql/test_json/R/test_json_subfield_cross_scan_type_hijack
+++ b/test/sql/test_json/R/test_json_subfield_cross_scan_type_hijack
@@ -1,0 +1,83 @@
+-- name: test_json_subfield_cross_scan_type_hijack
+create table t (k int, j json) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values
+  (1, parse_json('{"v":3.75,"c":"str1"}')),
+  (2, parse_json('{"v":9.25,"c":5}')),
+  (3, parse_json('{"v":1.5,"c":"str3"}'));
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+select a.k, get_json_int(a.j, '$.v') as ai, get_json_double(b.j, '$.v') as bd
+  from t a join t b on a.k = b.k order by a.k;
+-- result:
+1	3	3.75
+2	9	9.25
+3	1	1.5
+-- !result
+select a.k, length(get_json_string(a.j, '$.v')) as len_s, get_json_int(b.j, '$.v') as bi
+  from t a join t b on a.k = b.k order by a.k;
+-- result:
+1	4	3
+2	4	9
+3	3	1
+-- !result
+select src, x from (
+  select 'int' as src, cast(get_json_int(j, '$.v') as string) as x from t
+  union all
+  select 'dbl' as src, cast(get_json_double(j, '$.v') as string) as x from t) u
+  order by src, x;
+-- result:
+dbl	1.5
+dbl	3.75
+dbl	9.25
+int	1
+int	3
+int	9
+-- !result
+select a.k from t a join t b on a.k + 1 = b.k
+  where get_json_string(a.j, '$.c') like 'str%' and get_json_int(b.j, '$.c') > 3
+  order by a.k;
+-- result:
+1
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select a.k, get_json_int(a.j, '$.v') as ai, get_json_double(b.j, '$.v') as bd
+  from t a join t b on a.k = b.k order by a.k;
+-- result:
+1	3	3.75
+2	9	9.25
+3	1	1.5
+-- !result
+select a.k, length(get_json_string(a.j, '$.v')) as len_s, get_json_int(b.j, '$.v') as bi
+  from t a join t b on a.k = b.k order by a.k;
+-- result:
+1	4	3
+2	4	9
+3	3	1
+-- !result
+select src, x from (
+  select 'int' as src, cast(get_json_int(j, '$.v') as string) as x from t
+  union all
+  select 'dbl' as src, cast(get_json_double(j, '$.v') as string) as x from t) u
+  order by src, x;
+-- result:
+dbl	1.5
+dbl	3.75
+dbl	9.25
+int	1
+int	3
+int	9
+-- !result
+select a.k from t a join t b on a.k + 1 = b.k
+  where get_json_string(a.j, '$.c') like 'str%' and get_json_int(b.j, '$.c') > 3
+  order by a.k;
+-- result:
+1
+-- !result

--- a/test/sql/test_json/R/test_json_subfield_mv_catalog_poisoning
+++ b/test/sql/test_json/R/test_json_subfield_mv_catalog_poisoning
@@ -1,0 +1,87 @@
+-- name: test_json_subfield_mv_catalog_poisoning
+create table base (k int, j json) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into base values
+  (1, parse_json('{"a":1}')),
+  (2, parse_json('{"a":"str"}')),
+  (3, parse_json('{"a":3}'));
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+-- result:
+1	1
+2	str
+3	3
+-- !result
+select count(*) as str_cnt from base where get_json_string(j, '$.a') = 'str';
+-- result:
+1
+-- !result
+create materialized view mv1 distributed by hash(k) buckets 1 refresh manual
+  properties("replication_num"="1") as select k, cast(j->'$.a' as bigint) as a from base;
+-- result:
+-- !result
+refresh materialized view mv1 with sync mode;
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+-- result:
+1	1
+2	str
+3	3
+-- !result
+select count(*) as str_cnt from base where get_json_string(j, '$.a') = 'str';
+-- result:
+1
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+-- result:
+1	1
+2	str
+3	3
+-- !result
+select count(*) as str_cnt from base where get_json_string(j, '$.a') = 'str';
+-- result:
+1
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+-- result:
+1	1
+2	str
+3	3
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+-- result:
+1	1
+2	str
+3	3
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+create materialized view mv2 distributed by hash(k) buckets 1 refresh manual
+  properties("replication_num"="1") as select k, get_json_string(j, '$.a') as a from base;
+-- result:
+-- !result
+refresh materialized view mv2 with sync mode;
+select k, a from mv2 order by k;
+-- result:
+1	1
+2	str
+3	3
+-- !result

--- a/test/sql/test_json/R/test_json_subfield_no_catalog_pollution
+++ b/test/sql/test_json/R/test_json_subfield_no_catalog_pollution
@@ -1,0 +1,128 @@
+-- name: test_json_subfield_no_catalog_pollution
+create table t (k int, j json) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t values
+  (1, parse_json('{"x":1,"y":"s1"}')),
+  (2, parse_json('{"x":"s2","y":"s2"}')),
+  (3, parse_json('{"x":3,"y":"s3"}'));
+-- result:
+-- !result
+create table dst (k int, v varchar(100)) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+select k, get_json_int(j, '$.x') as as_int from t order by k;
+-- result:
+1	1
+2	None
+3	3
+-- !result
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+-- result:
+1	1
+2	s2
+3	3
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select k, get_json_int(j, '$.x') as as_int from t order by k;
+-- result:
+1	1
+2	None
+3	3
+-- !result
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+-- result:
+1	1
+2	s2
+3	3
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+insert into dst select k, cast(get_json_int(j, '$.x') as varchar) from t;
+-- result:
+-- !result
+select k, v from dst order by k;
+-- result:
+1	1
+2	None
+3	3
+-- !result
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+-- result:
+1	1
+2	s2
+3	3
+-- !result
+select count(*) as str_cnt from t where get_json_string(j, '$.x') = 's2';
+-- result:
+1
+-- !result
+select sum(length(get_json_string(j, '$.x'))) as sum_len from t;
+-- result:
+4
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+-- result:
+1	1
+2	s2
+3	3
+-- !result
+select count(*) as str_cnt from t where get_json_string(j, '$.x') = 's2';
+-- result:
+1
+-- !result
+select sum(length(get_json_string(j, '$.x'))) as sum_len from t;
+-- result:
+4
+-- !result
+set cbo_json_v2_rewrite = true;
+-- result:
+-- !result
+insert into t select k, j from t where get_json_int(j, '$.x') = 1;
+-- result:
+-- !result
+select count(*) from t;
+-- result:
+4
+-- !result
+select count(*) from t a join t b on a.k = b.k
+  where get_json_int(a.j, '$.x') = 1 and get_json_string(b.j, '$.x') = '1';
+-- result:
+4
+-- !result
+set cbo_cte_reuse = false;
+-- result:
+-- !result
+select count(*) from (
+  with c as (select k, j from t where k < 100)
+  select c1.k from c c1 join c c2 on c1.k = c2.k
+  where get_json_int(c1.j, '$.x') = 1 and get_json_string(c2.j, '$.x') = '1') x;
+-- result:
+4
+-- !result
+set cbo_json_v2_rewrite = false;
+-- result:
+-- !result
+select count(*) from t a join t b on a.k = b.k
+  where get_json_int(a.j, '$.x') = 1 and get_json_string(b.j, '$.x') = '1';
+-- result:
+4
+-- !result
+select count(*) from (
+  with c as (select k, j from t where k < 100)
+  select c1.k from c c1 join c c2 on c1.k = c2.k
+  where get_json_int(c1.j, '$.x') = 1 and get_json_string(c2.j, '$.x') = '1') x;
+-- result:
+4
+-- !result

--- a/test/sql/test_json/T/test_json_subfield_cross_scan_type_hijack
+++ b/test/sql/test_json/T/test_json_subfield_cross_scan_type_hijack
@@ -1,0 +1,53 @@
+-- name: test_json_subfield_cross_scan_type_hijack
+-- The v2 JSON path rewrite registered its synthesized extended column on the live OlapTable and then
+-- reused it across scans keyed by path name alone, with no type in the key. Two scans of one table
+-- reading the same path at different types therefore shared one column, and the loser's slot kept the
+-- winner's type while still carrying the loser's bytes. Nothing reported an error -- the value was
+-- simply reinterpreted:
+--   * get_json_int over a double-typed subfield returned the double, or the raw IEEE-754 bit pattern
+--     read back as an integer (3.75 came out as 1074659328),
+--   * length() over the hijacked slot returned a NEGATIVE length (-3), which is the direct precursor
+--     to an out-of-bounds Slice read, and
+--   * a LIKE predicate landing on a slot hijacked to BIGINT handed eight integer bytes to
+--     LikePredicate::constant_starts_with_fn, which called memequal on them and took the whole BE
+--     process down with SIGSEGV.
+-- Every query below must agree with the same query under cbo_json_v2_rewrite=false.
+-- The table carries no flat_json property: this is purely the FE rewrite.
+create table t (k int, j json) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+insert into t values
+  (1, parse_json('{"v":3.75,"c":"str1"}')),
+  (2, parse_json('{"v":9.25,"c":5}')),
+  (3, parse_json('{"v":1.5,"c":"str3"}'));
+set cbo_json_v2_rewrite = true;
+-- Two scans of one table, one reading $.v as an int and one as a double.
+select a.k, get_json_int(a.j, '$.v') as ai, get_json_double(b.j, '$.v') as bd
+  from t a join t b on a.k = b.k order by a.k;
+-- The string side of the same path must keep a sane length.
+select a.k, length(get_json_string(a.j, '$.v')) as len_s, get_json_int(b.j, '$.v') as bi
+  from t a join t b on a.k = b.k order by a.k;
+-- The same collision reached through the two branches of a UNION ALL rather than a join.
+select src, x from (
+  select 'int' as src, cast(get_json_int(j, '$.v') as string) as x from t
+  union all
+  select 'dbl' as src, cast(get_json_double(j, '$.v') as string) as x from t) u
+  order by src, x;
+-- A LIKE predicate on the string form of $.c while the other scan reads it as an int. This is the
+-- shape that crashed the backend, so reaching the result at all is most of the assertion.
+select a.k from t a join t b on a.k + 1 = b.k
+  where get_json_string(a.j, '$.c') like 'str%' and get_json_int(b.j, '$.c') > 3
+  order by a.k;
+-- Control: with the rewrite off every answer above must come back unchanged.
+set cbo_json_v2_rewrite = false;
+select a.k, get_json_int(a.j, '$.v') as ai, get_json_double(b.j, '$.v') as bd
+  from t a join t b on a.k = b.k order by a.k;
+select a.k, length(get_json_string(a.j, '$.v')) as len_s, get_json_int(b.j, '$.v') as bi
+  from t a join t b on a.k = b.k order by a.k;
+select src, x from (
+  select 'int' as src, cast(get_json_int(j, '$.v') as string) as x from t
+  union all
+  select 'dbl' as src, cast(get_json_double(j, '$.v') as string) as x from t) u
+  order by src, x;
+select a.k from t a join t b on a.k + 1 = b.k
+  where get_json_string(a.j, '$.c') like 'str%' and get_json_int(b.j, '$.c') > 3
+  order by a.k;

--- a/test/sql/test_json/T/test_json_subfield_mv_catalog_poisoning
+++ b/test/sql/test_json/T/test_json_subfield_mv_catalog_poisoning
@@ -1,0 +1,43 @@
+-- name: test_json_subfield_mv_catalog_poisoning
+-- An asynchronous materialized view whose definition narrows a JSON subfield with a CAST used to
+-- poison its base table. MV refresh is an INSERT and does not copy its source table, so the v2 JSON
+-- path rewrite registered the synthesized extended column -- typed by whatever the MV asked for --
+-- on the live OlapTable. Every later statement reading that path picked the pinned column up:
+--   * get_json_string(j,'$.a') returned NULL for rows whose value is not an integer,
+--   * a predicate on the same expression stopped matching those rows while a projection still
+--     showed them, so the two disagreed,
+--   * dropping the MV did not undo any of it, and
+--   * creating another MV that reads the path at a different type failed outright with
+--     "type of exprs is not match slot's, expr_type=BIGINT, slot_type=VARCHAR".
+-- The base table below carries no flat_json property: this is purely the FE rewrite.
+create table base (k int, j json) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+insert into base values
+  (1, parse_json('{"a":1}')),
+  (2, parse_json('{"a":"str"}')),
+  (3, parse_json('{"a":3}'));
+set cbo_json_v2_rewrite = true;
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+select count(*) as str_cnt from base where get_json_string(j, '$.a') = 'str';
+create materialized view mv1 distributed by hash(k) buckets 1 refresh manual
+  properties("replication_num"="1") as select k, cast(j->'$.a' as bigint) as a from base;
+refresh materialized view mv1 with sync mode;
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+select count(*) as str_cnt from base where get_json_string(j, '$.a') = 'str';
+-- Control at the point of maximum damage: the very same two reads with the rewrite off. On the
+-- unfixed build these two still answered correctly while the two above did not, and that gap is
+-- precisely the bug -- the rewrite has no licence to disagree with its own switched-off self.
+set cbo_json_v2_rewrite = false;
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+select count(*) as str_cnt from base where get_json_string(j, '$.a') = 'str';
+set cbo_json_v2_rewrite = true;
+drop materialized view mv1;
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+-- Dropping the MV never undid the pinning, so the control has to be repeated here too.
+set cbo_json_v2_rewrite = false;
+select k, get_json_string(j, '$.a') as as_str from base order by k;
+set cbo_json_v2_rewrite = true;
+create materialized view mv2 distributed by hash(k) buckets 1 refresh manual
+  properties("replication_num"="1") as select k, get_json_string(j, '$.a') as a from base;
+refresh materialized view mv2 with sync mode;
+select k, a from mv2 order by k;

--- a/test/sql/test_json/T/test_json_subfield_no_catalog_pollution
+++ b/test/sql/test_json/T/test_json_subfield_no_catalog_pollution
@@ -1,0 +1,76 @@
+-- name: test_json_subfield_no_catalog_pollution
+-- The v2 JSON path rewrite used to register the synthesized extended column on the OlapTable through
+-- Table.addColumn(). The comment there claimed that was safe because planning always runs against a
+-- copied table, but that only holds for a plain SELECT: DML does not copy its source table, so
+-- INSERT ... SELECT and materialized view refresh both mutated the live catalog instance.
+--
+-- (1) InsertPlanner takes outputFullSchema from targetTable.getFullSchema(), which is a live
+--     reference. A self-referencing insert grew that list mid-optimize, so the sink tuple ended up
+--     with one more slot than there were output exprs and the statement failed with "number of exprs
+--     is not same with slots". Retrying succeeded, at the price of shipping a phantom always-NULL
+--     column on every load.
+-- (2) The registered column also doubled as a cross-scan dedup registry keyed by name alone. A second
+--     scan reading the same path with a different type reused the first column and inherited its
+--     type, so a self-join filtering on both the int and the string form of one path returned no rows.
+--
+-- Neither depends on flat_json: the table below has no flat_json.* property at all.
+create table t (k int, j json) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+insert into t values
+  (1, parse_json('{"x":1,"y":"s1"}')),
+  (2, parse_json('{"x":"s2","y":"s2"}')),
+  (3, parse_json('{"x":3,"y":"s3"}'));
+create table dst (k int, v varchar(100)) duplicate key(k)
+  distributed by hash(k) buckets 1 properties("replication_num"="1");
+set cbo_json_v2_rewrite = true;
+-- A plain SELECT plans against AnalyzerUtils.copyTable's copy and must leave no trace: reading $.x as
+-- an int here must not change how the very next statement reads it as a string.
+select k, get_json_int(j, '$.x') as as_int from t order by k;
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+-- Both readings, with the rewrite off, before anything has touched the catalog. This is the
+-- reference the two statements above have to match, and the two after the poisoning insert as well.
+set cbo_json_v2_rewrite = false;
+select k, get_json_int(j, '$.x') as as_int from t order by k;
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+set cbo_json_v2_rewrite = true;
+-- DML does not copy its source table. This cross-table insert is the most ordinary way to hit the
+-- leak -- it reports no error at all, it just pins $.x to BIGINT on the shared catalog object, after
+-- which every reader of that path gets NULL for the non-integer row.
+insert into dst select k, cast(get_json_int(j, '$.x') as varchar) from t;
+-- That insert is itself entirely correct -- get_json_int over a non-integer value is NULL by
+-- definition -- and it reports nothing unusual. What it silently did is pin $.x to BIGINT on the
+-- source table, so the damage only shows up in the statements that come after it.
+select k, v from dst order by k;
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+select count(*) as str_cnt from t where get_json_string(j, '$.x') = 's2';
+-- An aggregate over the string form reads the pinned column's bytes rather than the string it should
+-- have seen: with $.x pinned to BIGINT, sum(length(...)) summed lengths taken off the integer column
+-- instead of off '1' / 's2' / '3'.
+select sum(length(get_json_string(j, '$.x'))) as sum_len from t;
+-- Control for the three reads above, taken at the poisoned point rather than only at the end of the
+-- file: the rewrite must agree with its switched-off self on every one of them.
+set cbo_json_v2_rewrite = false;
+select k, get_json_string(j, '$.x') as as_str from t order by k;
+select count(*) as str_cnt from t where get_json_string(j, '$.x') = 's2';
+select sum(length(get_json_string(j, '$.x'))) as sum_len from t;
+set cbo_json_v2_rewrite = true;
+-- The self-referencing insert must succeed on the very first attempt.
+insert into t select k, j from t where get_json_int(j, '$.x') = 1;
+select count(*) from t;
+-- Two scans of one table reading $.x as int and as string each keep their own type.
+select count(*) from t a join t b on a.k = b.k
+  where get_json_int(a.j, '$.x') = 1 and get_json_string(b.j, '$.x') = '1';
+-- The same shape reached through an inlined CTE.
+set cbo_cte_reuse = false;
+select count(*) from (
+  with c as (select k, j from t where k < 100)
+  select c1.k from c c1 join c c2 on c1.k = c2.k
+  where get_json_int(c1.j, '$.x') = 1 and get_json_string(c2.j, '$.x') = '1') x;
+-- Control: with the rewrite off both answers must be identical.
+set cbo_json_v2_rewrite = false;
+select count(*) from t a join t b on a.k = b.k
+  where get_json_int(a.j, '$.x') = 1 and get_json_string(b.j, '$.x') = '1';
+select count(*) from (
+  with c as (select k, j from t where k < 100)
+  select c1.k from c c1 join c c2 on c1.k = c2.k
+  where get_json_int(c1.j, '$.x') = 1 and get_json_string(c2.j, '$.x') = '1') x;


### PR DESCRIPTION
## Why I'm doing:

`JsonPathRewriteRule` synthesizes an extended column for every JSON subfield access and registered it on the `OlapTable` through `Table.addColumn()`. The comment there claimed this was safe because planning always runs against a copied table — but that only holds for a plain `SELECT`. DML does not copy its source table, so `INSERT... SELECT` and materialized view refresh both mutated the live catalog instance.

One root cause, three classes of failure. All of them were reproduced on a shared-data cluster against both the fixed and the unfixed build.

### A. The BE process crashes

```sql
select a.k from t a join t b on a.k + 1 = b.k
 where get_json_string(a.j,'$.c') like 'str%' and get_json_int(b.j,'$.c') > 3;
```

```
PC: memequal(char const*, unsigned long, char const*, unsigned long)
*** SIGSEGV (@0x2) received by PID 2744863 ***
 @ UnpackConstColumnBinaryFunction<ConstantStartsImpl>::evaluate<(LogicalType)17, (LogicalType)17, (LogicalType)24>
 @ LikePredicate::constant_starts_with_fn
 @ ColumnExprPredicate::evaluate
 @ SegmentIterator::_filter_by_expr_predicates
```

Two scans read the same path, `a`'s slot is hijacked to BIGINT by `b`'s, and `LIKE 'str%'` hands eight integer bytes to `memequal` as if they were a `Slice`. Reproduced twice independently; on the fixed build the SIGSEGV counter does not move and both scans keep their own type.

### B. Wrong results, silently

No error, and nothing in the profile or in `/metrics` marks the rewrite as having happened.

| Query | Before | Correct |
|---|---|---|
| `get_json_int(j,'$.v')` where `$.v = 3.75` | `3.75` — a double came back from an int function | `3` |
| the same, while another scan reads it as a double | `1074659328` — the IEEE-754 bit pattern of 3.75 read as an integer | `3` |
| `length(get_json_string(j,'$.v'))` | **`-3`** — a negative length, the direct precursor to an out-of-bounds `Slice` read | `4` |
| `sum(length(get_json_string(j,'$.x')))` | **`-1`** — a negative sum | `4` |
| after an MV refresh: `count(*) from base where cast(j->'$.a' as string) is null` | **`600`** — 600 of 800 rows silently became NULL | `0` |
| after a cross-table insert: `get_json_string(j,'$.x')` on the source table | `NULL` | `s2` |

The MV case is the hardest to diagnose: the data itself is intact (`j->'$.a'` still reads back `"s1"`), only the way it is read is wrong — and `DROP MATERIALIZED VIEW` does not undo it. The table stays poisoned until the FE restarts.

### C. Three distinct errors

**1. A self-referencing insert fails on its first attempt.**

```
mysql> insert into t select k, j from t where get_json_int(j,'$.a') = 1;
ERROR 1064 (HY000): number of exprs is not same with slots backend [id=10242]

mysql> insert into t select k, j from t where get_json_int(j,'$.a') = 1; -- same statement again
Query OK, 1 row affected
```

`InsertPlanner` takes `outputFullSchema` from `targetTable.getFullSchema()`, which hands back the live list; the rewrite grew it mid-optimize, so the sink tuple ended up one slot wider than the output exprs. The retry succeeds because `fullSchema` is already three columns wide by then — at the price of shipping a phantom always-NULL column on every load from that point on (`<slot 11>: NULL` in the plan). `DESC` and `information_schema.columns` both read `getBaseSchema()`, so that column is invisible; the error was the only signal that anything had happened.

**2. Two scans, or two concurrent sessions, reading one path at different types collide.**

```
ERROR 1064 (HY000): type of exprs is not match slot's,
 expr_type=BIGINT, slot_type=VARCHAR, slot_name=v backend [id=10242]
```

Which type wins depends on thread interleaving: an isomorphic race observed 8 wrong and 4 correct outcomes over 12 runs.

**3. Once poisoned, no second MV can read that path at another type.**

```
ERROR 1064 (HY000): execute task mv-112118 failed: Refresh mv mv_s failed after 1 times,
 type of exprs is not match slot's, expr_type=BIGINT, slot_type=VARCHAR, slot_name=a_str
```

An irreversible modelling block: a JSON path admits exactly one MV type, first come first served — and the first one may well be somebody else's.

### What triggers it

None of this needs `flat_json` — the tables above carry no `flat_json.*` property at all. The switch is **`cbo_json_v2_rewrite`, which defaults to true since 4.0**. The reference answer everywhere below is the same statement with that variable turned off.

## What I'm doing:

The extended column is a per-query artifact: it only travels through the scan's `colRefToColumnMetaMap` and its `ColumnAccessPath` list, and neither consults the table schema. `TColumnAccessPath` carries a path string and a type but no column id, and the BE rebuilds the column itself in `extend_schema_by_access_paths()`, assigning its own unique ids. So `createExtendedColumn()` now returns a fresh `Column` without registering it, and without the unique id allocation that bumped the persisted `maxColUniqueId` for no reader on the read path.

Dropping the registration also drops the cross-scan reuse it provided. That reuse was never load-bearing: the two scans already build their own `ColumnRefOperator`, their own `colRefToColumnMetaMap` and their own `ColumnAccessPath` list — sharing the `Column` instance only propagated the wrong type, which is class A and class B above. `Column` has value-based `equals`/`hashCode`, and the one map keyed by `Column` (`columnMetaToColRefMap`) never receives extended columns, so nothing downstream depends on instance identity.

`DecodeCollector` was the single consumer that resolved extended columns back through the table, and it did so without a null check. It now reads the scan's own map first — the same source `checkExtendedColumn()` in that file already uses. Without this the low-cardinality collector NPEs on any `get_json_string` query that goes through the rewrite and the statement fails during planning; with it, the global-dictionary path is unchanged (`testGlobalDictRewrite` still asserts its 15 `DictDecode` plans). The V1 low-cardinality rewrite (`AddDecodeNodeForDictStringRule`, reachable only with `low_cardinality_optimize_v2 = false`) already guards the same lookup with `columnObj!= null`; its behaviour is byte-identical before and after this change, verified by running the same workload on both builds.

The cross-scan branch of `hasCaseCollidingJsonSubfields` guarded against exactly the reuse this change removes, so it goes as well; its per-scan branch stays.

One boundary worth calling out for review, and it is worth stating precisely because I got it wrong at first. On a table that owns a physical column named exactly like a JSON subfield path (a real `j.a` next to a JSON column `j`), `createExtendedColumn()` used to look the name up in the table and hand back that physical column, so `j->'$.a'` resolved to it. A predicate on that path then compared an integer constant against a VARCHAR slot and took the whole BE process down:

```
*** SIGSEGV (@0x0) received by PID 2881844 ***
 @ std::__cxx11::basic_string<char,...>::basic_string(char const*, unsigned long,...)
 @ starrocks::get_predicate_value<false, starrocks::Slice>(...)
 @ starrocks::ChunkPredicateBuilder<...>::normalize_in_or_equal_predicate<...>
 @ starrocks::ScanConjunctsManager::parse_conjuncts()
 @ starrocks::connector::LakeDataSource::rebuild_scan_conjuncts(...)
```

That lookup is gone, and the crash goes with it — verified on a shared-data cluster, where `select count(*) from t where get_json_int(j,'$.a') = 1` on such a table takes the backend down on the unfixed build and returns without crashing on the fixed one.

It does not, however, start reading the JSON subfield. The BE binds extended columns by name (`field_index(slot->col_name())`), so the synthesized `j.a` still collides with the real `j.a` in the tablet schema, and the same statement now answers 0 where the correct answer is 1 (`cbo_json_v2_rewrite = false` answers 1). Projecting both in one select also still fails with `Duplicate key j.a`, on both builds. Those are the BE half of the same name-collision defect and are not addressed here; what this change does to them is turn a process crash into a wrong answer, which is an improvement but not a fix. A table with a column named after a JSON subfield path is the only way to reach any of it.

## Tests

Four plan tests plus three SQL integration tests. Every one of them fails on the unfixed build, verified by reverting only the two source files and rerunning: `JsonPathRewriteTest` then reports 40 run / 15 errors (the 15 are the pre-existing `testGlobalDictRewrite` cases hitting the `DecodeCollector` NPE) and the four new ones fail as well.

Note the control everywhere is `cbo_json_v2_rewrite = false`, not `flat_json.enable`. None of the tables in these tests carry a `flat_json.*` property — this is a rewrite bug, not a flat-JSON bug, and the same statements misbehave on plain tables.

**`JsonPathRewriteTest`** — plan level
- `testExtendedColumnNotRegisteredOnTable`: after planning a DML that reads a JSON subfield, the table's `fullSchema` size, `getColumn("j.a")` and `maxColUniqueId` are all unchanged, and stay unchanged when the same statement is planned again. It has to drive this through an `INSERT... SELECT`: a plain SELECT plans against `AnalyzerUtils.copyTable`'s copy and would pass even without the fix.
- `testSelfReferencingInsertHasNoPhantomColumn`: `OUTPUT EXPRS:1: k | 2: j` with no third slot, and the plan is byte-identical when planned twice.
- `testCrossScanSamePathDifferentTypes` and `testInlinedCteSamePathDifferentTypes`: two scans reading `$.x` as int and as string each keep their own path type — `/j(bigint(20))/x(bigint(20))` and `/j(varchar)/x(varchar)` — instead of the second one inheriting the first's.

**`test/sql/test_json`** — end to end, executed against both builds on a shared-data cluster
- `test_json_subfield_no_catalog_pollution`: both DML entry points (cross-table and self-referencing insert) with two controls — a plain SELECT immediately before the cross-table insert, which must leave no trace, and the same queries with the rewrite off, which is the reference answer. It also asserts what the poisoning insert itself writes: that statement's own result is correct (`get_json_int` over a non-integer value is NULL by definition) and must stay correct, so the damage is pinned on the side effect. The aggregate assertion is the sharpest one here — `sum(length(get_json_string(j,'$.x')))` returned `-1` before the fix.
- `test_json_subfield_mv_catalog_poisoning`: an async MV narrowing a JSON subfield with a CAST. On the unfixed build `get_json_string` returns NULL for the non-integer row, a predicate on that same expression counts 0 instead of 1, dropping the MV does not undo any of it, and creating a second MV that reads the path at another type fails outright.
- `test_json_subfield_cross_scan_type_hijack`: the value-level assertions for class A and class B — `get_json_int` returning `3.75`, `length()` returning `-3`, the UNION ALL branches disagreeing, and the `LIKE` query that crashes the backend. Every query is repeated with `cbo_json_v2_rewrite = false` and both blocks must agree.

Line by line against both builds: the unfixed build differs on 5 assertions in the first file and 7 in the second, and fails the third one outright — the `LIKE` statement takes the BE down, so the run stops there and the remaining control block never executes.

Regression: `JsonPathRewriteTest` (44), `LowCardinalityTest` (74), `LowCardinalityTest2` (106), `JsonTypeTest` (6), `PruneComplexSubfieldTest` (62), `InsertPlanTest` (39), and the existing `test/sql/test_json` cases — including `test_json_subfield_case_collision_self_join`, which covers exactly the cross-scan guard this change deletes and still returns `CAP1/low1`, `CAP2/low2`. Separately, all 163 reproduction scripts from the flat-JSON audit were run three times (fixed / unfixed / fixed again, as an A-A control, restarting the BE between any case that killed it): 136 identical, 8 genuinely different, 5 of those attributable to this change and 3 to counters and background task timing. No case got worse.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5