### PR TITLE
[BugFix] Declare PSlotDescriptor.global_dict_words as bytes to stop UTF-8 warnings

### DIFF
--- a/be/test/data_sink/CMakeLists.txt
+++ b/be/test/data_sink/CMakeLists.txt
@@ -118,6 +118,7 @@ set(DATA_SINK_TABLET_TEST_FILES
     ${BE_TEST_MACOS_LINK_STUBS}
     tablet/multi_olap_table_sink_test.cpp
     tablet/range_router_test.cpp
+    tablet/tablet_sink_global_dict_words_test.cpp
     tablet/tablet_sink_index_channel_test.cpp
     tablet/tablet_sink_sender_range_test.cpp
     tablet/olap_table_sink_test.cpp

--- a/be/test/data_sink/tablet/tablet_sink_global_dict_words_test.cpp
+++ b/be/test/data_sink/tablet/tablet_sink_global_dict_words_test.cpp
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <google/protobuf/stubs/logging.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "base/utility/defer_op.h"
+#include "gen_cpp/internal_service.pb.h"
+
+namespace starrocks {
+
+namespace {
+std::vector<std::string>* g_protobuf_logs = nullptr;
+
+void capture_protobuf_log(google::protobuf::LogLevel, const char*, int, const std::string& message) {
+    if (g_protobuf_logs != nullptr) {
+        g_protobuf_logs->push_back(message);
+    }
+}
+} // namespace
+
+// The global dict words carried by PTabletWriterOpenRequest are raw column values.
+// A low-cardinality VARCHAR column may hold non-UTF-8 bytes (GBK text, binary
+// blobs, ...). When the field was declared as a protobuf `string`, every
+// serialize/parse of the open request logged
+//   "String field 'starrocks.PSlotDescriptor.global_dict_words' contains invalid UTF-8 data"
+// for each such word. Declaring it as `bytes` keeps the wire format and the C++
+// accessors unchanged and stops the check from firing.
+TEST(TabletSinkGlobalDictWordsTest, non_utf8_dict_words_round_trip_without_protobuf_warnings) {
+    std::vector<std::string> logs;
+    g_protobuf_logs = &logs;
+    auto* old_handler = google::protobuf::SetLogHandler(&capture_protobuf_log);
+    DeferOp restore([&]() {
+        google::protobuf::SetLogHandler(old_handler);
+        g_protobuf_logs = nullptr;
+    });
+
+    const std::string non_utf8_word(
+            "\xff\xfe\x80"
+            "abc",
+            6);
+    const std::string utf8_word("中文");
+
+    PTabletWriterOpenRequest request;
+    auto* slot = request.mutable_schema()->add_slot_descs();
+    slot->set_id(1);
+    slot->set_parent(0);
+    slot->mutable_slot_type();
+    slot->set_column_pos(0);
+    slot->set_byte_offset(0);
+    slot->set_null_indicator_byte(0);
+    slot->set_null_indicator_bit(0);
+    slot->set_col_name("c1");
+    slot->set_slot_idx(0);
+    slot->set_is_materialized(true);
+    slot->add_global_dict_words(non_utf8_word);
+    slot->add_global_dict_words(utf8_word);
+    slot->set_global_dict_version(7);
+
+    std::string buffer;
+    ASSERT_TRUE(request.SerializePartialToString(&buffer));
+
+    PTabletWriterOpenRequest parsed;
+    ASSERT_TRUE(parsed.ParsePartialFromString(buffer));
+    ASSERT_EQ(1, parsed.schema().slot_descs_size());
+    const auto& parsed_slot = parsed.schema().slot_descs(0);
+    ASSERT_EQ(2, parsed_slot.global_dict_words_size());
+    EXPECT_EQ(non_utf8_word, parsed_slot.global_dict_words(0));
+    EXPECT_EQ(utf8_word, parsed_slot.global_dict_words(1));
+    EXPECT_EQ(7, parsed_slot.global_dict_version());
+
+    EXPECT_TRUE(logs.empty()) << "unexpected protobuf log: " << logs.front();
+}
+
+} // namespace starrocks

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -51,7 +51,9 @@ message PSlotDescriptor {
     required string col_name = 8;
     required int32 slot_idx = 9;
     required bool is_materialized = 10;
-    repeated string global_dict_words = 11; 
+    // Raw dictionary words copied from column values; they are not guaranteed to be
+    // valid UTF-8, so this must stay `bytes` (wire-compatible with the old `string`).
+    repeated bytes global_dict_words = 11;
     optional int64 global_dict_version = 12;
     optional bool is_nullable = 13; // replace null_indicator_bit & null_indicator_byte
     optional bool is_virtual = 14;


### PR DESCRIPTION
## Why I'm doing:

The tablet sink copies the raw words of a low-cardinality global dictionary into PSlotDescriptor.global_dict_words when it opens the load channel. The words are column values, so a VARCHAR column that stores non-UTF-8 bytes (GBK text, binary blobs, ...) makes protobuf log

  String field 'starrocks.PSlotDescriptor.global_dict_words' contains
  invalid UTF-8 data when serializing a protocol buffer.

once per word on every tablet writer open RPC, on both the sending and the receiving BE. Under proto2 the payload still goes through intact, so this is pure log noise, but it fires on every load into such a table.

Declare the field as `bytes`. It has the same wire type as `string`, so mixed-version clusters keep interoperating, and the generated C++ accessors still use std::string, so no BE code changes. Nothing in the FE reads the field.

Add a gtest that serializes and parses an open request carrying a non-UTF-8 dict word under a capturing protobuf log handler; it fails with the old `string` declaration and passes with `bytes`.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
