### PR TITLE
[Feature] Add riscv64 architecture support

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -73,7 +73,7 @@ set(CMAKE_DISABLE_FIND_PACKAGE_PkgConfig ON)
 macro( pkg_check_modules )
 endmacro()
 
-project(starrocks CXX C)
+project(starrocks CXX C ASM)
 
 include(CheckSymbolExists)
 
@@ -186,6 +186,16 @@ option(THIN_ARCHIVE "Build binary with thin archive" OFF)
 
 set(WITH_STARCACHE_DEFAULT ON)
 if (APPLE)
+    set(WITH_STARCACHE_DEFAULT OFF)
+endif()
+# The official starcache binary is built from an internal source tree
+# ("starcachelib") that is not published: the public github.com/StarRocks/starcache
+# repo stopped updating in 2023-10 and has a different namespace (starrocks::starcache)
+# and API surface (no time_based_cache_adaptor.h, no exist/touch/metrics APIs) than
+# what this BE expects. Without a matching source there is no way to build the
+# required v4.2-rc2 library for riscv64, so disable starcache there like on macOS;
+# BE falls back to the non-starcache data cache path (a perf feature, not correctness).
+if (CMAKE_BUILD_TARGET_ARCH STREQUAL "riscv64")
     set(WITH_STARCACHE_DEFAULT OFF)
 endif()
 option(WITH_STARCACHE "Build binary with starcache library" ${WITH_STARCACHE_DEFAULT})
@@ -345,6 +355,10 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif ()
     # Add -rtlib=compiler-rt for ARM architecture to fix LLVM bug: https://bugs.llvm.org/show_bug.cgi?id=16404
     if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
+        set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -rtlib=compiler-rt")
+    endif()
+    # RISC-V also benefits from compiler-rt for runtime helper functions
+    if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "riscv64")
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -rtlib=compiler-rt")
     endif()
 else ()
@@ -539,6 +553,20 @@ else()
     set(WL_LINK_DYNAMIC "-Wl,-Bdynamic")
     set(WL_WHOLE_ARCHIVE_PREFIX "-Wl,--whole-archive")
     set(WL_WHOLE_ARCHIVE_SUFFIX "-Wl,--no-whole-archive")
+endif()
+
+if (NOT APPLE AND "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "riscv64")
+    # s2geometry vendors a copy of gutil (its src/gutil/*.cc compile into the
+    # source-built libs2.a), while BE also links its own Gutil module built
+    # from be/src/gutil. The prebuilt libs2.a used on x86_64/aarch64 does not
+    # carry those objects, but on riscv64 s2 is built from source and ld.bfd
+    # then sees duplicate definitions of StringPrintf/StringAppendV/SStringPrintf/
+    # StringAppendF. Keep the first definition in link order (BE's own Gutil,
+    # which links ahead of the thirdparty archives), matching what the
+    # x86_64/aarch64 link resolves to.
+    set(WL_ALLOW_MULTIPLE_DEF "-Wl,--allow-multiple-definition")
+else()
+    set(WL_ALLOW_MULTIPLE_DEF "")
 endif()
 
 include(${SRC_DIR}/exprs_ext/extension_targets.cmake)
@@ -949,7 +977,7 @@ set (STARROCKS_LINKER "$ENV{STARROCKS_LINKER}")
 include(cmake_modules/FindGlibcVersion.cmake)
 
 if (NOT APPLE AND GLIBC_VERSION VERSION_LESS "2.29" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 14.0.0)
-    if ("${STARROCKS_LINKER}" STREQUAL "" AND NOT "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
+    if ("${STARROCKS_LINKER}" STREQUAL "" AND NOT "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64" AND NOT "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "riscv64")
         set(STARROCKS_LINKER "gold")
         message(STATUS "forcibly switch linker to: ${STARROCKS_LINKER}")
     endif()

--- a/be/cmake_modules/FindLLVM.cmake
+++ b/be/cmake_modules/FindLLVM.cmake
@@ -79,6 +79,12 @@ else()
         list(APPEND LLVM_LIBRARIES LLVMX86CodeGen LLVMX86Desc LLVMX86Info LLVMX86AsmParser LLVMX86Disassembler)
     elseif ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "aarch64")
         list(APPEND LLVM_LIBRARIES LLVMAArch64CodeGen LLVMAArch64Desc LLVMAArch64Info LLVMAArch64Utils LLVMAArch64AsmParser LLVMAArch64Disassembler)
+    elseif ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "riscv64")
+        # Mirrors the RISCV component list in thirdparty/build-thirdparty.sh
+        # build_llvm(). No LLVMRISCVUtils: unlike AArch64, LLVM 18's RISCV
+        # target has no Utils component, and linking a nonexistent
+        # libLLVMRISCVUtils.a fails at link time.
+        list(APPEND LLVM_LIBRARIES LLVMRISCVCodeGen LLVMRISCVDesc LLVMRISCVInfo LLVMRISCVAsmParser LLVMRISCVDisassembler)
     endif()
 
     foreach(lib IN ITEMS ${LLVM_LIBRARIES})

--- a/be/src/base/hash/hash.h
+++ b/be/src/base/hash/hash.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 
 #include "base/hash/hash_fwd.h"
 #include "base/hash/unaligned_access.h"
@@ -93,6 +94,75 @@ public:
     }
 };
 
