### PR TITLE
[Refactor] Drop three pieces of state the lake PK index does not need

### DIFF
--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -419,8 +419,7 @@ Status LakePersistentIndex::upsert(size_t n, const Slice* keys, const IndexValue
     // writes, and this is also what fixes the order of an upsert against the deletes around it.
     std::shared_ptr<std::set<KeyIndex>> not_founds = std::make_shared<std::set<KeyIndex>>();
     size_t num_found;
-    RETURN_IF_ERROR(
-            _memtable->upsert(n, keys, values, old_values, not_founds.get(), &num_found, _version.major_number()));
+    RETURN_IF_ERROR(_memtable->upsert(n, keys, values, old_values, not_founds.get(), &num_found, _publish_version));
 
     // Resolving what those keys previously mapped to is the expensive remote-IO half, and it is
     // read-only, so it is the part that can be deferred.
@@ -499,7 +498,7 @@ Status LakePersistentIndex::erase(size_t n, const Slice* keys, IndexValue* old_v
     // memtable (not safe for concurrent writes) and preserves the in-transaction upsert/delete order.
     // `not_founds` collects the keys the active memtable could not resolve; their previous rss_rowid
     // still has to be read back from the inactive memtables and sstables to build the delete vector.
-    RETURN_IF_ERROR(_memtable->erase(n, keys, old_values, &not_founds, &num_found, _version.major_number(), del_rssid));
+    RETURN_IF_ERROR(_memtable->erase(n, keys, old_values, &not_founds, &num_found, _publish_version, del_rssid));
 
     // The reverse lookup above is the expensive remote-IO part of a delete publish. For a large delete
     // it dominates, so parallelise it across disjoint key-index subsets when worthwhile, mirroring
@@ -634,7 +633,7 @@ Status LakePersistentIndex::try_replace(size_t n, const Slice* keys, const Index
             failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);
         }
     }
-    RETURN_IF_ERROR(_memtable->replace(keys, values, replace_idxes, _version.major_number()));
+    RETURN_IF_ERROR(_memtable->replace(keys, values, replace_idxes, _publish_version));
     RETURN_IF_ERROR(flush_memtable());
     return Status::OK();
 }
@@ -642,7 +641,7 @@ Status LakePersistentIndex::try_replace(size_t n, const Slice* keys, const Index
 Status LakePersistentIndex::replace(size_t n, const Slice* keys, const IndexValue* values,
                                     const std::vector<uint32_t>& replace_indexes) {
     std::vector<size_t> tmp_replace_idxes(replace_indexes.begin(), replace_indexes.end());
-    RETURN_IF_ERROR(_memtable->replace(keys, values, tmp_replace_idxes, _version.major_number()));
+    RETURN_IF_ERROR(_memtable->replace(keys, values, tmp_replace_idxes, _publish_version));
     RETURN_IF_ERROR(flush_memtable());
     return Status::OK();
 }

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -176,12 +176,12 @@ public:
     // Stamp the version that every subsequent memtable entry carries. Called once per publish,
     // before any upsert/erase/replace.
     //
-    // This replaces the inherited PersistentIndex::prepare(version, n), which set the same _version
-    // and then flipped four flags -- _dump_snapshot, _flushed, _need_bloom_filter and the error state
-    // -- that only the local-disk implementation reads. The version was the only part that reached
-    // this class, via `_version.major_number()` in upsert/erase/replace, which made the publish
-    // version's route into the memtable considerably harder to follow than it needed to be.
-    void set_publish_version(const EditVersion& version) { _version = version; }
+    // A plain version number, not an EditVersion: only the major number ever reached the memtable,
+    // so holding both halves meant callers built an `EditVersion(v, 0)` for the minor to be dropped
+    // again on the way in. (Before #78570 this arrived through the inherited
+    // PersistentIndex::prepare(version, n), which also flipped four flags only the local-disk
+    // implementation reads.)
+    void set_publish_version(int64_t version) { _publish_version = version; }
 
     Status flush_memtable(bool force = false);
 
@@ -263,7 +263,7 @@ private:
     // load_from_lake_tablet(), which is also where it was set while this derived from PersistentIndex.
     size_t _key_size{0};
     // The version stamped on memtable entries; see set_publish_version().
-    EditVersion _version;
+    int64_t _publish_version{0};
 };
 
 } // namespace lake

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -150,6 +150,10 @@ public:
 
     int32_t current_fileset_index() const { return (int32_t)_sstable_filesets.size() - 1; }
 
