### PR TITLE
[BugFix] Fix GCS Broker Load with inline service account key on gcs-connector 3.x

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudConfigurationProvider.java
@@ -42,6 +42,15 @@ public class GCPCloudConfigurationProvider implements CloudConfigurationProvider
     public static final String IMPERSONATION_SERVICE_ACCOUNT_KEY = "fs.gs.auth.impersonation.service.account";
     public static final String ACCESS_TOKEN_PROVIDER_IMPL =
             "com.starrocks.connector.gcp.TemporaryGCPAccessTokenProvider";
+    public static final String AUTH_TYPE_COMPUTE_ENGINE = "COMPUTE_ENGINE";
+    // gcs-connector 3.x dropped inline service-account credentials (2.x read these keys directly) and its
+    // SERVICE_ACCOUNT_JSON_KEYFILE mode only accepts a local keyfile path. StarRocks keeps accepting the
+    // inline key through this provider, which reads the same keys and mints access tokens itself.
+    public static final String SERVICE_ACCOUNT_ACCESS_TOKEN_PROVIDER_IMPL =
+            "com.starrocks.connector.gcp.ServiceAccountGCPAccessTokenProvider";
+    public static final String SERVICE_ACCOUNT_EMAIL_KEY = "fs.gs.auth.service.account.email";
+    public static final String SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY = "fs.gs.auth.service.account.private.key.id";
+    public static final String SERVICE_ACCOUNT_PRIVATE_KEY_KEY = "fs.gs.auth.service.account.private.key";
 
     @Override
     public CloudConfiguration build(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/gcp/GCPCloudCredential.java
@@ -77,12 +77,24 @@ public class GCPCloudCredential implements CloudCredential {
             hadoopConfiguration.put("fs.gs.endpoint", endpoint);
         }
         if (useComputeEngineServiceAccount) {
-            hadoopConfiguration.put("fs.gs.auth.type", "COMPUTE_ENGINE");
-        } else if (hasServiceAccountCredentials()) {
-            hadoopConfiguration.put("fs.gs.auth.type", "SERVICE_ACCOUNT_JSON_KEYFILE");
-            hadoopConfiguration.put("fs.gs.auth.service.account.email", serviceAccountEmail);
-            hadoopConfiguration.put("fs.gs.auth.service.account.private.key.id", serviceAccountPrivateKeyId);
-            hadoopConfiguration.put("fs.gs.auth.service.account.private.key", serviceAccountPrivateKey);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.AUTH_TYPE_KEY,
+                    GCPCloudConfigurationProvider.AUTH_TYPE_COMPUTE_ENGINE);
+        } else if (hasServiceAccountCredentials() && !hasAccessToken()) {
+            // A vended access token takes precedence (see below); do not ship the unused private key with it.
+            // gcs-connector 3.x has no auth type that accepts an inline private key: SERVICE_ACCOUNT_JSON_KEYFILE
+            // opens fs.gs.auth.service.account.json.keyfile (NPE when unset) and the inline keys below are
+            // ignored. Route through StarRocks' own AccessTokenProvider, which reads them and mints tokens.
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.AUTH_TYPE_KEY,
+                    GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY,
+                    GCPCloudConfigurationProvider.SERVICE_ACCOUNT_ACCESS_TOKEN_PROVIDER_IMPL);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY,
+                    GCPCloudConfigurationProvider.SERVICE_ACCOUNT_ACCESS_TOKEN_PROVIDER_IMPL);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_EMAIL_KEY, serviceAccountEmail);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY,
+                    serviceAccountPrivateKeyId);
+            hadoopConfiguration.put(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_PRIVATE_KEY_KEY,
+                    serviceAccountPrivateKey);
         }
         // Skip impersonation when a vended access token is present: gcs-connector would apply
         // impersonation on top of the token, and vended tokens lack IAM impersonation permission.

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -393,7 +393,9 @@ public class CloudConfigurationFactoryTest {
                         "cred=GCPCloudCredential{endpoint='http://xx', useComputeEngineServiceAccount=false, " +
                         "serviceAccountEmail='XX', serviceAccountPrivateKeyId='XX', serviceAccountPrivateKey='XX', " +
                         "impersonationServiceAccount='XX', accessToken='', accessTokenExpiresAt=''}}");
