### PR TITLE
[Enhancement] Add RAW_FILE mode to paimon_reader_mode

### DIFF
--- a/docs/en/sql-reference/System_variable.md
+++ b/docs/en/sql-reference/System_variable.md
@@ -1572,7 +1572,7 @@ Used for MySQL client compatibility. No practical usage.
 
 ### paimon_reader_mode
 
-* **Description**: Controls the reader used for Paimon tables. Valid values are `AUTO`, `JNI`, and `NATIVE` (case-insensitive). `AUTO` lets StarRocks automatically choose the appropriate reader. `JNI` always uses the JNI reader. `NATIVE` uses the paimon-cpp native reader. Note that `paimon_force_jni_reader` takes precedence over this variable: if it is set to `true`, the JNI reader is always used.
+* **Description**: Controls the reader used for Paimon tables. Valid values are `AUTO`, `JNI`, `NATIVE`, and `RAW_FILE` (case-insensitive). `AUTO` lets StarRocks automatically choose the appropriate reader: splits that can be read as raw Parquet or ORC data files use the StarRocks native file reader, and all other splits use the JNI reader. `JNI` always uses the JNI reader. `NATIVE` uses the paimon-cpp native reader. `RAW_FILE` only uses the StarRocks native file reader and fails the query if any split cannot be read that way, for example, a primary key table split that still needs to be merged, a data file in a format other than Parquet or ORC, or a system table. `RAW_FILE` is mainly intended for testing and benchmarking a specific reader path. Note that `paimon_force_jni_reader` takes precedence over this variable: if it is set to `true`, the JNI reader is always used.
 * **Default**: AUTO
 * **Data type**: String
 * **Introduced in**: v4.2

--- a/docs/ja/sql-reference/System_variable.md
+++ b/docs/ja/sql-reference/System_variable.md
@@ -1296,7 +1296,7 @@ MySQL クライアント互換性のために使用されます。実際の用�
 
 ### paimon_reader_mode
 
-* **説明**: Paimon テーブルで使用する Reader を制御します。有効な値は `AUTO`、`JNI`、`NATIVE` で、大文字と小文字は区別されません。`AUTO` は StarRocks が適切な Reader を自動的に選択します。`JNI` は常に JNI Reader を使用します。`NATIVE` は paimon-cpp ネイティブ Reader を使用します。なお、`paimon_force_jni_reader` はこの変数より優先されます。`true` に設定されている場合、常に JNI Reader が使用されます。
+* **説明**: Paimon テーブルで使用する Reader を制御します。有効な値は `AUTO`、`JNI`、`NATIVE`、`RAW_FILE` で、大文字と小文字は区別されません。`AUTO` は StarRocks が適切な Reader を自動的に選択します。Parquet または ORC の生データファイルとして直接読み取れる Split には StarRocks ネイティブファイル Reader を使用し、それ以外の Split には JNI Reader を使用します。`JNI` は常に JNI Reader を使用します。`NATIVE` は paimon-cpp ネイティブ Reader を使用します。`RAW_FILE` は StarRocks ネイティブファイル Reader のみを使用し、生データファイルとして読み取れない Split（マージが必要な主キーテーブルの Split、Parquet/ORC 以外の形式のデータファイル、システムテーブルなど）が存在する場合はクエリがエラーになります。`RAW_FILE` は主に、特定の Reader パスをテストおよびベンチマークする目的で使用します。なお、`paimon_force_jni_reader` はこの変数より優先されます。`true` に設定されている場合、常に JNI Reader が使用されます。
 * **デフォルト**: AUTO
 * **データ型**: String
 * **導入バージョン**: v4.2

--- a/docs/zh/sql-reference/System_variable.md
+++ b/docs/zh/sql-reference/System_variable.md
@@ -1340,7 +1340,7 @@ FROM test;
 
 ### paimon_reader_mode
 
