### PR TITLE
[BugFix] Keep nested lambda hoists inside the scope that defines them

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/exprreuse/ScalarOperatorsReuse.java
@@ -312,20 +312,28 @@ public class ScalarOperatorsReuse {
         // this information will help us determine whether an operator can be reused.
         public Set<ColumnRefOperator> currentLambdaArguments;
         public Set<ColumnRefOperator> outerLambdaArguments;
+        public Set<ColumnRefOperator> currentLambdaLocalRefs;
+        public Set<ColumnRefOperator> outerLambdaLocalRefs;
         public ColumnRefSet usedColumns;
 
         public CommonOperatorContext(boolean isPartOfLambdaExpr) {
             this.isPartOfLambdaExpr = isPartOfLambdaExpr;
             this.currentLambdaArguments = Sets.newHashSet();
             this.outerLambdaArguments = Sets.newHashSet();
+            this.currentLambdaLocalRefs = Sets.newHashSet();
+            this.outerLambdaLocalRefs = Sets.newHashSet();
             this.usedColumns = new ColumnRefSet();
         }
 
         public CommonOperatorContext(boolean isPartOfLambdaExpr, Set<ColumnRefOperator> currentLambdaArguments,
-                                     Set<ColumnRefOperator> outerLambdaArguments) {
+                                     Set<ColumnRefOperator> outerLambdaArguments,
+                                     Set<ColumnRefOperator> currentLambdaLocalRefs,
+                                     Set<ColumnRefOperator> outerLambdaLocalRefs) {
             this.isPartOfLambdaExpr = isPartOfLambdaExpr;
             this.currentLambdaArguments = currentLambdaArguments;
             this.outerLambdaArguments = outerLambdaArguments;
+            this.currentLambdaLocalRefs = currentLambdaLocalRefs;
+            this.outerLambdaLocalRefs = outerLambdaLocalRefs;
             this.usedColumns = new ColumnRefSet();
         }
     }
