### PR TITLE
[BugFix] Stop folding dict exprs through derived dicts that have their own codes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -31,7 +31,6 @@ import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
-import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
@@ -184,30 +183,7 @@ class DecodeContext {
         }
     }
 
-    private boolean isNullSensitiveToRef(ScalarOperator op, int refId) {
-        if (!op.getUsedColumns().contains(refId)) {
-            return false;
-        }
-        if (op instanceof IsNullPredicateOperator) {
-            return true;
-        }
-        if (op instanceof CallOperator) {
-            String fn = ((CallOperator) op).getFnName();
-            if (FunctionSet.IFNULL.equalsIgnoreCase(fn) || FunctionSet.COALESCE.equalsIgnoreCase(fn)
-                    || FunctionSet.NULLIF.equalsIgnoreCase(fn) || FunctionSet.CONCAT_WS.equalsIgnoreCase(fn)) {
-                return true;
-            }
-        }
-        for (ScalarOperator child : op.getChildren()) {
-            if (isNullSensitiveToRef(child, refId)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     private void rewriteGlobalDict() {
-        GlobalDictRewriter dictRewriter = new GlobalDictRewriter();
         for (Integer stringId : stringRefToDefineExprMap.keySet()) {
             if (stringRefToDicts.containsKey(stringId)) {
                 continue;
@@ -224,22 +200,20 @@ class DecodeContext {
             }
             ScalarOperator stringDefineExpr = stringRefToDefineExprMap.get(stringId);
 
-            // Check before flattening: if a NULL-sensitive expression is built on a DERIVED dict
-            // (one defined by another expression, not a base column), do NOT flatten it through the
-            // child define. Keep it referencing the intermediate dict directly, so producer and
-            // consumer build the dictionary the same way (a derived dict carries a synthetic NULL
-            // code that flattening would drop).
-            ColumnRefOperator keepUseRef = getUseStringRef(stringDefineExpr);
-            if (keepUseRef != null && !stringRefToDicts.containsKey(keepUseRef.getId())
-                    && stringRefToDefineExprMap.containsKey(keepUseRef.getId())
-                    && isNullSensitiveToRef(stringDefineExpr, keepUseRef.getId())) {
-                ColumnRefOperator keepDictRef = stringRefToDictRefMap.get(keepUseRef);
-                globalDictsExpr.put(dictRef.getId(),
-                        new DictMappingOperator(keepDictRef, stringDefineExpr.clone(), dictRef.getType()));
-                continue;
-            }
-
-            ScalarOperator defineExpr = stringDefineExpr.accept(dictRewriter, null);
+            // Folding through a column is only valid when that column's codes are the codes of the
+            // column we fold onto. BE derives a dictionary by evaluating the define expression over
+            // the input dictionary, then de-duplicating and sorting the results (codes 1..n). So a
+            // column defined by a real expression (B : lower(C)) has its own code space that is not
+            // C's, and folding A through it (dictMapping(C, upper(lower(C)))) makes the fragment that
+            // receives B's codes (e.g. across an exchange, after a distinct aggregation) look them up
+            // in a mapping built for C's codes: the values no longer line up ("Dict Decode failed").
+            // Stop the fold at such a column and define A over B's dictionary instead. Only columns
+            // whose define reduces to a plain column reference (aliases, min/max, array element, ...)
+            // share the code space of their source and stay foldable.
+            ColumnRefOperator useStringRef = getUseStringRef(stringDefineExpr);
+            int stopStringId = useStringRef != null && hasOwnDictCodes(useStringRef.getId())
+                    ? useStringRef.getId() : -1;
+            ScalarOperator defineExpr = stringDefineExpr.accept(new GlobalDictRewriter(stopStringId), null);
             List<ColumnRefOperator> defineUsedStringRef = defineExpr.getColumnRefs();
             Preconditions.checkState(!defineUsedStringRef.isEmpty());
 
@@ -247,6 +221,16 @@ class DecodeContext {
             ScalarOperator globalDictExpr = new DictMappingOperator(defineUsedDictRef, defineExpr, dictRef.getType());
             globalDictsExpr.put(dictRef.getId(), globalDictExpr);
         }
+    }
+
+    // Whether the string column's dictionary codes are its own (built by BE from a define
+    // expression) rather than the codes of the base column it is ultimately derived from.
+    private boolean hasOwnDictCodes(int stringId) {
+        if (stringRefToDicts.containsKey(stringId) || !stringRefToDefineExprMap.containsKey(stringId)) {
+            return false;
+        }
+        ScalarOperator folded = stringRefToDefineExprMap.get(stringId).accept(new GlobalDictRewriter(-1), null);
+        return !folded.isColumnRef();
     }
 
     private void rewriteStringExpressions() {
@@ -643,11 +627,20 @@ class DecodeContext {
     }
 
     private class GlobalDictRewriter extends BaseScalarOperatorShuttle {
+        // string column at which folding stops: it is kept as the dict mapping's input column
+        // instead of being replaced by its own define expression (-1: fold down to the base column)
+        private final int stopStringId;
+
+        GlobalDictRewriter(int stopStringId) {
+            this.stopStringId = stopStringId;
+        }
+
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator variable, Void ignore) {
             // string dict expression use origin string column
             ScalarOperator define = stringRefToDefineExprMap.get(variable.getId());
-            if (define.isColumnRef() && variable.getId() == ((ColumnRefOperator) define).getId()) {
+            if (variable.getId() == stopStringId
+                    || (define.isColumnRef() && variable.getId() == ((ColumnRefOperator) define).getId())) {
                 // mock to string column
                 return new ColumnRefOperator(variable.getId(), variable.getType(), variable.getName(),
                         variable.isNullable());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -1286,6 +1286,43 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
+    public void testNestedDictExprKeepsIntermediateDict() throws Exception {
+        // The outer expression is not NULL-sensitive, but the inner CASE result has dictionary codes
+        // of its own (BE builds them from the CASE define). Folding the outer IF onto S_ADDRESS would
+        // make the fragment that receives the CASE codes after the exchange look them up in a mapping
+        // built for S_ADDRESS codes ("Dict Decode failed"), so the IF must stay over the CASE dict.
+        String sql = "select distinct if(subq.x = subq.x, subq.x, '-') as y "
+                + "from (select distinct case when S_ADDRESS = 'a' then 'A' else 'B' end as x "
+                + "from supplier_nullable) subq";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "if(<place-holder> = 'a', 'A', 'B')");
+        assertContains(plan, "if(<place-holder> = <place-holder>, <place-holder>, '-')");
+        assertNotContains(plan, "if(if(");
+    }
+
+    @Test
+    public void testAggregateOverDerivedDictKeepsIntermediateDict() throws Exception {
+        // max over a derived dict: the aggregate wrapper is still stripped from the define, but the
+        // mapping is defined over the derived (upper) dict instead of being folded onto S_ADDRESS.
+        String sql = "select max(x) from (select distinct upper(S_ADDRESS) as x from supplier_nullable) t";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "Global Dict Exprs:\n" +
+                "    12: DictDefine(11: S_ADDRESS, [upper(<place-holder>)])\n" +
+                "    13: DictDefine(upper, [<place-holder>])");
+        assertNotContains(plan, "max(<place-holder>)");
+    }
+
+    @Test
+    public void testAliasChainOverDerivedDictStaysFolded() throws Exception {
+        // An alias (identity define) shares the codes of its source, so folding through it is safe
+        // and the plan keeps the flat DictDefine over the base column.
+        String sql = "select distinct upper(y) from (select x as y from (select S_ADDRESS as x " +
+                "from supplier_nullable) a) b";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "DictDefine(10: S_ADDRESS, [upper(<place-holder>)])");
+    }
+
+    @Test
     public void testDictMappingGroupByReservesExtraCode() throws Exception {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         try {
@@ -2008,15 +2045,17 @@ public class LowCardinalityTest2 extends PlanTestBase {
         assertContains(plan, "  Global Dict Exprs:\n" +
                 "    27: DictDefine(26: S_ADDRESS, [lower(<place-holder>)])");
 
+        // min/max over a derived dict are defined over that dict (they carry its codes), not folded
+        // onto S_ADDRESS
         assertContains(plan, "  Global Dict Exprs:\n" +
-                "    32: DictDefine(25: S_ADDRESS, [concat(<place-holder>, '1')])\n" +
-                "    33: DictDefine(26: S_ADDRESS, [concat(<place-holder>, '2')])\n" +
+                "    32: DictDefine(concat, [<place-holder>])\n" +
+                "    33: DictDefine(concat, [<place-holder>])\n" +
                 "    34: DictDefine(25: S_ADDRESS, [upper(<place-holder>)])\n" +
                 "    27: DictDefine(26: S_ADDRESS, [lower(<place-holder>)])\n" +
                 "    28: DictDefine(25: S_ADDRESS, [concat(<place-holder>, '1')])\n" +
                 "    29: DictDefine(26: S_ADDRESS, [concat(<place-holder>, '2')])\n" +
-                "    30: DictDefine(25: S_ADDRESS, [upper(<place-holder>)])\n" +
-                "    31: DictDefine(26: S_ADDRESS, [lower(<place-holder>)])\n");
+                "    30: DictDefine(34: upper, [<place-holder>])\n" +
+                "    31: DictDefine(27: lower, [<place-holder>])\n");
     }
 
     @Test
@@ -2035,15 +2074,17 @@ public class LowCardinalityTest2 extends PlanTestBase {
         assertContains(plan, "  Global Dict Exprs:\n" +
                 "    27: DictDefine(26: S_ADDRESS, [lower(<place-holder>)])");
 
+        // min/max over a derived dict are defined over that dict (they carry its codes), not folded
+        // onto S_ADDRESS
         assertContains(plan, "  Global Dict Exprs:\n" +
-                "    32: DictDefine(25: S_ADDRESS, [concat(<place-holder>, '1')])\n" +
-                "    33: DictDefine(26: S_ADDRESS, [concat(<place-holder>, '2')])\n" +
+                "    32: DictDefine(concat, [<place-holder>])\n" +
+                "    33: DictDefine(concat, [<place-holder>])\n" +
                 "    34: DictDefine(25: S_ADDRESS, [upper(<place-holder>)])\n" +
                 "    27: DictDefine(26: S_ADDRESS, [lower(<place-holder>)])\n" +
                 "    28: DictDefine(25: S_ADDRESS, [concat(<place-holder>, '1')])\n" +
                 "    29: DictDefine(26: S_ADDRESS, [concat(<place-holder>, '2')])\n" +
-                "    30: DictDefine(25: S_ADDRESS, [upper(<place-holder>)])\n" +
-                "    31: DictDefine(26: S_ADDRESS, [lower(<place-holder>)])\n");
+                "    30: DictDefine(34: upper, [<place-holder>])\n" +
+                "    31: DictDefine(27: lower, [<place-holder>])\n");
     }
 
     @Test
@@ -2102,9 +2143,12 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "   FROM (select distinct upper(S_ADDRESS) c from supplier) t_a_0) t_a_1;";
 
         String plan = getVerboseExplain(sql);
+        // lower() over the derived upper() dict stays over that dict instead of being folded onto
+        // S_ADDRESS as lower(upper(...)): the fragment above the exchange evaluates it on upper's codes
         assertContains(plan, "Global Dict Exprs:\n" +
                 "    12: DictDefine(11: S_ADDRESS, [upper(<place-holder>)])\n" +
-                "    13: DictDefine(11: S_ADDRESS, [lower(upper(<place-holder>))])");
+                "    13: DictDefine(12: upper, [lower(<place-holder>)])");
+        assertNotContains(plan, "lower(upper(");
     }
 
     @Test
@@ -2340,7 +2384,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "   SELECT REVERSE(S_ADDRESS) x1, CONCAT(S_COMMENT, '1') y1, S_SUPPKEY FROM supplier_nullable) x " +
                 "GROUP BY S_SUPPKEY ";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "17: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
+        assertContains(plan, "17: DictDefine(REVERSE, [<place-holder>])");
         assertContains(plan, "15: DictDefine(13: S_ADDRESS, [reverse(<place-holder>)])");
     }
 

--- a/test/sql/test_low_cardinality/R/test_derived_dict_keep_intermediate
+++ b/test/sql/test_low_cardinality/R/test_derived_dict_keep_intermediate
@@ -1,0 +1,98 @@
+-- name: test_derived_dict_keep_intermediate
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = true;
+-- result:
+-- !result
+CREATE TABLE `dict_expr_exchange` (
+  `id` int NULL,
+  `lot_state` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into dict_expr_exchange
+select
+    generate_series,
+    case
+        when generate_series % 4 = 0 then 'created'
+        when generate_series % 7 = 0 then null
+        else 'running'
+    end
+from TABLE(generate_series(1, 4096));
+-- result:
+-- !result
+CREATE TABLE `lkeys` (
+  `id` int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into lkeys values (4), (8), (999998), (999999);
+-- result:
+-- !result
+[UC] analyze full table dict_expr_exchange;
+function: wait_global_dict_ready('lot_state', 'dict_expr_exchange')
+-- result:
+
+-- !result
+function: assert_explain_contains('select if(subq.wip_status = subq.wip_status, subq.wip_status, \'-\') as w from (select distinct case when lot_state in (\'created\') then \'Created\' else \'WIP\' end as wip_status from dict_expr_exchange) subq order by w', 'Decode')
+-- result:
+None
+-- !result
+[ORDER]select
+    if(subq.wip_status = subq.wip_status, subq.wip_status, '-') as w
+from (
+    select distinct
+        case when lot_state in ('created') then 'Created' else 'WIP' end as wip_status
+    from dict_expr_exchange
+) subq
+order by w;
+-- result:
+Created
+WIP
+-- !result
+function: assert_explain_contains('select if(subq.w = subq.w, subq.w, \'-\') as r from (select distinct case when lot_state = \'created\' then null when lot_state is null then \'X\' else lot_state end as w from dict_expr_exchange) subq order by r', 'Decode')
+-- result:
+None
+-- !result
+[ORDER]select
+    if(subq.w = subq.w, subq.w, '-') as r
+from (
+    select distinct
+        case when lot_state = 'created' then null when lot_state is null then 'X' else lot_state end as w
+    from dict_expr_exchange
+) subq
+order by r;
+-- result:
+-
+X
+running
+-- !result
+function: assert_explain_contains('select if(t.w = t.w, t.w, \'-\') as r from lkeys l left join (select id, case when lot_state in (\'created\') then \'Created\' else \'WIP\' end as w from dict_expr_exchange) t on l.id = t.id order by r', 'Decode')
+-- result:
+None
+-- !result
+[ORDER]select
+    if(t.w = t.w, t.w, '-') as r
+from lkeys l
+left join (
+    select id, case when lot_state in ('created') then 'Created' else 'WIP' end as w
+    from dict_expr_exchange
+) t on l.id = t.id
+order by r;
+-- result:
+-
+-
+Created
+Created
+-- !result

--- a/test/sql/test_low_cardinality/T/test_derived_dict_keep_intermediate
+++ b/test/sql/test_low_cardinality/T/test_derived_dict_keep_intermediate
@@ -1,0 +1,79 @@
+-- name: test_derived_dict_keep_intermediate
+
+set cbo_enable_low_cardinality_optimize = true;
+set low_cardinality_optimize_v2 = true;
+
+CREATE TABLE `dict_expr_exchange` (
+  `id` int NULL,
+  `lot_state` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into dict_expr_exchange
+select
+    generate_series,
+    case
+        when generate_series % 4 = 0 then 'created'
+        when generate_series % 7 = 0 then null
+        else 'running'
+    end
+from TABLE(generate_series(1, 4096));
+
+CREATE TABLE `lkeys` (
+  `id` int NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 2
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into lkeys values (4), (8), (999998), (999999);
+
+[UC] analyze full table dict_expr_exchange;
+
+function: wait_global_dict_ready('lot_state', 'dict_expr_exchange')
+
+-- An expression over a DERIVED dict (the distinct CASE below) must keep referencing the
+-- intermediate dict instead of being flattened onto the base column, otherwise the
+-- fragment on the other side of the exchange derives the dict differently and decode fails.
+function: assert_explain_contains('select if(subq.wip_status = subq.wip_status, subq.wip_status, \'-\') as w from (select distinct case when lot_state in (\'created\') then \'Created\' else \'WIP\' end as wip_status from dict_expr_exchange) subq order by w', 'Decode')
+
+[ORDER]select
+    if(subq.wip_status = subq.wip_status, subq.wip_status, '-') as w
+from (
+    select distinct
+        case when lot_state in ('created') then 'Created' else 'WIP' end as wip_status
+    from dict_expr_exchange
+) subq
+order by w;
+
+-- The intermediate expression itself yields NULL for some rows; the outer expression must
+-- see that NULL (not the base column's NULL) when it is evaluated through the dict.
+function: assert_explain_contains('select if(subq.w = subq.w, subq.w, \'-\') as r from (select distinct case when lot_state = \'created\' then null when lot_state is null then \'X\' else lot_state end as w from dict_expr_exchange) subq order by r', 'Decode')
+
+[ORDER]select
+    if(subq.w = subq.w, subq.w, '-') as r
+from (
+    select distinct
+        case when lot_state = 'created' then null when lot_state is null then 'X' else lot_state end as w
+    from dict_expr_exchange
+) subq
+order by r;
+
+-- The intermediate column becomes NULL through an outer join (no matching build row);
+-- the outer expression must be evaluated on that NULL, not on a value derived from the base.
+function: assert_explain_contains('select if(t.w = t.w, t.w, \'-\') as r from lkeys l left join (select id, case when lot_state in (\'created\') then \'Created\' else \'WIP\' end as w from dict_expr_exchange) t on l.id = t.id order by r', 'Decode')
+
+[ORDER]select
+    if(t.w = t.w, t.w, '-') as r
+from lkeys l
+left join (
+    select id, case when lot_state in ('created') then 'Created' else 'WIP' end as w
+    from dict_expr_exchange
+) t on l.id = t.id
+order by r;


### PR DESCRIPTION
## Why I'm doing:


BE builds a derived dictionary by evaluating the define expression over the input dictionary, then de-duplicating and sorting the results into codes 1..n, and builds the code_convert_map from the codes of the dictionary the DictDefine names. DecodeContext used to fold a chain of derived dicts onto the base column (A: f(B), B: g(C) -> A: f(g(C)) over C). A fragment that receives B's codes, for example above the exchange of a distinct aggregation, then evaluates A's mapping, which was built for C's codes, on B's codes: the codes no longer line up and the query fails with "Dict Decode failed" or returns wrong values.

#75246 guarded this only for NULL-sensitive outer expressions (IS NULL, ifnull, coalesce, ...). The misalignment does not depend on NULL handling at all: `if(w = w, w, '-')` over a distinct CASE, or `lower(x)` over a distinct `upper(...)`, hit it just the same.

Replace the NULL-sensitivity list with a structural rule: a fold may only pass through a column whose define reduces to a plain column reference (aliases, min/max, array element, unnest), because such a column shares the codes of its source. A column defined by a real expression has its own code space, so the fold stops there and the outer DictDefine is expressed over that column's dictionary. The kept path now also goes through GlobalDictRewriter, so aggregate and array wrappers are stripped instead of being emitted verbatim.

Add unit tests for the three shapes (non-NULL-sensitive outer expression, aggregate over a derived dict, alias chain stays folded) and a SQL test that covers the distinct CASE, partial-NULL CASE and left-join cases end to end.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