-* 描述：控制 Paimon 表使用的 Reader。有效值为 `AUTO`、`JNI` 和 `NATIVE`（不区分大小写）。`AUTO` 表示由 StarRocks 自动选择合适的 Reader。`JNI` 始终使用 JNI Reader。`NATIVE` 使用 paimon-cpp 原生 Reader。注意 `paimon_force_jni_reader` 的优先级高于本变量：一旦其设置为 `true`，将始终使用 JNI Reader。
+* 描述：控制 Paimon 表使用的 Reader。有效值为 `AUTO`、`JNI`、`NATIVE` 和 `RAW_FILE`（不区分大小写）。`AUTO` 表示由 StarRocks 自动选择合适的 Reader：能够直接按 Parquet 或 ORC 原始数据文件读取的 Split 使用 StarRocks 原生文件 Reader，其余 Split 使用 JNI Reader。`JNI` 始终使用 JNI Reader。`NATIVE` 使用 paimon-cpp 原生 Reader。`RAW_FILE` 只使用 StarRocks 原生文件 Reader，一旦存在无法按原始文件读取的 Split（例如仍需合并的主键表 Split、非 Parquet/ORC 格式的数据文件、系统表），查询将直接报错。`RAW_FILE` 主要用于测试和性能对比时精确控制 Reader 路径。注意 `paimon_force_jni_reader` 的优先级高于本变量：一旦其设置为 `true`，将始终使用 JNI Reader。
 * 默认值：AUTO
 * 类型：String
 * 引入版本：v4.2

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -159,42 +159,66 @@ public class PaimonScanNode extends ScanNode {
         if (sessionVariable.getPaimonForceJNIReader()) {
             paimonReaderMode = PaimonReaderMode.JNI;
         }
+        boolean preferRawFiles =
+                paimonReaderMode == PaimonReaderMode.AUTO || paimonReaderMode == PaimonReaderMode.RAW_FILE;
         Map<BinaryRow, Long> selectedPartitions = Maps.newHashMap();
         for (Split split : splits) {
-            if (split instanceof DataSplit dataSplit) {
-                Optional<List<RawFile>> optionalRawFiles = dataSplit.convertToRawFiles();
-                if (paimonReaderMode == PaimonReaderMode.AUTO && optionalRawFiles.isPresent()) {
-                    List<RawFile> rawFiles = optionalRawFiles.get();
-                    boolean supportedDataFileFormat =
-                            rawFiles.stream().allMatch(p -> fromType(p.format()) != THdfsFileFormat.UNKNOWN);
-                    if (supportedDataFileFormat) {
-                        Optional<List<DeletionFile>> deletionFiles = dataSplit.deletionFiles();
-                        for (int i = 0; i < rawFiles.size(); i++) {
-                            if (deletionFiles.isPresent()) {
-                                splitRawFileScanRangeLocations(rawFiles.get(i), deletionFiles.get().get(i));
-                            } else {
-                                splitRawFileScanRangeLocations(rawFiles.get(i), null);
-                            }
-                        }
-                    } else {
-                        long totalFileLength = getTotalFileLength(dataSplit);
-                        addSDKSplitScanRangeLocations(paimonReaderMode, dataSplit, predicateInfo, totalFileLength);
-                    }
-                } else {
-                    long totalFileLength = getTotalFileLength(dataSplit);
-                    addSDKSplitScanRangeLocations(paimonReaderMode, dataSplit, predicateInfo, totalFileLength);
-                }
+            Optional<List<RawFile>> rawFiles =
+                    preferRawFiles ? rawFilesReadableByStarRocks(split) : Optional.empty();
+            if (rawFiles.isPresent()) {
+                DataSplit dataSplit = (DataSplit) split;
+                addRawFileScanRangeLocations(dataSplit, rawFiles.get());
+                selectedPartitions.computeIfAbsent(dataSplit.partition(), k -> nextPartitionId());
+            } else if (paimonReaderMode == PaimonReaderMode.RAW_FILE) {
+                throw rawFileReaderUnavailable(split);
+            } else if (split instanceof DataSplit dataSplit) {
+                long totalFileLength = getTotalFileLength(dataSplit);
+                addSDKSplitScanRangeLocations(paimonReaderMode, dataSplit, predicateInfo, totalFileLength);
                 selectedPartitions.computeIfAbsent(dataSplit.partition(), k -> nextPartitionId());
             } else {
                 // paimon system table
                 long length = getEstimatedLength(split.rowCount(), tupleDescriptor);
                 addSDKSplitScanRangeLocations(paimonReaderMode, split, predicateInfo, length);
             }
-
         }
         scanNodePredicates.setSelectedPartitionIds(selectedPartitions.values());
         traceReaderMetrics();
         traceDeletionVectorMetrics();
+    }
+
+    // Raw parquet/orc files StarRocks can scan with its own reader; empty when the split needs a Paimon SDK reader.
+    private Optional<List<RawFile>> rawFilesReadableByStarRocks(Split split) {
+        if (!(split instanceof DataSplit dataSplit)) {
+            return Optional.empty();
+        }
+        return dataSplit.convertToRawFiles()
+                .filter(files -> files.stream().allMatch(f -> fromType(f.format()) != THdfsFileFormat.UNKNOWN));
+    }
+
+    private void addRawFileScanRangeLocations(DataSplit dataSplit, List<RawFile> rawFiles) {
+        Optional<List<DeletionFile>> deletionFiles = dataSplit.deletionFiles();
+        for (int i = 0; i < rawFiles.size(); i++) {
+            DeletionFile deletionFile = deletionFiles.isPresent() ? deletionFiles.get().get(i) : null;
+            splitRawFileScanRangeLocations(rawFiles.get(i), deletionFile);
+        }
+    }
+
+    private StarRocksConnectorException rawFileReaderUnavailable(Split split) {
+        String splitDesc;
+        String reason;
+        if (!(split instanceof DataSplit dataSplit)) {
+            splitDesc = split.getClass().getSimpleName();
+            reason = "it is not a data split (e.g. a system table)";
+        } else {
+            splitDesc = dataSplit.bucketPath();
+            reason = dataSplit.convertToRawFiles().isEmpty()
+                    ? "it must be merged by the Paimon SDK (e.g. an uncompacted primary-key split)"
+                    : "its data files are not in parquet or orc format";
+        }
+        return new StarRocksConnectorException(
+                "paimon_reader_mode=RAW_FILE cannot read split [%s] of table %s.%s because %s. " +
+                        "Run a full compaction on the table, or use paimon_reader_mode AUTO, JNI, or NATIVE.",
+                splitDesc, paimonTable.getCatalogDBName(), paimonTable.getCatalogTableName(), reason);
     }
 
     private void traceReaderMetrics() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -131,7 +131,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public enum PaimonReaderMode {
         AUTO,
         JNI,
-        NATIVE
+        NATIVE,
+        // StarRocks' own parquet/orc reader over raw data files; splits that cannot be read that way fail.
+        RAW_FILE
     }
 
     public enum BinaryEncodingFormat {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableVarConverters.java
@@ -79,7 +79,7 @@ public class VariableVarConverters {
             try {
                 return SessionVariable.PaimonReaderMode.valueOf(mode).name();
             } catch (IllegalArgumentException e) {
-                throw new DdlException("paimon_reader_mode only supports AUTO, JNI, or NATIVE");
+                throw new DdlException("paimon_reader_mode only supports AUTO, JNI, NATIVE, or RAW_FILE");
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PaimonScanNodeTest.java
@@ -354,6 +354,139 @@ public class PaimonScanNodeTest {
     }
 
     @Test
+    public void testSetupScanRangeLocationsRawFileMode(
+            @Mocked GlobalStateMgr globalStateMgr, @Mocked MetadataMgr metadataMgr, @Mocked PaimonTable table) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setSessionVariable(new SessionVariable());
+        ctx.getSessionVariable().setPaimonReaderMode("raw_file");
+        ctx.setThreadLocalInfo();
+        try {
+            DeletionFile deletionFile = new DeletionFile("delete-file", 7, 11, 0L);
+            DataSplit parquetSplit = createRawConvertibleDataSplit("parquet", List.of(deletionFile));
+            DataSplit orcSplit = createRawConvertibleDataSplit("orc", List.of());
+            List<RemoteFileInfo> remoteFiles = createRemoteFiles(parquetSplit, orcSplit);
+            new Expectations() {
+                {
+                    GlobalStateMgr.getCurrentState();
+                    result = globalStateMgr;
+                    globalStateMgr.getMetadataMgr();
+                    result = metadataMgr;
+                    metadataMgr.getRemoteFiles((Table) any, (GetRemoteFilesParams) any);
+                    result = remoteFiles;
+                }
+            };
+
+            TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+            desc.setTable(table);
+            PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
+            scanNode.setupScanRangeLocations(desc, null, -1);
+
+            List<TScanRangeLocations> ranges = scanNode.getScanRangeLocations(10);
+            Assertions.assertEquals(2, ranges.size());
+            for (TScanRangeLocations range : ranges) {
+                THdfsScanRange hdfsScanRange = range.getScan_range().getHdfs_scan_range();
+                Assertions.assertNotEquals(THdfsFileFormat.UNKNOWN, hdfsScanRange.getFile_format());
+                Assertions.assertFalse(hdfsScanRange.isUse_paimon_jni_reader());
+                Assertions.assertFalse(hdfsScanRange.isUse_paimon_native_reader());
+                Assertions.assertFalse(hdfsScanRange.isSetPaimon_split_info());
+                Assertions.assertFalse(hdfsScanRange.isSetPaimon_split_info_binary());
+            }
+            Assertions.assertTrue(ranges.get(0).getScan_range().getHdfs_scan_range().isSetPaimon_deletion_file());
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testRawFileModeRejectsSplitsNeedingSdk(
+            @Mocked GlobalStateMgr globalStateMgr, @Mocked MetadataMgr metadataMgr, @Mocked PaimonTable table) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setSessionVariable(new SessionVariable());
+        ctx.getSessionVariable().setPaimonReaderMode("RAW_FILE");
+        ctx.setThreadLocalInfo();
+        try {
+            // Every split that AUTO would silently route to the SDK readers must fail under RAW_FILE:
+            // a raw-convertible split in an unsupported file format, a split that needs merging,
+            // and a non-data (system table) split.
+            List<List<RemoteFileInfo>> rejected = List.of(
+                    createRemoteFiles(createRawConvertibleDataSplit("unknown", List.of())),
+                    createRemoteFiles(createDataSplit()),
+                    createRemoteFiles(new TestSplit()));
+            List<String> reasons = List.of("not in parquet or orc format", "merged by the Paimon SDK",
+                    "not a data split");
+            for (int i = 0; i < rejected.size(); i++) {
+                List<RemoteFileInfo> remoteFiles = rejected.get(i);
+                new Expectations() {
+                    {
+                        GlobalStateMgr.getCurrentState();
+                        result = globalStateMgr;
+                        globalStateMgr.getMetadataMgr();
+                        result = metadataMgr;
+                        metadataMgr.getRemoteFiles((Table) any, (GetRemoteFilesParams) any);
+                        result = remoteFiles;
+                        times = 1;
+                    }
+                };
+
+                TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+                desc.setTable(table);
+                PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
+                StarRocksConnectorException exception = Assertions.assertThrows(StarRocksConnectorException.class,
+                        () -> scanNode.setupScanRangeLocations(desc, null, -1));
+                Assertions.assertTrue(exception.getMessage().contains("paimon_reader_mode=RAW_FILE"),
+                        exception.getMessage());
+                Assertions.assertTrue(exception.getMessage().contains(reasons.get(i)), exception.getMessage());
+                Assertions.assertTrue(scanNode.getScanRangeLocations(10).isEmpty());
+            }
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
+    public void testForceJniReaderOverridesRawFileMode(
+            @Mocked GlobalStateMgr globalStateMgr, @Mocked MetadataMgr metadataMgr, @Mocked PaimonTable table) {
+        ConnectContext ctx = new ConnectContext();
+        ctx.setSessionVariable(new SessionVariable() {
+            @Override
+            public boolean getPaimonForceJNIReader() {
+                return true;
+            }
+        });
+        ctx.getSessionVariable().setPaimonReaderMode("RAW_FILE");
+        ctx.setThreadLocalInfo();
+        try {
+            List<RemoteFileInfo> remoteFiles =
+                    createRemoteFiles(createRawConvertibleDataSplit("parquet", List.of()), createDataSplit());
+            new Expectations() {
+                {
+                    GlobalStateMgr.getCurrentState();
+                    result = globalStateMgr;
+                    globalStateMgr.getMetadataMgr();
+                    result = metadataMgr;
+                    metadataMgr.getRemoteFiles((Table) any, (GetRemoteFilesParams) any);
+                    result = remoteFiles;
+                }
+            };
+
+            TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+            desc.setTable(table);
+            PaimonScanNode scanNode = new PaimonScanNode(new PlanNodeId(0), desc, "XXX");
+            scanNode.setupScanRangeLocations(desc, null, -1);
+
+            List<TScanRangeLocations> ranges = scanNode.getScanRangeLocations(10);
+            Assertions.assertEquals(2, ranges.size());
+            for (TScanRangeLocations range : ranges) {
+                THdfsScanRange hdfsScanRange = range.getScan_range().getHdfs_scan_range();
+                Assertions.assertTrue(hdfsScanRange.isUse_paimon_jni_reader());
+                Assertions.assertFalse(hdfsScanRange.isUse_paimon_native_reader());
+            }
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+
+    @Test
     public void testNativeSplitSerializationFailure(@Mocked PaimonTable table) {
         ConnectContext ctx = new ConnectContext();
         ctx.setThreadLocalInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -38,6 +38,10 @@ public class SessionVariableTest {
         Assertions.assertEquals("NATIVE", nativeMode);
         sessionVariable.setPaimonReaderMode(nativeMode);
         Assertions.assertEquals(SessionVariable.PaimonReaderMode.NATIVE, sessionVariable.getPaimonReaderMode());
+        String rawFileMode = VariableVarConverters.convert(SessionVariable.PAIMON_READER_MODE, "raw_file");
+        Assertions.assertEquals("RAW_FILE", rawFileMode);
+        sessionVariable.setPaimonReaderMode(rawFileMode);
+        Assertions.assertEquals(SessionVariable.PaimonReaderMode.RAW_FILE, sessionVariable.getPaimonReaderMode());
 
         Assertions.assertThrows(DdlException.class,
                 () -> VariableVarConverters.convert(SessionVariable.PAIMON_READER_MODE, "invalid"));


### PR DESCRIPTION
## Why I'm doing:

`paimon_reader_mode` currently offers `AUTO`, `JNI`, and `NATIVE`. Only two of the three Paimon read paths can be pinned explicitly:

- `JNI` (or `paimon_force_jni_reader`) always uses the paimon-java JNI reader.
- `NATIVE` routes every data split to the paimon-cpp reader.
- The third path, StarRocks' own parquet/orc reader over raw data files, is only reachable through `AUTO`, and `AUTO` silently falls back to JNI whenever a split cannot be converted to raw files (an uncompacted primary-key split, a non-parquet/orc data file, a system table).

That silent fallback makes it impossible to hold the reader fixed when benchmarking or bisecting reader behaviour: a query may quietly mix the StarRocks raw-file reader and the JNI reader, and the only way to notice is to inspect the query profile afterwards.

## What I'm doing:

Add a fourth mode, `paimon_reader_mode = RAW_FILE`:

- Splits that can be read as raw parquet/orc files use the StarRocks native file reader, exactly as under `AUTO`.
- Any other split fails the query at plan time with a `StarRocksConnectorException` that names the split (bucket path), the table, why the raw-file reader cannot serve it, and how to proceed (run a full compaction, or use `AUTO`/`JNI`/`NATIVE`).
- `paimon_force_jni_reader = true` still takes precedence, as it does over the other modes.

`AUTO`, `JNI`, and `NATIVE` behaviour is unchanged. The split routing loop in `PaimonScanNode` is restructured around a single "raw files readable by StarRocks" check so the new mode adds one branch instead of a fallback at every SDK call site.

Observability: the existing `Tracers` EXTERNAL counters (`starRocksNativeReaderRead*`, `paimonNativeReaderRead*`, `jniReaderRead*`) and the deletion-vector tracing still run once per plan and keep their semantics; under `RAW_FILE` every counted split is a StarRocks-native one. No new signal was needed; the new error message is the only added surface.

Tests:

- `PaimonScanNodeTest`: `RAW_FILE` routes parquet/orc raw-convertible splits (with and without deletion files) to the StarRocks reader and sets no JNI/paimon-cpp flags; `RAW_FILE` rejects an unsupported-format split, a split that needs merging, and a non-data split with the expected reasons; `paimon_force_jni_reader` overrides `RAW_FILE`.
- `SessionVariableTest`: converter accepts `raw_file` and the getter returns `RAW_FILE`.
- Docs for `paimon_reader_mode` updated in `docs/en`, `docs/zh`, and `docs/ja`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjEqn3Q4QojKPfJrHJcPJP