### PR TITLE
[Doc] Document user, role and privilege synchronization for the migration tool

### DIFF
--- a/docs/en/administration/data_migration_tool.md
+++ b/docs/en/administration/data_migration_tool.md
@@ -377,6 +377,15 @@ replication_job_batch_size=10
 report_interval_seconds=300
 
 enable_table_property_sync=false
+
+# privilege config
+enable_privilege_sync=false
+ddl_job_allow_drop_user_target_only=false
+ddl_job_allow_drop_role_target_only=false
+ddl_job_allow_drop_inconsistent_user=true
+ddl_job_allow_revoke_grant_target_only=false
+privilege_sync_exclude_users=
+privilege_sync_exclude_roles=
 ```
 
 The description of the parameters is as follows:
@@ -427,6 +436,13 @@ The description of the parameters is as follows:
 | ddl_job_allow_drop_inconsistent_view      | Whether to allow the migration tool to delete inconsistent views between the source and target clusters. The default is `true`, meaning they will be deleted. You can use the default value for this item. The migration tool will automatically synchronize the deleted views during the migration. |
 | ddl_job_allow_drop_view_target_only       | Whether to allow the migration tool to delete views that are deleted in the source cluster to keep the views consistent between the source and target clusters. The default is `true`, meaning they will be deleted. You can use the default value for this item. |
 | enable_table_property_sync                | Whether to enable synchronization for table properties.       |
+| enable_privilege_sync                     | Whether to enable synchronization for users, roles, and their privileges. The default is `false`, which means account metadata is not synchronized. |
+| ddl_job_allow_drop_user_target_only       | Whether to allow the migration tool to delete users that exist only in the target cluster but not in the source cluster. The default is `false`, which means they will not be deleted. |
+| ddl_job_allow_drop_role_target_only       | Whether to allow the migration tool to delete roles that exist only in the target cluster but not in the source cluster. The default is `false`, which means they will not be deleted. |
+| ddl_job_allow_drop_inconsistent_user      | Whether to allow the migration tool to rebuild (that is, drop and re-create) a user whose definition is inconsistent between the source and target clusters. The default is `true`. A user is only rebuilt when their privileges have been read in the same cycle, so that the privileges can be granted again immediately. |
+| ddl_job_allow_revoke_grant_target_only    | Whether to allow the migration tool to revoke privileges that are granted only in the target cluster but not in the source cluster. The default is `false`, which means they will not be revoked. |
+| privilege_sync_exclude_users              | The users that the migration tool must leave untouched, with multiple users separated by commas (`,`). A user can be specified either as a user name (`jack`) or as a full user identity (`'jack'@'%'`). `root` and the user specified in `target_cluster_user` are always excluded. |
+| privilege_sync_exclude_roles              | The roles that the migration tool must leave untouched, with multiple roles separated by commas (`,`). |
 
 <Tabs groupId="migrationPath">
 <TabItem value="sourceNothing" label="Migrate from Shared-nothing" default>
@@ -563,6 +579,26 @@ TARGET_frontend-0.frontend.mynamespace.svc.cluster.local=10.1.2.1;9030:19030
 </TabItem>
 </Tabs>
 
+### Synchronize users, roles, and privileges (Optional)
+
+By default, the migration tool does not synchronize account metadata. If you set `enable_privilege_sync` to `true`, the tool also synchronizes users, roles, and their privileges from the source cluster to the target cluster.
+
+Each time the tool retrieves metadata, it reads the users, roles, and privileges of both clusters, compares them, and executes the DDL statements needed to make the target cluster consistent with the source cluster. User definitions are obtained using `SHOW CREATE USER`, which returns the password as ciphertext, so no plaintext password is handled during migration.
+
+The following objects are never modified by the migration tool:
+
+- `root` and the user specified in `target_cluster_user`. Overwriting the password of the target cluster's `root` would lock out its operators, and dropping the account that the tool uses to connect would break the tool's own connection.
+- The immutable built-in roles `root`, `db_admin`, `cluster_admin`, `user_admin`, and `security_admin`. The `public` role is built-in but mutable, so its privileges are synchronized while the role itself is left alone.
+- The users specified in `privilege_sync_exclude_users` and the roles specified in `privilege_sync_exclude_roles`.
+
+:::note
+
+- The FE of both clusters must support `SHOW CREATE USER`. If the FE of either cluster does not support this statement, users and their privileges are skipped, and only roles and role privileges are synchronized.
+- The progress of privilege synchronization is printed to the log file **log/sync.INFO.log** with the prefix `Sync privilege progress`. It lists the status of each of the four units: roles, role privileges, users, and user privileges.
+- In one-time synchronization mode (`one_time_run_mode=true`), the tool exits successfully only after privileges have also converged. It exits with a failure if either cluster does not support `SHOW CREATE USER`, or if privileges remain inconsistent across three consecutive comparisons.
+
+:::
+
 ## Step 3: Start the Migration Tool
 
 After configuring the tool, start the migration tool to initiate the data migration process.
@@ -690,6 +726,7 @@ The list of objects that support synchronization currently is as follows (those 
 - Internal tables and their data
 - Materialized view schemas and their building statements (The data in the materialized view will not be synchronized. And if the base tables of the materialized view is not synchronized to the target cluster, the background refresh task of the materialized view reports an error.)
 - Logical views
+- Users, roles, and their privileges (not synchronized by default, enabled by `enable_privilege_sync`)
 
 For migration between shared-data clusters:
 

--- a/docs/ja/administration/data_migration_tool.md
+++ b/docs/ja/administration/data_migration_tool.md
@@ -377,6 +377,15 @@ replication_job_batch_size=10
 report_interval_seconds=300
 
 enable_table_property_sync=false
+
+# privilege config
+enable_privilege_sync=false
+ddl_job_allow_drop_user_target_only=false
+ddl_job_allow_drop_role_target_only=false
+ddl_job_allow_drop_inconsistent_user=true
+ddl_job_allow_revoke_grant_target_only=false
+privilege_sync_exclude_users=
+privilege_sync_exclude_roles=
 ```
 
 パラメーターの説明は以下の通りです。