-        Assertions.assertEquals("SERVICE_ACCOUNT_JSON_KEYFILE", conf.get("fs.gs.auth.type"));
+        Assertions.assertEquals("ACCESS_TOKEN_PROVIDER", conf.get("fs.gs.auth.type"));
+        Assertions.assertEquals("com.starrocks.connector.gcp.ServiceAccountGCPAccessTokenProvider",
+                conf.get("fs.gs.auth.access.token.provider"));
         Assertions.assertEquals("XX", conf.get("fs.gs.auth.service.account.email"));
         Assertions.assertEquals("XX", conf.get("fs.gs.auth.service.account.private.key.id"));
         Assertions.assertEquals("XX", conf.get("fs.gs.auth.service.account.private.key"));

--- a/fe/fe-core/src/test/java/com/starrocks/credential/gcp/GCPCloudCredentialTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/gcp/GCPCloudCredentialTest.java
@@ -35,7 +35,16 @@ public class GCPCloudCredentialTest {
         Configuration conf = new Configuration();
         credential.applyToConfiguration(conf);
 
-        assertEquals("SERVICE_ACCOUNT_JSON_KEYFILE", conf.get("fs.gs.auth.type"));
+        // gcs-connector 3.x cannot consume an inline key directly: SERVICE_ACCOUNT_JSON_KEYFILE would
+        // open fs.gs.auth.service.account.json.keyfile and NPE, so the key must go through our provider.
+        assertEquals(GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER,
+                conf.get(GCPCloudConfigurationProvider.AUTH_TYPE_KEY));
+        assertEquals(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_ACCESS_TOKEN_PROVIDER_IMPL,
+                conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY));
+        assertEquals(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_ACCESS_TOKEN_PROVIDER_IMPL,
+                conf.get(GCPCloudConfigurationProvider.LEGACY_ACCESS_TOKEN_PROVIDER_IMPL_KEY));
+        assertNull(conf.get("fs.gs.auth.service.account.json.keyfile"));
+        assertNull(conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_KEY));
         assertEquals("test@project.iam.gserviceaccount.com",
                 conf.get("fs.gs.auth.service.account.email"));
         assertEquals("key-id-123",
@@ -99,6 +108,49 @@ public class GCPCloudCredentialTest {
 
         assertEquals("COMPUTE_ENGINE", conf.get("fs.gs.auth.type"));
         assertNull(conf.get("fs.gs.auth.service.account.email"));
+        assertNull(conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY));
         assertTrue(credential.validate());
+    }
+
+    @Test
+    public void testServiceAccountCredentialsKeepImpersonation() {
+        GCPCloudCredential credential = new GCPCloudCredential(
+                "", false,
+                "test@project.iam.gserviceaccount.com",
+                "key-id-123",
+                "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----",
+                "impersonated@project.iam.gserviceaccount.com", null, null);
+
+        Configuration conf = new Configuration();
+        credential.applyToConfiguration(conf);
+
+        // Unlike vended tokens, a service-account key may impersonate, so gcs-connector should still
+        // layer ImpersonatedCredentials on top of the provider-issued credentials.
+        assertEquals("impersonated@project.iam.gserviceaccount.com",
+                conf.get(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY));
+        assertEquals(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_ACCESS_TOKEN_PROVIDER_IMPL,
+                conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY));
+    }
+
+    @Test
+    public void testVendedTokenOverridesServiceAccountProvider() {
+        GCPCloudCredential credential = new GCPCloudCredential(
+                "", false,
+                "test@project.iam.gserviceaccount.com",
+                "key-id-123",
+                "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----",
+                "", "ya29.access-token", "2026-12-31T00:00:00Z");
+
+        Configuration conf = new Configuration();
+        credential.applyToConfiguration(conf);
+
+        assertEquals(GCPCloudConfigurationProvider.AUTH_TYPE_ACCESS_TOKEN_PROVIDER,
+                conf.get(GCPCloudConfigurationProvider.AUTH_TYPE_KEY));
+        assertEquals(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_IMPL,
+                conf.get(GCPCloudConfigurationProvider.ACCESS_TOKEN_PROVIDER_KEY));
+        // The service account key is unused in this mode and must not be propagated.
+        assertNull(conf.get(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_EMAIL_KEY));
+        assertNull(conf.get(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY));
+        assertNull(conf.get(GCPCloudConfigurationProvider.SERVICE_ACCOUNT_PRIVATE_KEY_KEY));
     }
 }

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/gcp/ServiceAccountGCPAccessTokenProvider.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/gcp/ServiceAccountGCPAccessTokenProvider.java
@@ -1,0 +1,167 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.gcp;
+
+// gcs-connector ships google-auth-library relocated inside its shaded jar. hadoop-ext is compiled
+// against, and only ever runs next to, that shaded jar (FE lib/ and BE lib/jni-packages/), so the
+// relocated class is the one that is guaranteed to be on the classpath.
+import com.google.cloud.hadoop.repackaged.gcs.com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Date;
+
+/**
+ * {@link AccessTokenProvider} that mints GCS access tokens from an inline service-account key
+ * (email + private key id + PEM private key) supplied through the Hadoop {@link Configuration}.
+ *
+ * <p>gcs-connector 3.x removed the inline {@code fs.gs.auth.service.account.{email,private.key.id,private.key}}
+ * credentials it accepted in 2.x; its {@code SERVICE_ACCOUNT_JSON_KEYFILE} mode only reads a JSON keyfile from
+ * a local path. StarRocks users pass the key inline via {@code gcp.gcs.service_account_*} properties, so this
+ * provider is plugged in through {@code fs.gs.auth.type=ACCESS_TOKEN_PROVIDER} to keep that interface working
+ * without materialising a keyfile on every FE/BE node.
+ */
+public class ServiceAccountGCPAccessTokenProvider implements AccessTokenProvider {
+    private static final Logger LOG = LogManager.getLogger(ServiceAccountGCPAccessTokenProvider.class);
+
+    // Same key names gcs-connector 2.x used for inline service-account credentials; 3.x ignores them,
+    // which is why this provider reads them itself.
+    public static final String SERVICE_ACCOUNT_EMAIL_KEY = "fs.gs.auth.service.account.email";
+    public static final String SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY = "fs.gs.auth.service.account.private.key.id";
+    public static final String SERVICE_ACCOUNT_PRIVATE_KEY_KEY = "fs.gs.auth.service.account.private.key";
+    // Honoured by gcs-connector for its own credential types; honoured here too so tests (or private
+    // token endpoints) can redirect the OAuth2 exchange.
+    public static final String TOKEN_SERVER_URL_KEY = "fs.gs.token.server.url";
+
+    private static final String CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform";
+    // Refresh a little before the token actually expires so in-flight requests never carry a stale token.
+    private static final long REFRESH_MARGIN_MS = 60_000L;
+    // Lifetime assumed when the token response carries no expiration. google-auth requires expires_in for
+    // service account tokens, so this is defensive; it is deliberately shorter than Google's 1h default.
+    private static final long DEFAULT_TOKEN_LIFETIME_MS = 30 * 60_000L;
+
+    private Configuration config;
+    private ServiceAccountCredentials credentials;
+    private String serviceAccountEmail;
+    private AccessToken cachedToken;
+
+    public ServiceAccountGCPAccessTokenProvider() {
+        // Instantiated reflectively by gcs-connector; configuration arrives through setConf().
+    }
+
+    @Override
+    public void setConf(Configuration config) {
+        this.config = config;
+        this.credentials = null;
+        this.cachedToken = null;
+        if (config == null) {
+            return;
+        }
+        String email = config.get(SERVICE_ACCOUNT_EMAIL_KEY, "");
+        String privateKeyId = config.get(SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY, "");
+        String privateKey = config.get(SERVICE_ACCOUNT_PRIVATE_KEY_KEY, "");
+        if (email.isEmpty() || privateKeyId.isEmpty() || privateKey.isEmpty()) {
+            throw new IllegalArgumentException(String.format(
+                    "GCS service account credentials are incomplete: %s%s%s must all be set when using %s",
+                    email.isEmpty() ? SERVICE_ACCOUNT_EMAIL_KEY + " " : "",
+                    privateKeyId.isEmpty() ? SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY + " " : "",
+                    privateKey.isEmpty() ? SERVICE_ACCOUNT_PRIVATE_KEY_KEY + " " : "",
+                    getClass().getName()));
+        }
+        this.serviceAccountEmail = email;
+        try {
+            ServiceAccountCredentials.Builder builder = ServiceAccountCredentials.newBuilder()
+                    .setClientEmail(email)
+                    .setPrivateKeyId(privateKeyId)
+                    .setPrivateKeyString(normalizePrivateKey(privateKey))
+                    .setScopes(Collections.singletonList(CLOUD_PLATFORM_SCOPE));
+            String tokenServerUrl = config.get(TOKEN_SERVER_URL_KEY, "");
+            if (!tokenServerUrl.isEmpty()) {
+                builder.setTokenServerUri(URI.create(tokenServerUrl));
+            }
+            this.credentials = builder.build();
+        } catch (IOException | IllegalArgumentException e) {
+            // Never echo the key material back; the message only names which account failed.
+            throw new IllegalArgumentException(
+                    "Invalid GCS service account private key for " + email + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Configuration getConf() {
+        return config;
+    }
+
+    @Override
+    public AccessTokenType getAccessTokenType() {
+        return AccessTokenType.GENERIC;
+    }
+
+    @Override
+    public synchronized AccessToken getAccessToken() {
+        if (cachedToken == null || isExpiringSoon(cachedToken)) {
+            try {
+                refresh();
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to obtain GCS access token for service account " + serviceAccountEmail, e);
+            }
+        }
+        return cachedToken;
+    }
+
+    @Override
+    public synchronized void refresh() throws IOException {
+        if (credentials == null) {
+            throw new IOException(getClass().getName() + " is not configured; setConf() must be called with "
+                    + SERVICE_ACCOUNT_EMAIL_KEY + ", " + SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY + " and "
+                    + SERVICE_ACCOUNT_PRIVATE_KEY_KEY);
+        }
+        com.google.cloud.hadoop.repackaged.gcs.com.google.auth.oauth2.AccessToken token =
+                credentials.refreshAccessToken();
+        cachedToken = new AccessToken(token.getTokenValue(),
+                expirationOrDefault(token.getExpirationTime(), Instant.now()));
+        LOG.debug("Refreshed GCS access token for service account {}", serviceAccountEmail);
+    }
+
+    /**
+     * Always attach a concrete expiration: a null one would make this provider cache the token forever, and
+     * gcs-connector's OAuth2Credentials likewise treats a token without expiration as never needing refresh.
+     */
+    static Instant expirationOrDefault(Date expiration, Instant now) {
+        return expiration == null ? now.plusMillis(DEFAULT_TOKEN_LIFETIME_MS) : expiration.toInstant();
+    }
+
+    private static boolean isExpiringSoon(AccessToken token) {
+        Instant expiration = token.getExpirationTime();
+        return expiration == null
+                || Instant.now().plusMillis(REFRESH_MARGIN_MS).isAfter(expiration);
+    }
+
+    /**
+     * Keys copied out of a JSON keyfile frequently arrive with literal {@code \n} escape sequences instead of
+     * real line breaks; the PEM reader needs real ones.
+     */
+    static String normalizePrivateKey(String privateKey) {
+        return privateKey.replace("\\n", "\n").trim();
+    }
+}

--- a/java-extensions/hadoop-ext/src/test/java/com/starrocks/connector/gcp/ServiceAccountGCPAccessTokenProviderTest.java
+++ b/java-extensions/hadoop-ext/src/test/java/com/starrocks/connector/gcp/ServiceAccountGCPAccessTokenProviderTest.java
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.gcp;
+
+import com.google.cloud.hadoop.fs.gcs.HadoopCredentialsConfiguration;
+import com.google.cloud.hadoop.repackaged.gcs.com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.hadoop.util.AccessTokenProvider;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ServiceAccountGCPAccessTokenProviderTest {
+
+    private static final String EMAIL = "test@project.iam.gserviceaccount.com";
+    private static final String KEY_ID = "key-id-123";
+
+    private static String pemPrivateKey;
+    private static HttpServer tokenServer;
+    private static String tokenServerUrl;
+    private static final AtomicInteger TOKEN_REQUESTS = new AtomicInteger();
+
+    @BeforeAll
+    public static void setUp() throws IOException, NoSuchAlgorithmException {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        pemPrivateKey = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8))
+                        .encodeToString(keyPair.getPrivate().getEncoded())
+                + "\n-----END PRIVATE KEY-----\n";
+
+        // Stand-in for https://oauth2.googleapis.com/token: accepts the signed JWT grant and returns a token.
+        tokenServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        tokenServer.createContext("/token", exchange -> {
+            int n = TOKEN_REQUESTS.incrementAndGet();
+            byte[] body = ("{\"access_token\":\"ya29.token-" + n
+                    + "\",\"expires_in\":3600,\"token_type\":\"Bearer\"}").getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+        tokenServer.start();
+        tokenServerUrl = "http://127.0.0.1:" + tokenServer.getAddress().getPort() + "/token";
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        if (tokenServer != null) {
+            tokenServer.stop(0);
+        }
+    }
+
+    private static Configuration serviceAccountConf(String privateKey) {
+        Configuration conf = new Configuration();
+        conf.set("fs.gs.auth.type", "ACCESS_TOKEN_PROVIDER");
+        conf.set("fs.gs.auth.access.token.provider", ServiceAccountGCPAccessTokenProvider.class.getName());
+        conf.set(ServiceAccountGCPAccessTokenProvider.SERVICE_ACCOUNT_EMAIL_KEY, EMAIL);
+        conf.set(ServiceAccountGCPAccessTokenProvider.SERVICE_ACCOUNT_PRIVATE_KEY_ID_KEY, KEY_ID);
+        conf.set(ServiceAccountGCPAccessTokenProvider.SERVICE_ACCOUNT_PRIVATE_KEY_KEY, privateKey);
+        conf.set(ServiceAccountGCPAccessTokenProvider.TOKEN_SERVER_URL_KEY, tokenServerUrl);
+        return conf;
+    }
+
+    @Test
+    public void testConnectorInitializesCredentialsWithoutKeyfile() throws IOException {
+        // Drive the real gcs-connector credential factory, i.e. the code path Broker Load hits when the
+        // GoogleHadoopFileSystem is created. Before this provider existed this threw
+        // NullPointerException from FileInputStream(null) because no JSON keyfile path was configured.
+        Configuration conf = serviceAccountConf(pemPrivateKey);
+        Assertions.assertNull(conf.get("fs.gs.auth.service.account.json.keyfile"));
+
+        GoogleCredentials credentials = HadoopCredentialsConfiguration.getCredentials(conf, "fs.gs");
+
+        Assertions.assertNotNull(credentials);
+        Assertions.assertNotNull(credentials.getAccessToken());
+        Assertions.assertTrue(credentials.getAccessToken().getTokenValue().startsWith("ya29.token-"));
+        Assertions.assertTrue(credentials.getAccessToken().getExpirationTime().toInstant().isAfter(Instant.now()));
+    }
+
+    @Test
+    public void testProviderMintsAndCachesToken() throws IOException {
+        ServiceAccountGCPAccessTokenProvider provider = new ServiceAccountGCPAccessTokenProvider();
+        provider.setConf(serviceAccountConf(pemPrivateKey));
+        Assertions.assertEquals(AccessTokenProvider.AccessTokenType.GENERIC, provider.getAccessTokenType());
+
+        int before = TOKEN_REQUESTS.get();
+        AccessTokenProvider.AccessToken first = provider.getAccessToken();
+        AccessTokenProvider.AccessToken second = provider.getAccessToken();
+        Assertions.assertEquals(before + 1, TOKEN_REQUESTS.get(), "valid token should be served from cache");
+        Assertions.assertEquals(first.getToken(), second.getToken());
+        Assertions.assertTrue(first.getExpirationTime().isAfter(Instant.now()));
+
+        provider.refresh();
+        Assertions.assertEquals(before + 2, TOKEN_REQUESTS.get(), "refresh() must always fetch a new token");
+        Assertions.assertNotEquals(first.getToken(), provider.getAccessToken().getToken());
+    }
+
+    @Test
+    public void testAcceptsEscapedNewlinesInPrivateKey() {
+        // Keys pasted out of a JSON keyfile commonly carry literal "\n" sequences.
+        String escaped = pemPrivateKey.replace("\n", "\\n");
+        ServiceAccountGCPAccessTokenProvider provider = new ServiceAccountGCPAccessTokenProvider();
+        provider.setConf(serviceAccountConf(escaped));
+        Assertions.assertNotNull(provider.getAccessToken().getToken());
+    }
+
+    @Test
+    public void testMissingCredentialsFailWithDescriptiveError() {
+        Configuration conf = serviceAccountConf(pemPrivateKey);
+        conf.unset(ServiceAccountGCPAccessTokenProvider.SERVICE_ACCOUNT_PRIVATE_KEY_KEY);
+        ServiceAccountGCPAccessTokenProvider provider = new ServiceAccountGCPAccessTokenProvider();
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> provider.setConf(conf));
+        Assertions.assertTrue(e.getMessage().contains(ServiceAccountGCPAccessTokenProvider.SERVICE_ACCOUNT_PRIVATE_KEY_KEY),
+                e.getMessage());
+    }
+
+    @Test
+    public void testMalformedPrivateKeyDoesNotLeakKeyMaterial() {
+        String bogus = "-----BEGIN PRIVATE KEY-----\nbm90LWEta2V5\n-----END PRIVATE KEY-----";
+        ServiceAccountGCPAccessTokenProvider provider = new ServiceAccountGCPAccessTokenProvider();
+        IllegalArgumentException e = Assertions.assertThrows(IllegalArgumentException.class,
+                () -> provider.setConf(serviceAccountConf(bogus)));
+        Assertions.assertTrue(e.getMessage().contains(EMAIL), e.getMessage());
+        Assertions.assertFalse(e.getMessage().contains("bm90LWEta2V5"), e.getMessage());
+    }
+
+    @Test
+    public void testMissingExpirationGetsDefaultLifetime() {
+        Instant now = Instant.parse("2026-09-04T00:00:00Z");
+        Instant explicit = Instant.parse("2026-09-04T01:00:00Z");
+        Assertions.assertEquals(explicit,
+                ServiceAccountGCPAccessTokenProvider.expirationOrDefault(Date.from(explicit), now));
+        Instant defaulted = ServiceAccountGCPAccessTokenProvider.expirationOrDefault(null, now);
+        Assertions.assertTrue(defaulted.isAfter(now), "token without expiration must still expire");
+        Assertions.assertTrue(defaulted.isBefore(now.plusSeconds(3600)),
+                "assumed lifetime must not exceed Google's default 1h token lifetime");
+    }
+
+    @Test
+    public void testUnconfiguredProviderFails() {
+        ServiceAccountGCPAccessTokenProvider provider = new ServiceAccountGCPAccessTokenProvider();
+        Assertions.assertThrows(IOException.class, provider::refresh);
+        Assertions.assertThrows(UncheckedIOException.class, provider::getAccessToken);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Broker Load with explicit GCS service account credentials still fails on 4.0.8+ after #70012:

```
type:ETL_RUN_FAIL; msg:java.lang.NullPointerException
  at java.io.FileInputStream.<init>
  at com.google.cloud.hadoop.util.HadoopCredentialsConfiguration.getCredentialsInternal
```

`gcs-connector 3.x` dropped the inline `fs.gs.auth.service.account.{email,private.key.id,private.key}` credentials that 2.x accepted. `SERVICE_ACCOUNT_JSON_KEYFILE` (set by #70012) only reads a local JSON keyfile path, which StarRocks never sets, so the connector opens `FileInputStream(null)`. 3.x has no auth type that accepts an inline private key; the only hook is `ACCESS_TOKEN_PROVIDER`.

## What I'm doing:

- Add `ServiceAccountGCPAccessTokenProvider` (hadoop-ext): reads the inline key from the Hadoop configuration and mints OAuth2 access tokens via the connector's bundled google-auth library, refreshing before expiry.
- `GCPCloudCredential` emits `fs.gs.auth.type=ACCESS_TOKEN_PROVIDER` with this provider for service account credentials. User-facing `gcp.gcs.*` properties are unchanged; impersonation and vended-token precedence behave as before.
- Missing or malformed keys now fail with an error naming the missing key or the service account, without leaking key material.

Tests: the new hadoop-ext test drives the real `gcs-connector 3.0.13` credential factory against a local token endpoint (the #70012 tests only checked configuration strings, which is why this was missed). Verified on `starrocks/allin1-ubuntu:4.0.13` against a real bucket: the same `LOAD` is `CANCELLED` with the NPE unpatched and `FINISHED` with the patched jars.

Follow-up to #70012 / #70011.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
