### PR TITLE
[BugFix] Validate bitshuffle page sizes in the pre-decoder before use (backport #78357)

### DIFF
--- a/be/src/storage/rowset/bitshuffle_page.h
+++ b/be/src/storage/rowset/bitshuffle_page.h
@@ -54,6 +54,7 @@
 #include "storage/type_traits.h"
 #include "storage/types.h"
 #include "types/date_value.hpp"
+#include "util/bit_util.h"
 #include "util/coding.h"
 #include "util/faststring.h"
 #include "util/slice.h"
@@ -256,7 +257,10 @@ public:
         _num_elements = decode_fixed32_le((const uint8_t*)&_data[0]);
         _compressed_size = decode_fixed32_le((const uint8_t*)&_data[4]);
         _num_element_after_padding = decode_fixed32_le((const uint8_t*)&_data[8]);
-        if (_num_element_after_padding != ALIGN_UP(_num_elements, 8U)) {
+        // Not ALIGN_UP(): its mask is 32-bit, so ALIGN_UP(0xffffffff, 8U) wraps
+        // to 0 and would accept a corrupted page whose padded count is 0.
+        // RoundUpToPowerOf2() rounds at full 64-bit width instead.
+        if (_num_element_after_padding != static_cast<size_t>(BitUtil::RoundUpToPowerOf2(_num_elements, 8))) {
             std::stringstream ss;
             ss << "num of element information corrupted,"
                << " _num_element_after_padding:" << _num_element_after_padding << ", _num_elements:" << _num_elements;

--- a/be/src/storage/rowset/storage_page_decoder.cpp
+++ b/be/src/storage/rowset/storage_page_decoder.cpp
@@ -18,6 +18,7 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/raw_container_checked.h"
 #include "storage/rowset/bitshuffle_wrapper.h"
+#include "util/bit_util.h"
 #include "util/coding.h"
 #include "util/raw_container.h"
 
@@ -34,14 +35,65 @@ public:
     }
     Status decode_page_data(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
                             std::unique_ptr<std::vector<uint8_t>>* page, Slice* page_slice) override {
+        size_t header_size = _reserve_head_size + BITSHUFFLE_PAGE_HEADER_SIZE;
+        // All the sizes below come straight from the (possibly corrupted) page
+        // bytes, so validate them before they drive any allocation or memcpy.
+        if (page_slice->size < header_size) {
+            return Status::Corruption(strings::Substitute("invalid bitshuffle page size:$0, header size:$1",
+                                                          page_slice->size, header_size));
+        }
         size_t num_elements = decode_fixed32_le((const uint8_t*)page_slice->data + _reserve_head_size + 0);
         size_t compressed_size = decode_fixed32_le((const uint8_t*)page_slice->data + _reserve_head_size + 4);
         size_t num_element_after_padding = decode_fixed32_le((const uint8_t*)page_slice->data + _reserve_head_size + 8);
         size_t size_of_element = decode_fixed32_le((const uint8_t*)page_slice->data + _reserve_head_size + 12);
-        DCHECK_EQ(num_element_after_padding, ALIGN_UP(num_elements, 8U));
+        // Not ALIGN_UP(): its mask is 32-bit, so a corrupted num_elements near
+        // 2^32 wraps -- ALIGN_UP(0xffffffff, 8U) is 0 and would match a crafted
+        // padded count of 0. RoundUpToPowerOf2() rounds at full 64-bit width.
+        size_t expected_padded = static_cast<size_t>(BitUtil::RoundUpToPowerOf2(num_elements, 8));
+        if (num_element_after_padding != expected_padded) {
+            return Status::Corruption(strings::Substitute("bitshuffle element count corrupted, padded:$0, num:$1",
+                                                          num_element_after_padding, num_elements));
+        }
+        if (compressed_size < BITSHUFFLE_PAGE_HEADER_SIZE || compressed_size > page_slice->size - _reserve_head_size) {
+            return Status::Corruption(strings::Substitute("invalid bitshuffle compressed size:$0, page size:$1",
+                                                          compressed_size, page_slice->size));
+        }
+        // bitshuffle::decompress_lz4() takes no input length: it derives how far
+        // to read from the element count and the per-block framing, so a page
+        // that declares elements but carries an empty compressed body makes it
+        // read past the body into the trailer (or past the buffer entirely),
+        // before the post-call consumed-bytes check can reject the page. Only a
+        // genuinely empty page is header-only: the builder writes
+        // compressed_size == BITSHUFFLE_PAGE_HEADER_SIZE only when the padded
+        // element count is 0.
+        if (num_element_after_padding != 0 && compressed_size == BITSHUFFLE_PAGE_HEADER_SIZE) {
+            return Status::Corruption(
+                    strings::Substitute("empty bitshuffle compressed body for $0 elements", num_element_after_padding));
+        }
+        // Same element sizes BitShufflePageDecoder::init accepts; anything else
+        // (e.g. 0xffffffff) would drive an absurd allocation below.
+        switch (size_of_element) {
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 8:
+        case 12:
+        case 16:
+        case 32:
+            break;
+        default:
+            return Status::Corruption(strings::Substitute("invalid bitshuffle size_of_elem:$0", size_of_element));
+        }
 
-        size_t header_size = _reserve_head_size + BITSHUFFLE_PAGE_HEADER_SIZE;
         size_t data_size = num_element_after_padding * size_of_element;
+        // LZ4 cannot expand beyond ~255x, so a decoded size far past the
+        // compressed body is corrupt; reject it before allocating (load paths
+        // may run with memory-limit enforcement disabled).
+        if (data_size > 256 * (compressed_size - BITSHUFFLE_PAGE_HEADER_SIZE) + 4096) {
+            return Status::Corruption(strings::Substitute(
+                    "implausible bitshuffle decoded size:$0 for compressed size:$1", data_size, compressed_size));
+        }
 
         // data_size is size of decoded_data
         // compressed_size contains encoded_data size and BITSHUFFLE_PAGE_HEADER_SIZE
@@ -64,6 +116,16 @@ public:
         if (footer->type() == DATA_PAGE) {
             const DataPageFooterPB& data_footer = footer->data_page_footer();
             null_size = data_footer.nullmap_size();
+        }
+        // The trailer sizes come from the page footer; a malformed page could
+        // claim more trailer bytes than the input actually holds (reading past
+        // page_slice and writing past decompressed_page below), or fewer,
+        // leaving surplus bytes that end up inside the cached page whose footer
+        // is parsed from its very end. The input must be consumed exactly.
+        if (page_slice->size - _reserve_head_size - compressed_size != (size_t)null_size + footer_size) {
+            return Status::Corruption(strings::Substitute(
+                    "bitshuffle page trailer mismatch, page size:$0, compressed size:$1, trailer size:$2",
+                    page_slice->size, compressed_size, (size_t)null_size + footer_size));
         }
         memcpy(decompressed_body.data + decompressed_body.size,
                page_slice->data + header_size + (compressed_size - BITSHUFFLE_PAGE_HEADER_SIZE),

--- a/be/test/storage/rowset/bitshuffle_page_test.cpp
+++ b/be/test/storage/rowset/bitshuffle_page_test.cpp
@@ -506,4 +506,149 @@ TEST_F(BitShufflePageTest, TestDecodeVectorized) {
                                        BitShufflePageDecoder<TYPE_BIGINT>>();
 }
 
+// A corrupted or truncated bitshuffle page must be rejected by the page-load
+// pre-decoder with a clear error instead of driving out-of-bounds reads or
+// writes from sizes taken straight from the page bytes.
+// NOLINTNEXTLINE
+TEST_F(BitShufflePageTest, TestCorruptedPagePreDecodeRejected) {
+    const uint32_t size = 1000;
+    std::unique_ptr<int32_t[]> ints(new int32_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    BitshufflePageBuilder<TYPE_INT> page_builder(options);
+    ASSERT_EQ(size, page_builder.add(reinterpret_cast<const uint8_t*>(ints.get()), size));
+    OwnedSlice s = page_builder.finish()->build();
+    std::string good(s.slice().data, s.slice().size);
+
+    auto decode = [](std::string page_bytes, uint32_t footer_size = 0) {
+        Slice slice(page_bytes.data(), page_bytes.size());
+        std::unique_ptr<std::vector<uint8_t>> page;
+        starrocks::PageFooterPB footer;
+        footer.set_type(starrocks::DATA_PAGE);
+        footer.mutable_data_page_footer()->set_nullmap_size(0);
+        return StoragePageDecoder::decode_page(&footer, footer_size, starrocks::BIT_SHUFFLE, &page, &slice);
+    };
+
+    // Sanity: the untouched page decodes fine.
+    ASSERT_TRUE(decode(good).ok());
+
+    // Page smaller than the 16-byte bitshuffle header.
+    ASSERT_FALSE(decode(good.substr(0, BITSHUFFLE_PAGE_HEADER_SIZE - 1)).ok());
+
+    // Compressed size larger than the page (header bytes [4,8)).
+    {
+        std::string bad = good;
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 4, good.size() + 100);
+        ASSERT_FALSE(decode(bad).ok());
+    }
+
+    // Compressed size smaller than the bitshuffle header itself.
+    {
+        std::string bad = good;
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 4, BITSHUFFLE_PAGE_HEADER_SIZE - 8);
+        ASSERT_FALSE(decode(bad).ok());
+    }
+
+    // Padded element count that does not match num_elements (header bytes [8,12)).
+    {
+        std::string bad = good;
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 8, 12345678);
+        ASSERT_FALSE(decode(bad).ok());
+    }
+
+    // num_elements = 0xffffffff with a padded count of 0: ALIGN_UP(0xffffffff,
+    // 8U) wraps to 0 with the 32-bit mask, so a full-width check is required to
+    // reject this instead of reconstructing a page that reports ~4.29e9 rows.
+    {
+        std::string bad = good;
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 0, 0xffffffff);
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 8, 0);
+        ASSERT_FALSE(decode(bad).ok());
+    }
+
+    // A page that declares elements but carries an empty compressed body
+    // (compressed_size == BITSHUFFLE_PAGE_HEADER_SIZE) must be rejected before
+    // the decompressor runs: decompress_lz4() takes no input length, so it
+    // would read the trailer as block framing. Only a genuinely empty page
+    // (padded count 0) is header-only.
+    {
+        std::string bad = good;
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 0, 1);
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 4, BITSHUFFLE_PAGE_HEADER_SIZE);
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 8, 8);
+        ASSERT_FALSE(decode(bad).ok());
+    }
+
+    // An element size outside the supported set would drive an absurd
+    // allocation (e.g. 8 * 0xffffffff bytes) before any decode.
+    {
+        std::string bad = good;
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 12, 0xffffffff);
+        ASSERT_FALSE(decode(bad).ok());
+    }
+
+    // Consistent but implausibly large element counts (decoded size far past
+    // what LZ4 could ever expand to) must be rejected before allocating.
+    {
+        std::string bad = good;
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 0, 100000000);
+        encode_fixed32_le(reinterpret_cast<uint8_t*>(bad.data()) + 8, 100000000);
+        ASSERT_FALSE(decode(bad).ok());
+    }
+
+    // A trailer (nullmap/footer) claimed to be larger than the bytes actually
+    // present after the compressed body must be rejected, not copied.
+    ASSERT_FALSE(decode(good, /*footer_size=*/8).ok());
+
+    // Surplus bytes between the compressed body and the trailer must be
+    // rejected too: the input has to be consumed exactly, otherwise the
+    // cached page (whose footer is parsed from its end) is polluted.
+    ASSERT_FALSE(decode(good + std::string(3, 'x')).ok());
+}
+
+TEST_F(BitShufflePageTest, TestReadByRowids) {
+    const uint32_t size = 100;
+    std::unique_ptr<int32_t[]> ints(new int32_t[size]);
+    for (int i = 0; i < size; i++) {
+        ints.get()[i] = i;
+    }
+
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    BitshufflePageBuilder<TYPE_INT> page_builder(options);
+
+    size_t added = page_builder.add(reinterpret_cast<const uint8_t*>(ints.get()), size);
+    ASSERT_EQ(size, added);
+    OwnedSlice s = page_builder.finish()->build();
+
+    Slice encoded_data = s.slice();
+    starrocks::PageFooterPB footer;
+    footer.set_type(starrocks::DATA_PAGE);
+    starrocks::DataPageFooterPB* data_page_footer = footer.mutable_data_page_footer();
+    data_page_footer->set_nullmap_size(0);
+    std::unique_ptr<std::vector<uint8_t>> page = nullptr;
+    Status st = StoragePageDecoder::decode_page(&footer, 0, starrocks::BIT_SHUFFLE, &page, &encoded_data);
+    ASSERT_TRUE(st.ok());
+
+    BitShufflePageDecoder<TYPE_INT> page_decoder(encoded_data);
+    st = page_decoder.init();
+    ASSERT_TRUE(st.ok());
+
+    auto column = ChunkFactory::column_from_field_type(TYPE_INT, false);
+    rowid_t rowids[] = {0, 50, 99};
+    size_t num_read = 3;
+    st = page_decoder.read_by_rowids(0, rowids, &num_read, column.get());
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(3, num_read);
+    ASSERT_EQ(3, column->size());
+
+    ASSERT_EQ(0, column->get(0).get_int32());
+    ASSERT_EQ(50, column->get(1).get_int32());
+    ASSERT_EQ(99, column->get(2).get_int32());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`BitShuffleDataDecoder::decode_page_data` (the page-load pre-decoder, dating back to segment_v2 in 2021) takes `num_elements`, `compressed_size`, `size_of_element`, the padded element count, and the trailer sizes straight from the page bytes and the parsed footer without any bounds checks. On a corrupted or maliciously crafted page this leads to out-of-bounds reads/writes and an uncapped allocation:

- a page shorter than the 16-byte header makes the header read run past the input;
- `compressed_size` below `BITSHUFFLE_PAGE_HEADER_SIZE` underflows the compressed-body slice length;
- `compressed_size` beyond the page overruns the input;
- an out-of-range `size_of_element` (e.g. `0xffffffff`) makes `data_size = num_element_after_padding * size_of_element` request roughly 32 GiB *before* any validation, and load paths may run with memory-limit enforcement disabled, so this can OOM/crash the BE rather than fail cleanly;
- a consistent but implausibly large element count claims a decoded size far past what LZ4 can ever expand to;
- a trailer (`nullmap_size + footer_size`) that does not exactly consume the bytes remaining after the compressed body either makes the tail memcpy read past `page_slice` and write past the freshly allocated destination, or leaves surplus bytes inside the cached page whose footer is parsed from its end.

The same latent pattern was found and fixed for the new ALP decoder during review of #78308; this PR fixes the original.

## What I'm doing:

Validate all page-derived sizes in `BitShuffleDataDecoder::decode_page_data` before they drive any allocation or memcpy, rejecting malformed pages with `Status::Corruption`:

- minimum header length;
- padded-element-count consistency (promoted from a `DCHECK` to a real check);
- `compressed_size` lower/upper bounds;
- `size_of_element` restricted to the set `BitShufflePageDecoder::init` accepts (`{1,2,3,4,8,12,16,32}`), so an absurd element size cannot drive the allocation;
- decoded size bounded by LZ4's ~255x maximum expansion, so an implausible element count is rejected before allocating;
- the trailer length must consume the remaining bytes exactly (neither over- nor under-claiming).

Adds `BitShufflePageTest.TestCorruptedPagePreDecodeRejected` with nine corrupted-page scenarios — truncated page, oversized `compressed_size`, undersized `compressed_size`, mismatched padded count, `0xffffffff` element size, implausibly large element count, over-claimed trailer, and surplus body bytes — all going through the production `StoragePageDecoder::decode_page` entry. Verified on a Release build: BitShufflePage suite 17/17 pass. No behavior change for valid pages.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Backport conflict resolution

Mergify's automatic cherry-pick of 8c008f4 onto `branch-4.0` hit conflicts in all three files (see #78639), so this PR carries the manually resolved backport and supersedes it.

Every conflict was the same mechanical cause: mainline has moved these headers from `util/` to `base/`, while `branch-4.0` has not. The 4.0 spellings were kept and only the newly required header was added.

| mainline | branch-4.0 |
|---|---|
| `base/bit/bit_util.h` | `util/bit_util.h` (added — the only new include) |
| `base/coding.h` | `util/coding.h` (already present) |
| `base/string/faststring.h` | `util/faststring.h` (already present) |
| `base/string/slice.h` | `util/slice.h` (already present) |
| `base/container/raw_container.h` | `util/raw_container.h` (already present) |

The test file conflicted only because the new `TestCorruptedPagePreDecodeRejected` case landed next to code that differs between the branches (`ChunkHelper` vs `ChunkFactory`, `TypeTraits<type>::CppType` vs `StorageCppType<Type>`); the 4.0 forms were kept and the new case was taken verbatim, since it depends on nothing beyond `StoragePageDecoder::decode_page`, whose signature is identical on both branches.

No fix logic was altered: all seven pre-decoder guards, both `BitUtil::RoundUpToPowerOf2` call sites and all ten rejection assertions are present and match mainline.

