### PR TITLE
[BugFix] Keep nested lambda hoists inside the scope that defines them

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
@@ -186,9 +186,10 @@ public class ScalarOperatorsReuse {
 
         @Override
         public ScalarOperator visitLambdaFunctionOperator(LambdaFunctionOperator operator, Void context) {
-            ScalarOperator newOperator = new LambdaFunctionOperator(operator.getRefColumns(),
+            LambdaFunctionOperator newOperator = new LambdaFunctionOperator(operator.getRefColumns(),
                     operator.getLambdaExpr().accept(this, null), operator.getType()
             );
+            newOperator.addColumnToExpr(operator.getColumnRefMap());
             return tryRewrite(newOperator);
         }
 
@@ -312,20 +313,28 @@ public class ScalarOperatorsReuse {
         // this information will help us determine whether an operator can be reused.
         public Set<ColumnRefOperator> currentLambdaArguments;
         public Set<ColumnRefOperator> outerLambdaArguments;
+        public Set<ColumnRefOperator> currentLambdaLocalRefs;
+        public Set<ColumnRefOperator> outerLambdaLocalRefs;
         public ColumnRefSet usedColumns;
 
         public CommonOperatorContext(boolean isPartOfLambdaExpr) {
             this.isPartOfLambdaExpr = isPartOfLambdaExpr;
             this.currentLambdaArguments = Sets.newHashSet();
             this.outerLambdaArguments = Sets.newHashSet();
+            this.currentLambdaLocalRefs = Sets.newHashSet();
+            this.outerLambdaLocalRefs = Sets.newHashSet();
             this.usedColumns = new ColumnRefSet();
         }
 
         public CommonOperatorContext(boolean isPartOfLambdaExpr, Set<ColumnRefOperator> currentLambdaArguments,
-                                     Set<ColumnRefOperator> outerLambdaArguments) {
+                                     Set<ColumnRefOperator> outerLambdaArguments,
+                                     Set<ColumnRefOperator> currentLambdaLocalRefs,
+                                     Set<ColumnRefOperator> outerLambdaLocalRefs) {
             this.isPartOfLambdaExpr = isPartOfLambdaExpr;
             this.currentLambdaArguments = currentLambdaArguments;
             this.outerLambdaArguments = outerLambdaArguments;
+            this.currentLambdaLocalRefs = currentLambdaLocalRefs;
+            this.outerLambdaLocalRefs = outerLambdaLocalRefs;
             this.usedColumns = new ColumnRefSet();
         }
     }
@@ -381,6 +390,17 @@ public class ScalarOperatorsReuse {
             return groups;
         }
 
+        private static void collectAllRefs(ScalarOperator operator, ColumnRefSet result) {
+            if (operator instanceof ColumnRefOperator) {
+                result.union(((ColumnRefOperator) operator).getId());
+            }
+            if (operator instanceof LambdaFunctionOperator) {
+                ((LambdaFunctionOperator) operator).getColumnRefMap().values()
+                        .forEach(value -> collectAllRefs(value, result));
+            }
+            operator.getChildren().forEach(child -> collectAllRefs(child, result));
+        }
+
         public boolean hasLambdaFunction() {
             return hasLambdaFunction;
         }
@@ -394,13 +414,15 @@ public class ScalarOperatorsReuse {
             int group = level.computeIfAbsent(id, k -> currentId++);
             CommonResult result = new CommonResult(depth, List.of(group));
 
-            boolean isDependentOnOuterLambda = context.usedColumns.containsAny(context.outerLambdaArguments);
+            boolean isDependentOnOuterLambda = context.usedColumns.containsAny(context.outerLambdaArguments)
+                    || context.usedColumns.containsAny(context.outerLambdaLocalRefs);
             if (isDependentOnOuterLambda) {
                 return result;
             }
 
             boolean isDependentOnCurrentLambdaArguments =
-                    context.usedColumns.containsAny(context.currentLambdaArguments);
+                    context.usedColumns.containsAny(context.currentLambdaArguments)
+                            || context.usedColumns.containsAny(context.currentLambdaLocalRefs);
             if (isDuplicated && !isDependentOnCurrentLambdaArguments) {
                 Set<OperatorId> commonGroup =
                         commonOperatorsByDepth.computeIfAbsent(depth, c -> Sets.newLinkedHashSet());
@@ -430,6 +452,8 @@ public class ScalarOperatorsReuse {
 
             if (scalarOperator instanceof LambdaFunctionOperator) {
                 context.currentLambdaArguments.addAll(((LambdaFunctionOperator) scalarOperator).getRefColumns());
+                context.currentLambdaLocalRefs.addAll(
+                        ((LambdaFunctionOperator) scalarOperator).getColumnRefMap().keySet());
             }
 
             CommonResult result = visitChildren(scalarOperator, context);
@@ -446,7 +470,8 @@ public class ScalarOperatorsReuse {
             }
             for (int i = 1; i < scalarOperator.getChildren().size(); i++) {
                 CommonOperatorContext childContext = new CommonOperatorContext(context.isPartOfLambdaExpr,
-                        context.currentLambdaArguments, context.outerLambdaArguments);
+                        context.currentLambdaArguments, context.outerLambdaArguments,
+                        context.currentLambdaLocalRefs, context.outerLambdaLocalRefs);
                 CommonResult res = scalarOperator.getChild(i).accept(this, childContext);
                 depth = Math.max(depth, res.depth);
                 groups.addAll(res.childrenGroup);
@@ -458,7 +483,9 @@ public class ScalarOperatorsReuse {
 
         @Override
         public CommonResult visitVariableReference(ColumnRefOperator variable, CommonOperatorContext context) {
-            if (variable.getOpType() == OperatorType.LAMBDA_ARGUMENT) {
+            if (variable.getOpType() == OperatorType.LAMBDA_ARGUMENT
+                    || context.currentLambdaLocalRefs.contains(variable)
+                    || context.outerLambdaLocalRefs.contains(variable)) {
                 context.usedColumns.union(variable);
             }
             return super.visitVariableReference(variable, context);
@@ -473,8 +500,13 @@ public class ScalarOperatorsReuse {
             newContext.outerLambdaArguments.addAll(context.outerLambdaArguments);
             newContext.outerLambdaArguments.addAll(context.currentLambdaArguments);
             newContext.currentLambdaArguments.addAll(scalarOperator.getRefColumns());
+            newContext.outerLambdaLocalRefs.addAll(context.outerLambdaLocalRefs);
+            newContext.outerLambdaLocalRefs.addAll(context.currentLambdaLocalRefs);
+            newContext.currentLambdaLocalRefs.addAll(scalarOperator.getColumnRefMap().keySet());
             CommonResult result = visit(scalarOperator.getLambdaExpr(), newContext);
             context.usedColumns.union(newContext.usedColumns);
+            scalarOperator.getColumnRefMap().values()
+                    .forEach(value -> collectAllRefs(value, context.usedColumns));
             return result;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
@@ -122,4 +122,43 @@ public class ScalarOperatorsReuseRuleTest extends PlanTestBase {
             connectContext.getSessionVariable().setEnablePredicateExprReuse(true);
         }
     }
+
+    @Test
+    public void testNestedLambdaHoistingKeepsTransitiveArgumentDependency() throws Exception {
+        String query = "select array_map(x -> array_map(y -> array_map(z -> abs(x) + abs(y) + z, v3), v3), v3)"
+                + " from tarray";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "  1:Project\n" +
+                "  |  <slot 7> : array_map(<slot 4> -> array_map(<slot 5> -> array_map(<slot 6> -> <slot 12> + " +
+                "CAST(<slot 6> AS LARGEINT), 3: v3)\n" +
+                "        lambda common expressions:{<slot 10> <-> abs(<slot 4>)}{<slot 11> <-> abs(<slot 5>)}" +
+                "{<slot 12> <-> <slot 10> + <slot 11>}\n" +
+                "        , 3: v3), 3: v3)\n" +
+                "  |  ");
+    }
+
+    @Test
+    public void testNestedInnerLambdaHoistsSurviveOuterRewrite() throws Exception {
+        String query = "select array_map(x -> array_map(y -> array_map("
+                + "z -> abs(x) + abs(x) + abs(y) + abs(y) + z, v3), v3), v3) from tarray";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "  1:Project\n" +
+                "  |  <slot 7> : array_map(<slot 4> -> array_map(<slot 5> -> array_map(<slot 6> -> <slot 9> + " +
+                "<slot 9> + <slot 10> + <slot 10> + CAST(<slot 6> AS LARGEINT)\n" +
+                "        lambda common expressions:{<slot 9> <-> abs(<slot 4>)}{<slot 10> <-> abs(<slot 5>)}\n" +
+                "        , 3: v3), 3: v3), 3: v3)");
+    }
+    @Test
+    public void testOuterCommonExprRewriteKeepsInnerLambdaHoists() throws Exception {
+        String query = "select array_map(x -> array_slice(array_map(y -> abs(x) + abs(x) + y, v3), x * 2, x * 2),"
+                + " v3) from tarray";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "  1:Project\n" +
+                "  |  <slot 6> : array_map(<slot 4> -> array_slice(array_map(<slot 5> -> <slot 8> + <slot 8> + " +
+                "CAST(<slot 5> AS LARGEINT)\n" +
+                "        lambda common expressions:{<slot 8> <-> abs(<slot 4>)}\n" +
+                "        , 3: v3), <slot 10>, <slot 10>)\n" +
+                "        lambda common expressions:{<slot 10> <-> <slot 4> * 2}\n" +
+                "        , 3: v3)");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Nested `array_map` calls can fail to plan. Three related holes, all from `CommonSubScalarOperatorCollector` and `ScalarOperatorRewriter` mishandling the common sub expressions a lambda has already hoisted into its own `columnRefMap`.

**1. A ref standing for a hoisted expression was not treated as a dependency.**

```sql
SELECT array_map(x -> array_map(y -> array_map(z -> abs(x) + abs(y) + z, v3), v3), v3)
FROM tarray
```

fails with `Input dependency cols check failed`. Those refs are ordinary column refs, but they are defined only inside the lambda holding them, and `usedColumns` recorded a ref only when its op type was `LAMBDA_ARGUMENT`. So an expression whose last remaining link to an argument had already become such a ref looked argument independent and was hoisted out of the scope that defines its inputs: the `y` lambda pass hoists `abs(x)` and `abs(y)`, its body keeps no mention of `y`, and the `x` lambda pass then hoists the inner `array_map` out while the refs stay behind.

**2. A hoisted expression can itself capture an enclosing lambda's argument, invisibly.**

```sql
SELECT array_map(x -> array_map(y -> array_map(z -> abs(x) + abs(x) + abs(y) + abs(y) + z, v3), v3), v3)
FROM tarray
```

fails the same check. Lambdas are rewritten innermost first, so here the duplicated `abs(x)` and `abs(y)` are hoisted during the *innermost* pass, into `z`'s own `columnRefMap`. `abs(y)` therefore captures `y` from inside a map that the walk never visits — it only visits a lambda's expression — so the inner `array_map` was judged independent of `y` and hoisted out of the lambda that binds it.

**3. Rebuilding a lambda discarded the definitions it had already hoisted.**

```sql
SELECT array_map(x -> array_slice(array_map(y -> abs(x) + abs(x) + y, v3), x * 2, x * 2), v3)
FROM tarray
```

fails the same check. Substituting a common sub expression rewrites the whole expression, and `ScalarOperatorRewriter#visitLambdaFunctionOperator` rebuilds a lambda through a constructor that cannot carry `columnRefMap`. Here the inner pass hoists `abs(x)` into the inner lambda's map, then `x * 2` is reused at the outer level; the rebuild performing that substitution reconstructs the inner lambda without its map, while its body still references those definitions.

## What I'm doing:

`CommonOperatorContext` carries the hoisted refs of the current and enclosing lambdas beside their arguments, in `currentLambdaLocalRefs` and `outerLambdaLocalRefs`, propagated exactly as the argument sets are. `visitVariableReference` records such a ref in `usedColumns`, and both dependency checks in `collectCommonOperatorsByDepth` consult them.

On leaving a lambda, the refs captured by its already hoisted definitions are collected into the enclosing scope's `usedColumns` with `collectAllRefs`, which walks every column ref including lambda arguments. `ColumnRefOperator#getUsedColumns` returns an empty set for `LAMBDA_ARGUMENT`, so it cannot be used for this; the collection targets the enclosing context so the lambda's own hoisting decisions are unchanged.

`ScalarOperatorRewriter#visitLambdaFunctionOperator` carries `getColumnRefMap()` onto the rebuilt lambda. The definitions are copied as they are rather than rewritten, so one that happens to be a common sub expression itself stays un-deduplicated, costing a reuse rather than correctness.

Lambda arguments keep their own sets and their own check. The two are different things: an argument is bound by the lambda, a hoisted ref is computed inside it. `usedColumns` still holds only what binds an expression to a lambda scope — ordinary column refs, resolvable anywhere, stay out of it.

`collectAllRefs` does not subtract the map's own keys the way `LambdaFunctionOperator#getUsedColumns` does, so a chain of hoists where one definition references another key reports a dependency that is strictly speaking redundant. Reporting a dependency where none exists only costs a hoist, so the change errs towards leaving expressions in place.

Three regression tests in `ScalarOperatorsReuseRuleTest` over the existing `tarray` fixture, one per query above. Each fails to plan before the change; after it every plan keeps the hoists as `lambda common expressions` inside the lambda that owns them.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