+    // Fixed encoded key size, or 0 for variable-length keys. Set from the tablet's primary-key
+    // schema and encoding type in load_from_lake_tablet(), so it is only meaningful once loaded.
+    size_t key_size() const { return _key_size; }
+
     // During large import, we may have many sst files to ingest and get, so we do parallel compaction to speedup the process.
     StatusOr<AsyncCompactCBPtr> early_sst_compact(lake::LakePersistentIndexParallelCompactMgr* compact_mgr,
                                                   TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -112,20 +112,24 @@ std::size_t LakePrimaryIndex::memory_usage() const {
     return _index != nullptr ? _index->memory_usage() : 0;
 }
 
-void LakePrimaryIndex::_set_pk_schema(const TabletMetadataPtr& metadata) {
+void LakePrimaryIndex::_init_encoded_key_size(const TabletMetadataPtr& metadata) {
     auto tablet_schema = std::make_shared<TabletSchema>(metadata->schema());
     std::vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
     for (auto i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_columns[i] = (ColumnId)i;
     }
-    _pk_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
-    // Shared-data always encodes with V1; the encoding type is otherwise a shared-nothing knob.
-    _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
+    auto pk_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    // V1 rather than the tablet's own encoding type, which is what PrimaryIndex::_set_schema did and
+    // what this value's one consumer needs. build_persistent_keys() only reads it when the encoded
+    // column is NOT binary, and encoded_primary_key_type() produces a non-binary column exactly for
+    // a single-column V1 key -- the case this computation is right for. A V2 tablet encodes to
+    // VARCHAR, takes the binary path, and never looks.
+    _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pk_schema, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
 }
 
 Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                        int64_t base_version, const MetaFileBuilder* builder) {
-    _set_pk_schema(metadata);
+    _init_encoded_key_size(metadata);
 
     // A shared-data primary-key tablet has exactly one index implementation. The metadata is
     // normalized to enabled + CLOUD_NATIVE at load time (force_cloud_native_pk_persistent_index),
@@ -584,7 +588,7 @@ std::string LakePrimaryIndex::to_string() const {
     return strings::Substitute("LakePrimaryIndex tablet:$0", _tablet_id);
 }
 
-Status LakePrimaryIndex::prepare(const EditVersion& version) {
+Status LakePrimaryIndex::prepare(int64_t version) {
     auto* index = _index.get();
     if (index == nullptr) {
         return Status::InternalError("prepare on an unloaded lake primary index");

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -21,7 +21,6 @@
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "gutil/strings/substitute.h"
-#include "storage/chunk_helper.h"
 #include "storage/lake/lake_persistent_index.h"
 #include "storage/lake/meta_file.h"
 #include "storage/lake/parallel_task_runner.h"
@@ -29,7 +28,6 @@
 #include "storage/lake/segment_pk_iterator.h"
 #include "storage/lake/tablet.h"
 #include "storage/parallel_upsert_context.h"
-#include "storage_primitive/primary_key_encoder.h"
 
 namespace starrocks::lake {
 
@@ -112,25 +110,8 @@ std::size_t LakePrimaryIndex::memory_usage() const {
     return _index != nullptr ? _index->memory_usage() : 0;
 }
 
-void LakePrimaryIndex::_init_encoded_key_size(const TabletMetadataPtr& metadata) {
-    auto tablet_schema = std::make_shared<TabletSchema>(metadata->schema());
-    std::vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
-    for (auto i = 0; i < tablet_schema->num_key_columns(); i++) {
-        pk_columns[i] = (ColumnId)i;
-    }
-    auto pk_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
-    // V1 rather than the tablet's own encoding type, which is what PrimaryIndex::_set_schema did and
-    // what this value's one consumer needs. build_persistent_keys() only reads it when the encoded
-    // column is NOT binary, and encoded_primary_key_type() produces a non-binary column exactly for
-    // a single-column V1 key -- the case this computation is right for. A V2 tablet encodes to
-    // VARCHAR, takes the binary path, and never looks.
-    _key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pk_schema, PrimaryKeyEncodingType::PK_ENCODING_TYPE_V1);
-}
-
 Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                        int64_t base_version, const MetaFileBuilder* builder) {
-    _init_encoded_key_size(metadata);
-
     // A shared-data primary-key tablet has exactly one index implementation. The metadata is
     // normalized to enabled + CLOUD_NATIVE at load time (force_cloud_native_pk_persistent_index),
     // so there is nothing to choose between.
@@ -193,7 +174,8 @@ Status LakePrimaryIndex::erase(const TabletMetadataPtr& metadata, const Column& 
     }
     Buffer<Slice> keys;
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
-    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), 0, pks.size(), &keys));
     // Cloud native index needs the delete's rssid as the rebuild point when erasing.
     RETURN_IF_ERROR(index->erase(pks.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()), del_rssid));
     old_values_to_deletes(old_values, deletes);
@@ -211,7 +193,8 @@ Status LakePrimaryIndex::bulk_erase(const TabletMetadataPtr& metadata, const Col
     }
     Buffer<Slice> keys;
     std::vector<uint64_t> old_values(pks.size(), NullIndexValue);
-    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), 0, pks.size(), &keys));
     RETURN_IF_ERROR(index->bulk_erase(pks.size(), vkeys, reinterpret_cast<IndexValue*>(old_values.data()), del_rssid,
                                       del_sst_meta, del_sst_range, version));
     old_values_to_deletes(old_values, deletes);
