### PR TITLE
[BugFix] Report the abort reason when a closed lake delta writer rejects a task

### DIFF
--- a/be/src/data_workflows/load/tablet_writer/lake_tablets_channel.cpp
+++ b/be/src/data_workflows/load/tablet_writer/lake_tablets_channel.cpp
@@ -92,7 +92,13 @@ public:
 
     void abort() override;
 
-    void abort(const std::vector<int64_t>& tablet_ids, const std::string& reason) override { return abort(); }
+    // A lake tablet has a single writer, so there is nothing to abort per tablet: the whole channel
+    // goes down. Record `reason` first, so requests rejected afterwards report it instead of a
+    // generic "writer closed" error.
+    void abort(const std::vector<int64_t>& tablet_ids, const std::string& reason) override {
+        cancel(reason);
+        return abort();
+    }
 
     void update_profile() override;
 

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include "base/testutil/sync_point.h"
@@ -30,6 +31,11 @@
 #include "storage/storage_metrics.h"
 
 namespace starrocks::lake {
+
+namespace {
+constexpr const char* kClosedMsg = "AsyncDeltaWriter has been closed";
+constexpr const char* kNotOpenedOrClosedMsg = "AsyncDeltaWriterImpl not opened or has been closed";
+} // namespace
 
 class AsyncDeltaWriterImpl {
     friend class MergeBlockTask;
@@ -124,6 +130,8 @@ private:
 
     Status do_open();
     bool closed();
+    // Status to report for a task rejected because the writer has been closed.
+    Status closed_status(std::string_view generic_msg) const;
 
     std::unique_ptr<DeltaWriter> _writer{};
     bthread::ExecutionQueueId<TaskPtr> _queue_id{kInvalidQueueId};
@@ -144,6 +152,19 @@ inline bool AsyncDeltaWriterImpl::closed() {
     return _closed;
 }
 
+// The generic "closed" message says nothing about why the load stopped. The writer is closed by
+// `TabletsChannel::abort()`, and on the cancel path `TabletsChannel::cancel()` runs first and
+// records the reason sent by the load coordinator, which carries the root cause (e.g. the query
+// error that triggered the cancel). Prefer that reason, so a sender whose RPC races with the abort
+// reports the root cause instead of this derived error.
+inline Status AsyncDeltaWriterImpl::closed_status(std::string_view generic_msg) const {
+    auto cancel_status = _writer->cancel_status();
+    if (!cancel_status.ok()) {
+        return cancel_status;
+    }
+    return Status::InternalError(generic_msg);
+}
+
 class MergeBlockTask : public Runnable {
 public:
     MergeBlockTask(std::shared_ptr<AsyncDeltaWriterImpl::FinishTask> finish_task, AsyncDeltaWriterImpl* async_writer)
@@ -152,7 +173,7 @@ public:
     void run() override {
         auto delta_writer = _async_writer->_writer.get();
         if (_async_writer->closed()) {
-            _finish_task->cb(Status::InternalError("AsyncDeltaWriter has been closed"));
+            _finish_task->cb(_async_writer->closed_status(kClosedMsg));
             return;
         }
         auto res = delta_writer->finish_with_txnlog(_finish_task->finish_mode);
@@ -186,7 +207,7 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
     for (; iter; ++iter) {
         // It's safe to run without checking `closed()` but doing so can make the task quit earlier on cancel/error.
         if (async_writer->closed()) {
-            st.update(Status::InternalError("AsyncDeltaWriter has been closed"));
+            st.update(async_writer->closed_status(kClosedMsg));
         }
         const auto& task_ptr = *iter;
         num_tasks += 1;
@@ -267,7 +288,7 @@ inline int AsyncDeltaWriterImpl::execute(void* meta, bthread::TaskIterator<Async
 inline Status AsyncDeltaWriterImpl::open() {
     std::lock_guard l(_mtx);
     if (_closed) {
-        return Status::InternalError("AsyncDeltaWriter has been closed");
+        return closed_status(kClosedMsg);
     }
     if (_opened) {
         return _status;
@@ -308,7 +329,7 @@ inline void AsyncDeltaWriterImpl::write(const Chunk* chunk, const uint32_t* inde
     task->indexes_size = indexes_size;
     task->cb = std::move(cb); // Do NOT touch |cb| since here
     if (int r = bthread::execution_queue_execute(_queue_id, task); r != 0) {
-        task->cb(Status::InternalError("AsyncDeltaWriterImpl not opened or has been closed"));
+        task->cb(closed_status(kNotOpenedOrClosedMsg));
     }
 }
 
@@ -317,7 +338,7 @@ inline void AsyncDeltaWriterImpl::flush(Callback cb) {
     task->cb = std::move(cb); // Do NOT touch |cb| since here
     if (int r = bthread::execution_queue_execute(_queue_id, task); r != 0) {
         LOG(WARNING) << "Fail to execution_queue_execute: " << r;
-        task->cb(Status::InternalError("AsyncDeltaWriterImpl not opened or has been closed"));
+        task->cb(closed_status(kNotOpenedOrClosedMsg));
     }
 }
 
@@ -330,7 +351,7 @@ inline void AsyncDeltaWriterImpl::finish(DeltaWriterFinishMode mode, FinishCallb
     // by the submitted tasks.
     if (int r = bthread::execution_queue_execute(_queue_id, task); r != 0) {
         LOG(WARNING) << "Fail to execution_queue_execute: " << r;
-        task->cb(Status::InternalError("AsyncDeltaWriterImpl not opened or has been closed"));
+        task->cb(closed_status(kNotOpenedOrClosedMsg));
     }
 }
 

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -234,9 +234,10 @@ public:
 
     bool already_finished() const { return _already_finished; }
 
-private:
+    // Returns the status passed to `cancel()`, or OK if the writer has never been cancelled.
     Status current_cancel_status() const;
 
+private:
     Status reset_memtable();
 
     Status fill_auto_increment_id(Chunk& chunk);
@@ -1239,6 +1240,10 @@ void DeltaWriter::close() {
 
 void DeltaWriter::cancel(const Status& st) {
     _impl->cancel(st);
+}
+
+Status DeltaWriter::cancel_status() const {
+    return _impl->current_cancel_status();
 }
 
 int64_t DeltaWriter::partition_id() const {

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -130,6 +130,10 @@ public:
     // After cancellation, subsequent write/flush operations will fail quickly.
     void cancel(const Status& st);
 
+    // The status passed to the first `cancel()` call, or OK if never cancelled.
+    // Callers use it to report why the writer stopped working instead of a generic error.
+    [[nodiscard]] Status cancel_status() const;
+
     [[nodiscard]] int64_t partition_id() const;
 
     [[nodiscard]] int64_t tablet_id() const;

--- a/be/test/data_workflows/load/tablet_writer/lake_tablets_channel_test.cpp
+++ b/be/test/data_workflows/load/tablet_writer/lake_tablets_channel_test.cpp
@@ -1110,6 +1110,76 @@ TEST_F(LakeTabletsChannelTest, test_finish_after_abort) {
     }
 }
 
+// The cancel RPC records a reason before aborting the channel. A sender whose eos races with the
+// abort must report that reason -- it carries the root cause of the load failure -- instead of the
+// generic "AsyncDeltaWriter has been closed" error.
+TEST_F(LakeTabletsChannelTest, test_finish_after_cancel_and_abort) {
+    constexpr const char* kCancelReason = "Cancelled by pipeline engine, reason: Division by zero";
+
+    auto open_request = _open_request;
+    open_request.set_num_senders(2);
+
+    ASSERT_OK(_tablets_channel->open(open_request, &_open_response, _schema_param, false));
+
+    {
+        constexpr int kChunkSize = 128;
+        constexpr int kChunkSizePerTablet = kChunkSize / 4;
+        auto chunk = generate_data(kChunkSize);
+
+        PTabletWriterAddChunkRequest add_chunk_request;
+        PTabletWriterAddBatchResult add_chunk_response;
+        add_chunk_request.set_index_id(kIndexId);
+        add_chunk_request.set_sender_id(0);
+        add_chunk_request.set_eos(true);
+        add_chunk_request.set_packet_seq(0);
+        add_chunk_request.set_timeout_ms(60000);
+
+        for (int i = 0; i < kChunkSize; i++) {
+            int64_t tablet_id = 10086 + (i / kChunkSizePerTablet);
+            add_chunk_request.add_tablet_ids(tablet_id);
+            add_chunk_request.add_partition_ids(tablet_id < 10088 ? 10 : 11);
+        }
+
+        ASSIGN_OR_ABORT(auto chunk_pb, serde::ProtobufChunkSerde::serialize(chunk));
+        add_chunk_request.mutable_chunk()->Swap(&chunk_pb);
+
+        bool close_channel;
+        _tablets_channel->add_chunk(&chunk, add_chunk_request, &add_chunk_response, &close_channel);
+        ASSERT_TRUE(add_chunk_response.status().status_code() == TStatusCode::OK);
+        ASSERT_FALSE(close_channel);
+
+        _tablets_channel->cancel(kCancelReason);
+        _tablets_channel->abort();
+
+        _tablets_channel->add_chunk(nullptr, add_chunk_request, &add_chunk_response, &close_channel);
+        ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, add_chunk_response.status().status_code());
+        ASSERT_FALSE(close_channel);
+    }
+    {
+        PTabletWriterAddChunkRequest finish_request;
+        PTabletWriterAddBatchResult finish_response;
+        finish_request.set_index_id(kIndexId);
+        finish_request.set_sender_id(1);
+        finish_request.set_eos(true);
+        finish_request.set_packet_seq(0);
+        finish_request.set_timeout_ms(60000);
+
+        bool close_channel;
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response, &close_channel);
+        ASSERT_EQ(TStatusCode::CANCELLED, finish_response.status().status_code());
+        ASSERT_GE(finish_response.status().error_msgs_size(), 1);
+        const auto& message = finish_response.status().error_msgs(0);
+        ASSERT_TRUE(message.find(kCancelReason) != std::string::npos) << message;
+        ASSERT_TRUE(message.find("AsyncDeltaWriter has been closed") == std::string::npos) << message;
+        ASSERT_TRUE(close_channel);
+
+        PTabletWriterAddBatchResult finish_response2;
+        _tablets_channel->add_chunk(nullptr, finish_request, &finish_response2, &close_channel);
+        ASSERT_EQ(TStatusCode::DUPLICATE_RPC_INVOCATION, finish_response2.status().status_code());
+        ASSERT_FALSE(close_channel);
+    }
+}
+
 TEST_F(LakeTabletsChannelTest, test_profile) {
     auto open_request = _open_request;
     open_request.set_num_senders(1);

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -580,6 +580,44 @@ TEST_F(LakeAsyncDeltaWriterTest, test_open_after_close) {
     ASSERT_EQ("AsyncDeltaWriter has been closed", st.message());
 }
 
+// A writer closed after being cancelled must report the cancel reason instead of the generic
+// "closed" message: the reason carries the root cause that the load coordinator has to surface.
+TEST_F(LakeAsyncDeltaWriterTest, test_open_and_write_after_cancel_and_close) {
+    static const int kChunkSize = 128;
+    auto chunk0 = generate_data(kChunkSize);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto txn_id = next_id();
+    auto tablet_id = _tablet_metadata->id();
+    ASSIGN_OR_ABORT(auto delta_writer, AsyncDeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_mgr.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(_partition_id)
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(_tablet_schema->id())
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+
+    delta_writer->cancel(Status::Cancelled("Division by zero"));
+    delta_writer->close();
+
+    auto st = delta_writer->open();
+    ASSERT_TRUE(st.is_cancelled()) << st;
+    ASSERT_TRUE(st.message().find("Division by zero") != std::string::npos) << st;
+
+    CountDownLatch write_latch(1);
+    delta_writer->write(&chunk0, indexes.data(), indexes.size(), [&](const Status& write_st) {
+        ASSERT_TRUE(write_st.is_cancelled()) << write_st;
+        ASSERT_TRUE(write_st.message().find("Division by zero") != std::string::npos) << write_st;
+        write_latch.count_down();
+    });
+    write_latch.wait();
+}
+
 TEST_F(LakeAsyncDeltaWriterTest, test_concurrent_write_and_close) {
     // Prepare data for writing
     static const int kChunkSize = 128;


### PR DESCRIPTION
## Why I'm doing:

In shared-data mode, an `insert into ... select` that fails with a user error can be reported to the client with a completely unrelated internal error. Seen in CI:

```
insert into t_div_dst select k1, k1/k2 as k2 from t_div_src;
-- expected: .*Division by zero.*
-- actual  : E: (5609, '172.21.241.88: AsyncDeltaWriter has been closed')
```

The load is cancelled correctly, but the message the user sees is a derived error, not the root cause:

1. The instance that hits `Division by zero` cancels its fragment, and its sink sends `tablet_writer_cancel` with the real reason (`NodeChannel::_cancel`, `tablet_sink_index_channel.cpp`).
2. On the destination BE, `LoadChannelMgr::cancel` runs `channel->cancel(reason)` (records the reason on every `DeltaWriter`) and then `channel->abort()`, which `close()`s every `AsyncDeltaWriter`.
3. Any **other** sender of the same load — a sink instance on another BE that has not been cancelled yet — has its `add_chunk` (typically the eos one) rejected by the now-closed writer with `Status::InternalError("AsyncDeltaWriter has been closed")`, stamped with the destination BE's IP by `LakeTabletsChannel::WriteContext::update_status`. That sender then fails its own fragment with this status and reports it.
4. `DefaultCoordinator.updateStatus` keeps the **first** non-OK status it receives. The root-cause instance reports only after tearing its sink down (cancel RPCs + `close_wait`), while the racing sender fails immediately, so the derived error frequently wins and becomes the `ERR_FAILED_WHEN_INSERT` message.

Note the asymmetry this fixes: a request arriving **after** the channel is removed already gets `ABORTED` plus the real reason (`LoadChannelMgr::_fail_rpc_request`). Only the in-flight race leaked the internal message.

## What I'm doing:

The reason is already recorded on the writer before it is closed, so report it instead of the generic message.

- `DeltaWriter::cancel_status()`: new accessor for the status passed to the first `cancel()` (OK if never cancelled).
- `AsyncDeltaWriterImpl::closed_status(generic_msg)`: returns that cancel status when present, otherwise the original message. Used by every path that rejects a task on a closed writer: `open()`, the `closed()` check in `execute()`, `MergeBlockTask`, and the `write()/flush()/finish()` fast-fail when the execution queue is already stopped.
- `LakeTabletsChannel::abort(tablet_ids, reason)` used to drop `reason`; it now records it first, like the channel-wide cancel path does.

A writer closed without ever being cancelled keeps the old message, so nothing changes for plain `close()`.

With the fix, the racing sender reports:

```
Cancelled: 172.21.241.88: Cancelled by pipeline engine, reason: Invalid argument: Division by zero BE:xxx
```

so whichever report reaches the FE first, the client sees the root cause.

Shared-nothing needs no equivalent change: it already behaves this way, and this PR only brings the lake writer in line with it.

- `DeltaWriter::cancel(st)` records `st` as `_err_status` (`_set_state(kAborted, st)`, first writer wins), and `write()/close()/commit()` return `get_err_status()` while in `kAborted`.
- Even the "queue already stopped" fallback uses the same precedence (`be/src/storage/async_delta_writer.cpp`):

```cpp
Status st = _writer->get_err_status();
if (st.ok()) {
    st = Status::InternalError("fail to call execution_queue_execute");
}
```

The lake writer had the reason available too — `LakeTabletsChannel::cancel(reason)` runs right before `abort()` and stores it on every `DeltaWriter` — but the `closed()` checks in `AsyncDeltaWriterImpl` ignored it. So the same abort race reported the root cause in shared-nothing and an internal implementation detail in shared-data.

The remaining gap is symmetric in both modes: an `abort()` that was not preceded by a `cancel(reason)` has no reason to report, and falls back to a generic message (`"aborted by others"` in shared-nothing, the original messages here). The cancel RPC path always records the reason first.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The error message and status code returned for a load that races with an abort change: `INTERNAL_ERROR "AsyncDeltaWriter has been closed"` becomes the recorded cancel status (typically `CANCELLED` with the coordinator's reason).

## Observability

Reviewed the existing signals on the cancelled-load path; no signal was added or removed:

- `DeltaWriterImpl::cancel()` already logs the cancel reason at INFO, so the reason now reported to the coordinator is already in the BE log.
- The `LOG_IF(ERROR, ...)` lines in `AsyncDeltaWriterImpl::execute()` now print the root cause instead of the generic "closed" text.
- No metric or profile counter is affected; only the content of the status returned to the load coordinator changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

New UTs:
- `LakeAsyncDeltaWriterTest.test_open_and_write_after_cancel_and_close`
- `LakeTabletsChannelTest.test_finish_after_cancel_and_abort`

The existing `test_open_after_close` / `test_finish_after_abort` cover the un-cancelled `close()`/`abort()` path and are unchanged.

> Not yet run locally (no Linux BE toolchain on this machine) — needs `./run-be-ut.sh --gtest_filter 'LakeAsyncDeltaWriterTest.*:LakeTabletsChannelTest.*'` before review.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

3.5 is not marked: it lacks `AsyncDeltaWriter::cancel()` (lake fast cancel), so there is no recorded reason to report there. The file moved to `be/src/data_workflows/load/tablet_writer/` on main, so the cherry-pick to 4.1/4.0 (`be/src/runtime/`) will likely need to be resolved manually.
