### PR TITLE
[BugFix] Merge relaxed dictionaries in unsigned byte order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheRelaxDictManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/CacheRelaxDictManager.java
@@ -76,7 +76,13 @@ public class CacheRelaxDictManager implements IRelaxDictManager, MemoryTrackable
             }
             return Optional.of(new ColumnDict(dict.build(), 0, 0));
         } else {
-            TreeSet<ByteBuffer> orderSet = new TreeSet<>(oldValue.get().getDict().keySet());
+            // Codes are re-assigned in key order below, and BE compares dictionary strings with memcmp
+            // (unsigned bytes) when it sorts on codes (min/max, ORDER BY, window). ByteBuffer's natural
+            // order compares bytes as signed, which puts every key with a high-bit byte (multi-byte
+            // UTF-8) first, so the merged codes would disagree with BE's order. Always merge with the
+            // unsigned comparator, the same one the union and join dictionary merges use.
+            TreeSet<ByteBuffer> orderSet = new TreeSet<>(ColumnDict.UNSIGNED_LEX);
+            orderSet.addAll(oldValue.get().getDict().keySet());
             int dictSize = statisticData.getIdsSize();
             for (int i = 0; i < dictSize; ++i) {
                 orderSet.add(statisticData.strings.get(i));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnDict.java
@@ -32,10 +32,11 @@ import java.util.Map;
 public final class ColumnDict extends StatsVersion {
     /**
      * Unsigned-byte lexicographic comparator. BE sorts dictionary strings via memcmp, which the C
-     * standard defines to compare bytes as unsigned char. ByteBuffer.compareTo on JDK 8 instead
-     * compares bytes as signed (Java 9 fixed this to unsigned), so any UTF-8 string with a high-bit
-     * byte (Cyrillic, CJK, etc.) sorts the opposite way on the two sides. Always use this comparator
-     * when ordering dictionary keys on the FE so the result matches BE regardless of JDK version.
+     * standard defines to compare bytes as unsigned char. ByteBuffer.compareTo instead compares
+     * bytes as signed (it is specified in terms of Byte.compare, on every JDK including 17 and 21),
+     * so any UTF-8 string with a high-bit byte (Cyrillic, CJK, etc.) sorts the opposite way on the
+     * two sides. Never order dictionary keys with ByteBuffer's natural order (sorted(), TreeSet,
+     * TreeMap); always use this comparator so the result matches BE.
      */
     public static final Comparator<ByteBuffer> UNSIGNED_LEX = (a, b) -> {
         int aPos = a.position();

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/CacheRelaxDictManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/CacheRelaxDictManagerTest.java
@@ -16,10 +16,12 @@ package com.starrocks.statistic;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.common.Status;
+import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.connector.statistics.ConnectorTableColumnKey;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -77,7 +79,8 @@ public class CacheRelaxDictManagerTest {
     private TResultBatch generateDictResult(int size) throws TException {
         TStatisticData sd = new TStatisticData();
         TGlobalDict dict = new TGlobalDict();
-        TreeSet<ByteBuffer> orderSet = new TreeSet<>();
+        // BE orders dictionary strings with memcmp, i.e. unsigned bytes
+        TreeSet<ByteBuffer> orderSet = new TreeSet<>(ColumnDict.UNSIGNED_LEX);
         for (int i = 0; i < size; i++) {
             orderSet.add(ByteBuffer.wrap(Integer.toString(i).getBytes(StandardCharsets.UTF_8)));
         }
@@ -255,6 +258,39 @@ public class CacheRelaxDictManagerTest {
 
             manager.removeGlobalDict(tableUUID, columnName);
         }
+    }
+
+    @Test
+    public void testMergeKeepsUnsignedByteOrder() {
+        // Existing dict as BE delivered it: memcmp order, codes 1..n. 'z' (0x7A) sorts before the
+        // multi-byte keys (0xC3.., 0xE4..) on BE; ByteBuffer's signed natural order would put them first.
+        ImmutableMap.Builder<ByteBuffer, Integer> oldDict = ImmutableMap.builder();
+        oldDict.put(utf8("a"), 1);
+        oldDict.put(utf8("z"), 2);
+        oldDict.put(utf8("中"), 3);
+        Optional<ColumnDict> oldValue = Optional.of(new ColumnDict(oldDict.build(), 0, 0));
+
+        // A refreshed collection that adds 'b' and 'é'; ids from BE are irrelevant to the merge.
+        TGlobalDict stat = new TGlobalDict();
+        stat.setIds(List.of(1, 2));
+        stat.setStrings(List.of(utf8("b"), utf8("é")));
+
+        List<String> expected = List.of("a", "b", "z", "é", "中");
+        for (boolean mergeVersion : new boolean[] {true, false}) {
+            Optional<ColumnDict> merged = Deencapsulation.invoke(CacheRelaxDictManager.class,
+                    "mergeStatToColumnDict", stat, oldValue, mergeVersion);
+            Assertions.assertTrue(merged.isPresent());
+            Assertions.assertEquals(expected.size(), merged.get().getDictSize());
+            for (int i = 0; i < expected.size(); i++) {
+                Integer code = merged.get().getDict().get(utf8(expected.get(i)));
+                Assertions.assertEquals(Integer.valueOf(i + 1), code,
+                        "code of " + expected.get(i) + " (mergeVersion=" + mergeVersion + ")");
+            }
+        }
+    }
+
+    private static ByteBuffer utf8(String s) {
+        return ByteBuffer.wrap(s.getBytes(StandardCharsets.UTF_8));
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {


### PR DESCRIPTION
## Why I'm doing:

CacheRelaxDictManager.mergeStatToColumnDict re-assigns dictionary codes from a TreeSet<ByteBuffer> built with ByteBuffer's natural order, which compares bytes as signed. BE orders dictionary strings with memcmp (unsigned), and the low-cardinality rewrite runs min/max, ORDER BY, TopN and window ORDER BY directly on the codes. After the first refresh of a lake table dictionary (asyncReload, or updateGlobalDict following a GlobalDictNotMatch), every key with a high-bit byte (multi-byte UTF-8: CJK, accented letters, emoji) sorts before ASCII on the FE but after it on the BE, so those queries return the wrong strings. The first load is not affected because it takes the ids as BE delivered them.

Use ColumnDict.UNSIGNED_LEX for the merge, the same comparator the join (#72778) and UNION (#76729) dictionary merges were already switched to, and correct the ColumnDict comment that claimed newer JDKs compare unsigned: ByteBuffer.compareTo is specified in terms of Byte.compare on every JDK. The test helper that emulates BE output now sorts the same way.

Add a regression test that merges {a, z, 中} with {b, é} and checks the codes follow unsigned byte order (a, b, z, é, 中); without the fix 'a' receives code 3.

Claude-Session: https://claude.ai/code/session_01YX6rH4y6XTjcBbjSGZGovu

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