@@ -486,7 +469,8 @@ Status LakePrimaryIndex::get(const Column& pks, std::vector<uint64_t>* rowids) c
         return Status::InternalError("get on an unloaded lake primary index");
     }
     Buffer<Slice> keys;
-    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), 0, pks.size(), &keys));
     return index->get(pks.size(), vkeys, reinterpret_cast<IndexValue*>(rowids->data()));
 }
 
@@ -504,7 +488,7 @@ Status LakePrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Colu
     slot.values.reserve(n);
     slot.old_values.resize(n, NullIndexValue);
     ASSIGN_OR_RETURN(const Slice* vkeys,
-                     PrimaryIndex::build_persistent_keys(pks, _key_size, idx_begin, idx_end, &slot.keys));
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), idx_begin, idx_end, &slot.keys));
     const uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
     for (uint32_t i = idx_begin; i < idx_end; i++) {
         slot.values.emplace_back(base + i);
@@ -526,7 +510,8 @@ Status LakePrimaryIndex::replace(uint32_t rssid, uint32_t rowid_start, const std
     for (size_t i = 0; i < pks.size(); i++) {
         values.emplace_back(base + i);
     }
-    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), 0, pks.size(), &keys));
     return index->replace(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), replace_indexes);
 }
 
@@ -543,7 +528,8 @@ Status LakePrimaryIndex::try_replace(uint32_t rssid, uint32_t rowid_start, const
     for (size_t i = 0; i < pks.size(); i++) {
         values.emplace_back(base + i);
     }
-    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, pks.size(), &keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), 0, pks.size(), &keys));
     return index->try_replace(pks.size(), vkeys, reinterpret_cast<IndexValue*>(values.data()), max_src_rssid, failed);
 }
 
