### PR TITLE
[BugFix] Do not use ForkJoinPool.commonPool() for external partition pruning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptExternalPartitionPruner.java
@@ -380,7 +380,11 @@ public class OptExternalPartitionPruner {
                 partitionKeys.add(new Pair<>(new PartitionKey(), 0L));
             }
 
-            partitionKeys.stream().parallel().forEach(entry -> {
+            // NOTE: keep this loop sequential. A parallel stream here runs on the JVM-wide
+            // ForkJoinPool.commonPool(), so query planning would depend on a pool the FE neither
+            // owns nor can interrupt; on the whole-phase-lock path the database lock is then held
+            // for the entire wait. A stalled common pool has already caused an FE-wide outage.
+            for (Pair<PartitionKey, Long> entry : partitionKeys) {
                 PartitionKey key = entry.first;
                 long partitionId = entry.second;
                 List<LiteralExpr> literals = key.getKeys();
@@ -396,11 +400,6 @@ public class OptExternalPartitionPruner {
                             .computeIfAbsent(literal, k -> Sets.newConcurrentHashSet());
                     partitions.add(partitionId);
                 }
-            });
-
-            for (Pair<PartitionKey, Long> entry : partitionKeys) {
-                PartitionKey key = entry.first;
-                long partitionId = entry.second;
                 operator.getScanOperatorPredicates().getIdToPartitionKey().put(partitionId, key);
             }
         } else if (table instanceof FlussTable) {
@@ -472,7 +471,11 @@ public class OptExternalPartitionPruner {
             partitionKeys.add(new Pair<>(new PartitionKey(), 0L));
         }
 
-        partitionKeys.stream().parallel().forEach(entry -> {
+        // NOTE: keep this loop sequential. A parallel stream here runs on the JVM-wide
+        // ForkJoinPool.commonPool(), so query planning would depend on a pool the FE neither
+        // owns nor can interrupt; on the whole-phase-lock path the database lock is then held
+        // for the entire wait. A stalled common pool has already caused an FE-wide outage.
+        for (Pair<PartitionKey, Long> entry : partitionKeys) {
             PartitionKey key = entry.first;
             long partitionId = entry.second;
             List<LiteralExpr> literals = key.getKeys();
@@ -488,10 +491,7 @@ public class OptExternalPartitionPruner {
                         .computeIfAbsent(literal, k -> Sets.newConcurrentHashSet());
                 partitions.add(partitionId);
             }
-        });
-
-        for (Pair<PartitionKey, Long> entry : partitionKeys) {
-            operator.getScanOperatorPredicates().getIdToPartitionKey().put(entry.second, entry.first);
+            operator.getScanOperatorPredicates().getIdToPartitionKey().put(partitionId, key);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

`OptExternalPartitionPruner` uses `stream().parallel()` in `initPartitionInfo()` and
`initFlussPartitionInfo()`. A parallel stream runs on the JVM-wide
`ForkJoinPool.commonPool()`, so query planning ends up depending on a pool the FE neither
owns nor can interrupt. We hit this in production, where a JVM-level thread-pool failure
became a cluster-wide FE outage.

### What we saw

Several planner threads permanently parked at this call site, each waiting on a **different**
`ForEachOps$ForEachTask` instance, with **identical `cpu=` counters across two thread dumps**
taken ~18 minutes apart (i.e. zero CPU consumed in between):

```
   java.lang.Thread.State: WAITING (on object monitor)
    at java.lang.Object.wait(java.base@11.0.20.1/Native Method)
    at java.util.concurrent.ForkJoinTask.externalAwaitDone(ForkJoinTask.java:330)
    - waiting to re-lock in wait() <0x...> (a java.util.stream.ForEachOps$ForEachTask)
    at java.util.concurrent.ForkJoinTask.doInvoke(ForkJoinTask.java:412)
    at java.util.concurrent.ForkJoinTask.invoke(ForkJoinTask.java:736)
    at java.util.stream.ForEachOps$ForEachOp.evaluateParallel(ForEachOps.java:159)
    at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:233)
    at java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:661)
    at ...OptExternalPartitionPruner.initPartitionInfo(OptExternalPartitionPruner.java:347)
    at ...OptExternalPartitionPruner.prunePartitionsImpl(OptExternalPartitionPruner.java:129)
    at ...ExternalScanPartitionPruneRule.transform(ExternalScanPartitionPruneRule.java:72)
    ...
    at com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:284)
```

Meanwhile **every** `commonPool` worker was idle, parked at `ForkJoinPool.runWorker:1628`
(the untimed park); none was on the timed keep-alive path, and the worker set was unchanged
between the two dumps.

**Blast radius.** One of those threads had entered planning through
`StatementPlanner.createQueryPlan()`, i.e. the whole-phase-lock path, so it holds a database
`INTENTION_SHARED` lock whose `unLock()` lives in a `finally` block it will never reach. The
slow-lock log confirms that thread as the owner, holding the lock for **over 3.5 hours** and
still counting. Everything needing a conflicting lock piled up behind it and kept growing
between the two dumps — **hundreds of threads**, dominated by `StatementPlanner.lock` (new
queries could not even begin planning), plus `RoutineLoadJob.plan`, MV refresh
(`PartitionBasedMvRefreshProcessor`), `ShowDataAction` and `DbsProcDir.fetchResult`.

Neither recovery mechanism works:

* `KILL QUERY` has no effect — `ForkJoinTask.invoke()` records the interrupt and re-enters
  `wait(0L)`.
* `new_planner_optimize_timeout` never fires — it is a cooperative check evaluated between
  optimizer rules, which a thread parked in `awaitDone` never reaches.

Both verified by reproducing the hang on a test cluster: freezing a single `commonPool`
worker inside the pruning lambda reproduces the exact stack above, `KILL QUERY` leaves the
thread parked with no CPU progress, and the planner timeout only fires once the worker is
released. The only recovery was an FE restart.

`main` is affected in the same way: `StatementPlanner` still runs `createQueryPlan()` inside
the lock scope and releases it only in `finally`. The lock-free planning path is conditional
on `areTablesCopySafe`, which excludes any statement touching a non-copy-safe table.

### Root cause

**1. Trigger — [JDK-8330017](https://bugs.openjdk.org/browse/JDK-8330017) /
[JDK-8351933](https://bugs.openjdk.org/browse/JDK-8351933): `ForkJoinPool` `ctl` RC subfield
overflow.** In `ForkJoinPool.runWorker()`, the worker keep-alive timeout path decrements the
TC subfield with a mask spanning both TC and RC:

```java
// jdk-11.0.20.1-ga, ForkJoinPool.java:1617
long nc = (UC_MASK & (c - TC_UNIT)) | (SP_MASK & pred);   // UC_MASK covers RC *and* TC
```

When TC is `0` (`total workers == parallelism`) the subtraction borrows into RC, leaking 1
per worker timeout. After ~32.7k leaks RC wraps from `-32768` to `+32767`, flipping the sign
of `ctl`. From then on `signalWork()` returns immediately at `if ((c = ctl) >= 0L) break;`
and never wakes a worker again, and `runWorker()`'s `rc <= 0` is never true so the pool never
drains — exactly the observed state. The affected FE had been up about four months; the JDK
report describes the bug appearing "in an application that had been running for 2/3 months".
Fixed in **JDK 11.0.30+**; **11.0.20 through 11.0.29 and 17u are affected**, 19.0.2+ is not.
Many StarRocks deployments run an affected JDK.

**2. Amplifier — this code.** `stream().parallel()` binds the completion of query planning to
`commonPool`. Once that pool stops making progress for *any* reason, planning hangs forever,
and on the whole-phase-lock path the database lock is never released.

There is also a feedback loop worth noting: pruning splits aggressively
(`sizeEstimate / (parallelism << 2)` — a 1823-partition table becomes ~456 tasks), so this
call site itself repeatedly drives `commonPool` to full parallelism and back, which is
precisely the churn pattern that drives the RC leak.

## What I'm doing:

Making both loops sequential, and merging each with the loop that already iterated the same
collection right after it, so the maps are now built in a single pass instead of two.
One file, 11 insertions / 11 deletions.

### Why remove `.parallel()` rather than something else

* **Upgrading the JDK is not sufficient.** `commonPool` is JVM-wide; any other task that
  fails to complete, from any library, reproduces the same hang. Not depending on it makes
  the FE immune regardless of JDK version.
* **A dedicated pool is not sufficient either.** `parallelStream()` cannot take a custom
  executor, and the `pool.submit(() -> ...).get()` workaround has its own issues
  ([JDK-8281524](https://bugs.openjdk.org/browse/JDK-8281524)). More importantly the
  structural problem is unchanged: planning would still hold a database lock across an
  uninterruptible join.
* **A sequential loop over the same collection already followed it**, so sequential iteration
  over `partitionKeys` was already accepted at this call site.

### Performance

Measured with the real `LiteralExpr` types (Linux, 104 cores, best-of-N after warm-up),
covering both the pruning loop and the sequential `createPartitionKey` loop that already
precedes it in the same method. **End-to-end delta after this change:**

| partitions | parallelism=103 | parallelism=16 | parallelism=8 |
|---:|---:|---:|---:|
| 100 | **-1.1 ms (-89%)** | **-0.4 ms (-75%)** | **-0.4 ms (-73%)** |
| 1,000 | **-3.1 ms (-83%)** | **-0.1 ms (-15%)** | **-0.0 ms (0%)** |
| 10,000 | +0.8 ms (+31%) | +0.8 ms (+31%) | +0.6 ms (+22%) |
| 100,000 | +16.0 ms (+173%) | +13.6 ms (+126%) | +12.6 ms (+97%) |
| 1,000,000 | +224.6 ms (+199%) | +220.7 ms (+154%) | +150.1 ms (+75%) |

Read honestly:

* **Below roughly 5,000 partitions — the overwhelming majority of tables — this is a
  speed-up.** Fork/join split and scheduling cost dominates the actual work; at 100
  partitions the current code is 16–26x *slower* than sequential.
* **Above that there is a real regression, but a bounded one**, and small next to what such a
  query already costs: at 1M partitions the *existing sequential* `createPartitionKey` loop
  in the same method already takes ~100 ms, and `listPartitionNames()` for 1M partitions is a
  multi-second HMS round trip.
* These numbers are **best-case for the current code** — measured with a warm pool. In an FE
  `commonPool` is usually idle between queries, so the parallel path additionally pays worker
  start-up in practice.

Trade-off in one line: a bounded, predictable regression of tens to a couple of hundred
milliseconds on very large partitioned tables, in exchange for removing an unbounded,
unrecoverable, cluster-wide failure mode. Happy to add a partition-count threshold or a
dedicated bounded pool instead if reviewers prefer, but I would rather keep this PR minimal
so it backports cleanly.

### Follow-ups (deliberately not in this PR)

1. **Downgrade the now-unnecessary concurrent containers.** With the loops sequential,
   `ConcurrentHashMap`/`ConcurrentSkipListMap`/`ConcurrentHashSet` can become
   `HashMap`/`TreeMap`/`HashSet`, recovering roughly 40% of the regression above (measured:
   44.66 ms -> 30.22 ms at 100k partitions).
2. **Remove the remaining `parallelStream()` call sites in the FE** — `ShowExecutor` (SHOW
   ROUTINE LOAD / SHOW STREAM LOAD) and `RoutineLoadMgr`. `RoutineLoadJob.getShowInfo()`
   acquires a database lock, which is a particularly poor fit for a shared pool. After that
   the FE no longer touches `commonPool` at all, and a checkstyle rule banning
   `parallelStream()` / `stream().parallel()` would keep it that way. (The FE currently has
   zero `CompletableFuture.*Async` call sites without an explicit executor, so this is cheap
   to enforce now.)
3. **Cache the `partitionName -> PartitionKey` conversion.** Partition *names* are already
   cached by `CachingHiveMetastore`, but `toPartitionValues()` + `createPartitionKey()` are
   redone on every call, and `PARTITION_PRUNE_RULES` is applied from six sites in
   `QueryOptimizer`, two of them `rewriteIterative`. This would help very large partitioned
   tables far more than parallelising the map insertion ever did.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The resulting maps are identical; iteration order was already unspecified
(`ConcurrentSkipListMap` orders by key, not by insertion).

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
  - behaviour-preserving change; existing partition-pruning tests cover it
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

Note on backports: `main` has two call sites, the second introduced together with the Fluss
connector. `branch-4.1`, `branch-4.0`, `branch-3.5` (and also `branch-3.4` / `branch-3.3`) do
not contain `initFlussPartitionInfo`, so only the `initPartitionInfo` hunk applies there and
the auto-backport will need manual conflict resolution for the second hunk.
