### PR TITLE
[BugFix] Stop external tables from widening FE metadata lock scope

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -30,6 +30,10 @@ public class BaseTableInfo {
     @SerializedName(value = "catalogName")
     private final String catalogName;
 
+    // dbId/tableId are only set by the internal-catalog constructor. For an external base table they stay at
+    // -1, which is never a valid internal id (ids start at GlobalStateMgr.NEXT_ID_INIT_VALUE, with the range
+    // below it reserved by SystemId). They must therefore never be used as a lock identity -- see
+    // MVRefreshProcessor.collectDatabases, which skips external base tables for exactly this reason.
     @SerializedName(value = "dbId")
     private long dbId = -1;
 
@@ -82,6 +86,11 @@ public class BaseTableInfo {
         }
     }
 
+    /**
+     * Whether dbId/tableId are usable, in particular as a lock identity. catalogName here is the one carried by
+     * the table object, so a resource-mapping base table lands in the external constructor and leaves tableId
+     * at -1, and its Database resolves through the connector -- neither id may be locked.
+     */
     public boolean isInternalCatalog() {
         return CatalogMgr.isInternalCatalog(catalogName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -51,6 +51,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.memory.estimate.IgnoreMemoryTrack;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.planner.DescriptorTable.ReferencedPartitionInfo;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TTableDescriptor;
 import org.apache.commons.lang.NotImplementedException;
@@ -272,6 +273,38 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
 
     public String getCatalogName() {
         return InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME;
+    }
+
+    /**
+     * Whether the FE metadata lock can protect this table, i.e. whether it may be a target of
+     * {@link com.starrocks.sql.analyzer.PlannerMetaLocker} / Locker. A table for which this is false is never
+     * in the lock set, so it must not influence lock scope either -- see
+     * AnalyzerUtils.CopyUnsafeTablesCollector.
+     * <p>
+     * The question is about ownership, not engine type: is this object's in-memory metadata something the FE
+     * itself owns and rewrites in place? Answering it by listing table types is what makes it fragile, because
+     * the list keeps missing cases:
+     * <ul>
+     *   <li>an internal view is neither native nor an FE transaction participant, yet AlterJobMgr.alterView
+     *       rewrites its definition, schema and security in place under this very lock;</li>
+     *   <li>a resource-mapping table (ENGINE=HIVE/ICEBERG/HUDI created from a resource) reports a
+     *       resource-mapping catalog name, yet HiveTable.modifyTableSchema clears and refills its fullSchema
+     *       inside lockDatabase(WRITE), and LocalMetastore.replayModifyHiveTableColumn does the same on
+     *       replay.</li>
+     * </ul>
+     * So the predicate is "does it live in an internal database", expressed as {@code !isExternalCatalog}.
+     * That is deliberately not {@code isInternalCatalog}: the two differ exactly on resource-mapping catalogs,
+     * which {@link CatalogMgr#isExternalCatalog} already classifies as not-external. It is also fail-closed --
+     * a table kind nobody has classified yet keeps its lock, which costs a little contention rather than
+     * silently losing mutual exclusion.
+     */
+    public boolean isMetaLockTarget() {
+        // Spelled out, CatalogMgr.isExternalCatalog negated is: the internal catalog, or a resource-mapping
+        // pseudo-catalog (ENGINE=HIVE/ICEBERG/HUDI created from a RESOURCE -- those live in an internal
+        // database too), or no catalog name at all (ENGINE=JDBC from a RESOURCE leaves it null, as do a few
+        // other connector tables). Using it rather than open-coding those three keeps the null case handled:
+        // both isInternalCatalog and isResourceMappingCatalog throw on a null name.
+        return !CatalogMgr.isExternalCatalog(getCatalogName());
     }
 
     public String getResourceName() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -457,6 +457,18 @@ public class ShowExecutor {
 
             MetaUtils.checkDbNullAndReport(db, dbName);
 
+            // The walk below resolves the database out of LocalMetastore *by id*, so it is only meaningful for
+            // an internal one -- StarRocks materialized views never live in an external catalog. An external
+            // database's id is minted by the connector and shares an id space with internal databases
+            // (CatalogMgr.createCatalog draws from CONNECTOR_ID_GENERATOR for resource-mapping catalogs and
+            // from GlobalStateMgr.getNextId for the rest), so walking with it can land on an unrelated
+            // internal database. Skip the walk rather than lock a foreign id to make it safe.
+            // The null test is load-bearing, not defensive: the null-catalog branch above resolves through
+            // LocalMetastore, and isInternalCatalog would throw on null.
+            if (catalogName != null && !CatalogMgr.isInternalCatalog(catalogName)) {
+                return new ShowResultSet(showResultMetaFactory.getMetadata(statement), EMPTY_SET);
+            }
+
             List<MaterializedView> materializedViews = Lists.newArrayList();
             List<Pair<OlapTable, MaterializedIndexMeta>> singleTableMVs = Lists.newArrayList();
             Locker locker = new Locker();
@@ -634,8 +646,20 @@ public class ShowExecutor {
             Map<String, String> tableMap = Maps.newTreeMap();
             MetaUtils.checkDbNullAndReport(db, statement.getDb());
 
+            // SHOW TABLES serves both internal and external catalogs. For an internal database db.getId() is a
+            // real id and the lock is real, so it must stay. For an external catalog it is not: the id is minted
+            // by the connector (a fresh CONNECTOR_ID_GENERATOR value per HiveMetastoreApiConverter.toDatabase,
+            // constant 0 for every JDBC database), so the lock either never contends or falsely serializes
+            // unrelated databases. Either way it protects nothing -- connector cache refresh replaces cache
+            // entries and never takes the FE Locker -- while the critical section below is 1 + N connector calls.
+            // Judged on the catalog name rather than through Table#isMetaLockTarget, because the id at stake
+            // is the one this name just produced: a resource-mapping catalog also resolves through the
+            // connector, so it counts as external here even though its tables do not.
+            boolean needLock = CatalogMgr.isInternalCatalog(catalogName);
             Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.READ);
+            if (needLock) {
+                locker.lockDatabase(db.getId(), LockType.READ);
+            }
             try {
                 List<String> tableNames = GlobalStateMgr.getCurrentState().getMetadataMgr()
                         .listTableNames(context, catalogName, dbName);
@@ -667,7 +691,9 @@ public class ShowExecutor {
                     tableMap.put(tableName, table.getMysqlType());
                 }
             } finally {
-                locker.unLockDatabase(db.getId(), LockType.READ);
+                if (needLock) {
+                    locker.unLockDatabase(db.getId(), LockType.READ);
+                }
             }
 
             for (Map.Entry<String, String> entry : tableMap.entrySet()) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshProcessor.java
@@ -697,8 +697,20 @@ public abstract class MVRefreshProcessor {
     }
 
     /**
-     * Collect all deduplicated databases of the materialized view's base tables.
-     * @return: the deduplicated databases of the materialized view's base tables,
+     * Collect all deduplicated databases of the materialized view's base tables that are worth locking.
+     * <p>
+     * Only internal-catalog base tables enter the lock set. An external base table carries no usable lock
+     * identity: {@link BaseTableInfo#getTableId()} is left at its -1 default by the external constructor, and
+     * the database id comes from the connector (a fresh CONNECTOR_ID_GENERATOR value for Hive, constant 0 for
+     * JDBC). Locking on those either never contends or serializes every external base table in the FE behind a
+     * single (0, -1) entry, while protecting nothing: connector metadata refresh replaces cache entries and
+     * never takes the FE Locker. This also makes the code agree with collectBaseTableSnapshotInfos' javadoc,
+     * which already states the base table metadata does not change during a refresh.
+     * <p>
+     * The database existence check still runs for every base table, external ones included, so the diagnostics
+     * are unchanged.
+     *
+     * @return: the deduplicated internal databases of the materialized view's base tables,
      * throw exception if the database does not exist.
      */
     public LockParams collectDatabases() {
@@ -712,6 +724,12 @@ public abstract class MVRefreshProcessor {
                 throw new DmlException("Materialized view %s.%s refresh failed: base table database %s does not exist",
                         db.getFullName(), mv.getName(), baseTableInfo.getDbInfoStr());
             }
+            // Judged on the catalog name BaseTableInfo carries, not through Table#isMetaLockTarget: the ids
+            // about to be locked are the ones this name produced, and a resource-mapping base table both
+            // resolves its Database through the connector and never gets a real tableId (see BaseTableInfo).
+            if (!baseTableInfo.isInternalCatalog()) {
+                continue;
+            }
             Database db = dbOpt.get();
             lockParams.add(db, baseTableInfo.getTableId());
         }
@@ -722,7 +740,10 @@ public abstract class MVRefreshProcessor {
      * Collect all base table snapshot infos for the mv which the snapshot infos are kept and used in the final
      * update meta phase.
      * 1. deep copy of the base table's metadata may be time costing, we can optimize it later.
-     * 2. no needs to lock the base table's metadata since the metadata is not changed during the refresh process.
+     * 2. internal base tables are locked for READ here because copyOnlyForQuery reads their in-memory partition
+     *    and index state, which a concurrent DDL can mutate. External base tables are not locked (see
+     *    collectDatabases): their metadata is not changed by the FE during the refresh, and the FE Locker has no
+     *    identity to lock them by anyway.
      * @return the base table and its snapshot info map
      */
     @VisibleForTesting

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -1035,9 +1035,14 @@ public class AnalyzerUtils {
     }
 
     /**
-     * CopySafe:
-     * 1. OlapTable & MaterializedView, that support the copyOnlyForQuery interface
-     * 2. External tables with immutable memory-structure
+     * CopySafe, i.e. the statement does not need the whole planning phase to run under the meta lock. A table
+     * qualifies when either:
+     * 1. the lock cannot protect it anyway, so it has no say -- see {@link Table#isMetaLockTarget}; or
+     * 2. planning can work off a private snapshot of it: native tables and MVs are shadow copied by
+     * copyOnlyForQuery, unless one carries more related MVs than skip_whole_phase_lock_mv_limit.
+     * <p>
+     * A lock target with no snapshot to plan against -- ENGINE=MYSQL / ELASTICSEARCH, ExternalOlapTable, and
+     * resource-mapping external tables -- is copy-unsafe and does hold the lock for the whole phase.
      */
     public static boolean areTablesCopySafe(StatementBase statementBase) {
         Map<TableName, Table> nonOlapTables = Maps.newHashMap();
@@ -1173,9 +1178,6 @@ public class AnalyzerUtils {
 
     private static class CopyUnsafeTablesCollector extends TableCollector {
 
-        private static final ImmutableSet<Table.TableType> IMMUTABLE_EXTERNAL_TABLES =
-                ImmutableSet.of(Table.TableType.HIVE, Table.TableType.ICEBERG, Table.TableType.FLUSS);
-
         public CopyUnsafeTablesCollector(Map<TableName, Table> tables) {
             super(tables);
         }
@@ -1191,18 +1193,27 @@ public class AnalyzerUtils {
             if (table instanceof SystemTable) {
                 return null;
             }
+            // A table the meta lock cannot protect has no say in how long that lock is held. Tables in an
+            // external catalog are exactly that set -- PlannerMetaLocker.resolveTable never puts them in the
+            // lock set -- so they abstain. Letting them vote only made the planner hold the *lockable* tables'
+            // locks across connector RPCs while giving the voter itself zero protection: an external table's
+            // planning-phase stability comes from the query-scoped ConnectorMetadata
+            // (MetadataMgr.QueryMetadatas), never from the meta lock.
+            if (!table.isMetaLockTarget()) {
+                return null;
+            }
+            // A lock target that planning can see through a private snapshot does not need the real thing
+            // held: OlapTable and MV are shadow copied by copyOnlyForQuery, and OptimisticVersion revalidates
+            // them on the lock-free path. The MV-count limit is the existing guard on that copy being cheap.
             int relatedMVCount = node.getTable().getRelatedMaterializedViews().size();
             boolean useNonLockOptimization = Config.skip_whole_phase_lock_mv_limit < 0 ||
                     relatedMVCount <= Config.skip_whole_phase_lock_mv_limit;
-            if ((table.isNativeTableOrMaterializedView() && useNonLockOptimization)) {
-                // OlapTable can be copied via copyOnlyForQuery
+            if (table.isNativeTableOrMaterializedView() && useNonLockOptimization) {
                 return null;
-            } else if (IMMUTABLE_EXTERNAL_TABLES.contains(table.getType())) {
-                // Immutable table
-                return null;
-            } else {
-                tables.put(node.getName(), node.getTable());
             }
+
+            // Lockable, and no snapshot to plan against: the lock has to stay for the whole phase.
+            tables.put(node.getName(), node.getTable());
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -251,6 +251,11 @@ public class PlannerMetaLocker implements AutoCloseable {
             return null;
         }
 
+        // Judged on the catalog *name*, because that is what the database is about to be resolved through:
+        // any other catalog, resource-mapping included, routes getDb to the connector and yields a
+        // connector-minted id that must never be locked. Returning early also keeps lock collection off the
+        // network. The check below re-asks the same question of the resolved table object, where the answer
+        // for resource-mapping is the opposite one -- see Table#isMetaLockTarget.
         if (!CatalogMgr.isInternalCatalog(catalogName)) {
             return null;
         }
@@ -266,6 +271,15 @@ public class PlannerMetaLocker implements AutoCloseable {
 
         Table table = metadataMgr.getTable(session, catalogName, dbName, tbName);
         if (table == null) {
+            return null;
+        }
+
+        // Only lock what the lock can protect. Same predicate AnalyzerUtils.CopyUnsafeTablesCollector uses to
+        // decide who may extend the lock's lifetime, so who gets locked and who decides for how long cannot
+        // drift apart. A no-op in practice -- a table reached through the internal catalog always lives in an
+        // internal database -- so this is here as the one named statement of the invariant, and as the anchor
+        // for asserting it inside Locker later.
+        if (!table.isMetaLockTarget()) {
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorExternalCatalogLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorExternalCatalogLockTest.java
@@ -1,0 +1,188 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.hive.MockedHiveMetadata;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.ShowStmt;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * SHOW TABLES / SHOW MATERIALIZED VIEWS must not lock an external-catalog database. Its id is minted by the
+ * connector (MockedHiveMetadata mirrors the real HiveMetastoreApiConverter.toDatabase by handing out a fresh id
+ * per call), so the lock protects nothing and can collide with an unrelated real id.
+ * <p>
+ * Detection works by making the mocked hive database report a *chosen* id and parking a WRITE lock on that id:
+ * if the executor still locks the external database, the statement blocks forever. testDetectorSeesARealLock is
+ * the control that proves the harness can actually observe a lock being taken.
+ */
+public class ShowExecutorExternalCatalogLockTest extends ConnectorPlanTestBase {
+
+    private static final long COLLIDING_DB_ID = 987654321L;
+
+    /** Mirrors MockedHiveMetadata except that the database id is fixed, so the test can contend on it. */
+    private static class FixedIdHiveMetadata extends MockedHiveMetadata {
+        @Override
+        public Database getDb(ConnectContext context, String dbName) {
+            return new Database(COLLIDING_DB_ID, dbName);
+        }
+    }
+
+    @AfterEach
+    public void restoreHiveMetadata() {
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) GlobalStateMgr.getCurrentState().getMetadataMgr();
+        metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME, new MockedHiveMetadata());
+    }
+
+    private static void useFixedIdHiveMetadata() {
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) GlobalStateMgr.getCurrentState().getMetadataMgr();
+        metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME, new FixedIdHiveMetadata());
+    }
+
+    /**
+     * Runs {@code sql} on another thread while this thread holds a WRITE lock on {@code contendedDbId}.
+     *
+     * @return true if the statement completed while the lock was held, i.e. it never tried to lock that id.
+     */
+    private static boolean completesWhileDbIsWriteLocked(String sql, long contendedDbId) throws Exception {
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+
+        // Parse and analyze before taking the lock, so the measurement covers ShowExecutor.execute only.
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ShowStmt stmt = (ShowStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+
+        Locker holder = new Locker();
+        holder.lockDatabase(contendedDbId, LockType.WRITE);
+        Thread worker = new Thread(() -> {
+            try {
+                ctx.setThreadLocalInfo();
+                ShowExecutor.execute(stmt, ctx);
+            } catch (Throwable t) {
+                error.set(t);
+            } finally {
+                ConnectContext.remove();
+                done.countDown();
+            }
+        });
+        try {
+            worker.start();
+            boolean completed = done.await(3, TimeUnit.SECONDS);
+            if (completed && error.get() != null) {
+                throw new RuntimeException(error.get());
+            }
+            return completed;
+        } finally {
+            holder.unLockDatabase(contendedDbId, LockType.WRITE);
+            // If the statement was blocked, releasing lets it finish; never leave the thread parked.
+            worker.join(TimeUnit.SECONDS.toMillis(20));
+            if (error.get() != null) {
+                throw new RuntimeException(error.get());
+            }
+        }
+    }
+
+    /**
+     * Control: the same harness pointed at a genuine internal database must observe the lock. Without this,
+     * the two tests below would pass even if the detector were blind.
+     */
+    @Test
+    public void testDetectorSeesARealLock() throws Exception {
+        long internalDbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getId();
+        Assertions.assertFalse(completesWhileDbIsWriteLocked("show tables from test", internalDbId),
+                "SHOW TABLES on an internal database must still block behind a DB WRITE lock");
+    }
+
+    @Test
+    public void testShowTablesFromExternalCatalogTakesNoLock() throws Exception {
+        useFixedIdHiveMetadata();
+        Assertions.assertTrue(completesWhileDbIsWriteLocked("show tables from hive0.tpch", COLLIDING_DB_ID),
+                "SHOW TABLES on an external catalog must not lock the connector-minted database id");
+    }
+
+    @Test
+    public void testShowMaterializedViewsFromExternalCatalogTakesNoLock() throws Exception {
+        useFixedIdHiveMetadata();
+        Assertions.assertTrue(
+                completesWhileDbIsWriteLocked("show materialized views from hive0.tpch", COLLIDING_DB_ID),
+                "SHOW MATERIALIZED VIEWS on an external catalog must not lock the connector-minted database id");
+    }
+
+    /**
+     * The local-metastore walk is skipped entirely for an external catalog, so a connector-minted id that
+     * happens to equal a real internal database id cannot make the statement enumerate that database's tables
+     * without holding its lock. COLLIDING_DB_ID is pointed at the internal "test" database to force exactly
+     * that collision.
+     */
+    @Test
+    public void testShowMaterializedViewsFromExternalCatalogDoesNotWalkACollidingLocalDb() throws Exception {
+        // The internal database must actually contain an MV, otherwise the walk returns nothing either way
+        // and the assertion below would hold vacuously.
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "CREATE MATERIALIZED VIEW test.collision_probe_mv " +
+                        "DISTRIBUTED BY HASH(`v1`) BUCKETS 3 " +
+                        "REFRESH DEFERRED MANUAL " +
+                        "PROPERTIES ('replication_num' = '1') " +
+                        "AS SELECT v1, v2 FROM test.t0;");
+        try {
+            long internalDbId = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test").getId();
+            // Sanity: the same statement against the internal database does list it.
+            ConnectContext internalCtx = UtFrameUtils.createDefaultCtx();
+            ShowStmt internalStmt = (ShowStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "show materialized views from test", internalCtx);
+            Assertions.assertFalse(ShowExecutor.execute(internalStmt, internalCtx).getResultRows().isEmpty());
+
+            MockedMetadataMgr metadataMgr = (MockedMetadataMgr) GlobalStateMgr.getCurrentState().getMetadataMgr();
+            metadataMgr.registerMockedMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME,
+                    new MockedHiveMetadata() {
+                        @Override
+                        public Database getDb(ConnectContext context, String dbName) {
+                            return new Database(internalDbId, dbName);
+                        }
+                    });
+
+            ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+            ShowStmt stmt = (ShowStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "show materialized views from hive0.tpch", ctx);
+            Assertions.assertTrue(ShowExecutor.execute(stmt, ctx).getResultRows().isEmpty(),
+                    "an external catalog must not enumerate the internal database its id collides with");
+        } finally {
+            starRocksAssert.dropMaterializedView("collision_probe_mv");
+        }
+    }
+
+    @Test
+    public void testShowTablesStillWorksForBothCatalogKinds() throws Exception {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+
+        ShowStmt internal = (ShowStmt) UtFrameUtils.parseStmtWithNewParser("show tables from test", ctx);
+        Assertions.assertFalse(ShowExecutor.execute(internal, ctx).getResultRows().isEmpty());
+
+        ShowStmt external = (ShowStmt) UtFrameUtils.parseStmtWithNewParser("show tables from hive0.tpch", ctx);
+        Assertions.assertFalse(ShowExecutor.execute(external, ctx).getResultRows().isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshLockParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshLockParamsTest.java
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.common.util.concurrent.lock.LockParams;
+import com.starrocks.scheduler.MVTaskRunProcessor;
+import com.starrocks.scheduler.Task;
+import com.starrocks.scheduler.TaskBuilder;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunBuilder;
+import com.starrocks.scheduler.TaskRunContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An external base table has no usable lock identity: BaseTableInfo's external constructor leaves tableId at
+ * -1, and the database id comes from the connector. It must therefore never reach LockParams -- otherwise every
+ * MV in the FE built on a JDBC base table contends on the same (0, -1) entry. Internal base tables must keep
+ * their real entry, because collectBaseTableSnapshotInfos does copyOnlyForQuery on them.
+ */
+public class MVRefreshLockParamsTest extends MVTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        MVTestBase.beforeClass();
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+        starRocksAssert.useDatabase("test")
+                .withTable("CREATE TABLE test.lock_params_tbl\n" +
+                        "(\n" +
+                        "    k1 date,\n" +
+                        "    k2 int\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("CREATE MATERIALIZED VIEW test.lock_params_external_mv\n" +
+                        "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 3\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES ('replication_num' = '1')\n" +
+                        "AS SELECT l_orderkey, l_suppkey FROM hive0.partitioned_db.lineitem_par;")
+                .withMaterializedView("CREATE MATERIALIZED VIEW test.lock_params_mixed_mv\n" +
+                        "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES ('replication_num' = '1')\n" +
+                        "AS SELECT t.k2, h.l_suppkey FROM test.lock_params_tbl t " +
+                        "JOIN hive0.partitioned_db.lineitem_par h ON t.k2 = h.l_orderkey;");
+    }
+
+    private static LockParams collectDatabases(String mvName) throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        MaterializedView mv = (MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), mvName);
+        Assertions.assertNotNull(mv);
+
+        Task task = TaskBuilder.buildMvTask(mv, db.getFullName());
+        Map<String, String> properties = task.getProperties();
+        properties.put(TaskRun.IS_TEST, "true");
+
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
+        MVTaskRunProcessor mvTaskRunProcessor = new MVTaskRunProcessor();
+        TaskRunContext taskRunContext = new TaskRunContext();
+        taskRunContext.setTaskRun(taskRun);
+        taskRunContext.setCtx(connectContext);
+        taskRunContext.getCtx().setDatabase("test");
+        taskRunContext.setProperties(properties);
+        mvTaskRunProcessor.prepare(taskRunContext);
+
+        return mvTaskRunProcessor.getMVRefreshProcessor().collectDatabases();
+    }
+
+    @Test
+    public void testAllExternalBaseTablesTakeNoLock() throws Exception {
+        LockParams lockParams = collectDatabases("lock_params_external_mv");
+        Assertions.assertTrue(lockParams.getDbs().isEmpty(), "external base tables must not enter the lock set");
+        Assertions.assertTrue(lockParams.getTables().isEmpty(), "external base tables must not enter the lock set");
+    }
+
+    @Test
+    public void testMixedBaseTablesKeepOnlyTheInternalEntry() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
+        long internalTableId = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "lock_params_tbl").getId();
+
+        LockParams lockParams = collectDatabases("lock_params_mixed_mv");
+
+        // The internal base table still needs its READ lock: collectBaseTableSnapshotInfos copies it.
+        Assertions.assertEquals(Set.of(db.getId()), lockParams.getDbs().keySet());
+        Assertions.assertEquals(Set.of(internalTableId), lockParams.getTables().get(db.getId()));
+        // The -1 default that external BaseTableInfos carry must never show up as a lock id.
+        lockParams.getTables().values().forEach(ids -> Assertions.assertFalse(ids.contains(-1L)));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CopyUnsafeTablesCollectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/CopyUnsafeTablesCollectorTest.java
@@ -1,0 +1,195 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ExternalOlapTable;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.StarRocksExternalTable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.type.IntegerType;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Only a table the meta lock can actually protect -- one living in an internal database -- may decide how long
+ * that lock is held. Tables in an external catalog abstain, and are never in the lock set to begin with.
+ * Everything else keeps both properties, including the kinds whose engine is "external".
+ */
+public class CopyUnsafeTablesCollectorTest extends ConnectorPlanTestBase {
+
+    @BeforeAll
+    public static void createInternalDbExternalEngineTables() throws Exception {
+        starRocksAssert.useDatabase("test")
+                .withTable("CREATE EXTERNAL TABLE mysql_ext_tbl\n" +
+                        "(\n" +
+                        "    k1 INT,\n" +
+                        "    k2 VARCHAR(64)\n" +
+                        ")\n" +
+                        "ENGINE=mysql\n" +
+                        "PROPERTIES\n" +
+                        "(\n" +
+                        "    \"host\" = \"127.0.0.1\",\n" +
+                        "    \"port\" = \"3306\",\n" +
+                        "    \"user\" = \"mysql_user\",\n" +
+                        "    \"password\" = \"mysql_passwd\",\n" +
+                        "    \"database\" = \"mysql_db_test\",\n" +
+                        "    \"table\" = \"mysql_table_test\"\n" +
+                        ");")
+                .withView("CREATE VIEW lock_scope_view AS SELECT v1, v2 FROM test.t0");
+    }
+
+    private static boolean isCopySafe(String sql) throws Exception {
+        return AnalyzerUtils.areTablesCopySafe(UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+    }
+
+    /**
+     * The lock set as production computes it: PlannerMetaLocker is built in StatementPlanner before
+     * Analyzer.analyze, so a view is still a TableRelation there. Analyzing first would turn it into a
+     * ViewRelation and hide it from the collector entirely.
+     */
+    private static Set<Long> lockedTableIds(String sql) throws Exception {
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+        Map<Long, Database> dbs = new HashMap<>();
+        Map<Long, Set<Long>> tables = new HashMap<>();
+        PlannerMetaLocker.collectTablesNeedLock(stmt, connectContext, dbs, tables);
+        return tables.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
+    }
+
+    private static long tableId(String dbName, String tblName) {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(dbName, tblName).getId();
+    }
+
+    @Test
+    public void testExternalCatalogTableAbstains() throws Exception {
+        // JDBC and Paimon are not in IMMUTABLE_EXTERNAL_TABLES, so before the fix they voted copy-unsafe and
+        // made the planner hold the lockable tables' locks for the whole planning phase.
+        Assertions.assertTrue(isCopySafe("select * from jdbc0.partitioned_db0.tbl0"));
+        Assertions.assertTrue(isCopySafe("select * from paimon0.pmn_db1.unpartitioned_table"));
+        Assertions.assertTrue(isCopySafe("select * from hive0.tpch.lineitem"));
+    }
+
+    @Test
+    public void testMixedInternalAndExternalCatalogIsCopySafe() throws Exception {
+        Assertions.assertTrue(isCopySafe(
+                "select * from test.t0 join jdbc0.partitioned_db0.tbl0 on true"));
+        Assertions.assertTrue(isCopySafe(
+                "select * from test.t0, paimon0.pmn_db1.unpartitioned_table"));
+        Assertions.assertTrue(isCopySafe(
+                "with cte as (select * from test.t0) " +
+                        "select * from cte join jdbc0.partitioned_db0.tbl0 on true"));
+    }
+
+    /** An external-catalog table must not add itself to the lock set, alone or mixed with a lockable table. */
+    @Test
+    public void testExternalCatalogTableIsNotInTheLockSet() throws Exception {
+        Assertions.assertEquals(Set.of(), lockedTableIds("select * from jdbc0.partitioned_db0.tbl0"));
+        Assertions.assertEquals(Set.of(tableId("test", "t0")),
+                lockedTableIds("select * from test.t0 join jdbc0.partitioned_db0.tbl0 on true"));
+    }
+
+    /**
+     * An internal view is neither native nor an FE transaction participant, but AlterJobMgr.alterView rewrites
+     * its definition, schema, comment and security in place under this table's WRITE lock, so it must stay in
+     * the lock set. It still abstains from voting, so the lock is released after analysis as before.
+     */
+    @Test
+    public void testInternalViewIsLockableAndAbstains() throws Exception {
+        Assertions.assertTrue(
+                GlobalStateMgr.getCurrentState().getLocalMetastore().getTable("test", "lock_scope_view")
+                        .isMetaLockTarget());
+        Assertions.assertEquals(Set.of(tableId("test", "lock_scope_view")),
+                lockedTableIds("select * from test.lock_scope_view"));
+        Assertions.assertEquals(Set.of(tableId("test", "lock_scope_view"), tableId("test", "t0")),
+                lockedTableIds("select * from test.lock_scope_view v join test.t0 on v.v1 = test.t0.v1"));
+        // Views never reach the collector -- AstTraverser.visitView descends into the expanded query -- so a
+        // statement over one stays copy-safe and the lock is released after analysis.
+        Assertions.assertTrue(isCopySafe("select * from test.lock_scope_view"));
+    }
+
+    /** ENGINE=MYSQL lives in an internal database, so both its lock and its vote must be unchanged. */
+    @Test
+    public void testInternalDbExternalEngineTableIsUnchanged() throws Exception {
+        Assertions.assertFalse(isCopySafe("select * from test.mysql_ext_tbl"));
+        Assertions.assertFalse(isCopySafe(
+                "select * from test.t0 join test.mysql_ext_tbl on test.t0.v1 = mysql_ext_tbl.k1"));
+        // Mixing it with an external-catalog table must not rescue it either.
+        Assertions.assertFalse(isCopySafe(
+                "select * from test.mysql_ext_tbl join jdbc0.partitioned_db0.tbl0 on true"));
+
+        Assertions.assertEquals(Set.of(tableId("test", "mysql_ext_tbl")),
+                lockedTableIds("select * from test.mysql_ext_tbl"));
+    }
+
+    @Test
+    public void testNativeTableIsUnchanged() throws Exception {
+        Assertions.assertTrue(isCopySafe("select * from test.t0"));
+        Assertions.assertTrue(isCopySafe("select * from test.t0 join test.t1 on test.t0.v1 = test.t1.v4"));
+
+        Assertions.assertEquals(Set.of(tableId("test", "t0"), tableId("test", "t1")),
+                lockedTableIds("select * from test.t0 join test.t1 on test.t0.v1 = test.t1.v4"));
+    }
+
+    /**
+     * A resource-mapping table reports a resource_mapping_inside_catalog_* name, yet lives in an internal
+     * database and is rewritten in place by HiveTable.modifyTableSchema under lockDatabase(WRITE). This is the
+     * case that makes isMetaLockTarget() use !isExternalCatalog rather than isInternalCatalog -- the latter
+     * would answer false here and silently drop a load-bearing lock.
+     */
+    @Test
+    public void testResourceMappingTableIsLockable() {
+        HiveTable table = HiveTable.builder()
+                .setId(1L)
+                .setTableName("tbl1")
+                .setFullSchema(ImmutableList.of(new Column("k", IntegerType.INT, true)))
+                .setResourceName("my_hive_resource")
+                .build();
+        Assertions.assertTrue(
+                com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(
+                        table.getCatalogName()));
+        Assertions.assertFalse(com.starrocks.server.CatalogMgr.isInternalCatalog(table.getCatalogName()));
+        Assertions.assertTrue(table.isMetaLockTarget());
+    }
+
+    /** ENGINE=OLAP pointing at a remote cluster still lives in an internal database. */
+    @Test
+    public void testExternalOlapTableIsLockable() {
+        Assertions.assertTrue(new ExternalOlapTable().isMetaLockTarget());
+    }
+
+    /**
+     * TableType.STARROCKS (enterprise-only) only ever exists inside a `starrocks` external catalog, so it
+     * abstains. Asserting on the predicate rather than on a query because StarRocksConnector.bindConfig calls
+     * feClient.getCapabilities(), so creating such a catalog in a UT would try to reach a remote FE.
+     */
+    @Test
+    public void testStarRocksExternalTableAbstains() {
+        StarRocksExternalTable table = new StarRocksExternalTable(1L, "sr0", "db1", "tbl1",
+                ImmutableList.of(new Column("k", IntegerType.INT, true)), 7L, 10086L,
+                ImmutableList.of(), 0L, null);
+        Assertions.assertFalse(table.isMetaLockTarget());
+    }
+}

--- a/test/sql/test_deltalake/R/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/R/test_deltalake_collect_stats
@@ -18,6 +18,9 @@ set enable_query_trigger_analyze=false;
 set enable_delta_lake_column_statistics=false;
 -- result:
 -- !result
+set disable_table_stats_from_metadata_for_single_table=false;
+-- result:
+-- !result
 function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'cardinality=8')
 -- result:
 None

--- a/test/sql/test_deltalake/T/test_deltalake_collect_stats
+++ b/test/sql/test_deltalake/T/test_deltalake_collect_stats
@@ -12,6 +12,7 @@ create external catalog delta_test_${uuid0} PROPERTIES (
 set time_zone="Asia/Shanghai";
 set enable_query_trigger_analyze=false;
 set enable_delta_lake_column_statistics=false;
+set disable_table_stats_from_metadata_for_single_table=false;
 
 function: assert_explain_costs_contains('select col_tinyint from delta_test_${uuid0}.delta_oss_db.delta_lake_data_type', 'cardinality=8')
 


### PR DESCRIPTION
## Why I'm doing:

FE metadata locks protect in-memory metadata that the FE itself owns and rewrites in place. A table in an external catalog is not that — its metadata lives in the remote system, the connector refreshes it by replacing cache entries, and `PlannerMetaLocker.resolveTable` already refuses to put it in the lock set. Yet such a table could still decide how long *other* tables' locks were held, and three call sites locked on identities the connector had invented.

**1. An external table voted on how long lockable tables stay locked.**

`CopyUnsafeTablesCollector` decided `needWholePhaseLock` by table type against an allowlist (`{HIVE, ICEBERG, FLUSS}`). Anything outside it — Paimon, Delta, Kudu, JDBC, external StarRocks — voted copy-unsafe, and one such vote pinned the locks of every lockable table in the statement across the connector round-trips that statistics collection and split enumeration make:


```
SELECT * FROM internal_db.t JOIN paimon_cat.db.d ON...

 lock set = { internal_db.t } <- the paimon table is not in it
 paimon table's vote = copy-unsafe
 => internal_db.t stays locked for the whole planning phase, i.e. for one paimon RTT
 => a concurrent INSERT into internal_db.t blocks on transaction publish
```

The paimon table gains nothing from that lock; within a query its stability comes from the query-scoped `ConnectorMetadata`. The allowlist was also fail-into-lock: a newly added connector defaults into the bad path until someone remembers to extend it, which is how Paimon, Delta, Kudu and STARROCKS all arrived here.

**2. Three locks were taken on identities the connector invented.**

| source | id |
|---|---|
| `HiveMetastoreApiConverter.toDatabase` | a fresh `CONNECTOR_ID_GENERATOR` value per metastore-cache miss |
| `JDBCMetadata` | constant `0` for every JDBC database |
| `BaseTableInfo` (external constructor) | `tableId` left at its `-1` default |

`SHOW TABLES FROM hive_cat.db` locked an id that changes whenever the metastore cache entry is refreshed — a lock whose identity drifts under it, holding nothing while making `1 + N` connector calls. JDBC failed the other way: every JDBC database shares id `0`, so unrelated databases serialize behind one another. MV refresh combined both, entering every external base table into `LockParams` as `(connector-minted db id, -1)` — while the javadoc five lines above already stated that base table metadata does not change during a refresh and needs no lock.

## What I'm doing:

**Name the question once, and answer it by ownership rather than by table type.**

```java
// Table.java
public boolean isMetaLockTarget() {
 return!CatalogMgr.isExternalCatalog(getCatalogName());
}
```

`CatalogMgr.isExternalCatalog` is `!isNullOrEmpty(name) &&!isInternalCatalog(name) &&!isResourceMappingCatalog(name)`, so negated it reads: *the internal catalog, or a resource-mapping pseudo-catalog, or no catalog name at all*. That covers native tables and MVs, internal views, resource-mapping `ENGINE=HIVE/ICEBERG/HUDI`, `ENGINE=MYSQL`, `ENGINE=ELASTICSEARCH`, `ExternalOlapTable` and `ENGINE=JDBC` from a RESOURCE (whose catalog name is null) without naming any of them.

Enumerating types is what makes this fragile, and review found two cases such a list misses: an internal view is neither native nor an FE transaction participant, yet `AlterJobMgr.alterView` rewrites its definition, schema, comment and security through separate setters under that table's WRITE lock; a resource-mapping Hive table reports a `resource_mapping_inside_catalog_*` name, yet `HiveCacheUpdateProcessor` drives `HiveTable.modifyTableSchema`, which clears and refills `fullSchema` inside `lockDatabase(WRITE)`. Both must keep their locks. The predicate above is also fail-closed: an unclassified table kind keeps its lock, costing a little contention rather than silently losing mutual exclusion.

`PlannerMetaLocker.resolveTable` and `AnalyzerUtils.CopyUnsafeTablesCollector` share that one predicate, so *who gets locked* and *who decides for how long* cannot drift apart. The collector reduces to three positive guards, and `IMMUTABLE_EXTERNAL_TABLES` is gone:

```java
if (table instanceof SystemTable) return null; // immutable
if (!table.isMetaLockTarget()) return null; // lock cannot protect it
if (table.isNativeTableOrMaterializedView() && useNonLockOptimization) return null; // shadow copied
tables.put(...); // must hold the lock
```

**Drop the locks that were never real.** `ShowExecutor.visitShowTableStatement` locks only when the catalog is internal — the same entry point also serves `SHOW TABLES FROM internal_db`, where the id is real and the lock must stay, so this is a condition rather than a deletion. `MVRefreshProcessor.collectDatabases` keeps external base tables out of `LockParams`, removing the `(0, -1)` entry; mixed MVs keep their internal base tables' locks, which `collectBaseTableSnapshotInfos` needs for `copyOnlyForQuery`. The database existence check still runs for every base table, so diagnostics are unchanged, and the contradictory javadoc is corrected.

**`SHOW MATERIALIZED VIEWS` skips the local walk for external catalogs.** That loop resolves the database out of `LocalMetastore` *by id*, and the two id spaces are not partitioned — `CatalogMgr.createCatalog` draws from `ConnectorTableId.CONNECTOR_ID_GENERATOR` (offset 100,000,000) for resource-mapping catalogs and from `GlobalStateMgr.getNextId()` (from 10,000) for the rest, so a long-lived cluster can produce a match. StarRocks materialized views only ever live in an internal database, so the statement now returns empty for a non-internal catalog before locking or walking anything, and the lock below is unconditional again. This also fixes a pre-existing wrong answer: on a collision the previous code listed that internal database's MVs under the external catalog's name.

**Net effect on the lock set is zero relative to `main`** — no planner lock is removed. The behaviour change is that external-catalog tables stop forcing the whole-phase lock, plus the three connector-minted locks disappear.

**Tests.** Every fix has a test that fails without it, verified by reverting each change in turn:

- `CopyUnsafeTablesCollectorTest` — external-catalog tables abstain and stay out of the lock set; internal views, resource-mapping tables and `ExternalOlapTable` are lock targets. `testResourceMappingTableIsLockable` also pins that `isInternalCatalog` answers *false* for such a table, the trap that would reintroduce the lost lock. One test keeps the whole-phase-lock path reachable via the related-MV limit so the others cannot pass vacuously.
- `ShowExecutorExternalCatalogLockTest` — the mocked Hive database reports a chosen id and the test parks a WRITE lock on it, so any remaining lock attempt makes the statement block; a control test on a real internal database proves the detector observes a genuine lock. A separate test points that id at the internal `test` database, with an MV created in it, to pin the collision case.
- `MVRefreshLockParamsTest` — an all-external MV yields an empty `LockParams`; a mixed MV yields exactly the internal table's entry and never `-1`.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5