@@ -556,7 +542,8 @@ Status LakePrimaryIndex::upsert(uint32_t rssid, uint32_t rowid_start, const Colu
     const uint32_t n = pks.size();
     slot->values.reserve(n);
     slot->old_values.resize(n, NullIndexValue);
-    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, n, &slot->keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), 0, n, &slot->keys));
     const uint64_t base = (((uint64_t)rssid) << 32) + rowid_start;
     for (uint32_t i = 0; i < n; i++) {
         slot->values.emplace_back(base + i);
@@ -575,7 +562,8 @@ Status LakePrimaryIndex::upsert(uint32_t rssid, const std::vector<uint32_t>& row
     DCHECK_EQ(rowids.size(), n);
     slot->values.reserve(n);
     slot->old_values.resize(n, NullIndexValue);
-    ASSIGN_OR_RETURN(const Slice* vkeys, PrimaryIndex::build_persistent_keys(pks, _key_size, 0, n, &slot->keys));
+    ASSIGN_OR_RETURN(const Slice* vkeys,
+                     PrimaryIndex::build_persistent_keys(pks, index->key_size(), 0, n, &slot->keys));
     const uint64_t base = ((uint64_t)rssid) << 32;
     for (uint32_t i = 0; i < n; i++) {
         slot->values.emplace_back(base + rowids[i]);

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -221,7 +221,7 @@ public:
 
     // Stamp the version every memtable entry written by this publish carries. Called once, before
     // any upsert/erase, by UpdateManager::prepare_primary_index.
-    Status prepare(const EditVersion& version);
+    Status prepare(int64_t version);
 
     // Drop the loaded index, so the next lake_load() rebuilds it. [thread-safe]
     void unload();
@@ -237,9 +237,9 @@ private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
 
-    // Derive the encoded-key layout from the tablet's primary-key columns. Replaces
+    // Derive the fixed encoded-key size from the tablet's primary-key columns. Replaces
     // PrimaryIndex::_set_schema(), minus the in-memory hash index it also allocated.
-    void _set_pk_schema(const TabletMetadataPtr& metadata);
+    void _init_encoded_key_size(const TabletMetadataPtr& metadata);
 
     void _unload_without_lock();
 
@@ -255,8 +255,8 @@ private:
     Status _status;
 
     int64_t _tablet_id = 0;
-    // Encoded primary-key layout, set by _set_pk_schema() at load time.
-    Schema _pk_schema;
+    // Fixed encoded key size, or 0 for variable-length keys. Set by _init_encoded_key_size() at load
+    // time and consulted only by build_persistent_keys().
     size_t _key_size = 0;
 
     // We don't support multi version yet, but we record the latest data version for some checking

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -229,17 +229,11 @@ public:
     bool is_loaded() const;
     Status get_load_status() const;
     std::size_t memory_usage() const;
-    size_t key_size() const { return _key_size; }
-
     std::string to_string() const;
 
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
-
-    // Derive the fixed encoded-key size from the tablet's primary-key columns. Replaces
-    // PrimaryIndex::_set_schema(), minus the in-memory hash index it also allocated.
-    void _init_encoded_key_size(const TabletMetadataPtr& metadata);
 
     void _unload_without_lock();
 
@@ -255,9 +249,6 @@ private:
     Status _status;
 
     int64_t _tablet_id = 0;
-    // Fixed encoded key size, or 0 for variable-length keys. Set by _init_encoded_key_size() at load
-    // time and consulted only by build_persistent_keys().
-    size_t _key_size = 0;
 
     // We don't support multi version yet, but we record the latest data version for some checking
     int64_t _data_version = 0;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -198,7 +198,7 @@ StatusOr<IndexEntry*> UpdateManager::prepare_primary_index(
         return Status::InternalError(msg);
     }
     _block_cache->update_memory_usage();
-    st = index.prepare(EditVersion(new_version, 0));
+    st = index.prepare(new_version);
     if (!st.ok()) {
         // If prepare failed, release lock guard and remove index entry
         guard.reset(nullptr);

--- a/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_fileset_test.cpp
@@ -658,7 +658,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_reload_after_minor_compaction)
     {
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->set_publish_version(EditVersion(1, 0));
+        index->set_publish_version(1);
         ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000)); // Wait up to 60s
@@ -720,7 +720,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_reload_after_major_compaction)
                 all_key_slices[m].emplace_back((uint8_t*)(&all_keys[m][i]), sizeof(Key));
             }
 
-            index->set_publish_version(EditVersion(m, 0));
+            index->set_publish_version(m);
             std::vector<IndexValue> old_values(N);
             ASSERT_OK(index->upsert(N, all_key_slices[m].data(), all_values[m].data(), old_values.data()));
             ASSERT_OK(index->flush_memtable(true));
@@ -806,7 +806,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_multiple_reload_cycles) {
         {
             auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
             ASSERT_OK(index->init(_tablet_metadata));
-            index->set_publish_version(EditVersion(cycle, 0));
+            index->set_publish_version(cycle);
 
             std::vector<IndexValue> old_values(N);
             ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), old_values.data()));
@@ -866,7 +866,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_upsert_and_reload) {
 
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->set_publish_version(EditVersion(1, 0));
+        index->set_publish_version(1);
         ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000)); // Wait up to 60s