@@ -427,6 +436,13 @@ enable_table_property_sync=false
 | ddl_job_allow_drop_inconsistent_view                      | ソースクラスターとターゲットクラスター間で一致しないビューを移行ツールが削除することを許可するかどうか。デフォルトは `true`（削除する）。この項目にはデフォルト値を使用できます。移行ツールは移行中に削除されたビューを自動的に同期します。 |
 | ddl_job_allow_drop_view_target_only                       | ソースクラスターで削除されたビューをターゲットクラスターでも削除してビューの整合性を保つことを移行ツールに許可するかどうか。デフォルトは `true`（削除する）。この項目にはデフォルト値を使用できます。 |
 | enable_table_property_sync                                | テーブルプロパティの同期を有効にするかどうか。               |
+| enable_privilege_sync                                     | ユーザー、ロール、およびそれらの権限の同期を有効にするかどうか。デフォルトは `false`（アカウントメタデータを同期しない）。 |
+| ddl_job_allow_drop_user_target_only                       | ソースクラスターに存在せず、ターゲットクラスターにのみ存在するユーザーを移行ツールが削除することを許可するかどうか。デフォルトは `false`（削除しない）。 |
+| ddl_job_allow_drop_role_target_only                       | ソースクラスターに存在せず、ターゲットクラスターにのみ存在するロールを移行ツールが削除することを許可するかどうか。デフォルトは `false`（削除しない）。 |
+| ddl_job_allow_drop_inconsistent_user                      | ソースクラスターとターゲットクラスター間で定義が一致しないユーザーを移行ツールが再作成（削除してから作成）することを許可するかどうか。デフォルトは `true`。ユーザーが再作成されるのは、同じサイクルでそのユーザーの権限が読み取られている場合のみで、再作成後ただちに権限を再付与できるようにするためです。 |
+| ddl_job_allow_revoke_grant_target_only                    | ソースクラスターでは付与されておらず、ターゲットクラスターにのみ付与されている権限を移行ツールが取り消すことを許可するかどうか。デフォルトは `false`（取り消さない）。 |
+| privilege_sync_exclude_users                              | 移行ツールが変更しないユーザー。複数のユーザーはカンマ（`,`）で区切ります。ユーザーはユーザー名（`jack`）でも、完全なユーザー識別子（`'jack'@'%'`）でも指定できます。`root` と `target_cluster_user` に指定されたユーザーは常に除外されます。 |
+| privilege_sync_exclude_roles                              | 移行ツールが変更しないロール。複数のロールはカンマ（`,`）で区切ります。 |
 
 <Tabs groupId="migrationPath">
 <TabItem value="sourceNothing" label="共有なしからの移行" default>
@@ -563,6 +579,26 @@ TARGET_frontend-0.frontend.mynamespace.svc.cluster.local=10.1.2.1;9030:19030
 </TabItem>
 </Tabs>
 
