### PR TITLE
[BugFix] Keep explicit transactions on one tablet layout during reshard

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/MergeTabletJob.java
@@ -336,7 +336,7 @@ public class MergeTabletJob extends TabletReshardJob {
         Set<Long> ignoredCompactionTxnIds = GlobalStateMgr.getCurrentState().getCompactionMgr()
                 .cancelPreviousCompactions(endTransactionId, dbId, tableId, reshardingPhysicalPartitions.keySet());
         try {
-            if (!GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().isPreviousTransactionsFinished(
+            if (!GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().isPreviousTransactionsFinishedForReshard(
                     endTransactionId, dbId, List.of(tableId), ignoredCompactionTxnIds)) {
                 return;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -439,7 +439,7 @@ public class SplitTabletJob extends TabletReshardJob {
         ignoredTransactionIds.addAll(GlobalStateMgr.getCurrentState().getCompactionMgr()
                 .cancelPreviousCompactions(endTransactionId, dbId, tableId, reshardingPhysicalPartitions.keySet()));
         try {
-            if (!GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().isPreviousTransactionsFinished(
+            if (!GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().isPreviousTransactionsFinishedForReshard(
                     endTransactionId, dbId, List.of(tableId), ignoredTransactionIds)) {
                 return;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -221,15 +221,13 @@ public class OlapTableSink extends DataSink {
                 && explicitTxnState.getSourceType() == TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING) {
             txnState = explicitTxnState;
         }
-        TransactionState combinedTxnLogState = explicitTxnState != null
-                && explicitTxnState.getSourceType() == TransactionState.LoadJobSourceType.INSERT_STREAMING
-                ? null : txnState;
         if (txnState != null) {
             tSink.setTxn_trace_parent(txnState.getTraceParent());
             tSink.setLabel(txnState.getLabel());
-        }
-        if (combinedTxnLogState != null) {
-            tSink.setWrite_txn_log(combinedTxnLogState.isUseCombinedTxnLog());
+            if (explicitTxnState == null
+                    || explicitTxnState.getSourceType() != TransactionState.LoadJobSourceType.INSERT_STREAMING) {
+                tSink.setWrite_txn_log(txnState.isUseCombinedTxnLog());
+            }
         }
         tSink.setDb_id(dbId);
         tSink.setLoad_channel_timeout_s(loadChannelTimeoutS);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -221,10 +221,15 @@ public class OlapTableSink extends DataSink {
                 && explicitTxnState.getSourceType() == TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING) {
             txnState = explicitTxnState;
         }
+        TransactionState combinedTxnLogState = explicitTxnState != null
+                && explicitTxnState.getSourceType() == TransactionState.LoadJobSourceType.INSERT_STREAMING
+                ? null : txnState;
         if (txnState != null) {
             tSink.setTxn_trace_parent(txnState.getTraceParent());
             tSink.setLabel(txnState.getLabel());
-            tSink.setWrite_txn_log(txnState.isUseCombinedTxnLog());
+        }
+        if (combinedTxnLogState != null) {
+            tSink.setWrite_txn_log(combinedTxnLogState.isUseCombinedTxnLog());
         }
         tSink.setDb_id(dbId);
         tSink.setLoad_channel_timeout_s(loadChannelTimeoutS);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -1099,9 +1099,8 @@ public class OlapTableSink extends DataSink {
             List<Long> allTabletIds = new ArrayList<>();
             for (TOlapTablePartition tPhysicalPartition : partitionParam.getPartitions()) {
                 PhysicalPartition physicalPartition = table.getPhysicalPartition(tPhysicalPartition.getId());
-                List<MaterializedIndex> indexes = (txnState != null)
-                        ? txnState.getPartitionLoadedIndexes(table.getId(), physicalPartition)
-                        : physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
+                List<MaterializedIndex> indexes = selectWriteIndexes(
+                        table, physicalPartition, txnState, null);
                 for (MaterializedIndex index : indexes) {
                     for (Tablet tablet : index.getTablets()) {
                         allTabletIds.add(tablet.getId());
@@ -1124,9 +1123,8 @@ public class OlapTableSink extends DataSink {
             // tablets' replica in colocate mv index optimization.
             List<Long> selectedBackedIds = Lists.newArrayList();
             LOG.debug("partition: {}, physical partition: {}", tPhysicalPartition, physicalPartition);
-            List<MaterializedIndex> indexes = (txnState != null)
-                    ? txnState.getPartitionLoadedIndexes(table.getId(), physicalPartition)
-                    : physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL);
+            List<MaterializedIndex> indexes = selectWriteIndexes(
+                    table, physicalPartition, txnState, null);
             for (MaterializedIndex index : indexes) {
                 for (int idx = 0; idx < index.getTablets().size(); ++idx) {
                     Tablet tablet = index.getTablets().get(idx);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -214,10 +214,12 @@ public class OlapTableSink extends DataSink {
         tSink.setMiss_auto_increment_column(missAutoIncrementColumn);
         tSink.setAuto_increment_slot_id(autoIncrementSlotId);
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        TransactionState txnState = globalTransactionMgr.reserveExplicitTransactionLayout(
+        TransactionState explicitTxnState = globalTransactionMgr.reserveExplicitTransactionLayout(
                 txnId, dbId, dstTable.getId());
-        if (txnState == null) {
-            txnState = globalTransactionMgr.getTransactionState(dbId, txnId);
+        TransactionState txnState = globalTransactionMgr.getTransactionState(dbId, txnId);
+        if (txnState == null && explicitTxnState != null
+                && explicitTxnState.getSourceType() == TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING) {
+            txnState = explicitTxnState;
         }
         if (txnState != null) {
             tSink.setTxn_trace_parent(txnState.getTraceParent());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -118,7 +118,6 @@ import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
-import com.starrocks.transaction.ExplicitTxnState;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -215,24 +214,10 @@ public class OlapTableSink extends DataSink {
         tSink.setMiss_auto_increment_column(missAutoIncrementColumn);
         tSink.setAuto_increment_slot_id(autoIncrementSlotId);
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        TransactionState txnState = globalTransactionMgr.getTransactionState(dbId, txnId);
+        TransactionState txnState = globalTransactionMgr.reserveExplicitTransactionLayout(
+                txnId, dbId, dstTable.getId());
         if (txnState == null) {
-            // Multi-statement stream load plans its sub-task sinks during the load, before the
-            // explicit transaction is upserted into the DatabaseTransactionMgr at commit time, so
-            // getTransactionState misses. Fall back to the explicit transaction registry so the sink
-            // observes the transaction's combined-txn-log decision; otherwise write_txn_log stays at
-            // the per-tablet default while publish expects combined logs, wedging publish.
-            //
-            // Restricted to MULTI_STATEMENT_STREAMING on purpose: INSERT_STREAMING (BEGIN ... COMMIT)
-            // emits per-load-id txn logs that publish reads via the load_ids branch (which takes
-            // precedence over combined_txn_log), so its sink must keep the default per-load-id mode.
-            // Honoring the combined flag here would make BE skip those per-load-id logs and lose data.
-            ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(txnId);
-            if (explicitTxnState != null && explicitTxnState.getTransactionState() != null
-                    && explicitTxnState.getTransactionState().getSourceType()
-                            == TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING) {
-                txnState = explicitTxnState.getTransactionState();
-            }
+            txnState = globalTransactionMgr.getTransactionState(dbId, txnId);
         }
         if (txnState != null) {
             tSink.setTxn_trace_parent(txnState.getTraceParent());
@@ -386,20 +371,14 @@ public class OlapTableSink extends DataSink {
             return null;
         }
 
-        // normal transaction state
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        TransactionState txnState = globalTransactionMgr.getTransactionState(tSink.getDb_id(), txnId);
-
+        TransactionState txnState = globalTransactionMgr.reserveExplicitTransactionLayout(
+                txnId, tSink.getDb_id(), tSink.getTable_id());
         if (txnState == null) {
-            // explicit transaction state
-            ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(txnId);
-            if (explicitTxnState != null) {
-                txnState = explicitTxnState.getTransactionState();
-            }
-
-            if (txnState == null) {
-                throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, txnId);
-            }
+            txnState = globalTransactionMgr.getTransactionState(tSink.getDb_id(), txnId);
+        }
+        if (txnState == null) {
+            throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, txnId);
         }
 
         return txnState;
@@ -763,6 +742,16 @@ public class OlapTableSink extends DataSink {
         return filtered;
     }
 
+    private static List<MaterializedIndex> selectWriteIndexes(
+            OlapTable table, PhysicalPartition physicalPartition,
+            @Nullable TransactionState txnState, @Nullable Long targetWriteIndexId)
+            throws StarRocksException {
+        List<MaterializedIndex> candidates = txnState == null
+                ? physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL)
+                : txnState.getPartitionLoadedIndexes(table.getId(), physicalPartition);
+        return filterTargetWriteIndexes(candidates, physicalPartition, targetWriteIndexId);
+    }
+
     public static TOlapTablePartitionParam createPartition(long dbId, OlapTable table,
                                                            TupleDescriptor tupleDescriptor,
                                                            boolean enableAutomaticPartition,
@@ -809,9 +798,8 @@ public class OlapTableSink extends DataSink {
                         TOlapTablePartition tPartition = new TOlapTablePartition();
                         tPartition.setId(physicalPartition.getId());
                         setRangeKeys(rangePartitionInfo, partition, tPartition);
-                        List<MaterializedIndex> indexes = filterTargetWriteIndexes(
-                                physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL),
-                                physicalPartition, targetWriteIndexId);
+                        List<MaterializedIndex> indexes = selectWriteIndexes(
+                                table, physicalPartition, txnState, targetWriteIndexId);
                         setMaterializedIndexes(tPartition, indexes);
                         partitionParam.addToPartitions(tPartition);
                         if (txnState != null) {
@@ -892,9 +880,8 @@ public class OlapTableSink extends DataSink {
                         TOlapTablePartition tPartition = new TOlapTablePartition();
                         tPartition.setId(physicalPartition.getId());
                         setListPartitionValues(listPartitionInfo, partition, tPartition);
-                        List<MaterializedIndex> indexes = filterTargetWriteIndexes(
-                                physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL),
-                                physicalPartition, targetWriteIndexId);
+                        List<MaterializedIndex> indexes = selectWriteIndexes(
+                                table, physicalPartition, txnState, targetWriteIndexId);
                         setMaterializedIndexes(tPartition, indexes);
                         partitionParam.addToPartitions(tPartition);
                         if (txnState != null) {
@@ -937,9 +924,8 @@ public class OlapTableSink extends DataSink {
                     TOlapTablePartition tPartition = new TOlapTablePartition();
                     tPartition.setId(physicalPartition.getId());
                     // No lowerBound and upperBound for this range
-                    List<MaterializedIndex> indexes = filterTargetWriteIndexes(
-                            physicalPartition.getLatestMaterializedIndices(IndexExtState.ALL),
-                            physicalPartition, targetWriteIndexId);
+                    List<MaterializedIndex> indexes = selectWriteIndexes(
+                            table, physicalPartition, txnState, targetWriteIndexId);
                     setMaterializedIndexes(tPartition, indexes);
                     partitionParam.addToPartitions(tPartition);
                     if (txnState != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -286,6 +286,23 @@ public class DatabaseTransactionMgr {
         }
     }
 
+    public TransactionState activateTransactionTable(long transactionId, long tableId)
+            throws TransactionNotFoundException {
+        writeLock();
+        try {
+            TransactionState transactionState = unprotectedGetTransactionState(transactionId);
+            if (transactionState == null || !transactionState.isRunning()) {
+                throw new TransactionNotFoundException(transactionId);
+            }
+            if (!transactionState.getTableIdList().contains(tableId)) {
+                transactionState.addTableIdList(tableId);
+            }
+            return transactionState;
+        } finally {
+            writeUnlock();
+        }
+    }
+
     private void checkLabel(String label, TUniqueId requestId)
             throws LabelAlreadyUsedException, DuplicatedRequestException {
         /*

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/ExplicitTxnState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/ExplicitTxnState.java
@@ -20,6 +20,8 @@ import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.thrift.TUniqueId;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,7 @@ public class ExplicitTxnState {
     // Track tables that are WRITE targets (insert/update/delete) in this explicit transaction.
     // We use table id for uniqueness even if renamed.
     private final Set<Long> modifiedTableIds = new HashSet<>();
+    private final Map<Long, Set<Long>> planningLayoutReservations = new HashMap<>();
 
     public ExplicitTxnState() {
     }
@@ -73,6 +76,23 @@ public class ExplicitTxnState {
 
     public Set<Long> getModifiedTableIds() {
         return modifiedTableIds;
+    }
+
+    void reservePlanningLayout(long dbId, long tableId) {
+        planningLayoutReservations.computeIfAbsent(dbId, ignored -> new HashSet<>()).add(tableId);
+    }
+
+    boolean hasPlanningLayoutReservation(long dbId, List<Long> tableIds) {
+        Set<Long> reserved = planningLayoutReservations.get(dbId);
+        return reserved != null && !Collections.disjoint(reserved, tableIds);
+    }
+
+    Set<Long> getPlanningLayoutTables(long dbId) {
+        return planningLayoutReservations.getOrDefault(dbId, Collections.emptySet());
+    }
+
+    void retainPlanningLayoutsForDatabase(long dbId) {
+        planningLayoutReservations.keySet().removeIf(reservedDbId -> reservedDbId != dbId);
     }
 
     public static class ExplicitTxnStateItem {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -102,10 +102,9 @@ public class GlobalTransactionMgr implements MemoryTrackable {
     // ExplicitTxnStateItem, and the transaction state is recorded in TransactionState.
     private final Map<Long, ExplicitTxnState> explicitTxnStateMap = Maps.newConcurrentMap();
 
-    // Serializes the registration of explicit transaction states. `explicitTxnStateMap` itself is concurrent, but
-    // `BEGIN WITH LABEL` has to verify that the label is unused and publish the new state as a single atomic step:
-    // without this lock two concurrent sessions can both pass the uniqueness check before either of them publishes,
-    // and both `BEGIN` succeed with the same label.
+    // Serializes the lifecycle of explicit transaction states. `explicitTxnStateMap` itself is concurrent, but label
+    // checks, planning reservations, database registration, reshard watermarks, and removal must be atomic with
+    // respect to each other.
     private final Object explicitTxnStateLock = new Object();
 
     private final GlobalStateMgr globalStateMgr;
@@ -198,7 +197,53 @@ public class GlobalTransactionMgr implements MemoryTrackable {
     }
 
     public void clearExplicitTxnState(long txnId) {
-        explicitTxnStateMap.remove(txnId);
+        synchronized (explicitTxnStateLock) {
+            explicitTxnStateMap.remove(txnId);
+        }
+    }
+
+    @Nullable
+    public TransactionState reserveExplicitTransactionLayout(long txnId, long dbId, long tableId) {
+        synchronized (explicitTxnStateLock) {
+            ExplicitTxnState explicit = explicitTxnStateMap.get(txnId);
+            if (explicit == null || explicit.getTransactionState() == null) {
+                return null;
+            }
+            TransactionState state = explicit.getTransactionState();
+            if (state.getDbId() != 0 && state.getDbId() != dbId) {
+                throw ErrorReportException.report(ErrorCode.ERR_TXN_FORBID_CROSS_DB);
+            }
+            explicit.reservePlanningLayout(dbId, tableId);
+            return state;
+        }
+    }
+
+    public TransactionState registerExplicitTransactionState(long txnId, long dbId) throws StarRocksException {
+        synchronized (explicitTxnStateLock) {
+            ExplicitTxnState explicit = explicitTxnStateMap.get(txnId);
+            if (explicit == null || explicit.getTransactionState() == null) {
+                throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, txnId);
+            }
+            TransactionState state = explicit.getTransactionState();
+            if (state.getDbId() != 0 && state.getDbId() != dbId) {
+                throw ErrorReportException.report(ErrorCode.ERR_TXN_FORBID_CROSS_DB);
+            }
+            DatabaseTransactionMgr dbTxnMgr = getDatabaseTransactionMgr(dbId);
+            TransactionState registered = dbTxnMgr.getTransactionState(txnId);
+            if (registered == null) {
+                long originalDbId = state.getDbId();
+                state.setDbId(dbId);
+                try {
+                    dbTxnMgr.upsertTransactionState(state);
+                } catch (StarRocksException | RuntimeException e) {
+                    state.setDbId(originalDbId);
+                    throw e;
+                }
+                registered = state;
+            }
+            explicit.retainPlanningLayoutsForDatabase(dbId);
+            return registered;
+        }
     }
 
     /**
@@ -849,6 +894,32 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         }
     }
 
+    public boolean isPreviousTransactionsFinishedForReshard(
+            long endTransactionId, long dbId, List<Long> tableIdList,
+            Set<Long> excludeTransactionIds) throws AnalysisException {
+        synchronized (explicitTxnStateLock) {
+            DatabaseTransactionMgr dbTxnMgr = getDatabaseTransactionMgr(dbId);
+            if (!dbTxnMgr.isPreviousTransactionsFinished(
+                    endTransactionId, tableIdList, excludeTransactionIds)) {
+                return false;
+            }
+            long now = System.currentTimeMillis();
+            for (Map.Entry<Long, ExplicitTxnState> entry : explicitTxnStateMap.entrySet()) {
+                TransactionState state = entry.getValue().getTransactionState();
+                if (state == null || !state.isRunning() || entry.getKey() > endTransactionId
+                        || excludeTransactionIds.contains(entry.getKey())
+                        || !entry.getValue().hasPlanningLayoutReservation(dbId, tableIdList)) {
+                    continue;
+                }
+                LOG.debug("Explicit txn {} with age {} ms reserves db {} tables {} below reshard watermark {}",
+                        entry.getKey(), now - state.getPrepareTime(), dbId,
+                        entry.getValue().getPlanningLayoutTables(dbId), endTransactionId);
+                return false;
+            }
+            return true;
+        }
+    }
+
     /**
      * The txn cleaner will run at a fixed interval and try to delete expired and timeout txns:
      * expired: txn is in VISIBLE or ABORTED, and is expired.
@@ -862,10 +933,12 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         // Clean up orphaned explicit transaction states:
         // 1. txnState == null: orphaned entry (e.g., state lost after FE leader switch)
         // 2. txnState != null && isTimeout: BEGIN executed but no DML followed, timed out
-        explicitTxnStateMap.entrySet().removeIf(entry -> {
-            TransactionState txnState = entry.getValue().getTransactionState();
-            return txnState == null || txnState.isTimeout(currentMillis);
-        });
+        synchronized (explicitTxnStateLock) {
+            explicitTxnStateMap.entrySet().removeIf(entry -> {
+                TransactionState txnState = entry.getValue().getTransactionState();
+                return txnState == null || txnState.isTimeout(currentMillis);
+            });
+        }
     }
 
     public void removeExpiredTxns() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -246,6 +246,25 @@ public class GlobalTransactionMgr implements MemoryTrackable {
         }
     }
 
+    public ExplicitTxnState activateExplicitTransactionTable(long txnId, long dbId, long tableId)
+            throws StarRocksException {
+        synchronized (explicitTxnStateLock) {
+            ExplicitTxnState explicit = explicitTxnStateMap.get(txnId);
+            if (explicit == null || explicit.getTransactionState() == null) {
+                throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, txnId);
+            }
+            TransactionState state = explicit.getTransactionState();
+            if (state.getDbId() != 0 && state.getDbId() != dbId) {
+                throw ErrorReportException.report(ErrorCode.ERR_TXN_FORBID_CROSS_DB);
+            }
+            if (state.getDbId() != dbId) {
+                throw new TransactionNotFoundException(txnId);
+            }
+            getDatabaseTransactionMgr(dbId).activateTransactionTable(txnId, tableId);
+            return explicit;
+        }
+    }
+
     /**
      * the app could specify the transaction id
      * <p>

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -187,10 +187,6 @@ public class TransactionStmtExecutor {
         try {
             TransactionState transactionState = globalTransactionMgr.registerExplicitTransactionState(
                     context.getTxnId(), database.getId());
-            ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
-            if (explicitTxnState == null || explicitTxnState.getTransactionState() == null) {
-                throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, context.getTxnId());
-            }
 
             Map<TableName, Table> m = AnalyzerUtils.collectAllTable(dmlStmt);
             for (Table table : m.values()) {
@@ -202,9 +198,8 @@ public class TransactionStmtExecutor {
                 }
             }
 
-            if (!transactionState.getTableIdList().contains(targetTable.getId())) {
-                transactionState.addTableIdList(targetTable.getId());
-            }
+            ExplicitTxnState explicitTxnState = globalTransactionMgr.activateExplicitTransactionTable(
+                    context.getTxnId(), database.getId(), targetTable.getId());
             // record modified table id in explicit txn state for later SELECT validation
             explicitTxnState.addModifiedTableId(targetTable.getId());
 
@@ -243,12 +238,8 @@ public class TransactionStmtExecutor {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         TransactionState transactionState = globalTransactionMgr.registerExplicitTransactionState(
                 context.getTxnId(), dbId);
-        ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
-        if (explicitTxnState == null || explicitTxnState.getTransactionState() == null) {
-            throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, context.getTxnId());
-        }
-
-        transactionState.addTableIdList(tableId);
+        ExplicitTxnState explicitTxnState = globalTransactionMgr.activateExplicitTransactionTable(
+                context.getTxnId(), dbId, tableId);
 
         // record modified table id in explicit txn state for later SELECT validation
         explicitTxnState.addModifiedTableId(tableId);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -184,19 +184,12 @@ public class TransactionStmtExecutor {
                 context, execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift(), execPlan);
 
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-        ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
-        TransactionState transactionState = explicitTxnState.getTransactionState();
-
         try {
-            if (transactionState.getDbId() == 0) {
-                transactionState.setDbId(database.getId());
-                DatabaseTransactionMgr databaseTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                        .getDatabaseTransactionMgr(database.getId());
-                databaseTransactionMgr.upsertTransactionState(transactionState);
-            }
-
-            if (database.getId() != transactionState.getDbId()) {
-                throw ErrorReportException.report(ErrorCode.ERR_TXN_FORBID_CROSS_DB);
+            TransactionState transactionState = globalTransactionMgr.registerExplicitTransactionState(
+                    context.getTxnId(), database.getId());
+            ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
+            if (explicitTxnState == null || explicitTxnState.getTransactionState() == null) {
+                throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, context.getTxnId());
             }
 
             Map<TableName, Table> m = AnalyzerUtils.collectAllTable(dmlStmt);
@@ -248,14 +241,11 @@ public class TransactionStmtExecutor {
     public static void loadData(long dbId, long tableId, ExplicitTxnState.ExplicitTxnStateItem item,
             ConnectContext context) throws StarRocksException {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        TransactionState transactionState = globalTransactionMgr.registerExplicitTransactionState(
+                context.getTxnId(), dbId);
         ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
-        TransactionState transactionState = explicitTxnState.getTransactionState();
-
-        if (transactionState.getDbId() == 0) {
-            transactionState.setDbId(dbId);
-            DatabaseTransactionMgr databaseTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                    .getDatabaseTransactionMgr(dbId);
-            databaseTransactionMgr.upsertTransactionState(transactionState);
+        if (explicitTxnState == null || explicitTxnState.getTransactionState() == null) {
+            throw new StarRocksException(ErrorCode.ERR_TXN_NOT_EXIST, context.getTxnId());
         }
 
         transactionState.addTableIdList(tableId);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/MergeTabletJobTest.java
@@ -393,7 +393,8 @@ public class MergeTabletJobTest {
 
         new MockUp<GlobalTransactionMgr>() {
             @Mock
-            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+            public boolean isPreviousTransactionsFinishedForReshard(
+                    long endTransactionId, long dbId, List<Long> tableIds,
                     Set<Long> excludeTransactionIds) {
                 return false;
             }
@@ -415,7 +416,8 @@ public class MergeTabletJobTest {
 
         new MockUp<GlobalTransactionMgr>() {
             @Mock
-            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+            public boolean isPreviousTransactionsFinishedForReshard(
+                    long endTransactionId, long dbId, List<Long> tableIds,
                     Set<Long> excludeTransactionIds) throws AnalysisException {
                 throw new AnalysisException("mock");
             }
@@ -457,7 +459,8 @@ public class MergeTabletJobTest {
         };
         new MockUp<GlobalTransactionMgr>() {
             @Mock
-            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+            public boolean isPreviousTransactionsFinishedForReshard(
+                    long endTransactionId, long dbId, List<Long> tableIds,
                     Set<Long> excludeTransactionIds) {
                 excludeTxnIdsArg.set(excludeTransactionIds);
                 return waitFinished[0];
@@ -794,7 +797,7 @@ public class MergeTabletJobTest {
             };
             new MockUp<GlobalTransactionMgr>() {
                 @Mock
-                public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId,
+                public boolean isPreviousTransactionsFinishedForReshard(long endTransactionId, long dbId,
                         List<Long> tableIds, Set<Long> excludeTransactionIds) {
                     return true;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/SplitTabletJobTest.java
@@ -774,7 +774,8 @@ public class SplitTabletJobTest {
         };
         new MockUp<GlobalTransactionMgr>() {
             @Mock
-            public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId, List<Long> tableIds,
+            public boolean isPreviousTransactionsFinishedForReshard(
+                    long endTransactionId, long dbId, List<Long> tableIds,
                     Set<Long> excludeTransactionIds) {
                 excludeTxnIdsArg.set(excludeTransactionIds);
                 return false;
@@ -813,7 +814,7 @@ public class SplitTabletJobTest {
             };
             new MockUp<GlobalTransactionMgr>() {
                 @Mock
-                public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId,
+                public boolean isPreviousTransactionsFinishedForReshard(long endTransactionId, long dbId,
                         List<Long> tableIds, Set<Long> excludeTransactionIds) {
                     return true;
                 }
@@ -878,7 +879,7 @@ public class SplitTabletJobTest {
             };
             new MockUp<GlobalTransactionMgr>() {
                 @Mock
-                public boolean isPreviousTransactionsFinished(long endTransactionId, long dbId,
+                public boolean isPreviousTransactionsFinishedForReshard(long endTransactionId, long dbId,
                         List<Long> tableIds, Set<Long> excludeTransactionIds) {
                     return true;
                 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -78,7 +78,6 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
-import com.starrocks.transaction.ExplicitTxnState;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.type.IntegerType;
@@ -159,6 +158,8 @@ public class OlapTableSinkTest {
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 globalStateMgr.getNodeMgr().getClusterInfo();
@@ -185,8 +186,8 @@ public class OlapTableSinkTest {
     }
 
     // init() plans the sink during the load, before an explicit transaction (multi-statement stream
-    // load / BEGIN..COMMIT) is upserted into the DatabaseTransactionMgr. getTransactionState then
-    // returns null, so init() must fall back to the explicit transaction registry to observe the
+    // load / BEGIN..COMMIT) is upserted into the DatabaseTransactionMgr. It must reserve the
+    // explicit transaction layout to observe the
     // combined-txn-log decision; otherwise write_txn_log stays at the per-tablet default and publish
     // (which expects combined logs) wedges.
     @Test
@@ -205,19 +206,14 @@ public class OlapTableSinkTest {
         explicitState.setUseCombinedTxnLog(true);
         Deencapsulation.setField(explicitState, "sourceType",
                 TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING);
-        ExplicitTxnState explicitTxnState = new ExplicitTxnState();
-        explicitTxnState.setTransactionState(explicitState);
-
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentState();
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
-                globalTransactionMgr.getTransactionState(anyLong, anyLong);
-                result = null;
-                globalTransactionMgr.getExplicitTxnState(anyLong);
-                result = explicitTxnState;
+                globalTransactionMgr.reserveExplicitTransactionLayout(3L, 4L, 1L);
+                result = explicitState;
                 globalStateMgr.getNodeMgr().getClusterInfo();
                 result = new SystemInfoService();
                 dstTable.getId();
@@ -240,10 +236,7 @@ public class OlapTableSinkTest {
         Assertions.assertTrue(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
     }
 
-    // The explicit-txn fallback must NOT apply to INSERT_STREAMING (SQL BEGIN..COMMIT): that source
-    // emits per-load-id txn logs that publish reads via the load_ids branch (which takes precedence
-    // over combined_txn_log), so honoring the combined flag here would make BE skip those logs and
-    // drop data. write_txn_log must stay at the per-tablet/per-load-id default (false).
+    // Layout reservation applies to every explicit transaction source, including INSERT_STREAMING.
     @Test
     public void testInitDoesNotFallBackForInsertStreaming(
             @Mocked GlobalStateMgr globalStateMgr,
@@ -260,19 +253,14 @@ public class OlapTableSinkTest {
         explicitState.setUseCombinedTxnLog(true);
         Deencapsulation.setField(explicitState, "sourceType",
                 TransactionState.LoadJobSourceType.INSERT_STREAMING);
-        ExplicitTxnState explicitTxnState = new ExplicitTxnState();
-        explicitTxnState.setTransactionState(explicitState);
-
         new Expectations() {
             {
                 GlobalStateMgr.getCurrentState();
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
-                globalTransactionMgr.getTransactionState(anyLong, anyLong);
-                result = null;
-                globalTransactionMgr.getExplicitTxnState(anyLong);
-                result = explicitTxnState;
+                globalTransactionMgr.reserveExplicitTransactionLayout(3L, 4L, 1L);
+                result = explicitState;
                 globalStateMgr.getNodeMgr().getClusterInfo();
                 result = new SystemInfoService();
                 dstTable.getId();
@@ -292,7 +280,61 @@ public class OlapTableSinkTest {
                 TWriteQuorumType.MAJORITY, false, false, false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
-        Assertions.assertFalse(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
+        Assertions.assertTrue(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
+    }
+
+    // An explicit entry remains authoritative after the transaction has been registered. Planning a newly
+    // touched table must reserve it before consulting the ordinary per-database transaction registry.
+    @Test
+    public void testInitReservesExplicitTxnBeforeRegisteredTransactionLookup(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
+        TupleDescriptor tuple = getTuple();
+        SinglePartitionInfo partInfo = new SinglePartitionInfo();
+        partInfo.setReplicationNum(2, (short) 3);
+        MaterializedIndex index = new MaterializedIndex(2, MaterializedIndex.IndexState.NORMAL);
+        HashDistributionInfo distInfo = new HashDistributionInfo(
+                2, Lists.newArrayList(new Column("k1", IntegerType.BIGINT)));
+        Partition partition = new Partition(2, 22, "p1", index, distInfo);
+
+        TransactionState explicitState = new TransactionState();
+        explicitState.setUseCombinedTxnLog(true);
+        TransactionState registeredState = new TransactionState();
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getGlobalTransactionMgr();
+                result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(3L, 4L, 1L);
+                result = explicitState;
+                times = 2;
+                globalTransactionMgr.getTransactionState(4L, 3L);
+                result = registeredState;
+                minTimes = 0;
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = new SystemInfoService();
+                dstTable.getId();
+                result = 1;
+                dstTable.getPartitionInfo();
+                result = partInfo;
+                dstTable.getPartitions();
+                result = Lists.newArrayList(partition);
+                dstTable.getPartition(2L);
+                result = partition;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
+            }
+        };
+
+        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(2L),
+                TWriteQuorumType.MAJORITY, false, false, false);
+        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
+        sink.complete();
+
+        Assertions.assertTrue(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
+        Assertions.assertNotSame(registeredState, explicitState);
     }
 
     @Test
@@ -317,6 +359,8 @@ public class OlapTableSinkTest {
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 globalStateMgr.getNodeMgr().getClusterInfo();
@@ -591,6 +635,8 @@ public class OlapTableSinkTest {
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 globalStateMgr.getNodeMgr().getClusterInfo();
@@ -682,6 +728,9 @@ public class OlapTableSinkTest {
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
                 minTimes = 0;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
+                minTimes = 0;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 minTimes = 0;
@@ -763,6 +812,9 @@ public class OlapTableSinkTest {
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
                 minTimes = 0;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
+                minTimes = 0;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 minTimes = 0;
@@ -807,6 +859,8 @@ public class OlapTableSinkTest {
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 globalStateMgr.getNodeMgr().getClusterInfo();
@@ -858,6 +912,8 @@ public class OlapTableSinkTest {
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 globalStateMgr.getNodeMgr().getClusterInfo();
@@ -1118,6 +1174,8 @@ public class OlapTableSinkTest {
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 globalStateMgr.getNodeMgr().getClusterInfo();
@@ -1357,6 +1415,91 @@ public class OlapTableSinkTest {
         Assertions.assertEquals((Long) node2.getId(), nodes.get(0));
     }
 
+    // A reshard can install a newer index generation after the first sink is planned. Every later
+    // partition and location build in that transaction must remain on the original tablet layout.
+    @Test
+    public void testCreatePartitionAndLocationReuseLoadedIndexGeneration(
+            @Mocked GlobalStateMgr globalStateMgr) throws Exception {
+        SystemInfoService sysInfoService = new SystemInfoService();
+        MockedWarehouseManager warehouseManager = new MockedWarehouseManager();
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+                result = sysInfoService;
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+                globalStateMgr.getNodeMgr().getClusterInfo();
+                result = sysInfoService;
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
+            }
+        };
+
+        ComputeNode node = new ComputeNode(7010L, "127.0.0.1", 9071);
+        node.updateOnce(1, 2, 3);
+        sysInfoService.addComputeNode(node);
+        warehouseManager.setAllComputeNodeIds(List.of(node.getId()));
+        warehouseManager.setAliveComputeNodes(List.of(node));
+        warehouseManager.setComputeNodeIdsAssignToTablet(Sets.newHashSet(node.getId()));
+
+        long dbId = 7001L;
+        long tableId = 7002L;
+        long partitionId = 7003L;
+        long physicalPartitionId = 7004L;
+        long metaId = 7005L;
+        long oldIndexId = 7006L;
+        long newIndexId = 7007L;
+        long oldTabletId = 7008L;
+        long newTabletId = 7009L;
+
+        Column k1 = new Column("k1", IntegerType.BIGINT);
+        HashDistributionInfo distribution = new HashDistributionInfo(1, List.of(k1));
+        SinglePartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setReplicationNum(partitionId, (short) 1);
+        MaterializedIndex oldIndex = new MaterializedIndex(
+                oldIndexId, metaId, MaterializedIndex.IndexState.NORMAL, 1L);
+        oldIndex.addTablet(new LakeTablet(oldTabletId), null, false);
+        Partition partition = new Partition(
+                partitionId, physicalPartitionId, "p1", oldIndex, distribution);
+        LakeTable table = new LakeTable(
+                tableId, "pin_layout", List.of(k1), KeysType.PRIMARY_KEYS, partitionInfo, distribution);
+        Deencapsulation.setField(table, "baseIndexMetaId", metaId);
+        table.addPartition(partition);
+        table.setIndexMeta(metaId, "pin_layout", List.of(k1), 0, 0,
+                (short) 1, TStorageType.COLUMN, KeysType.PRIMARY_KEYS);
+
+        TransactionState txn = new TransactionState();
+        TOlapTablePartitionParam first = OlapTableSink.createPartition(
+                dbId, table, null, false, 0, List.of(partitionId), txn, null);
+        Assertions.assertEquals(oldTabletId,
+                first.getPartitions().get(0).getIndexes().get(0).getTablet_ids().get(0));
+
+        MaterializedIndex newIndex = new MaterializedIndex(
+                newIndexId, metaId, MaterializedIndex.IndexState.NORMAL, 1L);
+        newIndex.addTablet(new LakeTablet(newTabletId), null, false);
+        partition.getDefaultPhysicalPartition().addMaterializedIndex(newIndex, true);
+
+        TOlapTablePartitionParam second = OlapTableSink.createPartition(
+                dbId, table, null, false, 0, List.of(partitionId), txn, null);
+        Assertions.assertEquals(oldTabletId,
+                second.getPartitions().get(0).getIndexes().get(0).getTablet_ids().get(0));
+
+        TOlapTablePartitionParam fresh = OlapTableSink.createPartition(
+                dbId, table, null, false, 0, List.of(partitionId), new TransactionState(), null);
+        Assertions.assertEquals(newTabletId,
+                fresh.getPartitions().get(0).getIndexes().get(0).getTablet_ids().get(0));
+
+        TOlapTableLocationParam location = OlapTableSink.createLocation(table, second, false, txn);
+        Assertions.assertEquals(1, location.getTablets().size());
+        Assertions.assertEquals(oldTabletId, location.getTablets().get(0).getTablet_id());
+    }
+
     // Verifies that `Config.lake_enable_per_partition_coordinator_txn_log` is
     // propagated verbatim onto `TOlapTableSink.enable_lake_per_partition_coordinator_txn_log`
     // on every built sink plan. This is the FE-side half of the per-partition
@@ -1380,6 +1523,8 @@ public class OlapTableSinkTest {
                 result = globalStateMgr;
                 globalStateMgr.getGlobalTransactionMgr();
                 result = globalTransactionMgr;
+                globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
+                result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
                 result = new TransactionState();
                 globalStateMgr.getNodeMgr().getClusterInfo();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -151,6 +151,8 @@ public class OlapTableSinkTest {
         HashDistributionInfo distInfo = new HashDistributionInfo(
                 2, Lists.newArrayList(new Column("k1", IntegerType.BIGINT)));
         Partition partition = new Partition(2, 22, "p1", index, distInfo);
+        TransactionState registeredState = new TransactionState();
+        registeredState.setUseCombinedTxnLog(true);
 
         new Expectations() {
             {
@@ -161,7 +163,7 @@ public class OlapTableSinkTest {
                 globalTransactionMgr.reserveExplicitTransactionLayout(anyLong, anyLong, anyLong);
                 result = null;
                 globalTransactionMgr.getTransactionState(anyLong, anyLong);
-                result = new TransactionState();
+                result = registeredState;
                 globalStateMgr.getNodeMgr().getClusterInfo();
                 result = new SystemInfoService();
                 dstTable.getId();
@@ -183,6 +185,7 @@ public class OlapTableSinkTest {
         sink.complete();
         LOG.info("sink is {}", sink.toThrift());
         LOG.info("{}", sink.getExplainString("", TExplainLevel.NORMAL));
+        Assertions.assertTrue(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
     }
 
     // init() plans the sink during the load, before an explicit transaction (multi-statement stream
@@ -288,10 +291,10 @@ public class OlapTableSinkTest {
         Assertions.assertFalse(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
     }
 
-    // A registered transaction still reserves its explicit layout before the normal lookup, while
-    // the registered state remains authoritative for the combined transaction-log mode.
+    // A registered explicit INSERT_STREAMING transaction still reserves its layout, but the normal
+    // database lookup must not let the same state enable combined transaction logs.
     @Test
-    public void testInitReservesExplicitTxnBeforeRegisteredTransactionLookup(
+    public void testInitKeepsPerTabletTxnLogForRegisteredExplicitInsertStreaming(
             @Mocked GlobalStateMgr globalStateMgr,
             @Mocked GlobalTransactionMgr globalTransactionMgr) throws StarRocksException {
         TupleDescriptor tuple = getTuple();
@@ -304,7 +307,8 @@ public class OlapTableSinkTest {
 
         TransactionState explicitState = new TransactionState();
         explicitState.setUseCombinedTxnLog(true);
-        TransactionState registeredState = new TransactionState();
+        Deencapsulation.setField(explicitState, "sourceType",
+                TransactionState.LoadJobSourceType.INSERT_STREAMING);
 
         new Expectations() {
             {
@@ -316,7 +320,7 @@ public class OlapTableSinkTest {
                 result = explicitState;
                 times = 2;
                 globalTransactionMgr.getTransactionState(4L, 3L);
-                result = registeredState;
+                result = explicitState;
                 times = 1;
                 globalStateMgr.getNodeMgr().getClusterInfo();
                 result = new SystemInfoService();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -214,6 +214,8 @@ public class OlapTableSinkTest {
                 result = globalTransactionMgr;
                 globalTransactionMgr.reserveExplicitTransactionLayout(3L, 4L, 1L);
                 result = explicitState;
+                globalTransactionMgr.getTransactionState(4L, 3L);
+                result = null;
                 globalStateMgr.getNodeMgr().getClusterInfo();
                 result = new SystemInfoService();
                 dstTable.getId();
@@ -236,7 +238,8 @@ public class OlapTableSinkTest {
         Assertions.assertTrue(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
     }
 
-    // Layout reservation applies to every explicit transaction source, including INSERT_STREAMING.
+    // Layout reservation applies to every explicit transaction source, but INSERT_STREAMING must
+    // keep its per-load-id logs rather than enabling the combined transaction log.
     @Test
     public void testInitDoesNotFallBackForInsertStreaming(
             @Mocked GlobalStateMgr globalStateMgr,
@@ -261,6 +264,8 @@ public class OlapTableSinkTest {
                 result = globalTransactionMgr;
                 globalTransactionMgr.reserveExplicitTransactionLayout(3L, 4L, 1L);
                 result = explicitState;
+                globalTransactionMgr.getTransactionState(4L, 3L);
+                result = null;
                 globalStateMgr.getNodeMgr().getClusterInfo();
                 result = new SystemInfoService();
                 dstTable.getId();
@@ -280,11 +285,11 @@ public class OlapTableSinkTest {
                 TWriteQuorumType.MAJORITY, false, false, false);
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
-        Assertions.assertTrue(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
+        Assertions.assertFalse(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
     }
 
-    // An explicit entry remains authoritative after the transaction has been registered. Planning a newly
-    // touched table must reserve it before consulting the ordinary per-database transaction registry.
+    // A registered transaction still reserves its explicit layout before the normal lookup, while
+    // the registered state remains authoritative for the combined transaction-log mode.
     @Test
     public void testInitReservesExplicitTxnBeforeRegisteredTransactionLookup(
             @Mocked GlobalStateMgr globalStateMgr,
@@ -312,7 +317,7 @@ public class OlapTableSinkTest {
                 times = 2;
                 globalTransactionMgr.getTransactionState(4L, 3L);
                 result = registeredState;
-                minTimes = 0;
+                times = 1;
                 globalStateMgr.getNodeMgr().getClusterInfo();
                 result = new SystemInfoService();
                 dstTable.getId();
@@ -333,8 +338,7 @@ public class OlapTableSinkTest {
         sink.init(new TUniqueId(1, 2), 3, 4, 1000);
         sink.complete();
 
-        Assertions.assertTrue(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
-        Assertions.assertNotSame(registeredState, explicitState);
+        Assertions.assertFalse(sink.toThrift().getOlap_table_sink().isWrite_txn_log());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -81,6 +81,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Mockito.mock;
@@ -116,6 +117,15 @@ public class ExplicitTxnTest {
         Long txnId;
         while ((txnId = dbTxnMgr.getMinActiveTxnId().orElse(null)) != null) {
             mgr.abortTransaction(dbId, txnId, "ExplicitTxnTest isolation");
+        }
+    }
+
+    private static void awaitLatch(CountDownLatch latch, String message) {
+        try {
+            Assertions.assertTrue(latch.await(10, TimeUnit.SECONDS), message);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
         }
     }
 
@@ -228,6 +238,15 @@ public class ExplicitTxnTest {
 
     @Test
     public void testInsertSameTable() throws IOException, DdlException {
+        AtomicInteger activationCount = new AtomicInteger();
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public ExplicitTxnState activateExplicitTransactionTable(
+                    Invocation invocation, long txnId, long dbId, long tableId) throws StarRocksException {
+                activationCount.incrementAndGet();
+                return invocation.proceed(txnId, dbId, tableId);
+            }
+        };
         new MockUp<DefaultCoordinator>() {
             @Mock
             public void exec() throws StarRocksException, RpcException, InterruptedException {
@@ -282,12 +301,14 @@ public class ExplicitTxnTest {
 
         TransactionStmtExecutor.loadData(database, olapTable, new ExecPlan(), (DmlStmt) stmt, stmt.getOrigStmt(), context);
         Assertions.assertFalse(context.getState().isError());
+        Assertions.assertEquals(1, activationCount.get());
         try {
             TransactionStmtExecutor.loadData(database, olapTable, new ExecPlan(), (DmlStmt) stmt, stmt.getOrigStmt(), context);
             Assertions.fail();
         } catch (ErrorReportException e) {
             Assertions.assertEquals(ErrorCode.ERR_TXN_IMPORT_SAME_TABLE, e.getErrorCode());
         }
+        Assertions.assertEquals(1, activationCount.get());
     }
 
     @Test
@@ -1091,7 +1112,7 @@ public class ExplicitTxnTest {
     }
 
     @Test
-    public void testDatabaseLoadDataRejectsStateRemovedAfterRegistration() throws Exception {
+    public void testDatabaseLoadDataRejectsStateRemovedBeforeActivation() throws Exception {
         GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
         Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
@@ -1108,11 +1129,10 @@ public class ExplicitTxnTest {
         try {
             new MockUp<GlobalTransactionMgr>() {
                 @Mock
-                public TransactionState registerExplicitTransactionState(
-                        Invocation invocation, long transactionId, long dbId) throws StarRocksException {
-                    TransactionState registered = invocation.proceed(transactionId, dbId);
+                public ExplicitTxnState activateExplicitTransactionTable(
+                        Invocation invocation, long transactionId, long dbId, long tableId) throws StarRocksException {
                     mgr.clearExplicitTxnState(transactionId);
-                    return registered;
+                    return invocation.proceed(transactionId, dbId, tableId);
                 }
             };
 
@@ -1120,13 +1140,14 @@ public class ExplicitTxnTest {
                     new OriginStatement("insert"), context);
             Assertions.assertTrue(context.getState().isError());
             Assertions.assertTrue(context.getState().getErrorMessage().contains(Long.toString(txnId)));
+            Assertions.assertFalse(state.getTableIdList().contains(table1.getId()));
         } finally {
             cleanupExplicitState(mgr, state);
         }
     }
 
     @Test
-    public void testStreamLoadDataRejectsStateRemovedAfterRegistration() throws Exception {
+    public void testStreamLoadDataRejectsStateRemovedBeforeActivation() throws Exception {
         GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
         Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
@@ -1140,11 +1161,10 @@ public class ExplicitTxnTest {
         try {
             new MockUp<GlobalTransactionMgr>() {
                 @Mock
-                public TransactionState registerExplicitTransactionState(
-                        Invocation invocation, long transactionId, long dbId) throws StarRocksException {
-                    TransactionState registered = invocation.proceed(transactionId, dbId);
+                public ExplicitTxnState activateExplicitTransactionTable(
+                        Invocation invocation, long transactionId, long dbId, long tableId) throws StarRocksException {
                     mgr.clearExplicitTxnState(transactionId);
-                    return registered;
+                    return invocation.proceed(transactionId, dbId, tableId);
                 }
             };
 
@@ -1152,7 +1172,200 @@ public class ExplicitTxnTest {
                     () -> TransactionStmtExecutor.loadData(db1.getId(), table1.getId(),
                             new ExplicitTxnState.ExplicitTxnStateItem(), context));
             Assertions.assertTrue(exception.getMessage().contains(Long.toString(txnId)));
+            Assertions.assertFalse(state.getTableIdList().contains(table1.getId()));
         } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testExplicitTableActivationRejectsStateClearedAfterRegistration() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        abortRunningTransactions(mgr, db1.getId());
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "activation-after-clear", 60_000L);
+        try {
+            mgr.registerExplicitTransactionState(txnId, db1.getId());
+            mgr.clearExplicitTxnState(txnId);
+
+            StarRocksException exception = Assertions.assertThrows(StarRocksException.class,
+                    () -> mgr.activateExplicitTransactionTable(txnId, db1.getId(), table1.getId()));
+            Assertions.assertTrue(exception.getMessage().contains(Long.toString(txnId)));
+            Assertions.assertFalse(state.getTableIdList().contains(table1.getId()));
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testDatabaseTableActivationRejectsMissingTransaction() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+
+        TransactionNotFoundException exception = Assertions.assertThrows(TransactionNotFoundException.class,
+                () -> mgr.getDatabaseTransactionMgr(db1.getId()).activateTransactionTable(txnId, 1L));
+        Assertions.assertTrue(exception.getMessage().contains(Long.toString(txnId)));
+    }
+
+    @Test
+    public void testDatabaseTableActivationRejectsFinishedTransaction() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        abortRunningTransactions(mgr, db1.getId());
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "activation-after-finish", 60_000L);
+        try {
+            mgr.registerExplicitTransactionState(txnId, db1.getId());
+            mgr.abortTransaction(db1.getId(), txnId, "finish before activation");
+
+            Assertions.assertThrows(TransactionNotFoundException.class,
+                    () -> mgr.getDatabaseTransactionMgr(db1.getId())
+                            .activateTransactionTable(txnId, table1.getId()));
+            Assertions.assertFalse(state.getTableIdList().contains(table1.getId()));
+        } finally {
+            mgr.clearExplicitTxnState(txnId);
+        }
+    }
+
+    @Test
+    public void testDatabaseTableActivationIsIdempotent() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        abortRunningTransactions(mgr, db1.getId());
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "idempotent-table-activation", 60_000L);
+        try {
+            mgr.registerExplicitTransactionState(txnId, db1.getId());
+            DatabaseTransactionMgr dbTxnMgr = mgr.getDatabaseTransactionMgr(db1.getId());
+
+            Assertions.assertSame(state, dbTxnMgr.activateTransactionTable(txnId, table1.getId()));
+            Assertions.assertSame(state, dbTxnMgr.activateTransactionTable(txnId, table1.getId()));
+            Assertions.assertEquals(1, state.getTableIdList().stream()
+                    .filter(tableId -> tableId.equals(table1.getId())).count());
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testExplicitTableActivationSerializesWatermarkAndRemoval() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        abortRunningTransactions(mgr, db1.getId());
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "serialize-table-activation", 60_000L);
+        CountDownLatch activationEntered = new CountDownLatch(1);
+        CountDownLatch releaseActivation = new CountDownLatch(1);
+        CountDownLatch watermarkStarted = new CountDownLatch(1);
+        CountDownLatch removalStarted = new CountDownLatch(1);
+        AtomicBoolean blockActivation = new AtomicBoolean(true);
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        try {
+            mgr.registerExplicitTransactionState(txnId, db1.getId());
+            ExplicitTxnState explicit = mgr.getExplicitTxnState(txnId);
+            Assertions.assertNotNull(explicit);
+            new MockUp<TransactionState>() {
+                @Mock
+                public void addTableIdList(Invocation invocation, Long tableId) {
+                    TransactionState invokedState = invocation.getInvokedInstance();
+                    if (invokedState == state && tableId.equals(table1.getId())
+                            && blockActivation.compareAndSet(true, false)) {
+                        activationEntered.countDown();
+                        awaitLatch(releaseActivation, "activation was not released");
+                    }
+                    invocation.proceed(tableId);
+                }
+            };
+
+            Future<ExplicitTxnState> activation = executor.submit(
+                    () -> mgr.activateExplicitTransactionTable(txnId, db1.getId(), table1.getId()));
+            Assertions.assertTrue(activationEntered.await(10, TimeUnit.SECONDS));
+            Future<Boolean> watermark = executor.submit(() -> {
+                watermarkStarted.countDown();
+                return mgr.isPreviousTransactionsFinishedForReshard(
+                        txnId, db1.getId(), List.of(table1.getId()), Set.of());
+            });
+            Future<?> removal = executor.submit(() -> {
+                removalStarted.countDown();
+                mgr.clearExplicitTxnState(txnId);
+            });
+            Assertions.assertTrue(watermarkStarted.await(10, TimeUnit.SECONDS));
+            Assertions.assertTrue(removalStarted.await(10, TimeUnit.SECONDS));
+            Assertions.assertFalse(watermark.isDone());
+            Assertions.assertFalse(removal.isDone());
+
+            releaseActivation.countDown();
+            Assertions.assertSame(explicit, activation.get(10, TimeUnit.SECONDS));
+            removal.get(10, TimeUnit.SECONDS);
+            Assertions.assertFalse(watermark.get(10, TimeUnit.SECONDS));
+            Assertions.assertNull(mgr.getExplicitTxnState(txnId));
+            Assertions.assertTrue(state.getTableIdList().contains(table1.getId()));
+        } finally {
+            releaseActivation.countDown();
+            executor.shutdownNow();
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testDatabaseWatermarkSerializesTableActivation() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        abortRunningTransactions(mgr, db1.getId());
+        long secondTableId = table1.getId() + 1;
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "serialize-db-table-list", 60_000L);
+        CountDownLatch watermarkEntered = new CountDownLatch(1);
+        CountDownLatch releaseWatermark = new CountDownLatch(1);
+        CountDownLatch activationStarted = new CountDownLatch(1);
+        AtomicBoolean blockWatermark = new AtomicBoolean(true);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            mgr.registerExplicitTransactionState(txnId, db1.getId());
+            DatabaseTransactionMgr dbTxnMgr = mgr.getDatabaseTransactionMgr(db1.getId());
+            dbTxnMgr.activateTransactionTable(txnId, table1.getId());
+            new MockUp<TransactionState>() {
+                @Mock
+                public List<Long> getTableIdList(Invocation invocation) {
+                    TransactionState invokedState = invocation.getInvokedInstance();
+                    if (invokedState == state && blockWatermark.compareAndSet(true, false)) {
+                        watermarkEntered.countDown();
+                        awaitLatch(releaseWatermark, "watermark was not released");
+                    }
+                    return invocation.proceed();
+                }
+            };
+
+            Future<Boolean> watermark = executor.submit(() -> dbTxnMgr.isPreviousTransactionsFinished(
+                    txnId, List.of(secondTableId), Set.of()));
+            Assertions.assertTrue(watermarkEntered.await(10, TimeUnit.SECONDS));
+            Future<TransactionState> activation = executor.submit(() -> {
+                activationStarted.countDown();
+                return dbTxnMgr.activateTransactionTable(txnId, secondTableId);
+            });
+            Assertions.assertTrue(activationStarted.await(10, TimeUnit.SECONDS));
+            Assertions.assertFalse(activation.isDone());
+
+            releaseWatermark.countDown();
+            Assertions.assertTrue(watermark.get(10, TimeUnit.SECONDS));
+            Assertions.assertSame(state, activation.get(10, TimeUnit.SECONDS));
+            Assertions.assertFalse(dbTxnMgr.isPreviousTransactionsFinished(
+                    txnId, List.of(secondTableId), Set.of()));
+        } finally {
+            releaseWatermark.countDown();
+            executor.shutdownNow();
             cleanupExplicitState(mgr, state);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -17,7 +17,9 @@ package com.starrocks.transaction;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MockedLocalMetaStore;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
@@ -42,6 +44,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.UserRef;
 import com.starrocks.sql.ast.txn.BeginStmt;
@@ -54,6 +57,7 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Invocation;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.AfterAll;
@@ -68,8 +72,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -81,6 +87,37 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ExplicitTxnTest {
+
+    private TransactionState addExplicitState(GlobalTransactionMgr mgr, long txnId, String label, long timeoutMs) {
+        TransactionState state = new TransactionState(
+                txnId, label, null, TransactionState.LoadJobSourceType.INSERT_STREAMING,
+                new TransactionState.TxnCoordinator(
+                        TransactionState.TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
+                timeoutMs);
+        state.setPrepareTime(System.currentTimeMillis());
+        ExplicitTxnState explicit = new ExplicitTxnState();
+        explicit.setTransactionState(state);
+        mgr.addTransactionState(txnId, explicit);
+        return state;
+    }
+
+    private void cleanupExplicitState(GlobalTransactionMgr mgr, TransactionState state) throws StarRocksException {
+        try {
+            if (state.getDbId() != 0 && state.isRunning()) {
+                mgr.abortTransaction(state.getDbId(), state.getTransactionId(), "ExplicitTxnTest cleanup");
+            }
+        } finally {
+            mgr.clearExplicitTxnState(state.getTransactionId());
+        }
+    }
+
+    private void abortRunningTransactions(GlobalTransactionMgr mgr, long dbId) throws StarRocksException {
+        DatabaseTransactionMgr dbTxnMgr = mgr.getDatabaseTransactionMgr(dbId);
+        Long txnId;
+        while ((txnId = dbTxnMgr.getMinActiveTxnId().orElse(null)) != null) {
+            mgr.abortTransaction(dbId, txnId, "ExplicitTxnTest isolation");
+        }
+    }
 
     @AfterAll
     public static void tearDownPersistJournal() {
@@ -847,13 +884,428 @@ public class ExplicitTxnTest {
     }
 
     @Test
-    public void testAbortTimeoutTxnsCleanupExplicitTxnState() {
+    public void testReshardPlanningReservations() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        Database db2 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db2");
+        Table table2 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db2.getFullName(), "tbl1");
+        abortRunningTransactions(mgr, db1.getId());
+        abortRunningTransactions(mgr, db2.getId());
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "reshard-planning-reservation", 60_000L);
+        try {
+            Assertions.assertTrue(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+            Assertions.assertTrue(mgr.isPreviousTransactionsFinished(
+                    txnId, db1.getId(), List.of(table1.getId())));
+
+            Assertions.assertSame(state, mgr.reserveExplicitTransactionLayout(
+                    txnId, db1.getId(), table1.getId()));
+            Assertions.assertEquals(0, state.getDbId());
+            Assertions.assertTrue(state.getTableIdList().isEmpty());
+            Assertions.assertFalse(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+            Assertions.assertTrue(mgr.isPreviousTransactionsFinished(
+                    txnId, db1.getId(), List.of(table1.getId())));
+
+            Assertions.assertSame(state, mgr.reserveExplicitTransactionLayout(
+                    txnId, db2.getId(), table2.getId()));
+            Assertions.assertSame(state, mgr.registerExplicitTransactionState(txnId, db2.getId()));
+            Assertions.assertTrue(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+            Assertions.assertFalse(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db2.getId(), List.of(table2.getId()), Set.of()));
+            Assertions.assertTrue(state.getTableIdList().isEmpty());
+            Assertions.assertSame(state, mgr.registerExplicitTransactionState(txnId, db2.getId()));
+
+            ErrorReportException exception = Assertions.assertThrows(ErrorReportException.class,
+                    () -> mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), table1.getId()));
+            Assertions.assertEquals(ErrorCode.ERR_TXN_FORBID_CROSS_DB, exception.getErrorCode());
+            Assertions.assertEquals(ErrorCode.ERR_TXN_FORBID_CROSS_DB.formatErrorMsg(), exception.getMessage());
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testRegistrationFailureRestoresUnboundStateAndReservation() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        abortRunningTransactions(mgr, db1.getId());
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "registration-failure", 60_000L);
+        try {
+            mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), table1.getId());
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public void upsertTransactionState(TransactionState transactionState) throws AnalysisException {
+                    throw new AnalysisException("injected upsert failure");
+                }
+            };
+
+            AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
+                    () -> mgr.registerExplicitTransactionState(txnId, db1.getId()));
+            Assertions.assertEquals("injected upsert failure", exception.getMessage());
+            Assertions.assertEquals(0, state.getDbId());
+            Assertions.assertNull(mgr.getDatabaseTransactionMgr(db1.getId()).getTransactionState(txnId));
+            Assertions.assertFalse(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testRegisteredTransactionReservesNewTableDuringPlanning() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        abortRunningTransactions(mgr, db1.getId());
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long secondTableId = table1.getId() + 1;
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "registered-new-table", 60_000L);
+        try {
+            mgr.registerExplicitTransactionState(txnId, db1.getId());
+            state.addTableIdList(table1.getId());
+            mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), secondTableId);
+
+            Assertions.assertFalse(state.getTableIdList().contains(secondTableId));
+            Assertions.assertFalse(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(secondTableId), Set.of()));
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testDatabaseLoadDataRegistrationFailureRestoresUnboundState() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "database-load-registration-failure", 60_000L);
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(txnId);
+        context.setExecutionId(new TUniqueId(txnId, txnId));
+        context.setQualifiedUser("u1");
+        context.setCurrentUserIdentity(new UserIdentity("u1", "%"));
+        try {
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public void upsertTransactionState(TransactionState transactionState) throws AnalysisException {
+                    throw new AnalysisException("injected upsert failure");
+                }
+            };
+
+            TransactionStmtExecutor.loadData(db1, table1, new ExecPlan(), mock(DmlStmt.class),
+                    new OriginStatement("insert"), context);
+            Assertions.assertTrue(context.getState().isError());
+            Assertions.assertTrue(context.getState().getErrorMessage().contains("injected upsert failure"));
+            Assertions.assertEquals(0, state.getDbId());
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testStreamLoadDataRegistrationFailureRestoresUnboundState() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "stream-load-registration-failure", 60_000L);
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(txnId);
+        context.setExecutionId(new TUniqueId(txnId, txnId));
+        context.setQualifiedUser("u1");
+        context.setCurrentUserIdentity(new UserIdentity("u1", "%"));
+        try {
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public void upsertTransactionState(TransactionState transactionState) throws AnalysisException {
+                    throw new AnalysisException("injected upsert failure");
+                }
+            };
+
+            AnalysisException exception = Assertions.assertThrows(AnalysisException.class,
+                    () -> TransactionStmtExecutor.loadData(db1.getId(), table1.getId(),
+                            new ExplicitTxnState.ExplicitTxnStateItem(), context));
+            Assertions.assertEquals("injected upsert failure", exception.getMessage());
+            Assertions.assertEquals(0, state.getDbId());
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testDatabaseLoadDataRejectsMissingExplicitState() {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(txnId);
+        context.setExecutionId(new TUniqueId(txnId, txnId));
+        context.setQualifiedUser("u1");
+        context.setCurrentUserIdentity(new UserIdentity("u1", "%"));
+
+        Assertions.assertNull(mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), table1.getId()));
+        TransactionStmtExecutor.loadData(db1, table1, new ExecPlan(), mock(DmlStmt.class),
+                new OriginStatement("insert"), context);
+
+        Assertions.assertTrue(context.getState().isError());
+        Assertions.assertTrue(context.getState().getErrorMessage().contains(Long.toString(txnId)));
+    }
+
+    @Test
+    public void testStreamLoadDataRejectsMissingExplicitState() {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(txnId);
+
+        StarRocksException exception = Assertions.assertThrows(StarRocksException.class,
+                () -> TransactionStmtExecutor.loadData(db1.getId(), table1.getId(),
+                        new ExplicitTxnState.ExplicitTxnStateItem(), context));
+        Assertions.assertTrue(exception.getMessage().contains(Long.toString(txnId)));
+    }
+
+    @Test
+    public void testDatabaseLoadDataRejectsStateRemovedAfterRegistration() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "database-load-removed-state", 60_000L);
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(txnId);
+        context.setExecutionId(new TUniqueId(txnId, txnId));
+        context.setQualifiedUser("u1");
+        context.setCurrentUserIdentity(new UserIdentity("u1", "%"));
+        try {
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public TransactionState registerExplicitTransactionState(
+                        Invocation invocation, long transactionId, long dbId) throws StarRocksException {
+                    TransactionState registered = invocation.proceed(transactionId, dbId);
+                    mgr.clearExplicitTxnState(transactionId);
+                    return registered;
+                }
+            };
+
+            TransactionStmtExecutor.loadData(db1, table1, new ExecPlan(), mock(DmlStmt.class),
+                    new OriginStatement("insert"), context);
+            Assertions.assertTrue(context.getState().isError());
+            Assertions.assertTrue(context.getState().getErrorMessage().contains(Long.toString(txnId)));
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testStreamLoadDataRejectsStateRemovedAfterRegistration() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "stream-load-removed-state", 60_000L);
+        ConnectContext context = new ConnectContext();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setTxnId(txnId);
+        try {
+            new MockUp<GlobalTransactionMgr>() {
+                @Mock
+                public TransactionState registerExplicitTransactionState(
+                        Invocation invocation, long transactionId, long dbId) throws StarRocksException {
+                    TransactionState registered = invocation.proceed(transactionId, dbId);
+                    mgr.clearExplicitTxnState(transactionId);
+                    return registered;
+                }
+            };
+
+            StarRocksException exception = Assertions.assertThrows(StarRocksException.class,
+                    () -> TransactionStmtExecutor.loadData(db1.getId(), table1.getId(),
+                            new ExplicitTxnState.ExplicitTxnStateItem(), context));
+            Assertions.assertTrue(exception.getMessage().contains(Long.toString(txnId)));
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testReshardWatermarkSerializesRegistration() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "serialize-registration", 60_000L);
+        CountDownLatch watermarkEntered = new CountDownLatch(1);
+        CountDownLatch releaseWatermark = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), table1.getId());
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public boolean isPreviousTransactionsFinished(long endTransactionId, List<Long> tableIds,
+                        Set<Long> excludeTransactionIds) throws InterruptedException {
+                    watermarkEntered.countDown();
+                    Assertions.assertTrue(releaseWatermark.await(10, TimeUnit.SECONDS));
+                    return true;
+                }
+            };
+
+            Future<Boolean> watermark = executor.submit(() -> mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+            Assertions.assertTrue(watermarkEntered.await(10, TimeUnit.SECONDS));
+            Future<TransactionState> registration = executor.submit(
+                    () -> mgr.registerExplicitTransactionState(txnId, db1.getId()));
+            Assertions.assertFalse(registration.isDone());
+            releaseWatermark.countDown();
+            Assertions.assertFalse(watermark.get(10, TimeUnit.SECONDS));
+            Assertions.assertSame(state, registration.get(10, TimeUnit.SECONDS));
+        } finally {
+            releaseWatermark.countDown();
+            executor.shutdownNow();
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testReshardWatermarkSerializesExplicitRemoval() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "serialize-removal", 60_000L);
+        CountDownLatch watermarkEntered = new CountDownLatch(1);
+        CountDownLatch releaseWatermark = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), table1.getId());
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public boolean isPreviousTransactionsFinished(long endTransactionId, List<Long> tableIds,
+                        Set<Long> excludeTransactionIds) throws InterruptedException {
+                    watermarkEntered.countDown();
+                    Assertions.assertTrue(releaseWatermark.await(10, TimeUnit.SECONDS));
+                    return true;
+                }
+            };
+
+            Future<Boolean> watermark = executor.submit(() -> mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+            Assertions.assertTrue(watermarkEntered.await(10, TimeUnit.SECONDS));
+            Future<?> removal = executor.submit(() -> mgr.clearExplicitTxnState(txnId));
+            Assertions.assertFalse(removal.isDone());
+            releaseWatermark.countDown();
+            Assertions.assertFalse(watermark.get(10, TimeUnit.SECONDS));
+            removal.get(10, TimeUnit.SECONDS);
+            Assertions.assertTrue(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+        } finally {
+            releaseWatermark.countDown();
+            executor.shutdownNow();
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testRegistrationSerializesReshardWatermark() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "registration-serializes-watermark", 60_000L);
+        CountDownLatch upsertEntered = new CountDownLatch(1);
+        CountDownLatch releaseUpsert = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), table1.getId());
+            new MockUp<DatabaseTransactionMgr>() {
+                @Mock
+                public void upsertTransactionState(Invocation invocation, TransactionState transactionState)
+                        throws Exception {
+                    upsertEntered.countDown();
+                    Assertions.assertTrue(releaseUpsert.await(10, TimeUnit.SECONDS));
+                    invocation.proceed(transactionState);
+                }
+            };
+
+            Future<TransactionState> registration = executor.submit(
+                    () -> mgr.registerExplicitTransactionState(txnId, db1.getId()));
+            Assertions.assertTrue(upsertEntered.await(10, TimeUnit.SECONDS));
+            Future<Boolean> watermark = executor.submit(() -> mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+            Assertions.assertFalse(watermark.isDone());
+            releaseUpsert.countDown();
+            Assertions.assertSame(state, registration.get(10, TimeUnit.SECONDS));
+            Assertions.assertFalse(watermark.get(10, TimeUnit.SECONDS));
+        } finally {
+            releaseUpsert.countDown();
+            executor.shutdownNow();
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testClearReservedExplicitStateReleasesReshardWatermark() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        abortRunningTransactions(mgr, db1.getId());
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        TransactionState state = addExplicitState(mgr, txnId, "clear-reserved-state", 60_000L);
+        try {
+            mgr.reserveExplicitTransactionLayout(txnId, db1.getId(), table1.getId());
+            Assertions.assertFalse(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+            mgr.clearExplicitTxnState(txnId);
+            Assertions.assertTrue(mgr.isPreviousTransactionsFinishedForReshard(
+                    txnId, db1.getId(), List.of(table1.getId()), Set.of()));
+        } finally {
+            cleanupExplicitState(mgr, state);
+        }
+    }
+
+    @Test
+    public void testAbortTimeoutTxnsCleanupExplicitTxnState() throws Exception {
         // Test that abortTimeoutTxns() cleans up timed-out explicit transaction states
         ConnectContext context = new ConnectContext();
         context.setThreadLocalInfo();
         context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
 
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        abortRunningTransactions(globalTransactionMgr, db1.getId());
 
         // Create a transaction state with a very short timeout (already expired)
         long transactionId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
@@ -868,14 +1320,25 @@ public class ExplicitTxnTest {
         ExplicitTxnState explicitTxnState = new ExplicitTxnState();
         explicitTxnState.setTransactionState(transactionState);
         globalTransactionMgr.addTransactionState(transactionId, explicitTxnState);
+        try {
+            Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db1.getFullName(), "tbl1");
+            globalTransactionMgr.reserveExplicitTransactionLayout(transactionId, db1.getId(), table1.getId());
 
-        Assertions.assertNotNull(globalTransactionMgr.getExplicitTxnState(transactionId));
+            Assertions.assertNotNull(globalTransactionMgr.getExplicitTxnState(transactionId));
+            Assertions.assertFalse(globalTransactionMgr.isPreviousTransactionsFinishedForReshard(
+                    transactionId, db1.getId(), List.of(table1.getId()), Set.of()));
 
-        // Run timeout cleanup
-        globalTransactionMgr.abortTimeoutTxns();
+            // Run timeout cleanup
+            globalTransactionMgr.abortTimeoutTxns();
 
-        // Verify the timed-out state was cleaned up
-        Assertions.assertNull(globalTransactionMgr.getExplicitTxnState(transactionId));
+            // Verify the timed-out state was cleaned up
+            Assertions.assertNull(globalTransactionMgr.getExplicitTxnState(transactionId));
+            Assertions.assertTrue(globalTransactionMgr.isPreviousTransactionsFinishedForReshard(
+                    transactionId, db1.getId(), List.of(table1.getId()), Set.of()));
+        } finally {
+            cleanupExplicitState(globalTransactionMgr, transactionState);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

An explicit multi-statement SQL transaction on a shared-data table can lose rows or fail when a range tablet split/merge crosses statement boundaries.

For the silent-row-loss case, the first `INSERT_STREAMING` statement is planned before the transaction enters `DatabaseTransactionMgr` and writes a per-load-id log. Later statements see the same registered state with combined logging enabled and can switch to combined logs. `COMMIT` publishes through its `load_ids` list, so the missing per-load-id logs are legally skipped and only part of the transaction becomes visible.

For the layout race, partition construction selected the latest physical index while location construction reused `TransactionState`'s first loaded-index snapshot. A takeover between statements could therefore emit new tablet IDs with old tablet locations. Reshard CLEANING could also miss the planning-to-registration/table-activation handoff and retire the old mapping too early.

## What I'm doing:

- Reuse the transaction's first loaded-index snapshot for RANGE, LIST, and UNPARTITIONED partition and location construction.
- Reserve an explicit transaction's table layout before planning, and make registration, target-table activation, explicit cleanup, timeout cleanup, and the reshard-specific watermark atomic under a consistent lock order.
- Update the target table list under the database transaction manager write lock.
- Keep explicit SQL `INSERT_STREAMING` statements on per-load-id transaction logs before and after registration, while preserving ordinary and multi-statement stream-load combined-log behavior.
- Add deterministic regression tests for generation pinning, transaction-log mode, failure rollback, lifecycle cleanup, and registration/activation/watermark interleavings.

Fixes StarRocks/StarRocksTest#12104

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
