### PR TITLE
[BugFix] Reject an out-of-range vector-search query vector instead of aborting the BE

### DIFF
--- a/be/src/connector/lake/lake_connector.cpp
+++ b/be/src/connector/lake/lake_connector.cpp
@@ -504,7 +504,17 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
         _params.vector_search_option->vector_distance_column_name = _vector_distance_column_name;
         _params.vector_search_option->k = vector_options.vector_limit_k;
         for (const std::string& str : vector_options.query_vector) {
-            _params.vector_search_option->query_vector.push_back(std::stof(str));
+            // std::stof throws std::out_of_range / std::invalid_argument on a value that overflows
+            // float or is not a number, and the throw is uncaught here, so a query vector element the
+            // planner produced from a wrong-typed or out-of-range literal (e.g. 1e308, which exceeds
+            // FLT_MAX) aborts the BE. Parse without throwing and reject the query cleanly instead.
+            StringParser::ParseResult parse_result;
+            float value = StringParser::string_to_float<float>(str.data(), str.size(), &parse_result);
+            if (parse_result != StringParser::PARSE_SUCCESS) {
+                return Status::InvalidArgument(
+                        fmt::format("invalid query vector element for vector search: '{}'", str));
+            }
+            _params.vector_search_option->query_vector.push_back(value);
         }
         if (_runtime_state->query_options().__isset.ann_params) {
             _params.vector_search_option->query_params = _runtime_state->query_options().ann_params;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -317,7 +317,17 @@ Status OlapChunkSource::_init_reader_params(const std::vector<std::unique_ptr<Ol
         _params.vector_search_option->vector_distance_column_name = _vector_distance_column_name;
         _params.vector_search_option->k = vector_options.vector_limit_k;
         for (const std::string& str : vector_options.query_vector) {
-            _params.vector_search_option->query_vector.push_back(std::stof(str));
+            // std::stof throws std::out_of_range / std::invalid_argument on a value that overflows
+            // float or is not a number, and the throw is uncaught here, so a query vector element the
+            // planner produced from a wrong-typed or out-of-range literal (e.g. 1e308, which exceeds
+            // FLT_MAX) aborts the BE. Parse without throwing and reject the query cleanly instead.
+            StringParser::ParseResult parse_result;
+            float value = StringParser::string_to_float<float>(str.data(), str.size(), &parse_result);
+            if (parse_result != StringParser::PARSE_SUCCESS) {
+                return Status::InvalidArgument(
+                        fmt::format("invalid query vector element for vector search: '{}'", str));
+            }
+            _params.vector_search_option->query_vector.push_back(value);
         }
         if (_runtime_state->query_options().__isset.ann_params) {
             _params.vector_search_option->query_params = _runtime_state->query_options().ann_params;

--- a/test/sql/test_vector_index_query_vector_overflow/R/test_vector_index_query_vector_overflow
+++ b/test/sql/test_vector_index_query_vector_overflow/R/test_vector_index_query_vector_overflow
@@ -1,0 +1,31 @@
+-- name: test_vector_index_query_vector_overflow @sequential @native
+CREATE TABLE `t_ivfpq_overflow` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v` ARRAY<FLOAT> NOT NULL COMMENT "",
+  INDEX idx_v (`v`) USING VECTOR ("index_type" = "ivfpq", "dim" = "4", "metric_type" = "l2_distance", "is_vector_normed" = "false", "nbits" = "8", "nlist" = "16", "M_IVFPQ" = "2", "index_build_threshold" = "16")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO t_ivfpq_overflow SELECT number, [CAST(number AS FLOAT), 0, 0, 0] FROM TABLE(generate_series(1, 64)) t(number);
+-- result:
+-- !result
+select id from t_ivfpq_overflow order by approx_l2_distance(ARRAY<FLOAT>[1.0, 0.0, 0.0, 0.0], v) limit 1;
+-- result:
+1
+-- !result
+select id from t_ivfpq_overflow order by approx_l2_distance(ARRAY<FLOAT>[1e308, 0.0, 0.0, 0.0], v) limit 1;
+-- result:
+[REGEX].*invalid query vector element.*
+-- !result
+select id from t_ivfpq_overflow order by approx_l2_distance(ARRAY<TINYINT>[100, 100, 100, 100], v) limit 1;
+-- result:
+[REGEX]\d+
+-- !result

--- a/test/sql/test_vector_index_query_vector_overflow/T/test_vector_index_query_vector_overflow
+++ b/test/sql/test_vector_index_query_vector_overflow/T/test_vector_index_query_vector_overflow
@@ -1,0 +1,29 @@
+-- name: test_vector_index_query_vector_overflow @sequential @native
+-- A query-vector element that overflows float range (1e308 > FLT_MAX) used to
+-- reach an unguarded std::stof in OlapChunkSource::_init_reader_params and abort
+-- the BE. It must now be rejected with a clean error instead of crashing.
+CREATE TABLE `t_ivfpq_overflow` (
+  `id` bigint(20) NOT NULL COMMENT "",
+  `v` ARRAY<FLOAT> NOT NULL COMMENT "",
+  INDEX idx_v (`v`) USING VECTOR ("index_type" = "ivfpq", "dim" = "4", "metric_type" = "l2_distance", "is_vector_normed" = "false", "nbits" = "8", "nlist" = "16", "M_IVFPQ" = "2", "index_build_threshold" = "16")
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+INSERT INTO t_ivfpq_overflow SELECT number, [CAST(number AS FLOAT), 0, 0, 0] FROM TABLE(generate_series(1, 64)) t(number);
+
+-- A well-formed query vector still works and uses the index (nearest is id 1).
+select id from t_ivfpq_overflow order by approx_l2_distance(ARRAY<FLOAT>[1.0, 0.0, 0.0, 0.0], v) limit 1;
+
+-- Overflowing element must be a clean error, not a BE crash.
+select id from t_ivfpq_overflow order by approx_l2_distance(ARRAY<FLOAT>[1e308, 0.0, 0.0, 0.0], v) limit 1;
+
+-- The exact form the fuzzer found: a wrong-typed query vector (ARRAY<TINYINT>
+-- against an ARRAY<FLOAT> vector column). It is widened to FLOAT and reaches the
+-- same scan path; it must run cleanly, never crash.
+select id from t_ivfpq_overflow order by approx_l2_distance(ARRAY<TINYINT>[100, 100, 100, 100], v) limit 1;


### PR DESCRIPTION
## Why I'm doing:

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  stofc0b84ac ASAN (build c0b84ac distro ubuntu arch x86_64)
query_id:01a06791-99ed-7f44-be34-eae622bf5277, fragment_instance:01a06791-99ed-7f44-be34-eae622bf527a, plan_node_id:0
*** Aborted at 1788443991 (unix time) try "date -d @1788443991" if you are using GNU date ***
PC: @     0x7fbaaf4bbb2c pthread_kill
*** SIGABRT (@0x98f8b) received by PID 626571 (TID 0x7fb7d43866c0) LWP(627512) from PID 626571; stack trace: ***

    @         0x33b75047 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fbaaf4beed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x33b74846 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fbaaf462330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7fbaaf4bbb2c pthread_kill
    @     0x7fbaaf46227e gsignal
    @     0x7fbaaf4458ff abort
    @         0x3cc4bd9a __gnu_cxx::__verbose_terminate_handler()
    @         0x3cc4a2aa __cxxabiv1::__terminate(void (*)())
    @         0x3cc4a315 std::terminate()
    @     0x7fbaaf25a391 __cxa_throw
    @         0x3cd3350a __wrap___cxa_throw
    @         0x3cca65e3 std::__throw_out_of_range(char const*)
    @         0x1d3e81bc float __gnu_cxx::__stoa<float, float, char>(float (*)(char const*, char**), char const*, char const*, unsigned long*)
    @         0x1d3e4b35 std::__cxx11::stof(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned long*)
    @         0x1d3c6e5f starrocks::pipeline::OlapChunkSource::_init_reader_params(std::vector<std::unique_ptr<starrocks::OlapScanRange, std::default_delete<starrocks::OlapScanRange> >, std::allocator<std::unique_ptr<starrocks::Ol
apScanRange, std::default_delete<starrocks::OlapSca@
    @         0x1d3d094a starrocks::pipeline::OlapChunkSource::_init_olap_reader(starrocks::RuntimeState*)
    @         0x1d3ba10d starrocks::pipeline::OlapChunkSource::prepare(starrocks::RuntimeState*)
    @         0x1d38f4f0 starrocks::pipeline::ScanOperator::_pickup_morsel(starrocks::RuntimeState*, int)
    @         0x1d388d98 starrocks::pipeline::ScanOperator::_try_to_trigger_next_scan(starrocks::RuntimeState*)
    @         0x1d386bf5 starrocks::pipeline::ScanOperator::pull_chunk(starrocks::RuntimeState*)
    @         0x22d63642 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1d104ad6 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1d102bbc starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1d10b906 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1d10b072 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x1d10ab36 std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1b285bee std::function<void ()>::operator()() const
    @         0x2eddd72a starrocks::FunctionRunnable::run()
    @         0x2edd7530 starrocks::ThreadPool::dispatch_thread()
    @         0x2edf8ab2 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2edf7450 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)

```

OlapChunkSource::_init_reader_params parsed each query-vector element with
std::stof, which throws std::out_of_range (or std::invalid_argument) on a
value outside float range or not a number. The throw was uncaught, so a
query whose vector element the planner produced from a wrong-typed or
out-of-range literal -- e.g. approx_l2_distance(ARRAY<FLOAT>[1e308, ...], v),
1e308 exceeding FLT_MAX -- terminated the BE with SIGABRT during fragment
prepare. A wrong-typed query vector (ARRAY<TINYINT> against an ARRAY<FLOAT>
vector column) reaches the same path.

Parse with StringParser::string_to_float, which reports overflow/failure
through a ParseResult instead of throwing, and return InvalidArgument so the
query fails cleanly.

Found by the cluster fuzzer on a vector-index (IVFPQ) table.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
