### PR TITLE
[BugFix] Skip stale partition cleanup when no tables qualify

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -712,6 +712,7 @@ public class AnalyzeMgr implements Writable {
 
         if (tables.isEmpty()) {
             lastCleanTime = workTime;
+            return;
         }
 
         List<Long> tableIds = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/AnalyzeManagerTest.java
@@ -31,6 +31,14 @@ import java.time.LocalTime;
 
 public class AnalyzeManagerTest extends PlanTestBase {
     @Test
+    public void testClearStalePartitionStatsWithEmptyAnalyzeStatus() {
+        AnalyzeMgr analyzeMgr = new AnalyzeMgr();
+        analyzeMgr.getAnalyzeStatusMap().clear();
+        Deencapsulation.setField(analyzeMgr, "lastCleanTime", LocalDateTime.MIN);
+        Assertions.assertDoesNotThrow(() -> Deencapsulation.invoke(analyzeMgr, "clearStalePartitionStats"));
+    }
+
+    @Test
     public void testClearStatisticFromDroppedTable() {
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(
                 1, 2, Lists.newArrayList(), StatsConstants.AnalyzeType.FULL,


### PR DESCRIPTION
## Why I'm doing:

The statistics meta manager throws an exception when no tables need stale partition cleanup.

```text
2026-09-03 22:00:46.635Z ERROR (statistics meta manager|36) [Daemon.run():100] daemon thread got exception. name: statistics meta manager
java.lang.IllegalStateException: null
    at com.google.common.base.Preconditions.checkState(Preconditions.java:496) ~[spark-dpp-1.0.0.jar:?]
    at com.starrocks.statistic.StatisticSQLBuilder.buildDropTableInvalidPartitionSQL(StatisticSQLBuilder.java:299) ~[starrocks-fe.jar:?]
    at com.starrocks.statistic.StatisticExecutor.dropTableInvalidPartitionStatistics(StatisticExecutor.java:301) ~[starrocks-fe.jar:?]
    at com.starrocks.statistic.AnalyzeMgr.clearStalePartitionStats(AnalyzeMgr.java:653) ~[starrocks-fe.jar:?]
    at com.starrocks.statistic.AnalyzeMgr.clearStatisticFromDroppedPartition(AnalyzeMgr.java:571) ~[starrocks-fe.jar:?]
    at com.starrocks.statistic.StatisticsMetaManager.runAfterCatalogReady(StatisticsMetaManager.java:565) ~[starrocks-fe.jar:?]
    at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:78) ~[starrocks-fe.jar:?]
    at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[starrocks-fe.jar:?]
```

## What I'm doing:

Return early when no tables need cleanup, and add a regression test.

No observability change is needed because an empty cleanup is an expected no-op.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which drive auto-backporting
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