@@ -394,13 +402,15 @@ public class ScalarOperatorsReuse {
             int group = level.computeIfAbsent(id, k -> currentId++);
             CommonResult result = new CommonResult(depth, List.of(group));
 
-            boolean isDependentOnOuterLambda = context.usedColumns.containsAny(context.outerLambdaArguments);
+            boolean isDependentOnOuterLambda = context.usedColumns.containsAny(context.outerLambdaArguments)
+                    || context.usedColumns.containsAny(context.outerLambdaLocalRefs);
             if (isDependentOnOuterLambda) {
                 return result;
             }
 
             boolean isDependentOnCurrentLambdaArguments =
-                    context.usedColumns.containsAny(context.currentLambdaArguments);
+                    context.usedColumns.containsAny(context.currentLambdaArguments)
+                            || context.usedColumns.containsAny(context.currentLambdaLocalRefs);
             if (isDuplicated && !isDependentOnCurrentLambdaArguments) {
                 Set<OperatorId> commonGroup =
                         commonOperatorsByDepth.computeIfAbsent(depth, c -> Sets.newLinkedHashSet());
@@ -430,6 +440,8 @@ public class ScalarOperatorsReuse {
 
             if (scalarOperator instanceof LambdaFunctionOperator) {
                 context.currentLambdaArguments.addAll(((LambdaFunctionOperator) scalarOperator).getRefColumns());
+                context.currentLambdaLocalRefs.addAll(
+                        ((LambdaFunctionOperator) scalarOperator).getColumnRefMap().keySet());
             }
 
             CommonResult result = visitChildren(scalarOperator, context);
@@ -446,7 +458,8 @@ public class ScalarOperatorsReuse {
             }
             for (int i = 1; i < scalarOperator.getChildren().size(); i++) {
                 CommonOperatorContext childContext = new CommonOperatorContext(context.isPartOfLambdaExpr,
-                        context.currentLambdaArguments, context.outerLambdaArguments);
+                        context.currentLambdaArguments, context.outerLambdaArguments,
+                        context.currentLambdaLocalRefs, context.outerLambdaLocalRefs);
                 CommonResult res = scalarOperator.getChild(i).accept(this, childContext);
                 depth = Math.max(depth, res.depth);
                 groups.addAll(res.childrenGroup);
@@ -458,7 +471,9 @@ public class ScalarOperatorsReuse {
 
         @Override
         public CommonResult visitVariableReference(ColumnRefOperator variable, CommonOperatorContext context) {
-            if (variable.getOpType() == OperatorType.LAMBDA_ARGUMENT) {
+            if (variable.getOpType() == OperatorType.LAMBDA_ARGUMENT
+                    || context.currentLambdaLocalRefs.contains(variable)
+                    || context.outerLambdaLocalRefs.contains(variable)) {
                 context.usedColumns.union(variable);
             }
             return super.visitVariableReference(variable, context);
@@ -473,6 +488,9 @@ public class ScalarOperatorsReuse {
             newContext.outerLambdaArguments.addAll(context.outerLambdaArguments);
             newContext.outerLambdaArguments.addAll(context.currentLambdaArguments);
             newContext.currentLambdaArguments.addAll(scalarOperator.getRefColumns());
+            newContext.outerLambdaLocalRefs.addAll(context.outerLambdaLocalRefs);
+            newContext.outerLambdaLocalRefs.addAll(context.currentLambdaLocalRefs);
+            newContext.currentLambdaLocalRefs.addAll(scalarOperator.getColumnRefMap().keySet());
             CommonResult result = visit(scalarOperator.getLambdaExpr(), newContext);
             context.usedColumns.union(newContext.usedColumns);
             return result;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorsReuseRuleTest.java
@@ -122,4 +122,18 @@ public class ScalarOperatorsReuseRuleTest extends PlanTestBase {
             connectContext.getSessionVariable().setEnablePredicateExprReuse(true);
         }
     }
+
+    @Test
+    public void testNestedLambdaHoistingKeepsTransitiveArgumentDependency() throws Exception {
+        String query = "select array_map(x -> array_map(y -> array_map(z -> abs(x) + abs(y) + z, v3), v3), v3)"
+                + " from tarray";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "  1:Project\n" +
+                "  |  <slot 7> : array_map(<slot 4> -> array_map(<slot 5> -> array_map(<slot 6> -> <slot 12> + " +
+                "CAST(<slot 6> AS LARGEINT), 3: v3)\n" +
+                "        lambda common expressions:{<slot 10> <-> abs(<slot 4>)}{<slot 11> <-> abs(<slot 5>)}" +
+                "{<slot 12> <-> <slot 10> + <slot 11>}\n" +
+                "        , 3: v3), 3: v3)\n" +
+                "  |  ");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Nested `array_map` calls can fail to plan:

```sql
SELECT array_map(x -> array_map(y -> array_map(z -> abs(x) + abs(y) + z, v3), v3), v3)
FROM tarray
```

fails in `ScalarOperatorsReuse` with `Input dependency cols check failed`.

A lambda's common sub expressions are hoisted into its own `columnRefMap`, and the refs standing for them are ordinary column refs defined only inside that lambda. `usedColumns` recorded a ref only when its op type was `LAMBDA_ARGUMENT`, so an expression whose last remaining link to an argument had already become such a ref looked argument independent and was hoisted out of the scope that defines its inputs.

Walking the query above, the y lambda is processed first. `abs(x)` and `abs(y)` are both independent of `z`, so both are hoisted into the y lambda's `columnRefMap`, and its body becomes the sum of the two refs standing for them plus `z`. The x lambda pass then asks whether that inner `array_map` depends on `y`, finds no mention of it, and hoists the call out to the x lambda while the two refs stay behind in the y lambda. Nothing binds them there, so the input dependency check fails.

## What I'm doing:

`CommonOperatorContext` now carries the hoisted refs of the current and enclosing lambdas beside their arguments, in `currentLambdaLocalRefs` and `outerLambdaLocalRefs`, propagated exactly as the argument sets are. `visitVariableReference` records such a ref in `usedColumns`, and both dependency checks in `collectCommonOperatorsByDepth` consult them.

Lambda arguments keep their own sets and their own check. The two are different things: an argument is bound by the lambda, a hoisted ref is computed inside it. Keeping them apart leaves the existing `LAMBDA_ARGUMENT` branch in place.

`usedColumns` still holds only what binds an expression to a lambda scope — ordinary column refs, resolvable anywhere, stay out of it. Reporting a dependency where none exists only costs a hoist, so the change errs towards leaving expressions in place.

Regression test in `ScalarOperatorsReuseRuleTest` over the existing `tarray` fixture, on the query above. Before the fix it fails to plan; after it the inner `array_map` stays inside the lambda that owns its inputs.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  
 **3.5 has the same issue, but the fix can't be auto backported to it.**