+### ユーザー、ロール、権限の同期（オプション）
+
+デフォルトでは、移行ツールはアカウントメタデータを同期しません。`enable_privilege_sync` を `true` に設定すると、ソースクラスターのユーザー、ロール、およびそれらの権限もターゲットクラスターに同期されます。
+
+移行ツールはメタデータを取得するたびに、両クラスターのユーザー、ロール、権限を読み取って比較し、ターゲットクラスターをソースクラスターと一致させるために必要な DDL ステートメントを実行します。ユーザー定義は `SHOW CREATE USER` で取得され、このステートメントはパスワードを暗号文で返すため、移行中に平文のパスワードが扱われることはありません。
+
+以下のオブジェクトは移行ツールによって変更されることはありません。
+
+- `root` および `target_cluster_user` に指定されたユーザー。ターゲットクラスターの `root` のパスワードを上書きするとその運用者がログインできなくなり、ツールが接続に使用しているアカウントを削除するとツール自身の接続が切断されるためです。
+- 変更不可能な組み込みロール `root`、`db_admin`、`cluster_admin`、`user_admin`、`security_admin`。`public` は組み込みロールですが変更可能であるため、その権限は同期され、ロール自体は変更されません。
+- `privilege_sync_exclude_users` に指定されたユーザーおよび `privilege_sync_exclude_roles` に指定されたロール。
+
+:::note
+
+- 両クラスターの FE が `SHOW CREATE USER` をサポートしている必要があります。いずれかのクラスターの FE がこのステートメントをサポートしていない場合、ユーザーとその権限はスキップされ、ロールとロール権限のみが同期されます。
+- 権限同期の進捗は、`Sync privilege progress` というプレフィックスでログファイル **log/sync.INFO.log** に出力され、ロール、ロール権限、ユーザー、ユーザー権限の 4 つの単位それぞれの状態が示されます。
+- 一回限りの同期モード（`one_time_run_mode=true`）では、権限も一致した後にのみツールは正常終了します。いずれかのクラスターが `SHOW CREATE USER` をサポートしていない場合、または 3 回連続した比較で権限が一致しないままの場合、ツールは異常終了します。
+
+:::
+
 ## ステップ 3：移行ツールの起動
 
 ツールの設定が完了したら、移行ツールを起動してデータ移行プロセスを開始します。
@@ -690,6 +726,7 @@ ORDER BY TABLE_NAME;
 - 内部テーブルとそのデータ
 - マテリアライズドビューのスキーマおよびそのビルドステートメント（マテリアライズドビューのデータは同期されません。また、マテリアライズドビューのベーステーブルがターゲットクラスターに同期されていない場合、マテリアライズドビューのバックグラウンド更新タスクはエラーを報告します。）
 - 論理ビュー
+- ユーザー、ロール、およびそれらの権限（デフォルトでは同期されません。`enable_privilege_sync` で有効化します）
 
 共有データクラスター間の移行の場合：
 

--- a/docs/zh/administration/data_migration_tool.md
+++ b/docs/zh/administration/data_migration_tool.md
@@ -377,6 +377,15 @@ replication_job_batch_size=10
 report_interval_seconds=300
 
 enable_table_property_sync=false
