### PR TITLE
[UT] Run the two cases that toggle a global FE config sequentially

### DIFF
--- a/test/sql/test_agg/R/test_push_down_local_agg_through_union_all
+++ b/test/sql/test_agg/R/test_push_down_local_agg_through_union_all
@@ -1,4 +1,4 @@
--- name: test_push_down_local_agg_through_union_all @mac
+-- name: test_push_down_local_agg_through_union_all @mac @sequential
 DROP TABLE IF EXISTS t_push_down_local_agg_union_all_result_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_agg/T/test_push_down_local_agg_through_union_all
+++ b/test/sql/test_agg/T/test_push_down_local_agg_through_union_all
@@ -1,4 +1,4 @@
--- name: test_push_down_local_agg_through_union_all @mac
+-- name: test_push_down_local_agg_through_union_all @mac @sequential
 DROP TABLE IF EXISTS t_push_down_local_agg_union_all_result_${uuid0};
 
 CREATE TABLE t_push_down_local_agg_union_all_result_${uuid0} (

--- a/test/sql/test_global_dict/R/global_dict_with_union
+++ b/test/sql/test_global_dict/R/global_dict_with_union
@@ -1,4 +1,4 @@
--- name: test_global_dict_with_union
+-- name: test_global_dict_with_union @sequential
 CREATE TABLE test_table_1 (
     id INT,
     value VARCHAR(10)

--- a/test/sql/test_global_dict/T/global_dict_with_union
+++ b/test/sql/test_global_dict/T/global_dict_with_union
@@ -1,4 +1,4 @@
--- name: test_global_dict_with_union
+-- name: test_global_dict_with_union @sequential
 
 -- test_union_filter_after_union
 -- expect: Filter -> Union -> Scan


### PR DESCRIPTION
## Why I'm doing:

`test_push_down_local_agg_through_union_all` and `test_global_dict_with_union` both mutate
`push_down_non_grouped_aggregate_below_union` with `ADMIN SET FRONTEND CONFIG`, which is
**cluster-global, not session-scoped**. SQL-Tester runs its default group with several workers
against one FE, so the two race.

The first case asserts plan shape on both sides of the switch — with the config off it requires
`assert_explain_not_contains('AGGREGATE (merge serialize)')`. The second is 966 lines long and
holds the config at `true` from **line 950 to its very last line**, so for the final seconds of an
~80s case the flag is globally on. A worker that starts the first case inside that window sees the
pushed-down plan while the case believes it disabled the rule, and the negative assertion fails:

```
sr_sql_lib.py:3433, in assert_explain_not_contains
AssertionError: False is not true : assert expect AGGREGATE (merge serialize) is found in plan
```

Observed twice on #78219, whose diff is BE-only and inert at its default config, and reproduced as
a pure scheduling difference against a PR with the identical `BASE_VERSION`:

| | agg case | `global_dict_with_union` | outcome |
|---|---|---|---|
| #78219 | 10:04:52.68 → **10:04:54.26** | … → 10:04:54.02 | ran entirely inside the last **1.3 s** → FAIL |
| #78633 | 09:07:41 → 09:07:42.95 | … → 09:07:48.80 | ended ~6 s early, i.e. before line 950 → ok |

Both runs used `BASE_VERSION 2bda1dbffed3f696ff7786412bedfd57183f5b73`, so the case is not broken
on main — only the interleaving differs.

## What I'm doing:

Tagging both cases `@sequential`, which is what this repo already does for cases that write a
global FE config (`test_http_request_security`, `test_http_request_basic`). They then run in the
sequential pass with concurrency forced to 1 (`test/run.py:191`), so neither can observe the
other's config writes — and, just as importantly, neither leaves a global flag flipped underneath
the parallel pool, where any query with a non-grouped aggregate over `UNION ALL` could pick it up.

The toggles themselves stay. The one in `global_dict_with_union` is the regression cover added
with #77624, which opted `PushDownNonGroupedAggregateBelowUnion` out when a `DictMappingOperator`
appears in the rewrite.

Only the `-- name:` line of each case changes (`T/` and `R/` both, since the chooser reads the tag
from either).

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

Test-only. The two cases keep running, in the sequential pass instead of the parallel one.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYLtQ1wdy6Y4R74n3Kg1Gf