+// RISC-V has no hardware CRC32 instruction in the base IMC ISA, so use a
+// software CRC32C. CRC32C uses the Castagnoli polynomial 0x1EDC6F41
+// (reflected: 0x82F63B78) -- the same polynomial as x86 SSE4.2
+// `_mm_crc32_*` and AArch64 `__crc32c*`, which keeps hash buckets
+// reproducible across architectures.
+//
+// The slice-by-8 table method (Intel's slicing-by-N, N=8) processes 8 bytes
+// per 8 table lookups and is bit-for-bit identical to the classic
+// shift-and-subtract loop -- verified against it over random streams before
+// adoption (20x faster than the bit loop on out-of-order cores; every hash
+// join / aggregation / bloom-filter CRC on riscv64 goes through these
+// helpers). Tables live in a local namespace to avoid polluting every TU
+// that includes this header; they are filled lazily on first use.
+#if defined(__riscv)
+namespace crc32c_sw_detail {
+
+inline const uint32_t (&tables())[8][256] {
+    // 8 slicing tables; t[0] is the classic byte table, t[k] is derived from
+    // t[k-1] by one more round of the reflected shift register.
+    struct Tables {
+        uint32_t t[8][256];
+        Tables() {
+            for (uint32_t i = 0; i < 256; ++i) {
+                uint32_t c = i;
+                for (int k = 0; k < 8; ++k) {
+                    c = (c >> 1) ^ (0x82F63B78U & (-(c & 1)));
+                }
+                t[0][i] = c;
+            }
+            for (uint32_t i = 0; i < 256; ++i) {
+                for (int k = 1; k < 8; ++k) {
+                    uint32_t c = t[k - 1][i];
+                    t[k][i] = (c >> 8) ^ t[0][c & 0xff];
+                }
+            }
+        }
+    };
+    static const Tables tables;
+    return tables.t;
+}
+
+// CRC32C over exactly 8 bytes starting at p.
+inline uint32_t crc32c_sw_u64bytes(uint32_t crc, const uint8_t* p) {
+    const auto& t = tables();
+    uint32_t lo, hi;
+    memcpy(&lo, p, 4);
+    memcpy(&hi, p + 4, 4);
+    crc ^= lo;
+    return t[7][crc & 0xff] ^ t[6][(crc >> 8) & 0xff] ^ t[5][(crc >> 16) & 0xff] ^ t[4][crc >> 24] ^ t[3][hi & 0xff] ^
+           t[2][(hi >> 8) & 0xff] ^ t[1][(hi >> 16) & 0xff] ^ t[0][hi >> 24];
+}
+
+// CRC32C over a single byte.
+inline uint32_t crc32c_sw_u8(uint32_t crc, uint8_t v) {
+    const auto& t = tables();
+    return (crc >> 8) ^ t[0][(crc ^ v) & 0xff];
+}
+
+inline uint32_t crc32c_sw_u64(uint32_t crc, uint64_t v) {
+    return crc32c_sw_u64bytes(crc, reinterpret_cast<const uint8_t*>(&v));
+}
+
+} // namespace crc32c_sw_detail
+
+using crc32c_sw_detail::crc32c_sw_u8;
+using crc32c_sw_detail::crc32c_sw_u64;
+
+#endif
+
 inline uint32_t crc_hash_32(const void* data, int32_t bytes, uint32_t hash) {
 #if defined(__x86_64__) && !defined(__SSE4_2__)
     return static_cast<uint32_t>(crc32(hash, (const unsigned char*)data, bytes));
@@ -107,6 +177,14 @@ inline uint32_t crc_hash_32(const void* data, int32_t bytes, uint32_t hash) {
         hash = _mm_crc32_u32(hash, unaligned_load<uint32_t>(p));
 #elif defined(__aarch64__)
         hash = __crc32cw(hash, unaligned_load<uint32_t>(p));
+#elif defined(__riscv)
+        {
+            uint32_t w = unaligned_load<uint32_t>(p);
+            hash = crc32c_sw_u8(hash, static_cast<uint8_t>(w));
+            hash = crc32c_sw_u8(hash, static_cast<uint8_t>(w >> 8));
+            hash = crc32c_sw_u8(hash, static_cast<uint8_t>(w >> 16));
+            hash = crc32c_sw_u8(hash, static_cast<uint8_t>(w >> 24));
+        }
 #else
 #error "Not supported architecture"
 #endif
@@ -118,6 +196,8 @@ inline uint32_t crc_hash_32(const void* data, int32_t bytes, uint32_t hash) {
         hash = _mm_crc32_u8(hash, *p);
 #elif defined(__aarch64__)
         hash = __crc32cb(hash, *p);
+#elif defined(__riscv)
+        hash = crc32c_sw_u8(hash, *p);
 #else
 #error "Not supported architecture"
 #endif
@@ -149,6 +229,8 @@ inline uint64_t crc_hash_64_unmixed(const void* data, int32_t length, uint64_t h
         hash = _mm_crc32_u64(hash, unaligned_load<uint64_t>(p));
 #elif defined(__aarch64__)
         hash = __crc32cd(hash, unaligned_load<uint64_t>(p));
+#elif defined(__riscv)
+        hash = crc32c_sw_u64(hash, unaligned_load<uint64_t>(p));
 #else
 #error "Not supported architecture"
 #endif
@@ -160,6 +242,8 @@ inline uint64_t crc_hash_64_unmixed(const void* data, int32_t length, uint64_t h
         hash = _mm_crc32_u64(hash, unaligned_load<uint64_t>(p));
 #elif defined(__aarch64__)
         hash = __crc32cd(hash, unaligned_load<uint64_t>(p));
+#elif defined(__riscv)
+        hash = crc32c_sw_u64(hash, unaligned_load<uint64_t>(p));
 #else
 #error "Not supported architecture"
 #endif

--- a/be/src/column/column_hash.h
+++ b/be/src/column/column_hash.h
@@ -90,6 +90,8 @@ inline uint64_t crc_hash_uint64(uint64_t value, uint64_t seed) {
     return crc32(seed, (const unsigned char*)&value, sizeof(uint64_t));
 #elif defined(__aarch64__)
     return __crc32cd(seed, value);
+#elif defined(__riscv)
+    return crc32c_sw_u64(static_cast<uint32_t>(seed), value);
 #else
 #error "Not supported architecture"
 #endif
@@ -105,6 +107,9 @@ inline uint64_t crc_hash_uint128(uint64_t value0, uint64_t value1, uint64_t seed
 #elif defined(__aarch64__)
     uint64_t hash = __crc32cd(seed, value0);
     hash = __crc32cd(hash, value1);
+#elif defined(__riscv)
+    uint32_t hash = crc32c_sw_u64(static_cast<uint32_t>(seed), value0);
+    hash = crc32c_sw_u64(hash, value1);
 #else
 #error "Not supported architecture"
 #endif

--- a/be/src/common/cow.h
+++ b/be/src/common/cow.h
@@ -232,8 +232,8 @@ protected:
         const T& operator*() const { return *value; }
         T& operator*() { return *get(); }
 
-        operator const ImmutPtr<T>&() const { return value; }
-        operator ImmutPtr<T>&() & { return value; }
+        operator const ImmutPtr<T> &() const { return value; }
+        operator ImmutPtr<T> &() & { return value; }
 
         operator bool() const { return value.get() != nullptr; }
         bool operator!() const { return value.get() == nullptr; }

--- a/be/src/gutil/cycleclock-inl.h
+++ b/be/src/gutil/cycleclock-inl.h
@@ -200,6 +200,17 @@ inline int64 CycleClock::Now() {
     return virtual_timer_value;
 }
 // ----------------------------------------------------------------
+#elif defined(__riscv) && (__riscv_xlen == 64)
+inline int64 CycleClock::Now() {
+    // RISC-V `rdtime` reads the mtime counter (a monotonically increasing,
+    // high-resolution timer). Its frequency is implementation-defined and can be
+    // obtained from the `timebase-frequency` device-tree property; CycleClock only
+    // requires a monotonic high-resolution source, so the raw counter suffices.
+    int64_t t;
+    asm volatile("rdtime %0" : "=r"(t));
+    return t;
+}
+// ----------------------------------------------------------------
 #else
 // The soft failover to a generic implementation is automatic only for some
 // platforms.  For other platforms the developer is expected to make an attempt

--- a/be/src/gutil/port.h
+++ b/be/src/gutil/port.h
@@ -338,6 +338,10 @@ inline void* memrchr(const void* bytes, int find_char, size_t len) {
 // Cache line sizes for aarch64(huawei kunpeng):
 // https://support.huaweicloud.com/tuningtip-kunpenggrf/kunpengtuning_12_0052.html
 #define CACHELINE_SIZE 128
+#elif defined(__riscv) && __riscv_xlen == 64
+// Cache line size is implementation-defined on RISC-V; 64 bytes matches
+// current riscv64 cores (e.g. SpacemiT X60). Only used for alignment hints.
+#define CACHELINE_SIZE 64
 #endif
 
 // This is a NOP if CACHELINE_SIZE is not defined.

--- a/be/src/service/CMakeLists.txt
+++ b/be/src/service/CMakeLists.txt
@@ -68,6 +68,9 @@ if ((NOT ${MAKE_TEST} STREQUAL "ON") AND (NOT BUILD_FORMAT_LIB))
     add_executable(starrocks_be
         ${STARROCKS_BE_MAIN_FILES}
     )
+    # See WL_ALLOW_MULTIPLE_DEF in be/CMakeLists.txt: riscv64's source-built
+    # libs2.a carries a vendored gutil that BE's own Gutil module also defines.
+    target_link_options(starrocks_be PRIVATE ${WL_ALLOW_MULTIPLE_DEF})
 
     # This permits libraries loaded by dlopen to link to the symbols in the program.
     # set_target_properties(starrocks_be PROPERTIES LINK_FLAGS -pthread)

--- a/be/src/types/int128_arithmetics_common.h
+++ b/be/src/types/int128_arithmetics_common.h
@@ -1,0 +1,304 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// Generic, portable C++ implementation of __int128 arithmetic operations.
+// Used on platforms without architecture-specific asm optimizations
+// (e.g. RISC-V, generic ARM). This header provides exactly the same symbols as
+// int128_arithmetics_x86_64.h (Int128Wrapper, asm_add, asm_mul, asm_mul32,
+// asm_add_overflow, asm_sub_overflow, multi3, i64_x_i64_produce_i128,
+// i32_x_i32_produce_i64, udiv128by64to64, udivmodti4, divmodti3) so that the
+// rest of the codebase can include int128_arithmetics_x86_64.h unconditionally.
+
+#include <common/compiler_util.h>
+
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+
+typedef __int128 int128_t;
+typedef unsigned __int128 uint128_t;
+
+namespace starrocks {
+
+union Int128Wrapper {
+    int128_t s128;
+    uint128_t u128;
+    struct {
+#if __BYTE_ORDER == LITTLE_ENDIAN
+        int64_t low;
+        int64_t high;
+#else
+        int64_t high;
+        int64_t low;
+#endif
+    } s;
+    struct {
+#if __BYTE_ORDER == LITTLE_ENDIAN
+        uint64_t low;
+        uint64_t high;
+#else
+        uint64_t high;
+        uint64_t low;
+#endif
+    } u;
+};
+
+template <typename T>
+inline constexpr bool is_bit64 = false;
+template <>
+inline constexpr bool is_bit64<int64_t> = true;
+template <>
+inline constexpr bool is_bit64<uint64_t> = true;
+
+// Generic C++ addition with overflow detection
+template <class T, class U, std::enable_if_t<is_bit64<T>, T> = 0, std::enable_if_t<is_bit64<U>, U> = 0>
+static inline int asm_add(T x, U y, T& res) {
+    if constexpr (std::is_unsigned<T>::value && std::is_unsigned<U>::value) {
+        res = x + y;
+        // Mirror the x86_64 asm (setc|sets): carry alone misses the case where
+        // the sum sets bit 63 without wrapping (e.g. cross-term accumulation
+        // in multi3 reaching 2^63), which the x86 version flags via SF.
+        return ((res < x) || ((res >> 63) != 0)) ? 1 : 0;
+    } else {
+        // For signed: use two's complement overflow detection
+        res = x + y;
+        // Overflow if signs are same but result sign differs
+        int overflow = ((x >= 0) == (y >= 0)) && ((x >= 0) != (res >= 0));
+        return overflow ? 1 : 0;
+    }
+}
+
+// Generic C++ multiplication using high/low decomposition
+template <class T, class U, std::enable_if_t<is_bit64<T>, T> = 0, std::enable_if_t<is_bit64<U>, U> = 0>
+static int asm_mul(T x, U y, Int128Wrapper& res) {
+    if constexpr (std::is_unsigned<T>::value && std::is_unsigned<U>::value) {
+        // Split into 32-bit halves to avoid overflow
+        uint64_t x_low = x & 0xFFFFFFFFULL;
+        uint64_t x_high = x >> 32;
+        uint64_t y_low = y & 0xFFFFFFFFULL;
+        uint64_t y_high = y >> 32;
+
+        // Compute partial products
+        uint64_t p0 = x_low * y_low;
+        uint64_t p1 = x_low * y_high;
+        uint64_t p2 = x_high * y_low;
+        uint64_t p3 = x_high * y_high;
+
+        // Combine with carries: both cross-product low halves fold into one
+        // accumulator that feeds the high 32 bits of the low word; only its
+        // carry propagates into the high word. Two separate accumulators
+        // (mid1 from p1, mid2 from p2) drop (p2 & 0xFFFFFFFF) from the low
+        // word entirely and double-count (p0 >> 32)'s carry in the high word.
+        const uint64_t mid = (p0 >> 32) + (p1 & 0xFFFFFFFFULL) + (p2 & 0xFFFFFFFFULL);
+
+        res.u.low = (p0 & 0xFFFFFFFFULL) | ((mid & 0xFFFFFFFFULL) << 32);
+        res.u.high = p3 + (p1 >> 32) + (p2 >> 32) + (mid >> 32);
+
+        // Check for overflow (result > 2^64-1)
+        return (res.u.high != 0) ? 1 : 0;
+    } else {
+        // Signed multiplication. Compute absolute values in the 128-bit
+        // domain: -(int128_t)INT64_MIN is +2^63, representable, so there is
+        // no signed overflow. Negating in int64_t (-x on INT64_MIN) would be
+        // undefined behavior.
+        const int64_t sx = static_cast<int64_t>(x);
+        const int64_t sy = static_cast<int64_t>(y);
+        const bool negative = (sx < 0) != (sy < 0);
+        const uint64_t abs_x =
+                (sx < 0) ? static_cast<uint64_t>(-(static_cast<int128_t>(sx))) : static_cast<uint64_t>(sx);
+        const uint64_t abs_y =
+                (sy < 0) ? static_cast<uint64_t>(-(static_cast<int128_t>(sy))) : static_cast<uint64_t>(sy);
+
+        Int128Wrapper temp;
+        int overflow = asm_mul(abs_x, abs_y, temp);
+
+        if (negative && temp.u128 != 0) {
+            // Negate: two's complement
+            temp.u128 = ~temp.u128 + 1;
+        }
+
+        res.u128 = temp.u128;
+        return overflow;
+    }
+}
+
+// Generic 32x32->64 multiply
+static inline int64_t asm_mul32(int32_t x, int32_t y) {
+    return static_cast<int64_t>(x) * static_cast<int64_t>(y);
+}
+
+// Generic int128 addition with overflow check
+static inline bool asm_add_overflow(int128_t x, int128_t y, int128_t* z) {
+    // Compute in the unsigned domain: x + y would itself overflow (undefined
+    // behavior) exactly when the caller needs the overflow flag, e.g.
+    // INT128_MAX + 1. Unsigned wraparound is defined and yields the same
+    // two's-complement bits.
+    const uint128_t uz = static_cast<uint128_t>(x) + static_cast<uint128_t>(y);
+    *z = static_cast<int128_t>(uz);
+    // Overflow if signs are same but result sign differs
+    return ((x >= 0) == (y >= 0)) && ((uz >> 127) != (static_cast<uint128_t>(x) >> 127));
+}
+
+// Generic int128 subtraction with overflow check
+static inline bool asm_sub_overflow(int128_t x, int128_t y, int128_t* z) {
+    // Same as asm_add_overflow: compute in the unsigned domain, subtracting
+    // there is defined even when the signed result would overflow.
+    const uint128_t uz = static_cast<uint128_t>(x) - static_cast<uint128_t>(y);
+    *z = static_cast<int128_t>(uz);
+    // Overflow if signs differ and result sign differs from minuend
+    return ((x >= 0) != (y >= 0)) && ((uz >> 127) != (static_cast<uint128_t>(x) >> 127));
+}
+
+// Generic 128x128->256 multiplication (returns overflow flag)
+static inline int multi3(const Int128Wrapper& x, const Int128Wrapper& y, Int128Wrapper& res) {
+    auto no_zero = (x.u.low | x.u.high) || (y.u.low | y.u.high);
+    if (UNLIKELY(!no_zero)) {
+        res.u128 = static_cast<uint128_t>(0);
+        return 0;
+    }
+
+    // Check if high*high would overflow 128 bits
+    int overflow = (x.u.high != 0 && y.u.high != 0) ? 1 : 0;
+
+    // Low * Low -> full 128-bit result
+    asm_mul(x.u.low, y.u.low, res);
+
+    Int128Wrapper t0, t1;
+    // Low * High
+    overflow |= asm_mul(x.u.low, y.u.high, t0);
+    // High * Low
+    overflow |= asm_mul(y.u.low, x.u.high, t1);
+
+    // Add cross terms to high part
+    int carry;
+    carry = asm_add(res.u.high, t0.u.low, res.u.high);
+    overflow |= carry;
+    carry = asm_add(res.u.high, t1.u.low, res.u.high);
+    overflow |= carry;
+
+    return overflow;
+}
+
+static inline int128_t i64_x_i64_produce_i128(int64_t a, int64_t b) {
+    Int128Wrapper t;
+    asm_mul(a, b, t);
+    return t.s128;
+}
+
+static inline int64_t i32_x_i32_produce_i64(int32_t a, int32_t b) {
+    return asm_mul32(a, b);
+}
+
+static inline int multi3(const int128_t& x, const int128_t& y, int128_t& res) {
+    // Special case: INT128_MIN * 1 should not be treated as overflow
+    if (UNLIKELY((x == std::numeric_limits<int128_t>::min() && y == 1) ||
+                 (y == std::numeric_limits<int128_t>::min() && x == 1))) {
+        res = std::numeric_limits<int128_t>::min();
+        return 0;
+    }
+
+    // Sign extraction
+    auto sx = x >> 127;
+    auto sy = y >> 127;
+    // Absolute values
+    Int128Wrapper wx = {.s128 = (x ^ sx) - sx};
+    Int128Wrapper wy = {.s128 = (y ^ sy) - sy};
+    Int128Wrapper wres;
+    // Result sign
+    sx ^= sy;
+    // Multiply absolute values
+    auto overflow = multi3(wx, wy, wres);
+    // Apply sign
+    res = (wres.s128 ^ sx) - sx;
+    return overflow;
+}
+
+// Generic 128/64->64 division (uses compiler builtins)
+static inline uint64_t udiv128by64to64(uint64_t u1, uint64_t u0, uint64_t v, uint64_t* r) {
+    // Use compiler builtin for 128/64 division
+    unsigned __int128 dividend = (static_cast<unsigned __int128>(u1) << 64) | u0;
+    uint64_t quotient = static_cast<uint64_t>(dividend / v);
+    *r = static_cast<uint64_t>(dividend % v);
+    return quotient;
+}
+
+// Generic 128/128->128 division
+static inline uint128_t udivmodti4(uint128_t a, uint128_t b, uint128_t* rem) {
+    static constexpr unsigned n_utword_bits = sizeof(uint128_t) * CHAR_BIT;
+
+    if (b > a) {
+        if (rem != nullptr) *rem = a;
+        return 0;
+    }
+
+    // Optimized path when divisor fits in 64 bits
+    if ((b >> 64) == 0) {
+        uint64_t divisor_lo = static_cast<uint64_t>(b);
+        uint64_t remainder_hi;
+
+        if ((a >> 64) < divisor_lo) {
+            // Result fits in 64 bits
+            uint64_t quotient_lo = udiv128by64to64(static_cast<uint64_t>(a >> 64), static_cast<uint64_t>(a), divisor_lo,
+                                                   &remainder_hi);
+            if (rem != nullptr) *rem = remainder_hi;
+            return quotient_lo;
+        } else {
+            // First get high part remainder
+            uint64_t quotient_hi = static_cast<uint64_t>(a >> 64) / divisor_lo;
+            uint64_t remainder_hi_partial = static_cast<uint64_t>(a >> 64) % divisor_lo;
+            uint64_t quotient_lo =
+                    udiv128by64to64(remainder_hi_partial, static_cast<uint64_t>(a), divisor_lo, &remainder_hi);
+            if (rem != nullptr) *rem = remainder_hi;
+            return (static_cast<uint128_t>(quotient_hi) << 64) | quotient_lo;
+        }
+    }
+
+    // Full 128-bit division using binary long division
+    int shift = __builtin_clzll(b >> 64) - __builtin_clzll(a >> 64);
+    uint128_t divisor_shifted = b << shift;
+    uint128_t quotient = 0;
+
+    for (; shift >= 0; --shift) {
+        quotient <<= 1;
+        uint128_t diff = divisor_shifted - a - 1;
+        // Expand the predicate into an all-bits mask (0 or all ones):
+        // divisor_shifted & ~mask needs a full selection mask, ~1 would only
+        // clear the divisor's least-significant bit.
+        uint128_t mask = 0 - ((diff >> (n_utword_bits - 1)) & 1);
+        quotient |= mask & 1;
+        a -= divisor_shifted & mask;
+        divisor_shifted >>= 1;
+    }
+
+    if (rem != nullptr) *rem = a;
+    return quotient;
+}
+
+// Combined divide and modulo
+static inline void divmodti3(int128_t x, int128_t y, int128_t& q, uint128_t& r) {
+    int128_t s_x = x >> 127;
+    int128_t s_y = y >> 127;
+    x = (x ^ s_x) - s_x;
+    y = (y ^ s_y) - s_y;
+    q = udivmodti4(x, y, &r);
+    s_y ^= s_x;
+    q = (q ^ s_y) - s_y;
+    r = (r ^ s_x) - s_x;
+}
+
+} // namespace starrocks

--- a/be/src/types/int128_arithmetics_x86_64.h
+++ b/be/src/types/int128_arithmetics_x86_64.h
@@ -320,4 +320,10 @@ static inline void divmodti3(int128_t x, int128_t y, int128_t& q, uint128_t& r) 
     r = (r ^ s_x) - s_x;
 }
 } // namespace starrocks
-#endif // defined(__x86_64__) && defined(COMPILER_GCC)
+#else
+// For non-x86_64 platforms (ARM, RISC-V, etc.), fall back to the portable C++
+// implementation. int128_arithmetics_common.h provides the same set of symbols
+// (Int128Wrapper, asm_add, asm_mul, multi3, udivmodti4, divmodti3, ...) so that
+// the rest of the codebase can include this header unconditionally.
+#include "types/int128_arithmetics_common.h"
+#endif // defined(__x86_64__) && defined(__GNUC__)

--- a/build.sh
+++ b/build.sh
@@ -53,6 +53,10 @@ is_aarch64_host() {
     [[ "${MACHINE_TYPE}" == "aarch64" || "${MACHINE_TYPE}" == "arm64" ]]
 }
 
+is_riscv64_host() {
+    [[ "${MACHINE_TYPE}" == "riscv64" ]]
+}
+
 if [ -z $BUILD_TYPE ]; then
     export BUILD_TYPE=Release
 fi
@@ -237,7 +241,9 @@ WITH_CLANG_TIDY=OFF
 WITH_GLIBC_COMPAT=OFF
 WITH_COMPRESS=ON
 THIN_ARCHIVE=OFF
-if starrocks_is_darwin; then
+if starrocks_is_darwin || is_riscv64_host; then
+    # riscv64: the official starcache binary is built from an unpublished
+    # internal source tree; see be/CMakeLists.txt (WITH_STARCACHE_DEFAULT).
     WITH_STARCACHE=OFF
 else
     WITH_STARCACHE=ON
@@ -247,7 +253,11 @@ WITH_PAIMON_CPP=OFF
 USE_STAROS=OFF
 BUILD_JAVA_EXT=ON
 OUTPUT_COMPILE_TIME=OFF
-if starrocks_is_darwin; then
+if starrocks_is_darwin || is_riscv64_host; then
+    # riscv64: tenann ships prebuilt binaries only (no riscv64 build and no
+    # buildable upstream source); see thirdparty/vars-riscv64.sh
+    # RISCV64_UNSUPPORTED_PACKAGES. The vector-index code paths are compiled
+    # out via the missing WITH_TENANN define.
     WITH_TENANN=OFF
 else
     WITH_TENANN=ON
@@ -498,6 +508,15 @@ if starrocks_is_darwin; then
     fi
 elif is_aarch64_host; then
     JAVA_LIBRARY_PATH=${JAVA_HOME}/jre/lib/aarch64/server/
+elif is_riscv64_host; then
+    # RISC-V uses JDK 11+ (e.g. Adoptium Temurin 21), where libjvm.so lives in
+    # ${JAVA_HOME}/lib/server/ (modular layout, no jre/ subdir). Fall back to the
+    # legacy jre/lib/riscv64/server/ layout for older distributions.
+    if [[ -d "${JAVA_HOME}/lib/server" ]]; then
+        JAVA_LIBRARY_PATH=${JAVA_HOME}/lib/server/
+    else
+        JAVA_LIBRARY_PATH=${JAVA_HOME}/jre/lib/riscv64/server/
+    fi
 else
     JAVA_LIBRARY_PATH=${JAVA_HOME}/jre/lib/amd64/server/
 fi

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -159,7 +159,8 @@ WITH_CONNECTOR_BENCHMARK=ON
 WITH_CONNECTOR_ELASTICSEARCH=ON
 WITH_CONNECTOR_JDBC=ON
 WITH_CONNECTOR_MYSQL=ON
-if starrocks_is_darwin; then
+if starrocks_is_darwin || [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+    # riscv64: no buildable starcache source; see be/CMakeLists.txt.
     WITH_STARCACHE=OFF
 else
     WITH_STARCACHE=ON
@@ -167,7 +168,11 @@ fi
 WITH_DEBUG_SYMBOL_SPLIT=ON
 BUILD_JAVA_EXT=ON
 BUILD_TARGET=
-if starrocks_is_darwin; then
+if starrocks_is_darwin || [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+    # riscv64: tenann ships prebuilt binaries only (no riscv64 build and no
+    # buildable upstream source); see thirdparty/vars-riscv64.sh
+    # RISCV64_UNSUPPORTED_PACKAGES. The vector-index code paths are compiled
+    # out via the missing WITH_TENANN define.
     WITH_TENANN=OFF
 else
     WITH_TENANN=ON
@@ -405,6 +410,8 @@ done < <(find "${CMAKE_BUILD_DIR}" -type f \( -name "*.so" -o -name "*.so.*" -o 
 jvm_arch="amd64"
 if [[ "${MACHINE_TYPE}" == "aarch64" || "${MACHINE_TYPE}" == "arm64" ]]; then
     jvm_arch="aarch64"
+elif [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+    jvm_arch="riscv64"
 fi
 
 if starrocks_is_darwin; then

--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -374,6 +374,8 @@ build_openssl() {
     OPENSSL_PLATFORM="linux-x86_64"
     if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
         OPENSSL_PLATFORM="linux-aarch64"
+    elif [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        OPENSSL_PLATFORM="linux64-riscv64"
     fi
 
     check_if_source_exist $OPENSSL_SOURCE
@@ -421,11 +423,22 @@ build_thrift() {
 # llvm
 build_llvm() {
     export CFLAGS="-O3 -fno-omit-frame-pointer -std=c99 -D_POSIX_C_SOURCE=200112L ${FILE_PREFIX_MAP_OPTION}"
-    export CXXFLAGS="-O3 -fno-omit-frame-pointer -Wno-class-memaccess ${FILE_PREFIX_MAP_OPTION}"
+    # gcc 15 (riscv64 host) no longer provides <cstdint> types transitively;
+    # llvm/ADT/SmallVector.h relies on that implicit include for
+    # uint64_t/uint32_t. `-include cstdint' injects it into every translation
+    # unit in one shot. Delivered via the exported CXXFLAGS, which CMake picks
+    # up as the initial CMAKE_CXX_FLAGS.
+    local llvm_cxxflags="-O3 -fno-omit-frame-pointer -Wno-class-memaccess ${FILE_PREFIX_MAP_OPTION}"
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        llvm_cxxflags="${llvm_cxxflags} -include cstdint"
+    fi
+    export CXXFLAGS="${llvm_cxxflags}"
 
     LLVM_TARGET="X86"
     if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
         LLVM_TARGET="AArch64"
+    elif [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        LLVM_TARGET="RISCV"
     fi
 
     LLVM_TARGETS_TO_BUILD=(
@@ -489,6 +502,11 @@ build_llvm() {
         LLVM_TARGETS_TO_BUILD+=("LLVMX86Info" "LLVMX86Desc" "LLVMX86CodeGen" "LLVMX86AsmParser" "LLVMX86Disassembler")
     elif [ "${LLVM_TARGET}" == "AArch64" ]; then
         LLVM_TARGETS_TO_BUILD+=("LLVMAArch64Info" "LLVMAArch64Desc" "LLVMAArch64CodeGen" "LLVMAArch64Utils" "LLVMAArch64AsmParser" "LLVMAArch64Disassembler")
+    elif [ "${LLVM_TARGET}" == "RISCV" ]; then
+        # No LLVMRISCVUtils here: unlike AArch64, LLVM 18's RISCV target has
+        # no Utils component (subdirs are AsmParser Disassembler MCTargetDesc
+        # MCA TargetInfo only), and make fails with "No rule to make target".
+        LLVM_TARGETS_TO_BUILD+=("LLVMRISCVInfo" "LLVMRISCVDesc" "LLVMRISCVCodeGen" "LLVMRISCVAsmParser" "LLVMRISCVDisassembler")
     fi
 
     LLVM_TARGETS_TO_INSTALL=()
@@ -567,11 +585,23 @@ build_glog() {
     check_if_source_exist $GLOG_SOURCE
     cd $TP_SOURCE_DIR/$GLOG_SOURCE
 
+    # glog's CMake defaults WITH_UNWIND=libunwind, which selects the
+    # stacktrace_libunwind-inl.h path and references _U<arch>_getcontext.
+    # On riscv64 the system libunwind does not resolve that symbol at link
+    # time, breaking the build. WITH_UNWIND=none is glog's official switch to
+    # disable unwinding entirely (CMAKE_DISABLE_FIND_PACKAGE_Unwind); it
+    # mirrors the historical *-remove-unwind-dependency patches for 0.3.3/0.4.0.
+    local glog_unwind_flags=""
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        glog_unwind_flags="-DWITH_UNWIND=none"
+    fi
+
     $CMAKE_CMD -G "${CMAKE_GENERATOR}" \
         -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
         -DBUILD_SHARED_LIBS=OFF \
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-        -DCMAKE_INSTALL_LIBDIR=lib
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        ${glog_unwind_flags}
 
     ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
@@ -687,7 +717,11 @@ build_gperftools() {
     check_if_source_exist $GPERFTOOLS_SOURCE
     cd $TP_SOURCE_DIR/$GPERFTOOLS_SOURCE
 
-    if [ ! -f configure ]; then
+    # Re-run autogen when configure.ac/m4 are newer than configure: the
+    # riscv64 pc_from_ucontext patch edits m4/, and a configure left over
+    # from a previous build (which autogen generated before that patch)
+    # silently keeps the old probe list and disables the cpu profiler.
+    if [[ ! -f configure || configure.ac -nt configure || m4/pc_from_ucontext.m4 -nt configure ]]; then
         ./autogen.sh
     fi
 
@@ -783,7 +817,14 @@ build_boost() {
     cd $TP_SOURCE_DIR/$BOOST_SOURCE
 
     # It is difficult to generate static linked b2, so we use LD_LIBRARY_PATH instead
-    ./bootstrap.sh --prefix=$TP_INSTALL_DIR
+    # Pin the toolset explicitly. The root bootstrap.sh has a strict option whitelist
+    # (it rejects engine-only options such as --cxx=) and, when no toolset is given,
+    # clears CXX/CXXFLAGS and asks tools/build/src/engine/build.sh to guess — which
+    # probes bare `g++` from PATH and dies with "Could not find a suitable toolset"
+    # when that lookup fails. --with-toolset=gcc skips the guess step; the engine
+    # still probes `g++`, which resolves to ${STARROCKS_GCC_HOME}/bin/g++ because
+    # this script already prepended it to PATH.
+    ./bootstrap.sh --prefix=$TP_INSTALL_DIR --with-toolset=gcc
     LD_LIBRARY_PATH=${STARROCKS_GCC_HOME}/lib:${STARROCKS_GCC_HOME}/lib64:${LD_LIBRARY_PATH} \
     ./b2 link=static runtime-link=static -j $PARALLEL --without-test --without-mpi --without-graph --without-graph_parallel --without-python cxxflags="-std=c++11 -g -fPIC -I$TP_INCLUDE_DIR -L$TP_LIB_DIR ${FILE_PREFIX_MAP_OPTION}" install
 }
@@ -837,6 +878,20 @@ build_kerberos() {
     cd $TP_SOURCE_DIR/$KRB5_SOURCE/src
     CFLAGS="-std=gnu17 -fcommon -fPIC ${FILE_PREFIX_MAP_OPTION}" LDFLAGS="-L$TP_INSTALL_DIR/lib -pthread -ldl" \
     ./configure --prefix=$TP_INSTALL_DIR --enable-static --disable-shared --with-spake-openssl=$TP_INSTALL_DIR
+    # MIT krb5's configure injects a strict -Werror=<flag> set into WARN_CFLAGS
+    # (see its configure: "for flag in ... error=discarded-qualifiers ...").
+    # On newer gcc (e.g. the SpacemiT K3 toolchain) krb5 1.19.4 trips
+    # -Werror=discarded-qualifiers: strchr()/strstr() return const char* but
+    # are assigned to char* (e.g. ccbase.c:207). Those are benign (the pointer
+    # is never written through), so downgrade that one -Werror= back to a
+    # warning by appending -Wno-error=discarded-qualifiers to the end of every
+    # generated WARN_CFLAGS (gcc honors the last flag of a kind). Idempotent:
+    # skip Makefiles already patched. Only applied on riscv64 where the newer
+    # gcc triggers this; other arches keep krb5's intended diagnostics.
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        find . -name Makefile -exec sed -i \
+            '/^WARN_CFLAGS[[:space:]]*=/ { /-Wno-error=discarded-qualifiers/! s/$/ -Wno-error=discarded-qualifiers/; }' {} +
+    fi
     make -j$PARALLEL
     make install
 }
@@ -845,7 +900,25 @@ build_kerberos() {
 build_sasl() {
     check_if_source_exist $SASL_SOURCE
     cd $TP_SOURCE_DIR/$SASL_SOURCE
-    CFLAGS="-fPIC" LDFLAGS="-L$TP_INSTALL_DIR/lib -lresolv -pthread -ldl" ./autogen.sh --prefix=$TP_INSTALL_DIR --enable-gssapi=yes --enable-static --disable-shared --with-openssl=$TP_INSTALL_DIR --with-gss_impl=mit --with-dblib=none
+
+    # riscv64: saslauthd/auth_shadow.c is the only cyrus-sasl unit that calls
+    # the password-hashing crypt(), which needs libcrypt (libxcrypt). Build the
+    # daemon whenever the linkable libcrypt.so is present (e.g. openEuler with
+    # libxcrypt-devel installed); only when it is missing (e.g. Bianbu without
+    # a standalone libcrypt) fall back to --with-saslauthd=no -- there the
+    # configure probe `cannot find -lcrypt' fails so hard it aborts even the
+    # basic "C compiler works" test. StarRocks itself only links the libsasl2
+    # client library (be/CMakeLists.txt) and the default plugins
+    # (plain/cram/digest/otp/gssapi/scram), none of which use crypt(), so the
+    # fallback is lossless for the BE binary. x86_64/aarch64 always build it.
+    local sasl_extra_conf=""
+    # (-x c before '-' so gcc reads the heredoc as C source, not link input)
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]] && ! ${CC:-cc} -x c -lcrypt -o /dev/null - <<< 'int main(void){return 0;}'; then
+        echo "riscv64: no linkable libcrypt, skipping saslauthd"
+        sasl_extra_conf="--with-saslauthd=no"
+    fi
+
+    CFLAGS="-fPIC" LDFLAGS="-L$TP_INSTALL_DIR/lib -lresolv -pthread -ldl" ./autogen.sh --prefix=$TP_INSTALL_DIR --enable-gssapi=yes --enable-static --disable-shared --with-openssl=$TP_INSTALL_DIR --with-gss_impl=mit --with-dblib=none $sasl_extra_conf
     make -j$PARALLEL
     make install
 }
@@ -872,8 +945,17 @@ build_pulsar() {
 
     cd $TP_SOURCE_DIR/$PULSAR_SOURCE
 
+    # gcc 15 (riscv64 host) no longer provides <cstdint> transitively; pulsar's
+    # public headers use uint64_t etc. without including it. `-include cstdint'
+    # injects the header into every translation unit. Other arches are untouched.
+    local -a pulsar_cmake_args=()
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        pulsar_cmake_args+=("-DCMAKE_CXX_FLAGS=-include cstdint")
+    fi
+
     $CMAKE_CMD -DCMAKE_LIBRARY_PATH=$TP_INSTALL_DIR/lib -DCMAKE_INCLUDE_PATH=$TP_INSTALL_DIR/include \
-        -DPROTOC_PATH=$TP_INSTALL_DIR/bin/protoc -DOPENSSL_ROOT_DIR=$TP_INSTALL_DIR -DBUILD_TESTS=OFF -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_DYNAMIC_LIB=OFF .
+        -DPROTOC_PATH=$TP_INSTALL_DIR/bin/protoc -DOPENSSL_ROOT_DIR=$TP_INSTALL_DIR -DBUILD_TESTS=OFF -DBUILD_PYTHON_WRAPPER=OFF -DBUILD_DYNAMIC_LIB=OFF \
+        "${pulsar_cmake_args[@]}" .
     ${BUILD_SYSTEM} -j$PARALLEL
 
     cp lib/libpulsar.a $TP_INSTALL_DIR/lib/
@@ -931,7 +1013,12 @@ build_arrow() {
     export ARROW_ZSTD_URL=${TP_SOURCE_DIR}/${ZSTD_NAME}
     export ARROW_THRIFT_URL=${TP_SOURCE_DIR}/${THRIFT_NAME}
     export LDFLAGS="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc"
-    if [[ "$THIRD_PARTY_BUILD_WITH_AVX2" == "OFF" ]] ; then
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        # RISC-V has no SSE/AVX; let Arrow auto-detect (DEFAULT) at compile time
+        # and disable runtime SIMD dispatch (NONE) since there is no x86 path to select.
+        arrow_simd_level=DEFAULT
+        arrow_runtime_simd_level=NONE
+    elif [[ "$THIRD_PARTY_BUILD_WITH_AVX2" == "OFF" ]] ; then
         # https://github.com/apache/arrow/blob/main/cpp/cmake_modules/DefineOptions.cmake#L179
         # default to SSE4_2 on x86 and NEON on Arm
         arrow_simd_level=DEFAULT
@@ -1009,6 +1096,16 @@ build_s2() {
     mkdir -p $BUILD_DIR
     cd $BUILD_DIR
     rm -rf CMakeCache.txt CMakeFiles/
+
+    # gcc 15 (riscv64 host) no longer provides <cstdint> transitively; s2's
+    # bundled absl copy (s2/third_party/absl/container/internal/container_memory.h)
+    # uses uintptr_t without including it. `-include cstdint' fixes every
+    # translation unit. Other arches are untouched.
+    local -a s2_cmake_args=()
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        s2_cmake_args+=("-DCMAKE_CXX_FLAGS=-include cstdint")
+    fi
+
     LDFLAGS="-L${TP_LIB_DIR} -static-libstdc++ -static-libgcc" \
     $CMAKE_CMD -G "${CMAKE_GENERATOR}" -DBUILD_SHARED_LIBS=0 -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
     -DCMAKE_INCLUDE_PATH="$TP_INSTALL_DIR/include" \
@@ -1018,7 +1115,8 @@ build_s2() {
     -DWITH_GFLAGS=ON \
     -DGLOG_ROOT_DIR="$TP_INSTALL_DIR/include" \
     -DWITH_GLOG=ON \
-    -DCMAKE_LIBRARY_PATH="$TP_INSTALL_DIR/lib;$TP_INSTALL_DIR/lib64" ..
+    -DCMAKE_LIBRARY_PATH="$TP_INSTALL_DIR/lib;$TP_INSTALL_DIR/lib64" \
+    "${s2_cmake_args[@]}" ..
     ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
 }
@@ -1037,6 +1135,9 @@ build_bitshuffle() {
     # Becuase aarch64 don't support avx2, disable it.
     if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
         arches="default neon"
+    elif [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        # bitshuffle has no RVV variant; build only the scalar (default) path.
+        arches="default"
     fi
 
     to_link=""
@@ -1082,8 +1183,10 @@ build_bitshuffle() {
 # When this problem is solved, a switch will be added to control.
 build_croaringbitmap() {
     FORCE_AVX=ON
-    # avx2 is not supported by aarch64.
+    # avx2 is not supported by aarch64 and riscv64.
     if [[ "${MACHINE_TYPE}" == "aarch64" ]]; then
+        FORCE_AVX=FALSE
+    elif [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
         FORCE_AVX=FALSE
     fi
     if [[ `cat /proc/cpuinfo |grep avx|wc -l` == "0" ]]; then
@@ -1238,9 +1341,19 @@ build_hyperscan() {
         FAT_RUNTIME_FLAG="-DFAT_RUNTIME=OFF"
     fi
 
+    # riscv64: the zte-riscv/vectorscan fork's vectorscan-rv branch provides a
+    # native riscv64 backend (cmake/platform.cmake detects ARCH_RISCV64, then
+    # cflags-riscv64.cmake probes RVV/Zbb/Zbc/Zicsr and falls back to scalar if
+    # the toolchain lacks them), so no SIMDe emulation layer is needed.
+    # BUILD_STATIC_LIBS=ON is required because vectorscan defaults it to OFF
+    # (unlike hyperscan), and BE links libhs.a statically.
+    local hs_extra_flags=""
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        hs_extra_flags="-DBUILD_STATIC_LIBS=ON"
+    fi
     $CMAKE_CMD -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${TP_INSTALL_DIR} -DBOOST_ROOT=$STARROCKS_THIRDPARTY/installed/include \
           -DCMAKE_CXX_COMPILER=$STARROCKS_GCC_HOME/bin/g++ -DCMAKE_C_COMPILER=$STARROCKS_GCC_HOME/bin/gcc  -DCMAKE_INSTALL_LIBDIR=lib \
-          -DBUILD_EXAMPLES=OFF -DBUILD_UNIT=OFF -DBUILD_BENCHMARKS=OFF ${FAT_RUNTIME_FLAG}
+          -DBUILD_EXAMPLES=OFF -DBUILD_UNIT=OFF -DBUILD_BENCHMARKS=OFF ${FAT_RUNTIME_FLAG} $hs_extra_flags
     ${BUILD_SYSTEM} -j$PARALLEL
     ${BUILD_SYSTEM} install
 }
@@ -1252,7 +1365,15 @@ build_mariadb() {
 
     unset CXXFLAGS
     unset CPPFLAGS
-    export CFLAGS="-O3 -fno-omit-frame-pointer -fPIC ${FILE_PREFIX_MAP_OPTION}"
+    # gcc 15 defaults to C23 (gnu23), where bool is a keyword and mariadb's
+    # `typedef char bool;' (include/ma_global.h) no longer compiles. Pin gnu11
+    # on riscv64 (the only gcc 15 host in this build matrix) so the old C
+    # dialect keeps that typedef legal.
+    local mariadb_c_std=""
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        mariadb_c_std="-std=gnu11"
+    fi
+    export CFLAGS="-O3 -fno-omit-frame-pointer -fPIC ${mariadb_c_std} ${FILE_PREFIX_MAP_OPTION}"
 
     # force use make build system, since ninja doesn't support install only headers
     CMAKE_GENERATOR="Unix Makefiles"
@@ -1365,6 +1486,9 @@ build_jemalloc() {
     local addition_opts
     if [[ $MACHINE_TYPE == "aarch64" ]] ; then
         # 64K for arm architecture
+        addition_opts=" --with-lg-page=16"
+    elif [[ $MACHINE_TYPE == "riscv64" ]] ; then
+        # change to 64K for riscv64 (e.g. SG2042 and other server SoCs use 64KiB pages)
         addition_opts=" --with-lg-page=16"
     else
         addition_opts=" --with-lg-page=12"
@@ -1511,9 +1635,21 @@ build_avro_cpp() {
 
 # serders
 build_serdes() {
-    export CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g"
+    # The C23/gcc-15 once_flag collision in tinycthread is fixed at source
+    # level (patches/libserdes-7.3.1-tinycthread-c23.patch, applied by
+    # download-thirdparty.sh). The gnu17 pin below stays as belt-and-braces
+    # for any other C23-vs-old-C code in this 2022 library.
+    local serdes_c_std=""
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        serdes_c_std="-std=gnu17"
+    fi
+    export CFLAGS="-O3 -fno-omit-frame-pointer -fPIC -g ${serdes_c_std}"
     check_if_source_exist $SERDES_SOURCE
     cd $TP_SOURCE_DIR/$SERDES_SOURCE
+    # mklove's configure caches CFLAGS into ./config.cache and reuses it on
+    # re-runs, which silently drops flag changes (and triple-accumulates them
+    # across runs). Remove the cache so the flags above take effect.
+    rm -f config.cache
     export LIBS="-lrt -lpthread -lcurl -ljansson -lrdkafka -lrdkafka++ -lavro -lssl -lcrypto -ldl"
     ./configure --prefix=${TP_INSTALL_DIR} \
                 --libdir=${TP_INSTALL_DIR}/lib \
@@ -1607,10 +1743,23 @@ build_absl() {
     check_if_source_exist "${ABSL_SOURCE}"
     cd "$TP_SOURCE_DIR/${ABSL_SOURCE}"
 
+    # gcc 15's libstdc++ stopped providing <cstdint> types (uintptr_t and
+    # friends) transitively; this 2022 abseil relies on that implicit include
+    # in dozens of headers, so `-include cstdint' forces the header into every
+    # translation unit's preprocessor in one shot instead of patching each file.
+    # riscv64 is the only machine type that ships gcc 15 in this build matrix.
+    # Use an array so the value keeps its space as one -D argument, and leaves
+    # the CMake call untouched (no -DCMAKE_CXX_FLAGS override) on other arches.
+    local -a absl_cmake_args=()
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        absl_cmake_args+=("-DCMAKE_CXX_FLAGS=-include cstdint")
+    fi
+
     ${CMAKE_CMD} -G "${CMAKE_GENERATOR}" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DCMAKE_INSTALL_PREFIX="$TP_INSTALL_DIR" \
-        -DCMAKE_CXX_STANDARD=17
+        -DCMAKE_CXX_STANDARD=17 \
+        "${absl_cmake_args[@]}"
 
     ${BUILD_SYSTEM} -j "${PARALLEL}"
     ${BUILD_SYSTEM} install
@@ -1741,6 +1890,15 @@ build_azure() {
     export AZURE_SDK_DISABLE_AUTO_VCPKG=true
     export PKG_CONFIG_LIBDIR=$TP_INSTALL_DIR
 
+    # gcc 15 (riscv64 host) no longer provides <cstdint> types transitively;
+    # azure attestation's crypto.hpp uses uint8_t without including it.
+    # Same -include cstdint injection as abseil/pulsar/s2/llvm. Array form
+    # keeps the space in one -D arg; empty (no -D) on other arches.
+    local -a azure_cmake_args=()
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]]; then
+        azure_cmake_args+=("-DCMAKE_CXX_FLAGS=-include cstdint")
+    fi
+
     ${CMAKE_CMD} -DCMAKE_INSTALL_PREFIX=$TP_INSTALL_DIR \
         -DBUILD_SHARED_LIBS=OFF \
         -DDISABLE_AZURE_CORE_OPENTELEMETRY=ON \
@@ -1750,7 +1908,8 @@ build_azure() {
         -DOPENSSL_ROOT_DIR=$TP_INSTALL_DIR \
         -DOPENSSL_USE_STATIC_LIBS=TRUE \
         -DLibXml2_ROOT=$TP_INSTALL_DIR \
-        -DCMAKE_INSTALL_LIBDIR=lib
+        -DCMAKE_INSTALL_LIBDIR=lib \
+        "${azure_cmake_args[@]}"
 
     ${BUILD_SYSTEM} -j "${PARALLEL}"
     ${BUILD_SYSTEM} install
@@ -1821,7 +1980,23 @@ build_paimon_cpp() {
         unset "${arrow_url_var}"
     done
 
+    # riscv64: paimon bundles ORC v2.1.1 as an ExternalProject and patches it
+    # with its own cmake_modules/orc.diff at build time. ORC's CpuInfoUtil.cc
+    # only knows X86/ARM; every other arch (riscv64 included) falls into the
+    # generic "PPC, ..." stub whose bodies ignore their parameters, and ORC's
+    # STOP_BUILD_ON_WARNING defaults ON (-Werror), so the stub fails with
+    # unused-parameter errors on riscv64. Append our hunk (consume the
+    # parameters with plain (void) casts -- the UNUSED macro in this file is
+    # only defined inside the X86 branch, so it does not exist on the generic
+    # path) to the in-tree orc.diff so the ExternalProject's PATCH_COMMAND
+    # applies both in one pass. The guard file keeps the append idempotent across re-runs;
+    # x86_64/aarch64 never enter this branch.
     cd $TP_SOURCE_DIR/$PAIMON_CPP_SOURCE
+    if [[ "${MACHINE_TYPE}" == "riscv64" ]] && [[ ! -f cmake_modules/orc.diff.riscv64 ]] ; then
+        cat $TP_PATCH_DIR/paimon-cpp-0.3.0-orc-riscv64-unused.patch >> cmake_modules/orc.diff
+        touch cmake_modules/orc.diff.riscv64
+    fi
+
     mkdir -p $BUILD_DIR
     cd $BUILD_DIR
     rm -rf CMakeCache.txt CMakeFiles/

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -312,6 +312,55 @@ do
         continue
     fi
 
+    # git-sourced packages (e.g. vectorscan/starcache on riscv64, which have
+    # no prebuilt binary tarball): clone instead of calling download_func,
+    # which treats an empty DOWNLOAD URL as a hard error. A package is a git
+    # source when its <PKG>_GIT_URL variable is non-empty.
+    GIT_URL_VAR=$TP_ARCH"_GIT_URL"
+    GIT_BRANCH_VAR=$TP_ARCH"_GIT_BRANCH"
+    GIT_COMMIT_VAR=$TP_ARCH"_GIT_COMMIT"
+    SOURCE_VAR=$TP_ARCH"_SOURCE"
+    if [[ -n "${!GIT_URL_VAR}" ]]; then
+        if [[ -d "$TP_SOURCE_DIR/${!SOURCE_VAR}" ]]; then
+            echo "Git source ${!SOURCE_VAR} already exists, skip clone."
+        else
+            echo "Cloning ${!SOURCE_VAR} from ${!GIT_URL_VAR} (${!GIT_BRANCH_VAR})"
+            git clone --depth 1 -b "${!GIT_BRANCH_VAR}" "${!GIT_URL_VAR}" "$TP_SOURCE_DIR/${!SOURCE_VAR}"
+            if [[ $? -ne 0 ]]; then
+                echo "Failed to git clone ${!SOURCE_VAR}"
+                exit 1
+            fi
+            # A branch tip is mutable: the same StarRocks commit could build
+            # different code as the fork advances. When <PKG>_GIT_COMMIT is
+            # set, check out that exact revision so builds are reproducible.
+            # (--depth 1 -b fetched only the branch tip, so if the pinned
+            # commit is not the tip, fetch it explicitly first.)
+            if [[ -n "${!GIT_COMMIT_VAR}" ]]; then
+                git -C "$TP_SOURCE_DIR/${!SOURCE_VAR}" cat-file -e "${!GIT_COMMIT_VAR}^{commit}" 2>/dev/null || \
+                git -C "$TP_SOURCE_DIR/${!SOURCE_VAR}" fetch --depth 1 origin "${!GIT_COMMIT_VAR}" || {
+                    echo "Failed to fetch ${!GIT_COMMIT_VAR} for ${!SOURCE_VAR}"
+                    exit 1
+                }
+                git -C "$TP_SOURCE_DIR/${!SOURCE_VAR}" checkout -q "${!GIT_COMMIT_VAR}" || {
+                    echo "Failed to pin ${!SOURCE_VAR} at commit ${!GIT_COMMIT_VAR}"
+                    exit 1
+                }
+            fi
+        fi
+        continue
+    fi
+
+    # Packages that are neither a git source nor a tarball download (empty
+    # <PKG>_DOWNLOAD with no <PKG>_GIT_URL) are excluded packages on this
+    # architecture (e.g. tenann/pprof on riscv64, filtered out of the build by
+    # package-manifest.sh but still present in the static TP_ARCHIVES list).
+    # Skip them instead of letting download_func fail on the empty URL.
+    URL=$TP_ARCH"_DOWNLOAD"
+    if [[ -z "${!URL}" ]]; then
+        echo "Skip ${TP_ARCH}: no download URL and not a git source (excluded package)."
+        continue
+    fi
+
     NAME=$TP_ARCH"_NAME"
     MD5SUM=$TP_ARCH"_MD5SUM"
     if test "x$REPOSITORY_URL" = x; then
@@ -527,6 +576,7 @@ if [[ -d $TP_SOURCE_DIR/$ROCKSDB_SOURCE ]] ; then
         apply_patch -p1 $TP_PATCH_DIR/rocksdb-6.22.1-metadata-header.patch
         apply_patch -p1 $TP_PATCH_DIR/rocksdb-6.22.1-gcc14.patch
         apply_patch -p1 $TP_PATCH_DIR/rocksdb-6.22.1-gcc14-extra.patch
+        apply_patch -p1 $TP_PATCH_DIR/rocksdb-6.22.1-riscv64-toku_time.patch
         touch $PATCHED_MARK
     fi
     cd -
@@ -551,7 +601,10 @@ if [[ -d $TP_SOURCE_DIR/$BRPC_SOURCE ]] ; then
         touch $PATCHED_MARK
     fi
     if [ ! -f $PATCHED_MARK ] && [ $BRPC_SOURCE == "brpc-1.9.0" ]; then
-        apply_patch $TP_PATCH_DIR/brpc-1.9.0.patch
+        apply_patch -p1 $TP_PATCH_DIR/brpc-1.9.0.patch
+        apply_patch -p1 $TP_PATCH_DIR/brpc-1.9.0-riscv64.patch
+        apply_patch -p1 $TP_PATCH_DIR/brpc-1.9.0-riscv64-atomic64.patch
+        apply_patch -p1 $TP_PATCH_DIR/brpc-1.9.0-riscv64-fcontext.patch
         touch $PATCHED_MARK
     fi
     cd -
@@ -601,6 +654,13 @@ if [[ -d $TP_SOURCE_DIR/$GPERFTOOLS_SOURCE ]] ; then
     if [ ! -f $PATCHED_MARK ] && [ $GPERFTOOLS_SOURCE = "gperftools-gperftools-2.7" ]; then
         apply_patch -p1 $TP_PATCH_DIR/tcmalloc_hook.patch
         apply_patch -p1 $TP_PATCH_DIR/gperftools_20251105.patch
+        apply_patch -p1 $TP_PATCH_DIR/gperftools-2.7-riscv64-cacheline.patch
+        apply_patch -p1 $TP_PATCH_DIR/gperftools-2.7-riscv64-futex.patch
+        apply_patch -p1 $TP_PATCH_DIR/gperftools-2.7-riscv64-mmap.patch
+        apply_patch -p1 $TP_PATCH_DIR/gperftools-2.7-riscv64-pc-from-ucontext.patch
+        # LSS riscv64 fallback: must come after the pc-from-ucontext patch so
+        # the patch chain stays in the same order as this list.
+        apply_patch -p1 $TP_PATCH_DIR/gperftools-2.7-riscv64-lss.patch
         touch $PATCHED_MARK
     fi
     cd -
@@ -760,6 +820,13 @@ if [[ -d $TP_SOURCE_DIR/$SERDES_SOURCE ]] ; then
     cd $TP_SOURCE_DIR/$SERDES_SOURCE
     if [ ! -f $PATCHED_MARK ] && [ $SERDES_SOURCE = "libserdes-7.3.1" ]; then
         apply_patch -p0 $TP_PATCH_DIR/libserdes-7.3.1.patch
+        # Rename tinycthread's once_flag/call_once/ONCE_FLAG_INIT to
+        # tct_once_flag/tct_call_once/TCT_ONCE_FLAG_INIT. This host's glibc
+        # declares the C2x once_flag/call_once even in gnu17 mode (not gated
+        # by __STDC_VERSION__ as upstream glibc is), so the emulating macros
+        # clash with glibc's declarations regardless of the -std= flag. The
+        # rename removes the collision unconditionally.
+        apply_patch -p1 $TP_PATCH_DIR/libserdes-7.3.1-tinycthread-c23.patch
         touch $PATCHED_MARK
     fi
     echo "Finished patching $SERDES_SOURCE"
@@ -774,9 +841,34 @@ if [[ -d $TP_SOURCE_DIR/$SASL_SOURCE ]] ; then
         apply_patch -p1 $TP_PATCH_DIR/sasl2-gcc14.patch
         # Keep md5.h ANSI prototypes enabled for the compilers StarRocks uses.
         apply_patch -p1 $TP_PATCH_DIR/sasl2-makemd5-prototypes.patch
+        # Fix K&R signal-handler declarations in saslauthd: handle_sigchld()/
+        # server_exit() are assigned to sa_handler (__sighandler_t = void(int))
+        # but declared void() (K&R empty params). GCC 14 turns the resulting
+        # -Wincompatible-pointer-types into a hard error by default.
+        apply_patch -p1 $TP_PATCH_DIR/sasl2-saslauthd-signal-handlers.patch
         touch $PATCHED_MARK
     fi
     echo "Finished patching $SASL_SOURCE"
+    cd -
+fi
+
+# patch openssl
+if [[ -d $TP_SOURCE_DIR/$OPENSSL_SOURCE ]] ; then
+    cd $TP_SOURCE_DIR/$OPENSSL_SOURCE
+    if [ ! -f $PATCHED_MARK ] && [ $OPENSSL_SOURCE = "openssl-3.5.7" ]; then
+        # 3.5.7 is the first pinned openssl with a riscv64 assembly path
+        # (aes-riscv64.pl). AES_set_decrypt_key tail-calls AES_set_encrypt_key
+        # with a bare `jal ra,<sym>` -- the only symbol-jal in all riscv64 asm
+        # generators. JAL reaches +/-1MiB and the linker cannot relax it wider
+        # into auipc+jalr, so any consumer statically linking the whole
+        # libcrypto.a into a large .so (e.g. libbrpc.so) exceeds the range and
+        # fails with "relocation truncated to fit: R_RISCV_JAL". Replace it
+        # with the `call` pseudo-instruction (auipc+jalr, +/-2GiB), which is
+        # what the callee-saved sequence around it already assumes.
+        apply_patch -p1 $TP_PATCH_DIR/openssl-3.5.7-riscv64-jal-range.patch
+        touch $PATCHED_MARK
+    fi
+    echo "Finished patching $OPENSSL_SOURCE"
     cd -
 fi
 

--- a/thirdparty/package-manifest.sh
+++ b/thirdparty/package-manifest.sh
@@ -125,6 +125,10 @@ starrocks_set_default_packages() {
     if [[ "$(uname -s)" == "Darwin" ]]; then
         starrocks_filter_default_packages "${DARWIN_UNSUPPORTED_PACKAGES:-}"
     fi
+
+    if [[ "${machine_type}" == "riscv64" ]]; then
+        starrocks_filter_default_packages "${RISCV64_UNSUPPORTED_PACKAGES:-}"
+    fi
 }
 
 # Print the packages of the default order starting from the given one, i.e. the

--- a/thirdparty/patches/brpc-1.9.0-riscv64-atomic64.patch
+++ b/thirdparty/patches/brpc-1.9.0-riscv64-atomic64.patch
@@ -1,0 +1,203 @@
+diff --git a/src/butil/atomicops.h b/src/butil/atomicops.h
+index cda1529..d5523dc 100644
+--- a/src/butil/atomicops.h
++++ b/src/butil/atomicops.h
+@@ -157,6 +157,8 @@ Atomic64 Release_Load(volatile const Atomic64* ptr);
+ #include "butil/atomicops_internals_mips_gcc.h"
+ #elif defined(COMPILER_GCC) && defined(ARCH_CPU_LOONGARCH64_FAMILY)
+ #include "butil/atomicops_internals_loongarch64_gcc.h"
++#elif defined(COMPILER_GCC) && defined(ARCH_CPU_RISCV64_FAMILY)
++#include "butil/atomicops_internals_riscv64_gcc.h"
+ #else
+ #error "Atomic operations are not supported on your platform"
+ #endif
+diff --git a/src/butil/atomicops_internals_riscv64_gcc.h b/src/butil/atomicops_internals_riscv64_gcc.h
+new file mode 100644
+index 0000000..5648802
+--- /dev/null
++++ b/src/butil/atomicops_internals_riscv64_gcc.h
+@@ -0,0 +1,184 @@
++// Copyright 2024 The Chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// This file is an internal atomic implementation, include butil/atomicops.h
++// instead. RISC-V 64 implementation using GCC __sync builtins, mirroring
++// atomicops_internals_gcc.h but additionally providing the Atomic64 overloads
++// that a 64-bit target requires. GCC lowers these to lr.w/sc.w (32-bit) and
++// lr.d/sc.d (64-bit) on riscv64.
++
++#ifndef BUTIL_ATOMICOPS_INTERNALS_RISCV64_GCC_H_
++#define BUTIL_ATOMICOPS_INTERNALS_RISCV64_GCC_H_
++
++namespace butil {
++namespace subtle {
++
++inline void MemoryBarrier() {
++  __sync_synchronize();
++}
++
++inline Atomic32 NoBarrier_CompareAndSwap(volatile Atomic32* ptr,
++                                         Atomic32 old_value,
++                                         Atomic32 new_value) {
++  Atomic32 prev_value;
++  do {
++    if (__sync_bool_compare_and_swap(ptr, old_value, new_value))
++      return old_value;
++    prev_value = *ptr;
++  } while (prev_value == old_value);
++  return prev_value;
++}
++
++inline Atomic32 NoBarrier_AtomicExchange(volatile Atomic32* ptr,
++                                         Atomic32 new_value) {
++  Atomic32 old_value;
++  do {
++    old_value = *ptr;
++  } while (!__sync_bool_compare_and_swap(ptr, old_value, new_value));
++  return old_value;
++}
++
++inline Atomic32 Barrier_AtomicIncrement(volatile Atomic32* ptr,
++                                        Atomic32 increment) {
++  for (;;) {
++    Atomic32 old_value = *ptr;
++    Atomic32 new_value = old_value + increment;
++    if (__sync_bool_compare_and_swap(ptr, old_value, new_value)) {
++      return new_value;
++    }
++  }
++}
++
++inline Atomic32 NoBarrier_AtomicIncrement(volatile Atomic32* ptr,
++                                          Atomic32 increment) {
++  return Barrier_AtomicIncrement(ptr, increment);
++}
++
++inline Atomic32 Acquire_CompareAndSwap(volatile Atomic32* ptr,
++                                       Atomic32 old_value,
++                                       Atomic32 new_value) {
++  // __sync_bool_compare_and_swap is a full memory barrier.
++  return NoBarrier_CompareAndSwap(ptr, old_value, new_value);
++}
++
++inline Atomic32 Release_CompareAndSwap(volatile Atomic32* ptr,
++                                       Atomic32 old_value,
++                                       Atomic32 new_value) {
++  return NoBarrier_CompareAndSwap(ptr, old_value, new_value);
++}
++
++inline void NoBarrier_Store(volatile Atomic32* ptr, Atomic32 value) {
++  *ptr = value;
++}
++
++inline void Acquire_Store(volatile Atomic32* ptr, Atomic32 value) {
++  *ptr = value;
++  MemoryBarrier();
++}
++
++inline void Release_Store(volatile Atomic32* ptr, Atomic32 value) {
++  MemoryBarrier();
++  *ptr = value;
++}
++
++inline Atomic32 NoBarrier_Load(volatile const Atomic32* ptr) {
++  return *ptr;
++}
++
++inline Atomic32 Acquire_Load(volatile const Atomic32* ptr) {
++  Atomic32 value = *ptr;
++  MemoryBarrier();
++  return value;
++}
++
++inline Atomic32 Release_Load(volatile const Atomic32* ptr) {
++  MemoryBarrier();
++  return *ptr;
++}
++
++// 64-bit versions of the operations. On riscv64 Atomic64 == intptr_t == long,
++// so these are the overloads actually invoked by LazyInstance and friends.
++
++inline Atomic64 NoBarrier_CompareAndSwap(volatile Atomic64* ptr,
++                                         Atomic64 old_value,
++                                         Atomic64 new_value) {
++  Atomic64 prev_value;
++  do {
++    if (__sync_bool_compare_and_swap(ptr, old_value, new_value))
++      return old_value;
++    prev_value = *ptr;
++  } while (prev_value == old_value);
++  return prev_value;
++}
++
++inline Atomic64 NoBarrier_AtomicExchange(volatile Atomic64* ptr,
++                                         Atomic64 new_value) {
++  Atomic64 old_value;
++  do {
++    old_value = *ptr;
++  } while (!__sync_bool_compare_and_swap(ptr, old_value, new_value));
++  return old_value;
++}
++
++inline Atomic64 Barrier_AtomicIncrement(volatile Atomic64* ptr,
++                                        Atomic64 increment) {
++  for (;;) {
++    Atomic64 old_value = *ptr;
++    Atomic64 new_value = old_value + increment;
++    if (__sync_bool_compare_and_swap(ptr, old_value, new_value)) {
++      return new_value;
++    }
++  }
++}
++
++inline Atomic64 NoBarrier_AtomicIncrement(volatile Atomic64* ptr,
++                                          Atomic64 increment) {
++  return Barrier_AtomicIncrement(ptr, increment);
++}
++
++inline Atomic64 Acquire_CompareAndSwap(volatile Atomic64* ptr,
++                                       Atomic64 old_value,
++                                       Atomic64 new_value) {
++  return NoBarrier_CompareAndSwap(ptr, old_value, new_value);
++}
++
++inline Atomic64 Release_CompareAndSwap(volatile Atomic64* ptr,
++                                       Atomic64 old_value,
++                                       Atomic64 new_value) {
++  return NoBarrier_CompareAndSwap(ptr, old_value, new_value);
++}
++
++inline void NoBarrier_Store(volatile Atomic64* ptr, Atomic64 value) {
++  *ptr = value;
++}
++
++inline void Acquire_Store(volatile Atomic64* ptr, Atomic64 value) {
++  *ptr = value;
++  MemoryBarrier();
++}
++
++inline void Release_Store(volatile Atomic64* ptr, Atomic64 value) {
++  MemoryBarrier();
++  *ptr = value;
++}
++
++inline Atomic64 NoBarrier_Load(volatile const Atomic64* ptr) {
++  return *ptr;
++}
++
++inline Atomic64 Acquire_Load(volatile const Atomic64* ptr) {
++  Atomic64 value = *ptr;
++  MemoryBarrier();
++  return value;
++}
++
++inline Atomic64 Release_Load(volatile const Atomic64* ptr) {
++  MemoryBarrier();
++  return *ptr;
++}
++
++}  // namespace butil::subtle
++}  // namespace butil
++
++#endif  // BUTIL_ATOMICOPS_INTERNALS_RISCV64_GCC_H_

--- a/thirdparty/patches/brpc-1.9.0-riscv64-fcontext.patch
+++ b/thirdparty/patches/brpc-1.9.0-riscv64-fcontext.patch
@@ -1,0 +1,148 @@
+diff --git a/src/bthread/context.cpp b/src/bthread/context.cpp
+index bafa927..730fabb 100644
+--- a/src/bthread/context.cpp
++++ b/src/bthread/context.cpp
+@@ -900,3 +900,129 @@ __asm (
+ );
+ 
+ #endif
++
++// riscv64 implementation (LP64D ABI). Mirrors the aarch64 design: ra is both a
++// saved register (offset 192) and double-written to a PC slot (offset 200), so
++// that make_fcontext can seed func into the PC slot and finish into the ra slot
++// independently. Callee-saved: fs0-fs11, s0-s11. Frame layout (jump/make agree):
++//   0..95 fs0-fs11, 96..191 s0-s11, 192 ra-slot, 200 PC-slot. Total 208 bytes.
++#if defined(BTHREAD_CONTEXT_PLATFORM_linux_riscv64) && defined(BTHREAD_CONTEXT_COMPILER_gcc)
++__asm (
++".text\n"
++".align  3\n"
++".global bthread_jump_fcontext\n"
++".type   bthread_jump_fcontext, @function\n"
++"bthread_jump_fcontext:\n"
++"    # reserve context-data on current stack\n"
++"    addi sp, sp, -208\n"
++
++"    # save fs0-fs11 (0..95)\n"
++"    fsd fs0,  0(sp)\n"
++"    fsd fs1,  8(sp)\n"
++"    fsd fs2, 16(sp)\n"
++"    fsd fs3, 24(sp)\n"
++"    fsd fs4, 32(sp)\n"
++"    fsd fs5, 40(sp)\n"
++"    fsd fs6, 48(sp)\n"
++"    fsd fs7, 56(sp)\n"
++"    fsd fs8, 64(sp)\n"
++"    fsd fs9, 72(sp)\n"
++"    fsd fs10, 80(sp)\n"
++"    fsd fs11, 88(sp)\n"
++
++"    # save s0-s11 (96..191)\n"
++"    sd s0,  96(sp)\n"
++"    sd s1, 104(sp)\n"
++"    sd s2, 112(sp)\n"
++"    sd s3, 120(sp)\n"
++"    sd s4, 128(sp)\n"
++"    sd s5, 136(sp)\n"
++"    sd s6, 144(sp)\n"
++"    sd s7, 152(sp)\n"
++"    sd s8, 160(sp)\n"
++"    sd s9, 168(sp)\n"
++"    sd s10, 176(sp)\n"
++"    sd s11, 184(sp)\n"
++
++"    # save ra into its register slot (192) and double-write into PC slot (200)\n"
++"    sd ra, 192(sp)\n"
++"    sd ra, 200(sp)\n"
++
++"    # store current sp into *ofc (a0)\n"
++"    sd sp, 0(a0)\n"
++"    # switch sp to nfc (a1)\n"
++"    mv sp, a1\n"
++
++"    # restore fs0-fs11\n"
++"    fld fs0,  0(sp)\n"
++"    fld fs1,  8(sp)\n"
++"    fld fs2, 16(sp)\n"
++"    fld fs3, 24(sp)\n"
++"    fld fs4, 32(sp)\n"
++"    fld fs5, 40(sp)\n"
++"    fld fs6, 48(sp)\n"
++"    fld fs7, 56(sp)\n"
++"    fld fs8, 64(sp)\n"
++"    fld fs9, 72(sp)\n"
++"    fld fs10, 80(sp)\n"
++"    fld fs11, 88(sp)\n"
++
++"    # restore s0-s11\n"
++"    ld s0,  96(sp)\n"
++"    ld s1, 104(sp)\n"
++"    ld s2, 112(sp)\n"
++"    ld s3, 120(sp)\n"
++"    ld s4, 128(sp)\n"
++"    ld s5, 136(sp)\n"
++"    ld s6, 144(sp)\n"
++"    ld s7, 152(sp)\n"
++"    ld s8, 160(sp)\n"
++"    ld s9, 168(sp)\n"
++"    ld s10, 176(sp)\n"
++"    ld s11, 184(sp)\n"
++
++"    # vp (a2) becomes return value (a0) of resumed context\n"
++"    mv a0, a2\n"
++"    # restore ra from its register slot (192); on first entry from make it is finish\n"
++"    ld ra, 192(sp)\n"
++"    # load resumed PC from PC slot (200); on first entry from make it is the func\n"
++"    ld t0, 200(sp)\n"
++"    # pop context-data\n"
++"    addi sp, sp, 208\n"
++"    # jump to resumed PC\n"
++"    jr t0\n"
++".size   bthread_jump_fcontext,.-bthread_jump_fcontext\n"
++"# Mark that we don't need executable stack.\n"
++".section .note.GNU-stack,\"\",%progbits\n"
++);
++#endif
++
++#if defined(BTHREAD_CONTEXT_PLATFORM_linux_riscv64) && defined(BTHREAD_CONTEXT_COMPILER_gcc)
++__asm (
++".text\n"
++".align  3\n"
++".global bthread_make_fcontext\n"
++".type   bthread_make_fcontext, @function\n"
++"bthread_make_fcontext:\n"
++"    # align a0 (allocated stack top) to 16 bytes\n"
++"    andi a0, a0, -16\n"
++"    # reserve context-data\n"
++"    addi a0, a0, -208\n"
++
++"    # a2 == context-function entry; store as resumed PC (200)\n"
++"    sd a2, 200(a0)\n"
++"    # store finish as ra (192): when the context-function returns, 'ret' jumps\n"
++"    # to ra == finish\n"
++"    lla t0, finish\n"
++"    sd t0, 192(a0)\n"
++
++"    ret\n"
++"finish:\n"
++"    # exit code zero\n"
++"    li a0, 0\n"
++"    call _exit\n"
++".size   bthread_make_fcontext,.-bthread_make_fcontext\n"
++"# Mark that we don't need executable stack.\n"
++".section .note.GNU-stack,\"\",%progbits\n"
++);
++#endif
+diff --git a/src/bthread/context.h b/src/bthread/context.h
+index 8de85af..3f3485b 100644
+--- a/src/bthread/context.h
++++ b/src/bthread/context.h
+@@ -42,6 +42,9 @@
+         #elif __loongarch64
+             #define BTHREAD_CONTEXT_PLATFORM_linux_loongarch64
+             #define BTHREAD_CONTEXT_CALL_CONVENTION
++        #elif __riscv && (__riscv_xlen == 64)
++            #define BTHREAD_CONTEXT_PLATFORM_linux_riscv64
++            #define BTHREAD_CONTEXT_CALL_CONVENTION
+ 	#endif
+ 
+   #elif defined(__MINGW32__) || defined (__MINGW64__)

--- a/thirdparty/patches/brpc-1.9.0-riscv64.patch
+++ b/thirdparty/patches/brpc-1.9.0-riscv64.patch
@@ -1,0 +1,47 @@
+diff --git a/src/butil/build_config.h b/src/butil/build_config.h
+index 5ddf382..c35ace2 100644
+--- a/src/butil/build_config.h
++++ b/src/butil/build_config.h
+@@ -138,6 +138,11 @@
+ #define ARCH_CPU_LOONGARCH64 1
+ #define ARCH_CPU_64_BITS 1
+ #define ARCH_CPU_LITTLE_ENDIAN 1
++#elif defined(__riscv) && (__riscv_xlen == 64)
++#define ARCH_CPU_RISCV64_FAMILY 1
++#define ARCH_CPU_RISCV64 1
++#define ARCH_CPU_64_BITS 1
++#define ARCH_CPU_LITTLE_ENDIAN 1
+ #else
+ #error Please add support for your architecture in butil/build_config.h
+ #endif
+diff --git a/src/butil/time.h b/src/butil/time.h
+index 005f551..b489221 100644
+--- a/src/butil/time.h
++++ b/src/butil/time.h
+@@ -254,6 +254,10 @@ inline uint64_t clock_cycles() {
+         : "=r" (stable_counter), "=r" (counter_id)
+         );
+     return stable_counter;
++#elif defined(__riscv) && (__riscv_xlen == 64)
++    uint64_t cycles;
++    __asm__ __volatile__ ("rdcycle %0" : "=r"(cycles));
++    return cycles;
+ #else
+   #error "unsupported arch"
+ #endif
+diff --git a/src/bthread/processor.h b/src/bthread/processor.h
+index 0dc26a5..7f0e4d0 100644
+--- a/src/bthread/processor.h
++++ b/src/bthread/processor.h
+@@ -30,6 +30,11 @@
+ # define cpu_relax() asm volatile("yield\n": : :"memory")
+ #elif defined(ARCH_CPU_LOONGARCH64_FAMILY)
+ # define cpu_relax() asm volatile("nop\n": : :"memory");
++#elif defined(ARCH_CPU_RISCV64_FAMILY)
++// 'pause' hint requires the Zihintpause extension in -march; emit the base-ISA
++// fence-based spin hint (same one glibc and Linux use) instead, which assembles
++// unconditionally on rv64gc.
++# define cpu_relax() asm volatile("fence iorw, io" : : : "memory")
+ #else
+ # define cpu_relax() asm volatile("pause\n": : :"memory")
+ #endif

--- a/thirdparty/patches/gperftools-2.7-riscv64-cacheline.patch
+++ b/thirdparty/patches/gperftools-2.7-riscv64-cacheline.patch
@@ -1,0 +1,14 @@
+diff --git a/src/base/basictypes.h b/src/base/basictypes.h
+index 42dbe5c..041aad1 100644
+--- a/src/base/basictypes.h
++++ b/src/base/basictypes.h
+@@ -381,6 +381,9 @@ class AssignAttributeStartEnd {
+ # elif (defined(__aarch64__))
+ #   define CACHELINE_ALIGNED __attribute__((aligned(64)))
+     // implementation specific, Cortex-A53 and 57 should have 64 bytes
++# elif (defined(__riscv))
++#   define CACHELINE_ALIGNED __attribute__((aligned(64)))
++    // RISC-V implementations (e.g. SpacemiT K3) typically have 64-byte cache lines
+ # elif (defined(__s390__))
+ #   define CACHELINE_ALIGNED __attribute__((aligned(256)))
+ # else

--- a/thirdparty/patches/gperftools-2.7-riscv64-futex.patch
+++ b/thirdparty/patches/gperftools-2.7-riscv64-futex.patch
@@ -1,0 +1,27 @@
+diff --git a/src/base/spinlock_linux-inl.h b/src/base/spinlock_linux-inl.h
+index aadf62a..88a1702 100644
+--- a/src/base/spinlock_linux-inl.h
++++ b/src/base/spinlock_linux-inl.h
+@@ -38,6 +38,22 @@
+ #include <limits.h>
+ #include "base/linux_syscall_support.h"
+ 
++#include <sys/syscall.h>
++#include <unistd.h>
++
++// gperftools 2.7's bundled linux_syscall_support.h only enables its inline
++// syscall wrappers for x86/arm/mips/ppc/aarch64/s390 (see its top-level #if).
++// On riscv64 the whole header is a no-op, so sys_futex is never declared and
++// spinlock_internal.cc fails to compile. Fall back to the glibc syscall()
++// wrapper for __NR_futex (declared in <unistd.h>, syscall number in
++// <sys/syscall.h>), which is what LSS would have generated anyway.
++#if defined(__riscv) && !defined(sys_futex)
++static inline int sys_futex(int *uaddr, int op, int val,
++                            void *timeout, void *uaddr2, int val3) {
++  return syscall(__NR_futex, uaddr, op, val, timeout, uaddr2, val3);
++}
++#endif
++
+ #define FUTEX_WAIT 0
+ #define FUTEX_WAKE 1
+ #define FUTEX_PRIVATE_FLAG 128

--- a/thirdparty/patches/gperftools-2.7-riscv64-lss.patch
+++ b/thirdparty/patches/gperftools-2.7-riscv64-lss.patch
@@ -1,0 +1,317 @@
+diff --git a/src/base/linux_syscall_support.h b/src/base/linux_syscall_support.h
+index 13aa415..efbd252 100644
+--- a/src/base/linux_syscall_support.h
++++ b/src/base/linux_syscall_support.h
+@@ -2909,5 +2909,311 @@ struct kernel_stat {
+ }
+ #endif
+ 
+-#endif
++#endif  /* end of the arch guard above: everything so far is a no-op on riscv64 */
++
++/* ------------------------------------------------------------------------
++ * riscv64 fallback for gperftools' bundled linux_syscall_support.h copy.
++ *
++ * The stock header above compiles away entirely on riscv64: its top-level
++ * #if lists only x86-32/64, ARM, MIPS, PPC, s390(x) and aarch64. Files that
++ * include it (profile-handler.cc, base/linuxthreads.cc,
++ * malloc_hook_mmap_linux.h) then fail with "sys_gettid was not declared"
++ * and friends. Re-define the subset they use, backed by glibc plus raw
++ * syscalls (__NR_gettid/__NR_getdents64/__NR_prctl/__NR_clone have no
++ * glibc wrapper). kernel_* type layouts follow LSS's own non-mips layouts
++ * so the callers compile unchanged; the glibc sigset_t (128 bytes) is
++ * bridged by copy, never by pointer cast. Other architectures are
++ * unaffected. Kept inside the include guard.
++ * ---------------------------------------------------------------------- */
++#if defined(__riscv) && __riscv_xlen == 64 && defined(__linux)
++
++#include <errno.h>
++#include <fcntl.h>
++#include <sched.h>
++#include <signal.h>
++#include <stdint.h>
++#include <string.h>
++#include <sys/ptrace.h>
++#include <sys/socket.h>
++#include <sys/stat.h>
++#include <sys/syscall.h>
++#include <sys/types.h>
++#include <sys/wait.h>
++#include <unistd.h>
++
++#define KERNEL_NSIG 64
++
++struct kernel_sigset_t {
++  unsigned long sig[(KERNEL_NSIG + 8*sizeof(unsigned long) - 1)/
++                    (8*sizeof(unsigned long))];
++};
++
++/* LSS non-mips field order (same as the stock definition above). */
++struct kernel_sigaction {
++  union {
++    void             (*sa_handler_)(int);
++    void             (*sa_sigaction_)(int, siginfo_t *, void *);
++  };
++  unsigned long      sa_flags;
++  void               (*sa_restorer)(void);
++  struct kernel_sigset_t sa_mask;
++};
++
++/* LSS kernel_stat (x86_64-style layout; only the fields linuxthreads.cc
++ * compares -- st_dev/st_ino and friends -- are filled in by the wrappers). */
++struct kernel_stat {
++  unsigned long              st_dev;
++  unsigned long              st_ino;
++  unsigned long              st_nlink;
++  unsigned int               st_mode;
++  unsigned int               st_uid;
++  unsigned int               st_gid;
++  unsigned int               __pad0;
++  unsigned long              st_rdev;
++  unsigned long              st_size;
++  unsigned long              st_blksize;
++  unsigned long              st_blocks;
++  unsigned long              st_atime_;
++  unsigned long              st_atime_nsec_;
++  unsigned long              st_mtime_;
++  unsigned long              st_mtime_nsec_;
++  unsigned long              st_ctime_;
++  unsigned long              st_ctime_nsec_;
++  unsigned long              __unused[3];
++};
++
++/* include/linux/dirent.h -- same as stock. */
++struct kernel_dirent64 {
++  unsigned long long d_ino;
++  long long          d_off;
++  unsigned short     d_reclen;
++  unsigned char      d_type;
++  char               d_name[256];
++};
++
++#define KERNEL_DIRENT kernel_dirent64
++#define GETDENTS      sys_getdents64
++
++static inline int sys_gettid(void) {
++  return (int)syscall(__NR_gettid);
++}
++
++static inline int sys__exit(int status) {
++  _exit(status);
++  return 0;
++}
++
++static inline int sys_getppid(void) {
++  return getppid();
++}
++
++static inline int sys_sched_yield(void) {
++  return sched_yield();
++}
++
++static inline int sys_socket(int domain, int type, int protocol) {
++  return socket(domain, type, protocol);
++}
++
++static inline int sys_fcntl(int fd, int cmd, long arg) {
++  return fcntl(fd, cmd, arg);
++}
++
++static inline int sys_open(const char *path, int flags, int mode) {
++  return open(path, flags, mode);
++}
++
++static inline int sys_close(int fd) {
++  return close(fd);
++}
++
++static inline ssize_t sys_read(int fd, void *buf, size_t count) {
++  return read(fd, buf, count);
++}
++
++static inline off_t sys_lseek(int fd, off_t offset, int whence) {
++  return lseek(fd, offset, whence);
++}
++
++static inline int sys_fstat(int fd, struct kernel_stat *st) {
++  struct stat glibc_st;
++  int rc = fstat(fd, &glibc_st);
++  if (rc == 0) {
++    st->st_dev     = glibc_st.st_dev;
++    st->st_ino     = glibc_st.st_ino;
++    st->st_nlink   = glibc_st.st_nlink;
++    st->st_mode    = glibc_st.st_mode;
++    st->st_uid     = glibc_st.st_uid;
++    st->st_gid     = glibc_st.st_gid;
++    st->st_rdev    = glibc_st.st_rdev;
++    st->st_size    = glibc_st.st_size;
++    st->st_blksize = glibc_st.st_blksize;
++    st->st_blocks  = glibc_st.st_blocks;
++  }
++  return rc;
++}
++
++static inline int sys_stat(const char *path, struct kernel_stat *st) {
++  struct stat glibc_st;
++  int rc = stat(path, &glibc_st);
++  if (rc == 0) {
++    st->st_dev     = glibc_st.st_dev;
++    st->st_ino     = glibc_st.st_ino;
++    st->st_nlink   = glibc_st.st_nlink;
++    st->st_mode    = glibc_st.st_mode;
++    st->st_uid     = glibc_st.st_uid;
++    st->st_gid     = glibc_st.st_gid;
++    st->st_rdev    = glibc_st.st_rdev;
++    st->st_size    = glibc_st.st_size;
++    st->st_blksize = glibc_st.st_blksize;
++    st->st_blocks  = glibc_st.st_blocks;
++  }
++  return rc;
++}
++
++static inline int sys_getdents64(int fd, struct kernel_dirent64 *dirp, size_t count) {
++  return (int)syscall(__NR_getdents64, fd, dirp, count);
++}
++
++static inline pid_t sys_waitpid(pid_t pid, int *status, int options) {
++  return waitpid(pid, status, options);
++}
++
++static inline int sys_prctl(int option, unsigned long arg2) {
++  return (int)syscall(__NR_prctl, option, arg2);
++}
++
++/* Raw syscall: glibc's ptrace() and its __ptrace_request enum are only
++ * declared under _GNU_SOURCE, which gperftools translation units do not
++ * guarantee. linuxthreads.cc passes PTRACE_* constants from <sys/ptrace.h>. */
++static inline long sys_ptrace(int request, pid_t pid, void *addr, void *data) {
++  return syscall(__NR_ptrace, request, pid, addr, data);
++}
++
++/* Mirrors the stock LSS ptrace_detach: yielding before PTRACE_DETACH reduces
++ * the risk of the tracee missing the detach and getting job-control signals
++ * sent to the real parent; SIGCONT right after wakes it up. */
++static inline int sys_ptrace_detach(pid_t pid) {
++  int rc, err;
++  sched_yield();
++  rc = (int)syscall(__NR_ptrace, PTRACE_DETACH, pid, (void *)0, (void *)0);
++  err = errno;
++  kill(pid, SIGCONT);
++  errno = err;
++  return rc;
++}
++
++static inline int sys_sigaltstack(const stack_t *ss, const stack_t *oss) {
++  return sigaltstack(ss, (stack_t *)oss);
++}
++
++static inline int sys_sigfillset(struct kernel_sigset_t *set) {
++  memset(&set->sig, -1, sizeof(set->sig));
++  return 0;
++}
++
++static inline int sys_sigemptyset(struct kernel_sigset_t *set) {
++  memset(&set->sig, 0, sizeof(set->sig));
++  return 0;
++}
++
++static inline int sys_sigdelset(struct kernel_sigset_t *set, int signum) {
++  if (signum < 1 || signum > (int)(8*sizeof(set->sig))) {
++    errno = EINVAL;
++    return -1;
++  }
++  set->sig[(signum - 1)/(8*sizeof(set->sig[0]))]
++      &= ~(1UL << ((signum - 1) % (8*sizeof(set->sig[0]))));
++  return 0;
++}
++
++static inline int sys_sigaction(int signum, const struct kernel_sigaction *act,
++                                struct kernel_sigaction *oldact) {
++  struct sigaction sa, sa_old;
++  struct sigaction *sa_ptr = act ? &sa : NULL;
++  struct sigaction *old_ptr = oldact ? &sa_old : NULL;
++  if (act) {
++    memset(&sa, 0, sizeof(sa));
++    sa.sa_handler = act->sa_handler_;
++    sa.sa_flags = (int)act->sa_flags;
++    /* glibc's sa_mask is a full 128-byte sigset_t; LSS's is 8 bytes. */
++    memcpy(&sa.sa_mask, &act->sa_mask, sizeof(act->sa_mask));
++  }
++  int rc = sigaction(signum, sa_ptr, old_ptr);
++  if (rc == 0 && oldact) {
++    memset(oldact, 0, sizeof(*oldact));
++    oldact->sa_handler_ = sa_old.sa_handler;
++    oldact->sa_flags = (unsigned long)sa_old.sa_flags;
++    memcpy(&oldact->sa_mask, &sa_old.sa_mask, sizeof(oldact->sa_mask));
++  }
++  return rc;
++}
++
++static inline int sys_sigprocmask(int how, const struct kernel_sigset_t *set,
++                                  struct kernel_sigset_t *oldset) {
++  /* LSS's kernel_sigset_t (8 bytes) is NOT layout-compatible with glibc's
++   * 128-byte sigset_t; bridge by copy, never by pointer cast. */
++  sigset_t s, s_old;
++  sigset_t *set_ptr = NULL;
++  sigset_t *old_ptr = oldset ? &s_old : NULL;
++  if (set) {
++    memset(&s, 0, sizeof(s));
++    memcpy(&s, set, sizeof(*set));
++    set_ptr = &s;
++  }
++  int rc = sigprocmask(how, set_ptr, old_ptr);
++  if (rc == 0 && oldset) {
++    memset(oldset, 0, sizeof(*oldset));
++    memcpy(oldset, &s_old, sizeof(*oldset));
++  }
++  return rc;
++}
++
++/* LSS clone() contract: the child (which shares the caller's address space;
++ * linuxthreads.cc always passes CLONE_VM) runs fn(arg) on child_stack and
++ * exits with its return value; the parent gets the child pid.
++ *
++ * Implemented as raw ecall with register-asm variables, same pattern as
++ * glibc's riscv64 syscall()/clone(): fn/arg ride in callee-saved s0/s1,
++ * which the kernel preserves across clone, and the whole child path stays
++ * inside the asm block so the compiler never reloads them relative to the
++ * (switched) stack pointer. Kernel argument order on riscv64 is
++ * a0=flags, a1=newsp, a2=parent_tidptr, a3=child_tidptr, a4=tls -- note
++ * child_tidptr before tls, same as glibc's riscv64 clone.S. child_stack is
++ * aligned down to 16 bytes for the psABI. glibc's clone() is avoided
++ * because its declaration needs _GNU_SOURCE and its variadic prototype
++ * could conflict with <sched.h>.
++ */
++static inline pid_t sys_clone(int (*fn)(void *), void *child_stack, int flags,
++                              void *arg, pid_t *parent_tidptr, void *newtls,
++                              pid_t *child_tidptr) {
++  register int (*fn_r)(void *) __asm__("s0") = fn;
++  register void *arg_r __asm__("s1") = arg;
++  register long a0 __asm__("a0") = flags;
++  register long a1 __asm__("a1") = (long)((uintptr_t)child_stack & ~(uintptr_t)15);
++  register long a2 __asm__("a2") = (long)parent_tidptr;
++  register long a3 __asm__("a3") = (long)child_tidptr;
++  register long a4 __asm__("a4") = (long)newtls;
++  register long a7 __asm__("a7") = __NR_clone;
++  __asm__ __volatile__(
++      "ecall\n"
++      "bnez a0, 1f\n"
++      "mv a0, %7\n"
++      "jalr %6\n"
++      "li a7, %8\n"
++      "ecall\n"
++      "1:\n"
++      : "+r"(a0), "+r"(a1), "+r"(a2), "+r"(a3), "+r"(a4), "+r"(a7)
++      : "r"(fn_r), "r"(arg_r), "i"(__NR_exit)
++      : "memory");
++  /* LSS_RETURN: kernel returns -errno in [-4095, -1]. */
++  if ((unsigned long)a0 < (unsigned long)-4095UL) {
++    return (pid_t)a0;
++  }
++  errno = (int)-a0;
++  return (pid_t)-1;
++}
++
++#endif /* __riscv && __riscv_xlen == 64 && __linux */
++
+ #endif

--- a/thirdparty/patches/gperftools-2.7-riscv64-mmap.patch
+++ b/thirdparty/patches/gperftools-2.7-riscv64-mmap.patch
@@ -1,0 +1,43 @@
+diff --git a/src/malloc_hook_mmap_linux.h b/src/malloc_hook_mmap_linux.h
+index 2f6116f..86635ff 100644
+--- a/src/malloc_hook_mmap_linux.h
++++ b/src/malloc_hook_mmap_linux.h
+@@ -46,6 +46,30 @@
+ #include <errno.h>
+ #include "base/linux_syscall_support.h"
+ 
++#include <sys/syscall.h>
++#include <unistd.h>
++
++// gperftools 2.7's bundled linux_syscall_support.h is a no-op on riscv64 (its
++// top-level arch guard lists only x86/arm/mips/ppc/aarch64/s390), so sys_mmap,
++// sys_munmap and sys_mremap are never declared. Provide them via the glibc
++// syscall() wrapper, matching the LSS signatures so do_mmap64/munmap/mremap
++// below compile unchanged. riscv64 uses the plain 6-arg mmap syscall (no
++// mmap2), same as aarch64/x86_64. __off64_t matches do_mmap64's offset type.
++#if defined(__riscv) && !defined(sys_mmap)
++static inline void* sys_mmap(void *start, size_t length, int prot, int flags,
++                             int fd, __off64_t offset) {
++  return (void*)syscall(__NR_mmap, start, length, prot, flags, fd, offset);
++}
++static inline int sys_munmap(void *start, size_t length) {
++  return (int)syscall(__NR_munmap, start, length);
++}
++static inline void* sys_mremap(void *old_address, size_t old_size,
++                               size_t new_size, int flags, void *new_address) {
++  return (void*)syscall(__NR_mremap, old_address, old_size, new_size, flags,
++                        new_address);
++}
++#endif
++
+ // The x86-32 case and the x86-64 case differ:
+ // 32b has a mmap2() syscall, 64b does not.
+ // 64b and 32b have different calling conventions for mmap().
+@@ -55,6 +79,7 @@
+ #if defined(__x86_64__) \
+     || defined(__PPC64__) \
+     || defined(__aarch64__) \
++    || defined(__riscv) \
+     || (defined(_MIPS_SIM) && (_MIPS_SIM == _ABI64 || _MIPS_SIM == _ABIN32)) \
+     || defined(__s390__)
+ 

--- a/thirdparty/patches/gperftools-2.7-riscv64-pc-from-ucontext.patch
+++ b/thirdparty/patches/gperftools-2.7-riscv64-pc-from-ucontext.patch
@@ -1,0 +1,17 @@
+diff --git a/m4/pc_from_ucontext.m4 b/m4/pc_from_ucontext.m4
+index 8b3e9a4..1c2f5d3 100644
+--- a/m4/pc_from_ucontext.m4
++++ b/m4/pc_from_ucontext.m4
+@@ -24,6 +24,12 @@
+    pc_fields="           uc_mcontext.gregs[[REG_PC]]"  # Solaris x86 (32 + 64 bit)
+    pc_fields="$pc_fields uc_mcontext.gregs[[REG_EIP]]" # Linux (i386)
+    pc_fields="$pc_fields uc_mcontext.gregs[[REG_RIP]]" # Linux (x86_64)
++  dnl glibc riscv64: mcontext_t exposes the register array as __gregs (no
++  dnl __ctx() renaming like x86's gregs) and defines REG_PC == 0 under
++  dnl _GNU_SOURCE, which this probe's test program already defines. Without
++  dnl this candidate the probe fails, configure silently disables the cpu
++  dnl profiler, and libprofiler + gperftools/profiler.h never get installed.
++  pc_fields="$pc_fields uc_mcontext.__gregs[[REG_PC]]" # Linux (riscv64)
+    pc_fields="$pc_fields uc_mcontext.sc_ip"            # Linux (ia64)
+    pc_fields="$pc_fields uc_mcontext.pc"               # Linux (mips)
+    pc_fields="$pc_fields uc_mcontext.uc_regs->gregs[[PT_NIP]]" # Linux (ppc)

--- a/thirdparty/patches/libserdes-7.3.1-tinycthread-c23.patch
+++ b/thirdparty/patches/libserdes-7.3.1-tinycthread-c23.patch
@@ -1,0 +1,64 @@
+diff --git a/src/tinycthread.h b/src/tinycthread.h
+--- a/src/tinycthread.h
++++ b/src/tinycthread.h
+@@ -461,11 +461,11 @@
+   typedef struct {
+     LONG volatile status;
+     CRITICAL_SECTION lock;
+-  } once_flag;
+-  #define ONCE_FLAG_INIT {0,}
++  } tct_once_flag;
++  #define TCT_ONCE_FLAG_INIT {0,}
+ #else
+-  #define once_flag pthread_once_t
+-  #define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
++  #define tct_once_flag pthread_once_t
++  #define TCT_ONCE_FLAG_INIT PTHREAD_ONCE_INIT
+ #endif
+ 
+ /** Invoke a callback exactly once
+@@ -474,9 +474,9 @@
+  * @param func Callback to invoke.
+  */
+ #if defined(_TTHREAD_WIN32_)
+-  void call_once(once_flag *flag, void (*func)(void));
++  void tct_call_once(tct_once_flag *flag, void (*func)(void));
+ #else
+-  #define call_once(flag,func) pthread_once(flag,func)
++  #define tct_call_once(flag,func) pthread_once(flag,func)
+ #endif
+ 
+ 
+diff --git a/src/tinycthread.c b/src/tinycthread.c
+--- a/src/tinycthread.c
++++ b/src/tinycthread.c
+@@ -925,7 +925,7 @@
+ #endif /* _TTHREAD_EMULATE_TIMESPEC_GET_ */
+ 
+ #if defined(_TTHREAD_WIN32_)
+-void call_once(once_flag *flag, void (*func)(void))
++void tct_call_once(tct_once_flag *flag, void (*func)(void))
+ {
+   /* The idea here is that we use a spin lock (via the
+      InterlockedCompareExchange function) to restrict access to the
+diff --git a/src/rest.c b/src/rest.c
+--- a/src/rest.c
++++ b/src/rest.c
+@@ -23,7 +23,7 @@
+ #include "rest.h"
+ #include "tinycthread.h"
+ 
+-static once_flag rest_global_init_once = ONCE_FLAG_INIT;
++static tct_once_flag rest_global_init_once = TCT_ONCE_FLAG_INIT;
+ 
+ static void unittest_url_encode (void);
+ 
+@@ -42,7 +42,7 @@
+ }
+ 
+ static void rest_init (void) {
+-        call_once(&rest_global_init_once, rest_init_cb);
++        tct_call_once(&rest_global_init_once, rest_init_cb);
+ }
+ 
+ 

--- a/thirdparty/patches/linux_syscall_support.h
+++ b/thirdparty/patches/linux_syscall_support.h
@@ -4555,4 +4555,190 @@ struct kernel_statfs {
 #endif
 
 #endif
+
+/* ------------------------------------------------------------------------
+ * riscv64 fallback for breakpad.
+ *
+ * The stock LSS above compiles away entirely on riscv64: its top-level #if
+ * lists only x86-32/64, ARM, MIPS, PPC, s390(x) and aarch64, and everything
+ * -- the kernel_* structs and all sys_* wrappers -- lives inside that guard.
+ * breakpad (which upstream assumes a riscv64-aware LSS) then fails with
+ * 'sys_mmap was not declared'. This block redefines the small subset
+ * breakpad actually uses, backed by glibc (raw ecall where glibc has no
+ * wrapper). That trades away LSS's "no libc needed after a crash" property
+ * on riscv64 only -- acceptable for the best-effort dump-writing path.
+ * Other architectures are completely unaffected.
+ * ---------------------------------------------------------------------- */
+#if defined(__riscv) && __riscv_xlen == 64
+
+/* gettid()/tgkill() and the full struct sigaction need _GNU_SOURCE */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/prctl.h>
+#include <sys/ptrace.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+
+/* ---- kernel_* types ----------------------------------------------------
+ * breakpad refers to them as `struct kernel_X', so token-level #defines to
+ * the glibc names expand correctly. On riscv64 (new-world asm-generic ABI)
+ * the glibc and kernel layouts coincide for all of these, and using the
+ * glibc types keeps CMSG_FIRSTHDR()/st_size & co. type-checking clean.
+ * ---------------------------------------------------------------------- */
+#define kernel_stat       stat
+#define kernel_stat64     stat
+#define kernel_sigset_t   sigset_t
+#define kernel_iovec      iovec
+#define kernel_msghdr     msghdr
+
+/* breakpad accesses LSS's sa_handler_ spelling on a kernel_sigaction, which
+ * glibc's struct sigaction does not have (it is sa_handler). Keep LSS's
+ * layout; sys_rt_sigaction converts to the glibc one. */
+struct kernel_sigaction {
+  void        (*sa_handler_)(int);
+  unsigned long sa_flags;
+  sigset_t   sa_mask;
+};
+
+/* riscv64 (asm-generic ABI) only has getdents64. breakpad's directory_reader
+ * reads only d_reclen/d_name, which the getdents64 record provides. */
+struct kernel_dirent {
+  uint64_t d_ino;
+  int64_t  d_off;
+  unsigned short d_reclen;
+  unsigned char  d_type;
+  char     d_name[];
+};
+
+/* breakpad accesses LSS's sa_handler_ spelling on a kernel_sigaction, which
+ * glibc's struct sigaction does not have. Provide the LSS layout and convert
+ * in the sys_rt_sigaction wrapper below. */
+struct lss_sigaction {
+  void        (*sa_handler_)(int);
+  unsigned long sa_flags;
+  sigset_t   sa_mask;
+};
+
+/* ---- sys_* entry points backed by glibc --------------------------------
+ * Real wrapper functions, NOT `#define sys_X X' token pastes: a macro would
+ * be hijacked by any enclosing C++ member/local of the same name (e.g.
+ * log.cc's logger::write turned `sys_write(2, buf, n)' into a call to the
+ * member). Distinct function names keep lookup unambiguous.
+ * ---------------------------------------------------------------------- */
+static inline int      sys_close(int fd) { return close(fd); }
+static inline void     sys_exit(int status) { _exit(status); }
+static inline int      sys_fstat(int fd, struct kernel_stat* st) { return fstat(fd, st); }
+static inline int      sys_fstat64(int fd, struct kernel_stat64* st) { return fstat(fd, st); }
+static inline pid_t    sys_getpid(void) { return getpid(); }
+static inline off_t    sys_lseek(int fd, off_t off, int whence) { return lseek(fd, off, whence); }
+static inline void*    sys_mmap(void* addr, size_t len, int prot, int flags, int fd, off_t off) { return mmap(addr, len, prot, flags, fd, off); }
+static inline int      sys_munmap(void* addr, size_t len) { return munmap(addr, len); }
+static inline int      sys_open(const char* path, int flags, mode_t mode) { return open(path, flags, mode); }
+static inline int      sys_pipe(int fds[2]) { return pipe(fds); }
+static inline int      sys_prctl(int option, unsigned long a2, unsigned long a3, unsigned long a4, unsigned long a5) { return prctl(option, a2, a3, a4, a5); }
+/* glibc's ptrace takes enum __ptrace_request as its first parameter in C++,
+ * which an int cannot convert to implicitly; cast explicitly. */
+static inline long     sys_ptrace(int request, pid_t pid, void* addr, void* data) { return ptrace((__ptrace_request)request, pid, addr, data); }
+static inline ssize_t  sys_read(int fd, void* buf, size_t count) { return read(fd, buf, count); }
+static inline ssize_t  sys_readlink(const char* path, char* buf, size_t size) { return readlink(path, buf, size); }
+static inline ssize_t  sys_sendmsg(int fd, const struct kernel_msghdr* msg, int flags) { return sendmsg(fd, msg, flags); }
+static inline int      sys_sigaltstack(const stack_t* ss, stack_t* oss) { return sigaltstack(ss, oss); }
+static inline int      sys_sigemptyset(kernel_sigset_t* set) { return sigemptyset(set); }
+static inline int      sys_stat(const char* path, struct kernel_stat* st) { return stat(path, st); }
+static inline pid_t    sys_waitpid(pid_t pid, int* status, int options) { return waitpid(pid, status, options); }
+static inline ssize_t  sys_write(int fd, const void* buf, size_t count) { return write(fd, buf, count); }
+
+/* ---- wrappers where the LSS signature differs from glibc's ------------- */
+
+/* LSS: 4 args (sigsetsize), kernel_sigaction is the LSS layout with the
+ * sa_handler_ field. breakpad always passes old=NULL. */
+static inline int sys_rt_sigaction(int sig, const struct kernel_sigaction* ksa,
+                                   struct kernel_sigaction* kold,
+                                   size_t sigsetsize) {
+  (void)sigsetsize;
+  const struct lss_sigaction* in = (const struct lss_sigaction*)ksa;
+  struct lss_sigaction* out = (struct lss_sigaction*)kold;
+  struct sigaction gsa;
+  struct sigaction gold;
+  struct sigaction* goldp = out ? &gold : NULL;
+  memset(&gsa, 0, sizeof(gsa));
+  if (in) {
+    gsa.sa_handler = in->sa_handler_;
+    gsa.sa_flags = (int)in->sa_flags;
+    memcpy(&gsa.sa_mask, &in->sa_mask, sizeof(gsa.sa_mask));
+  }
+  if (sigaction(sig, in ? &gsa : NULL, goldp) != 0)
+    return -1;
+  if (out) {
+    out->sa_handler_ = gold.sa_handler;
+    out->sa_flags = (unsigned long)gold.sa_flags;
+    memcpy(&out->sa_mask, &gold.sa_mask, sizeof(out->sa_mask));
+  }
+  return 0;
+}
+
+/* glibc has no getdents/getdents64 wrapper; raw syscall. */
+static inline int sys_getdents(int fd, struct kernel_dirent* buf, size_t len) {
+  return (int)syscall(__NR_getdents64, fd, buf, len);
+}
+
+/* glibc only exposes gettid()/tgkill() with _GNU_SOURCE (and tgkill from
+ * 2.30); either may be missing depending on what the including TU pulled in
+ * first. Raw syscalls avoid both hazards. */
+static inline pid_t sys_gettid(void) {
+  return (pid_t)syscall(__NR_gettid);
+}
+
+static inline int sys_tgkill(pid_t tgid, pid_t tid, int sig) {
+  return (int)syscall(__NR_tgkill, tgid, tid, sig);
+}
+
+/* LSS clone(fnc, child_stack, flags, arg, ...) runs fnc(arg) in the child
+ * and exits with its return value; the raw __NR_clone syscall only sets up
+ * the child's stack/registers. Mirrors LSS's x86_64 semantics with a riscv64
+ * ecall. */
+static inline pid_t sys_clone(int (*fnc)(void*), void* child_stack, int flags,
+                              void* arg, pid_t* parent_tidptr, void* newtls,
+                              pid_t* child_tidptr) {
+  /* riscv64 clone ABI: a0=flags, a1=newsp, a2=parent_tidptr,
+   * a3=child_tidptr, a4=tls (same register order as glibc's clone.S). The
+   * kernel adopts newsp as the child's sp, so no userspace stack switch. */
+  register long a0 __asm__("a0") = (long)flags;
+  register long a1 __asm__("a1") = (long)child_stack;
+  register long a2 __asm__("a2") = (long)parent_tidptr;
+  register long a3 __asm__("a3") = (long)child_tidptr;
+  register long a4 __asm__("a4") = (long)newtls;
+  register long a7 __asm__("a7") = (long)__NR_clone;
+  __asm__ __volatile__("ecall"
+                       : "+r"(a0)
+                       : "r"(a1), "r"(a2), "r"(a3), "r"(a4), "r"(a7)
+                       : "memory", "a5", "a6");
+  if (a0 < 0) {
+    errno = (int)-a0;
+    return -1;
+  }
+  if (a0 == 0) {
+    /* child: run fnc(arg), then exit with its value, never returning */
+    long rc = (long)fnc(arg);
+    register long e0 __asm__("a0") = rc;
+    register long e7 __asm__("a7") = (long)__NR_exit;
+    __asm__ __volatile__("ecall" : "+r"(e0) : "r"(e7) : "memory");
+    __builtin_unreachable();
+  }
+  return (pid_t)a0;
+}
+
+#endif /* __riscv && __riscv_xlen == 64 */
 #endif

--- a/thirdparty/patches/openssl-3.5.7-riscv64-jal-range.patch
+++ b/thirdparty/patches/openssl-3.5.7-riscv64-jal-range.patch
@@ -1,0 +1,12 @@
+diff --git a/crypto/aes/asm/aes-riscv64.pl b/crypto/aes/asm/aes-riscv64.pl
+--- a/crypto/aes/asm/aes-riscv64.pl
++++ b/crypto/aes/asm/aes-riscv64.pl
+@@ -1068,7 +1068,7 @@
+     addi    sp,sp,-16
+     sd      $KEYP,0(sp) # We need to hold onto this!
+     sd      ra,8(sp)
+-    jal     ra,AES_set_encrypt_key
++    call    AES_set_encrypt_key
+     ld      $KEYP,0(sp)
+     ld      ra,8(sp)
+     addi    sp,sp,16

--- a/thirdparty/patches/paimon-cpp-0.3.0-orc-riscv64-unused.patch
+++ b/thirdparty/patches/paimon-cpp-0.3.0-orc-riscv64-unused.patch
@@ -1,0 +1,18 @@
+diff --git a/c++/src/CpuInfoUtil.cc b/c++/src/CpuInfoUtil.cc
+--- a/c++/src/CpuInfoUtil.cc
++++ b/c++/src/CpuInfoUtil.cc
+@@ -485,10 +485,14 @@
+ #else
+     //------------------------------ PPC, ... ------------------------------//
+     bool ArchParseUserSimdLevel(const std::string& simdLevel, int64_t* hardwareFlags) {
++      (void)simdLevel;
++      (void)hardwareFlags;
+       return true;
+     }
+
+-    void ArchVerifyCpuRequirements(const CpuInfo* ci) {}
++    void ArchVerifyCpuRequirements(const CpuInfo* ci) {
++      (void)ci;
++    }
+
+ #endif  // X86, ARM, PPC

--- a/thirdparty/patches/rocksdb-6.22.1-riscv64-toku_time.patch
+++ b/thirdparty/patches/rocksdb-6.22.1-riscv64-toku_time.patch
@@ -1,0 +1,18 @@
+diff --git a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+index 4425a4a..c4ce2c0 100644
+--- a/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
++++ b/utilities/transactions/lock/range/range_tree/lib/portability/toku_time.h
+@@ -133,6 +133,13 @@ static inline tokutime_t toku_time_now(void) {
+   return result;
+ #elif defined(__powerpc__)
+   return __ppc_get_timebase();
++#elif defined(__riscv) && (__riscv_xlen == 64)
++  // RISC-V 64: read the cycle CSR (CPU cycle counter since boot), the
++  // equivalent of aarch64 cntvct_el0. A single rdcycle returns the full
++  // 64-bit cycle counter on RV64.
++  uint64_t cycles;
++  __asm__ __volatile__("rdcycle %0" : "=r"(cycles));
++  return cycles;
+ #else
+ #error No timer implementation for this platform
+ #endif

--- a/thirdparty/patches/sasl2-saslauthd-signal-handlers.patch
+++ b/thirdparty/patches/sasl2-saslauthd-signal-handlers.patch
@@ -1,0 +1,53 @@
+diff --git a/saslauthd/saslauthd-main.c b/saslauthd/saslauthd-main.c
+index ca5b725..2aca328 100644
+--- a/saslauthd/saslauthd-main.c
++++ b/saslauthd/saslauthd-main.c
+@@ -346,7 +346,7 @@ int main(int argc, char **argv) {
+ 	/*********************************************************
+ 	 * Enable general cleanup.
+ 	 **********************************************************/
+-	atexit(server_exit);
++	atexit(server_exit_atexit);
+ 
+ 	/*********************************************************
+ 	 * If required, enable the process model.
+@@ -876,7 +876,7 @@ pid_t have_baby() {
+ /*************************************************************
+  * Reap in all the dead children
+  **************************************************************/
+-void handle_sigchld() {
++void handle_sigchld(int sig) {
+ 	pid_t pid;
+ 
+ 	while ((pid = waitpid(-1, 0, WNOHANG)) > 0) {
+@@ -892,7 +892,13 @@ void handle_sigchld() {
+ /*************************************************************
+  * Do some final cleanup here.
+  **************************************************************/
+-void server_exit() {
++/* atexit wrapper: atexit requires void(*)(void); calling server_exit through
++ * an incompatible cast would be undefined behavior (C11 6.3.2.3p8). */
++void server_exit_atexit(void) {
++	server_exit(0);
++}
++
++void server_exit(int sig) {
+ 
+ 	/*********************************************************
+ 	 * If we're not the master process, don't do anything
+diff --git a/saslauthd/saslauthd-main.h b/saslauthd/saslauthd-main.h
+index 754626c..0582b35 100644
+--- a/saslauthd/saslauthd-main.h
++++ b/saslauthd/saslauthd-main.h
+@@ -96,8 +96,9 @@ extern void	set_mech_option(const char *);
+ extern void	set_run_path(const char *);
+ extern void	signal_setup();
+ extern void	detach_tty();
+-extern void	handle_sigchld();
+-extern void	server_exit();
++extern void	handle_sigchld(int);
++extern void	server_exit(int);
++extern void	server_exit_atexit(void);
+ extern pid_t	have_baby();
+ 
+ /* ipc api delcarations */

--- a/thirdparty/vars-riscv64.sh
+++ b/thirdparty/vars-riscv64.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#####################################################
+# Download url, filename and unpaced filename
+# of all thirdparties
+#
+# vars-${arch}.sh defines the thirdparties that are
+# architecure-related.
+#####################################################
+
+# OPEN JDK FOR riscv64
+# Adoptium Temurin provides official riscv64 builds. JDK 17 (matching the
+# aarch64 baseline) is available for riscv64.
+JDK_DOWNLOAD="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.13%2B11/OpenJDK17U-jdk_riscv64_linux_hotspot_17.0.13_11.tar.gz"
+JDK_NAME="OpenJDK17U-jdk_riscv64_linux_hotspot_17.0.13_11.tar.gz"
+JDK_SOURCE="jdk-17.0.13+11"
+# NOTE: verify the MD5 after a successful download; left as a placeholder so the
+# download script's checksum guard is a no-op until the real value is filled in.
+JDK_MD5SUM="6380891c4bf6854eef90d86d92e0f815"
+
+# HYPERSCAN for riscv64
+# The zte-riscv/vectorscan fork carries a native riscv64/RVV backend (ARCH_RISCV64
+# in cmake/platform.cmake, cflags-riscv64.cmake probing RVV/Zbb/Zbc/Zicsr with a
+# scalar fallback, src/util/arch/riscv64/*) ONLY on its vectorscan-rv branch; the
+# develop branch has none of that and dies with "Unsupported platform"
+# (CMakeLists.txt:144). Pin the branch explicitly. HYPERSCAN_* tarball fields are
+# left empty because this package is a git source, not a tarball download (the
+# download loop keys off HYPERSCAN_GIT_URL). The branch is mutable, so also pin
+# the exact commit (checked out after clone by download-thirdparty.sh): a moving
+# branch tip would make the same StarRocks commit build different vectorscan
+# code as the fork advances.
+HYPERSCAN_GIT_URL="https://github.com/zte-riscv/vectorscan.git"
+HYPERSCAN_GIT_BRANCH="vectorscan-rv"
+HYPERSCAN_GIT_COMMIT="a77354b0722781e5eb3b77a8583d2f8a0e4cec82"
+HYPERSCAN_SOURCE="vectorscan"
+HYPERSCAN_DOWNLOAD=""
+HYPERSCAN_NAME=""
+HYPERSCAN_MD5SUM=""
+
+# jindosdk for Aliyun OSS - use the generic linux version (no native libs)
+JINDOSDK_DOWNLOAD="https://cdn-thirdparty.starrocks.com/jindosdk-4.6.8-linux.tar.gz"
+JINDOSDK_NAME="jindosdk-4.6.8-linux.tar.gz"
+JINDOSDK_SOURCE="jindosdk-4.6.8-linux"
+JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
+
+# starcache - disabled on riscv64, see RISCV64_UNSUPPORTED_PACKAGES below. The
+# official v4.2-rc2 binary is built from an unpublished internal source tree
+# ("starcachelib"); the public github.com/StarRocks/starcache repo stopped
+# updating in 2023-10 and diverged (namespace starrocks::starcache, no
+# time_based_cache_adaptor.h, different API surface), so building from it
+# cannot produce the library this BE expects. be/CMakeLists.txt turns
+# WITH_STARCACHE off for riscv64 the same way as for macOS, and the data cache
+# falls back to the non-starcache path.
+STARCACHE_GIT_URL=""
+STARCACHE_GIT_BRANCH=""
+STARCACHE_SOURCE="starcache"
+STARCACHE_DOWNLOAD=""
+STARCACHE_NAME=""
+STARCACHE_MD5SUM=""
+
+# tenann and pprof have no riscv64 prebuilt binary and are excluded from the
+# riscv64 build entirely (see RISCV64_UNSUPPORTED_PACKAGES below). tenann is OFF
+# by default in be/CMakeLists.txt; pprof is a Go diagnostic tool (no C++ library
+# to link), so excluding it does not break the BE link, exactly as darwin does.
+# starcache is excluded because its official binary comes from an unpublished
+# internal source tree; see the starcache block above.
+
+# Packages excluded from the riscv64 thirdparty build because no riscv64
+# prebuilt exists and source-building them is out of scope. Mirrors the
+# DARWIN_UNSUPPORTED_PACKAGES mechanism in vars-darwin-aarch64.sh; consumed by
+# package-manifest.sh starrocks_set_default_packages.
+RISCV64_UNSUPPORTED_PACKAGES="tenann pprof starcache"


### PR DESCRIPTION
## Why I'm doing:

StarRocks currently lacks official support for the RISC‑V architecture. This PR enables basic compilation and runtime on riscv64 while preserving existing x86_64/aarch64/macOS workflows.

## What I'm doing:

Add riscv64 architecture support to StarRocks. The changes are fully gated on `riscv64` and do not affect other platforms.

**Changes summary**: 29 files, +2001 insertions, –23 deletions (14 in‑repo modifications + 15 new files).

Detailed changes:

- **thirdparty**: per-package riscv64 build gating (openssl/llvm/glog/gperftools/boost/krb5/sasl/arrow/bitshuffle/croaringbitmap/hyperscan/mariadb/jemalloc), git-source + excluded-package mechanisms, riscv64 patch chain (brpc fcontext and atomics, gperftools LSS fallback, rocksdb toku_time, libserdes C23, saslauthd signal handlers, openssl-3.5.7 JAL range, paimon ORC unused params)
- **BE**: software CRC32C (slice-by-8) for hash paths, portable int128, riscv cycleclock/cacheline, LLVM RISCV components, s2 multiple-definition link fix
- **build scripts**: starcache/tenann gating, JDK library path, ASM enablement
- **unsupported on riscv64** (no prebuilt binary, source build out of scope, excluded via `RISCV64_UNSUPPORTED_PACKAGES`): starcache (data cache falls back to the non-starcache path), tenann (vector index compiled out), pprof (Go diagnostic tool, nothing to link)

All changes are gated on riscv64; x86_64/aarch64/macOS build paths remain unchanged.

Fixes #78252

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5