+
+# privilege config
+enable_privilege_sync=false
+ddl_job_allow_drop_user_target_only=false
+ddl_job_allow_drop_role_target_only=false
+ddl_job_allow_drop_inconsistent_user=true
+ddl_job_allow_revoke_grant_target_only=false
+privilege_sync_exclude_users=
+privilege_sync_exclude_roles=
 ```
 
 各参数说明如下：
@@ -427,6 +436,13 @@ enable_table_property_sync=false
 | ddl_job_allow_drop_inconsistent_view              | 是否允许迁移工具删除源集群和目标集群之间不一致的视图。默认值为 `true`，表示将被删除。可以使用此项的默认值。迁移工具将在迁移期间自动同步被删除的视图。 |
 | ddl_job_allow_drop_view_target_only               | 是否允许迁移工具删除在源集群中已删除的视图，以保持源集群和目标集群之间的视图一致性。默认值为 `true`，表示将被删除。可以使用此项的默认值。 |
 | enable_table_property_sync                        | 是否启用表属性的同步。                                       |
+| enable_privilege_sync                             | 是否启用用户、角色及其权限的同步。默认值为 `false`，表示不同步账户元数据。 |
+| ddl_job_allow_drop_user_target_only               | 是否允许迁移工具删除仅存在于目标集群而不存在于源集群的用户。默认值为 `false`，表示不会被删除。 |
+| ddl_job_allow_drop_role_target_only               | 是否允许迁移工具删除仅存在于目标集群而不存在于源集群的角色。默认值为 `false`，表示不会被删除。 |
+| ddl_job_allow_drop_inconsistent_user              | 是否允许迁移工具重建（即删除后重新创建）源集群和目标集群之间定义不一致的用户。默认值为 `true`。仅当该用户的权限在同一轮次中被成功读取时才会重建，以便重建后立即重新授予其权限。 |
+| ddl_job_allow_revoke_grant_target_only            | 是否允许迁移工具回收仅在目标集群中授予而在源集群中未授予的权限。默认值为 `false`，表示不会被回收。 |
+| privilege_sync_exclude_users                      | 迁移工具不修改的用户，多个用户之间以英文逗号（`,`）分隔。用户可以指定为用户名（`jack`），也可以指定为完整的用户标识（`'jack'@'%'`）。`root` 和 `target_cluster_user` 中指定的用户始终被排除。 |
+| privilege_sync_exclude_roles                      | 迁移工具不修改的角色，多个角色之间以英文逗号（`,`）分隔。 |
 
 <Tabs groupId="migrationPath">
 <TabItem value="sourceNothing" label="从存算一体迁移" default>
@@ -563,6 +579,26 @@ TARGET_frontend-0.frontend.mynamespace.svc.cluster.local=10.1.2.1;9030:19030
 </TabItem>
 </Tabs>
 
+### 用户、角色和权限同步（可选）
+
+默认情况下，迁移工具不同步账户元数据。如果将 `enable_privilege_sync` 设置为 `true`，迁移工具还会将源集群的用户、角色及其权限同步到目标集群。
+
+迁移工具每次获取元数据时，都会读取源集群和目标集群的用户、角色及其权限，进行比对，并执行使目标集群与源集群保持一致所需的 DDL 语句。用户定义通过 `SHOW CREATE USER` 获取，该语句返回的密码为密文，因此迁移过程中不会处理明文密码。
+
+以下对象始终不会被迁移工具修改：
+
+- `root` 以及 `target_cluster_user` 中指定的用户。覆盖目标集群 `root` 的密码会导致目标集群的运维人员无法登录，删除迁移工具连接所使用的账号会中断工具自身的连接。
+- 不可变的内置角色 `root`、`db_admin`、`cluster_admin`、`user_admin` 和 `security_admin`。`public` 是内置角色但可以修改，因此其权限会被同步，而角色本身不会被改动。
+- `privilege_sync_exclude_users` 中指定的用户和 `privilege_sync_exclude_roles` 中指定的角色。
+
+:::note
+
+- 两个集群的 FE 都必须支持 `SHOW CREATE USER`。如果任一集群的 FE 不支持该语句，迁移工具将跳过用户及其权限，仅同步角色和角色权限。
+- 权限同步的进度会以 `Sync privilege progress` 为前缀打印到日志文件 **log/sync.INFO.log** 中，其中列出角色、角色权限、用户和用户权限四个部分各自的状态。
+- 在一次性同步模式（`one_time_run_mode=true`）下，只有权限也同步一致后，迁移工具才会成功退出。如果任一集群不支持 `SHOW CREATE USER`，或者权限在连续三次比对后仍不一致，迁移工具将以失败状态退出。
+
+:::
+
 ## 步骤三：启动迁移工具
 
 配置完成后，启动迁移工具以开始数据迁移过程。
@@ -690,6 +726,7 @@ ORDER BY TABLE_NAME;
 - 内部表及其数据
 - 物化视图的 Schema 及其构建语句（物化视图中的数据不会被同步。如果物化视图的基表未同步到目标集群，物化视图的后台刷新任务将报错。）
 - 逻辑视图
+- 用户、角色及其权限（默认不同步，通过 `enable_privilege_sync` 开启）
 
 对于存算分离集群之间的迁移：
 


### PR DESCRIPTION
## Why I'm doing:

data-migration-tool added synchronization of users, roles and grants to the cross-cluster data migration tool, behind the new `enable_privilege_sync` switch. The tool's documentation still describes the previous set of synchronized objects and does not mention any of the seven new configuration items, so users have no way to discover or configure the feature.

## What I'm doing:

Updating `administration/data_migration_tool.md` in all three languages:

- **sync.properties sample**: append the `# privilege config` block, matching the merged `conf/sync.properties` exactly (`enable_privilege_sync`, `ddl_job_allow_drop_user_target_only`, `ddl_job_allow_drop_role_target_only`, `ddl_job_allow_drop_inconsistent_user`, `ddl_job_allow_revoke_grant_target_only`, `privilege_sync_exclude_users`, `privilege_sync_exclude_roles`).
- **Parameter table**: describe each of the seven items, including their defaults and the fact that `root` and `target_cluster_user` are always excluded.
- **New section "Synchronize users, roles, and privileges (Optional)"** under Step 2: how the reconciliation works per metadata cycle, that user definitions come from `SHOW CREATE USER` so no plaintext password is handled, which objects are never modified (`root`, `target_cluster_user`, the immutable built-in roles, the two exclusion lists), the role-only degradation when an FE lacks `SHOW CREATE USER`, the `Sync privilege progress` log line, and the one-time-run-mode exit conditions.
- **Limits**: add users, roles and their privileges to the list of objects that support synchronization, noting it is off by default.

Documentation only — no product code is touched.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)