@@ -890,7 +890,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_upsert_and_reload) {
 
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->set_publish_version(EditVersion(2, 0));
+        index->set_publish_version(2);
 
         std::vector<IndexValue> old_values(N);
         ASSERT_OK(index->upsert(N, key_slices.data(), new_values.data(), old_values.data()));
@@ -945,7 +945,7 @@ TEST_F(LakePersistentIndexFilesetTest, test_index_concurrent_read_after_reload) 
     {
         auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
         ASSERT_OK(index->init(_tablet_metadata));
-        index->set_publish_version(EditVersion(1, 0));
+        index->set_publish_version(1);
         ASSERT_OK(index->insert(N, key_slices.data(), values.data(), 0));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(60 * 1000 * 1000)); // Wait up to 60s

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -752,7 +752,7 @@ TEST_F(LakePersistentIndexTest, test_erase_parallel_matches_serial) {
                 bks[j] = Slice((uint8_t*)(&bk[j]), sizeof(Key));
                 bv[j] = IndexValue((uint64_t)(gid + 1)); // distinct, non-null
             }
-            index->set_publish_version(EditVersion(b + 1, 0));
+            index->set_publish_version(b + 1);
             std::vector<IndexValue> old(kPerBatch);
             ASSERT_OK(index->upsert(kPerBatch, bks.data(), bv.data(), old.data()));
             ASSERT_OK(index->flush_memtable(true));
@@ -822,13 +822,13 @@ TEST_F(LakePersistentIndexTest, test_bulk_erase_matches_memtable) {
                 bks[j] = key_slices[gid];
                 bv[j] = IndexValue((uint64_t)(gid + 1));
             }
-            index->set_publish_version(EditVersion(b + 1, 0));
+            index->set_publish_version(b + 1);
             std::vector<IndexValue> old(per);
             CHECK_OK(index->upsert(per, bks.data(), bv.data(), old.data()));
             CHECK_OK(index->flush_memtable(true));
             CHECK_OK(index->sync_flush_all_memtables(10000000));
         }
-        index->set_publish_version(EditVersion(batches + 1, 0)); // version stamped on the delete tombstones
+        index->set_publish_version(batches + 1); // version stamped on the delete tombstones
         return index;
     };
 
@@ -1215,7 +1215,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
             total_values.emplace_back(j * 2);
             ++k;
         }
-        index->set_publish_version(EditVersion(i, 0));
+        index->set_publish_version(i);
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1316,7 +1316,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_drops_corrupted_cache) {
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->set_publish_version(EditVersion(i, 0));
+        index->set_publish_version(i);
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1404,7 +1404,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_open_corruption_drops_cach
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->set_publish_version(EditVersion(i, 0));
+        index->set_publish_version(i);
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1495,7 +1495,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_value_parse_corruption_dro
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->set_publish_version(EditVersion(i, 0));
+        index->set_publish_version(i);
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         // generate sst files.
@@ -1566,7 +1566,7 @@ TEST_F(LakePersistentIndexTest, test_apply_opcompaction_output_sstable_with_delv
         key_slices[i] = Slice((uint8_t*)(&keys[i]), sizeof(Key));
         values[i] = i * 2;
     }
-    index->set_publish_version(EditVersion(1, 0));
+    index->set_publish_version(1);
     std::vector<IndexValue> old_values(kNumKeys);
     ASSERT_OK(index->upsert(kNumKeys, key_slices.data(), values.data(), old_values.data()));
     ASSERT_OK(index->flush_memtable(true));
@@ -1668,7 +1668,7 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_with_tablet_range) {
             key_slices.emplace_back(keys.back());
             values.emplace_back(j * 2 + i);
         }
-        index->set_publish_version(EditVersion(i, 0));
+        index->set_publish_version(i);
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         ASSERT_OK(index->flush_memtable(true));
         // Wait for async flush to complete if any
@@ -1771,7 +1771,7 @@ TEST_F(LakePersistentIndexTest, test_range_single_int_pk_end_to_end) {
             key_slices.emplace_back(keys.back());
             values.emplace_back(key * 10);
         }
-        index->set_publish_version(EditVersion(batch, 0));
+        index->set_publish_version(batch);
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         ASSERT_OK(index->flush_memtable(true));
         ASSERT_OK(index->sync_flush_all_memtables(10000000)); // 10 seconds timeout
@@ -2328,7 +2328,7 @@ TEST_F(LakePersistentIndexTest, test_ingest_sst_skip_duplicate) {
             key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
             values.emplace_back(j * 2);
         }
-        index->set_publish_version(EditVersion(i, 0));
+        index->set_publish_version(i);
         vector<IndexValue> upsert_old_values(keys.size());
         ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
         ASSERT_OK(index->flush_memtable(true));
@@ -2422,7 +2422,7 @@ TEST_F(LakePersistentIndexTest, test_ingest_sst_preserves_shared_flag_for_new_ss
                 key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
                 values.emplace_back(j * 2);
             }
-            index->set_publish_version(EditVersion(i, 0));
+            index->set_publish_version(i);
             vector<IndexValue> upsert_old_values(keys.size());
             ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
             ASSERT_OK(index->flush_memtable(true));
@@ -3099,7 +3099,7 @@ TEST_F(LakePersistentIndexTest, test_commit_stamps_version) {
         key_slices.emplace_back((uint8_t*)(&keys[j]), sizeof(Key));
         values.emplace_back(j * 2);
     }
-    index->set_publish_version(EditVersion(publish_version, 0));
+    index->set_publish_version(publish_version);
     std::vector<IndexValue> old_values(N);
     ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), old_values.data()));
     ASSERT_OK(index->flush_memtable(true));


### PR DESCRIPTION
## Why I'm doing:

Three leftovers from #78570. That PR stopped `LakePrimaryIndex` and `LakePersistentIndex` deriving from the shared-nothing implementations, but carried over state inherited from them without checking whether it was actually used. Three pieces were not.

**An `EditVersion` where a version number would do.** `LakePersistentIndex` holds the version it stamps on memtable entries as an `EditVersion`, but only ever reads `_version.major_number()` — in `upsert`, `erase` and both `replace` overloads. The minor number reaches nothing. So every caller builds an `EditVersion(v, 0)` purely for the half of it that gets dropped again on the way in, `UpdateManager::prepare_primary_index` included.

**`LakePrimaryIndex::_pk_schema` is write-only.** Assigned in `_set_pk_schema()`, read on the next line to compute `_key_size`, then never again. It came from `PrimaryIndex`, where `pk_dump()` uses it — something a lake tablet never calls.

**`LakePrimaryIndex::_key_size` is a duplicate.** `key_size()` has no callers at all, and the member's eight uses are all the same one: an argument to `build_persistent_keys()`. `LakePersistentIndex` — the object those calls go on to — already computes the identical value at load time.

## What I'm doing:

`_publish_version` is an `int64_t`; `set_publish_version()` and `LakePrimaryIndex::prepare()` take one. `_pk_schema` and `_key_size` both go, and with them the whole `_init_encoded_key_size()` derivation, which built a `TabletSchema`, a column-id vector and a `Schema` on every index load only to extract one integer that was already sitting in the object next to it. The eight call sites ask `index->key_size()`.

Dropping `_key_size` also removes an invariant that held only by coincidence, and is worth recording as the reason this is the right direction rather than just less code. The two classes computed that size differently: `LakePrimaryIndex` hardcoded `PK_ENCODING_TYPE_V1`, inherited from `PrimaryIndex::_set_schema()`, while `LakePersistentIndex` uses the tablet's real encoding type — and `get_encoded_fixed_size()` returns 0 for V2, so the two values could disagree. It was harmless, but only because of which branch consumes it:

* `build_persistent_keys()` reads the value only when the encoded column is **not** binary.
* `encoded_primary_key_type()` yields a non-binary column exactly for a **single-column V1** key — the case the V1 computation is right for.
* A V2 tablet encodes to VARCHAR, takes the binary path, and never looks.

With one source, using the tablet's real encoding type, the question of what happens when they disagree no longer arises.

The two `_tablet_id`s remain duplicated across the two classes. That resolves when they merge; this PR is only about state neither class needs at all.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The stamped version is unchanged — it was always the major number, and that is what is now passed. The removed members were never read, and the key size now comes from the object the keys are built for. No config, metric, on-disk format or FE-facing change.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

No new tests: this removes unused state and narrows a parameter type. The 19 `set_publish_version(EditVersion(v, 0))` call sites in `lake_persistent_index_test.cpp` and `lake_persistent_index_fileset_test.cpp` now pass `v`, and those suites cover the stamping they exercise. The key-size change is exercised by every existing PK publish test, including the VARCHAR-key cases in `lake_persistent_index_test.cpp` that take the variable-length path.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

No backport: follows #78570, which is main-only.
