### PR TITLE
[Feature] Define native geo descriptor and transport contract

### DIFF
--- a/be/src/types/CMakeLists.txt
+++ b/be/src/types/CMakeLists.txt
@@ -18,6 +18,7 @@ ADD_BE_LIB(Types
     bitmap_value.cpp
     datum.cpp
     decimalv2_value.cpp
+    geo_type_descriptor.cpp
     int128_to_double.cpp
     hll.cpp
     json_value.cpp

--- a/be/src/types/geo_type_descriptor.cpp
+++ b/be/src/types/geo_type_descriptor.cpp
@@ -1,0 +1,170 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/geo_type_descriptor.h"
+
+namespace starrocks {
+namespace {
+
+#define ASSERT_GEO_ENUM_VALUE(thrift_value, protobuf_value) \
+    static_assert(static_cast<int>(thrift_value) == static_cast<int>(protobuf_value))
+
+ASSERT_GEO_ENUM_VALUE(TGeoLogicalType::UNKNOWN, GEO_LOGICAL_TYPE_UNKNOWN);
+ASSERT_GEO_ENUM_VALUE(TGeoLogicalType::GEOGRAPHY, GEO_LOGICAL_TYPE_GEOGRAPHY);
+ASSERT_GEO_ENUM_VALUE(TGeoLogicalType::GEOMETRY, GEO_LOGICAL_TYPE_GEOMETRY);
+ASSERT_GEO_ENUM_VALUE(TGeoCoordinateSystem::UNKNOWN, GEO_COORDINATE_SYSTEM_UNKNOWN);
+ASSERT_GEO_ENUM_VALUE(TGeoCoordinateSystem::SPHERICAL, GEO_COORDINATE_SYSTEM_SPHERICAL);
+ASSERT_GEO_ENUM_VALUE(TGeoCoordinateSystem::CARTESIAN, GEO_COORDINATE_SYSTEM_CARTESIAN);
+ASSERT_GEO_ENUM_VALUE(TGeoEdgeAlgorithm::UNKNOWN, GEO_EDGE_ALGORITHM_UNKNOWN);
+ASSERT_GEO_ENUM_VALUE(TGeoEdgeAlgorithm::GEODESIC, GEO_EDGE_ALGORITHM_GEODESIC);
+ASSERT_GEO_ENUM_VALUE(TGeoEdgeAlgorithm::LINEAR, GEO_EDGE_ALGORITHM_LINEAR);
+ASSERT_GEO_ENUM_VALUE(TGeoEncoding::UNKNOWN, GEO_ENCODING_UNKNOWN);
+ASSERT_GEO_ENUM_VALUE(TGeoEncoding::WKB, GEO_ENCODING_WKB);
+ASSERT_GEO_ENUM_VALUE(TGeoDimension::UNKNOWN, GEO_DIMENSION_UNKNOWN);
+ASSERT_GEO_ENUM_VALUE(TGeoDimension::XY, GEO_DIMENSION_XY);
+ASSERT_GEO_ENUM_VALUE(TGeoDimension::XYZ, GEO_DIMENSION_XYZ);
+ASSERT_GEO_ENUM_VALUE(TGeoDimension::XYM, GEO_DIMENSION_XYM);
+ASSERT_GEO_ENUM_VALUE(TGeoDimension::XYZM, GEO_DIMENSION_XYZM);
+ASSERT_GEO_ENUM_VALUE(TGeoDimension::MIXED, GEO_DIMENSION_MIXED);
+ASSERT_GEO_ENUM_VALUE(TGeoValidationState::UNKNOWN, GEO_VALIDATION_STATE_UNKNOWN);
+ASSERT_GEO_ENUM_VALUE(TGeoValidationState::UNVALIDATED, GEO_VALIDATION_STATE_UNVALIDATED);
+ASSERT_GEO_ENUM_VALUE(TGeoValidationState::STRUCTURALLY_VALIDATED, GEO_VALIDATION_STATE_STRUCTURALLY_VALIDATED);
+ASSERT_GEO_ENUM_VALUE(TGeoValidationState::SEMANTICALLY_VALIDATED, GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED);
+
+#undef ASSERT_GEO_ENUM_VALUE
+
+} // namespace
+
+GeoTypeDescriptor GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
+    GeoTypeDescriptor result;
+    if (thrift.__isset.logical_type) {
+        result.logical_type = thrift.logical_type;
+    }
+    if (thrift.__isset.coordinate_system) {
+        result.coordinate_system = thrift.coordinate_system;
+    }
+    if (thrift.__isset.edge_algorithm) {
+        result.edge_algorithm = thrift.edge_algorithm;
+    }
+    if (thrift.__isset.crs) {
+        result.crs = thrift.crs;
+    }
+    if (thrift.__isset.srid) {
+        result.srid = thrift.srid;
+    }
+    return result;
+}
+
+GeoTypeDescriptor GeoTypeDescriptor::from_protobuf(const PGeoTypeDesc& protobuf) {
+    GeoTypeDescriptor result;
+    if (protobuf.has_logical_type()) {
+        result.logical_type = static_cast<TGeoLogicalType::type>(protobuf.logical_type());
+    }
+    if (protobuf.has_coordinate_system()) {
+        result.coordinate_system = static_cast<TGeoCoordinateSystem::type>(protobuf.coordinate_system());
+    }
+    if (protobuf.has_edge_algorithm()) {
+        result.edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(protobuf.edge_algorithm());
+    }
+    if (protobuf.has_crs()) {
+        result.crs = protobuf.crs();
+    }
+    if (protobuf.has_srid()) {
+        result.srid = protobuf.srid();
+    }
+    return result;
+}
+
+TGeoTypeDesc GeoTypeDescriptor::to_thrift() const {
+    TGeoTypeDesc result;
+    result.__set_logical_type(logical_type);
+    result.__set_coordinate_system(coordinate_system);
+    result.__set_edge_algorithm(edge_algorithm);
+    if (!crs.empty()) {
+        result.__set_crs(crs);
+    }
+    if (srid.has_value()) {
+        result.__set_srid(*srid);
+    }
+    return result;
+}
+
+PGeoTypeDesc GeoTypeDescriptor::to_protobuf() const {
+    PGeoTypeDesc result;
+    result.set_logical_type(static_cast<PGeoLogicalType>(logical_type));
+    result.set_coordinate_system(static_cast<PGeoCoordinateSystem>(coordinate_system));
+    result.set_edge_algorithm(static_cast<PGeoEdgeAlgorithm>(edge_algorithm));
+    if (!crs.empty()) {
+        result.set_crs(crs);
+    }
+    if (srid.has_value()) {
+        result.set_srid(*srid);
+    }
+    return result;
+}
+
+bool GeoTypeDescriptor::operator==(const GeoTypeDescriptor& rhs) const {
+    return logical_type == rhs.logical_type && coordinate_system == rhs.coordinate_system &&
+           edge_algorithm == rhs.edge_algorithm && crs == rhs.crs && srid == rhs.srid;
+}
+
+GeoStorageDescriptor GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& thrift) {
+    GeoStorageDescriptor result;
+    if (thrift.__isset.encoding) {
+        result.encoding = thrift.encoding;
+    }
+    if (thrift.__isset.dimension) {
+        result.dimension = thrift.dimension;
+    }
+    if (thrift.__isset.validation_state) {
+        result.validation_state = thrift.validation_state;
+    }
+    return result;
+}
+
+GeoStorageDescriptor GeoStorageDescriptor::from_protobuf(const PGeoStorageDesc& protobuf) {
+    GeoStorageDescriptor result;
+    if (protobuf.has_encoding()) {
+        result.encoding = static_cast<TGeoEncoding::type>(protobuf.encoding());
+    }
+    if (protobuf.has_dimension()) {
+        result.dimension = static_cast<TGeoDimension::type>(protobuf.dimension());
+    }
+    if (protobuf.has_validation_state()) {
+        result.validation_state = static_cast<TGeoValidationState::type>(protobuf.validation_state());
+    }
+    return result;
+}
+
+TGeoStorageDesc GeoStorageDescriptor::to_thrift() const {
+    TGeoStorageDesc result;
+    result.__set_encoding(encoding);
+    result.__set_dimension(dimension);
+    result.__set_validation_state(validation_state);
+    return result;
+}
+
+PGeoStorageDesc GeoStorageDescriptor::to_protobuf() const {
+    PGeoStorageDesc result;
+    result.set_encoding(static_cast<PGeoEncoding>(encoding));
+    result.set_dimension(static_cast<PGeoDimension>(dimension));
+    result.set_validation_state(static_cast<PGeoValidationState>(validation_state));
+    return result;
+}
+
+bool GeoStorageDescriptor::operator==(const GeoStorageDescriptor& rhs) const {
+    return encoding == rhs.encoding && dimension == rhs.dimension && validation_state == rhs.validation_state;
+}
+
+} // namespace starrocks

--- a/be/src/types/geo_type_descriptor.h
+++ b/be/src/types/geo_type_descriptor.h
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "gen_cpp/Types_types.h"
+#include "gen_cpp/types.pb.h"
+
+namespace starrocks {
+
+// Semantic metadata for native geo values. This descriptor, rather than the
+// WKB payload, distinguishes planar GEOMETRY from spherical GEOGRAPHY.
+struct GeoTypeDescriptor {
+    TGeoLogicalType::type logical_type{TGeoLogicalType::UNKNOWN};
+    TGeoCoordinateSystem::type coordinate_system{TGeoCoordinateSystem::UNKNOWN};
+    TGeoEdgeAlgorithm::type edge_algorithm{TGeoEdgeAlgorithm::UNKNOWN};
+    std::string crs;
+    std::optional<int32_t> srid;
+
+    static GeoTypeDescriptor from_thrift(const TGeoTypeDesc& thrift);
+    static GeoTypeDescriptor from_protobuf(const PGeoTypeDesc& protobuf);
+
+    TGeoTypeDesc to_thrift() const;
+    PGeoTypeDesc to_protobuf() const;
+
+    bool operator==(const GeoTypeDescriptor& rhs) const;
+    bool operator!=(const GeoTypeDescriptor& rhs) const { return !(*this == rhs); }
+};
+
+// Physical metadata for the transported or persisted native geo payload.
+struct GeoStorageDescriptor {
+    TGeoEncoding::type encoding{TGeoEncoding::UNKNOWN};
+    TGeoDimension::type dimension{TGeoDimension::UNKNOWN};
+    TGeoValidationState::type validation_state{TGeoValidationState::UNKNOWN};
+
+    static GeoStorageDescriptor from_thrift(const TGeoStorageDesc& thrift);
+    static GeoStorageDescriptor from_protobuf(const PGeoStorageDesc& protobuf);
+
+    TGeoStorageDesc to_thrift() const;
+    PGeoStorageDesc to_protobuf() const;
+
+    bool operator==(const GeoStorageDescriptor& rhs) const;
+    bool operator!=(const GeoStorageDescriptor& rhs) const { return !(*this == rhs); }
+};
+
+} // namespace starrocks

--- a/be/src/types/type_descriptor.cpp
+++ b/be/src/types/type_descriptor.cpp
@@ -41,6 +41,12 @@ TypeDescriptor::TypeDescriptor(const std::vector<TTypeNode>& types, int* idx) {
         scale = (scalar_type.__isset.scale) ? scalar_type.scale : -1;
         precision = (scalar_type.__isset.precision) ? scalar_type.precision : -1;
         datetime_is_ntz = scalar_type.__isset.datetime_is_ntz && scalar_type.datetime_is_ntz;
+        if (scalar_type.__isset.geo_type_desc) {
+            geo_type_desc = GeoTypeDescriptor::from_thrift(scalar_type.geo_type_desc);
+        }
+        if (scalar_type.__isset.geo_storage_desc) {
+            geo_storage_desc = GeoStorageDescriptor::from_thrift(scalar_type.geo_storage_desc);
+        }
 
         if (type == TYPE_DECIMAL || type == TYPE_DECIMALV2 || type == TYPE_DECIMAL32 || type == TYPE_DECIMAL64 ||
             type == TYPE_DECIMAL128 || type == TYPE_DECIMAL256) {
@@ -122,6 +128,12 @@ void TypeDescriptor::to_thrift(TTypeDesc* thrift_type) const {
         if (datetime_is_ntz) {
             scalar_type.__set_datetime_is_ntz(true);
         }
+        if (geo_type_desc.has_value()) {
+            scalar_type.__set_geo_type_desc(geo_type_desc->to_thrift());
+        }
+        if (geo_storage_desc.has_value()) {
+            scalar_type.__set_geo_storage_desc(geo_storage_desc->to_thrift());
+        }
     }
 }
 
@@ -156,6 +168,12 @@ void TypeDescriptor::to_protobuf(PTypeDesc* proto_type) const {
         if (precision != -1) {
             scalar_type->set_precision(precision);
         }
+        if (geo_type_desc.has_value()) {
+            *scalar_type->mutable_geo_type_desc() = geo_type_desc->to_protobuf();
+        }
+        if (geo_storage_desc.has_value()) {
+            *scalar_type->mutable_geo_storage_desc() = geo_storage_desc->to_protobuf();
+        }
     }
 }
 
@@ -174,6 +192,12 @@ TypeDescriptor::TypeDescriptor(const google::protobuf::RepeatedPtrField<PTypeNod
         len = scalar_type.has_len() ? scalar_type.len() : -1;
         scale = scalar_type.has_scale() ? scalar_type.scale() : -1;
         precision = scalar_type.has_precision() ? scalar_type.precision() : -1;
+        if (scalar_type.has_geo_type_desc()) {
+            geo_type_desc = GeoTypeDescriptor::from_protobuf(scalar_type.geo_type_desc());
+        }
+        if (scalar_type.has_geo_storage_desc()) {
+            geo_storage_desc = GeoStorageDescriptor::from_protobuf(scalar_type.geo_storage_desc());
+        }
 
         if (type == TYPE_CHAR || type == TYPE_VARCHAR || type == TYPE_HLL) {
             DCHECK(scalar_type.has_len());

--- a/be/src/types/type_descriptor.h
+++ b/be/src/types/type_descriptor.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <optional>
 #include <ostream>
 #include <string>
 #include <vector>
@@ -23,6 +24,7 @@
 #include "gen_cpp/types.pb.h"    // for PTypeDesc
 #include "thrift/protocol/TDebugProtocol.h"
 #include "types/constexpr.h"
+#include "types/geo_type_descriptor.h"
 #include "types/logical_type.h"
 
 namespace starrocks {
@@ -50,6 +52,12 @@ struct TypeDescriptor {
     /// Default false means "shift a UTC instant into the session timezone" (Hive / Iceberg /
     /// Paimon LTZ); true means the value is a naive wall clock that must NOT be shifted.
     bool datetime_is_ntz{false};
+
+    // Native geo semantics and storage metadata. These descriptors are kept
+    // separate because identical WKB bytes may represent either planar
+    // GEOMETRY or spherical GEOGRAPHY values.
+    std::optional<GeoTypeDescriptor> geo_type_desc;
+    std::optional<GeoStorageDescriptor> geo_storage_desc;
 
     /// Must be kept in sync with FE's max precision/scale.
     static const int MAX_PRECISION = 76;
@@ -232,6 +240,9 @@ struct TypeDescriptor {
     }
 
     bool is_assignable(const TypeDescriptor& o) const {
+        if (geo_type_desc != o.geo_type_desc || geo_storage_desc != o.geo_storage_desc) {
+            return false;
+        }
         if (is_complex_type()) {
             if ((type != o.type) || (children.size() != o.children.size())) {
                 return false;
@@ -252,6 +263,9 @@ struct TypeDescriptor {
 
     bool operator==(const TypeDescriptor& o) const {
         if (type != o.type) {
+            return false;
+        }
+        if (geo_type_desc != o.geo_type_desc || geo_storage_desc != o.geo_storage_desc) {
             return false;
         }
         if (children != o.children) {

--- a/be/test/types/type_descriptor_test.cpp
+++ b/be/test/types/type_descriptor_test.cpp
@@ -842,4 +842,95 @@ TEST_F(TypeDescriptorTest, test_create_variant_type) {
     ASSERT_EQ(variant_desc.len, variant_desc2.len);
 }
 
+TEST_F(TypeDescriptorTest, geo_descriptor_thrift_round_trip) {
+    TypeDescriptor descriptor = TypeDescriptor::create_varbinary_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    descriptor.geo_type_desc = GeoTypeDescriptor{
+            .logical_type = TGeoLogicalType::GEOGRAPHY,
+            .coordinate_system = TGeoCoordinateSystem::SPHERICAL,
+            .edge_algorithm = TGeoEdgeAlgorithm::GEODESIC,
+            .crs = "OGC:CRS84",
+            .srid = 4326,
+    };
+    descriptor.geo_storage_desc = GeoStorageDescriptor{
+            .encoding = TGeoEncoding::WKB,
+            .dimension = TGeoDimension::XY,
+            .validation_state = TGeoValidationState::STRUCTURALLY_VALIDATED,
+    };
+
+    TTypeDesc thrift = descriptor.to_thrift();
+    ASSERT_TRUE(thrift.types.front().scalar_type.__isset.geo_type_desc);
+    ASSERT_TRUE(thrift.types.front().scalar_type.__isset.geo_storage_desc);
+    EXPECT_EQ("OGC:CRS84", thrift.types.front().scalar_type.geo_type_desc.crs);
+
+    TypeDescriptor round_trip = TypeDescriptor::from_thrift(thrift);
+    EXPECT_EQ(descriptor, round_trip);
+    EXPECT_TRUE(descriptor.is_assignable(round_trip));
+}
+
+TEST_F(TypeDescriptorTest, geo_descriptor_protobuf_round_trip) {
+    TypeDescriptor descriptor = TypeDescriptor::create_varbinary_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    descriptor.geo_type_desc = GeoTypeDescriptor{
+            .logical_type = TGeoLogicalType::GEOMETRY,
+            .coordinate_system = TGeoCoordinateSystem::CARTESIAN,
+            .edge_algorithm = TGeoEdgeAlgorithm::LINEAR,
+            .crs = "EPSG:3857",
+            .srid = 3857,
+    };
+    descriptor.geo_storage_desc = GeoStorageDescriptor{
+            .encoding = TGeoEncoding::WKB,
+            .dimension = TGeoDimension::XYZM,
+            .validation_state = TGeoValidationState::SEMANTICALLY_VALIDATED,
+    };
+
+    PTypeDesc protobuf = descriptor.to_protobuf();
+    ASSERT_TRUE(protobuf.types(0).scalar_type().has_geo_type_desc());
+    ASSERT_TRUE(protobuf.types(0).scalar_type().has_geo_storage_desc());
+    EXPECT_EQ("EPSG:3857", protobuf.types(0).scalar_type().geo_type_desc().crs());
+
+    TypeDescriptor round_trip = TypeDescriptor::from_protobuf(protobuf);
+    EXPECT_EQ(descriptor, round_trip);
+    EXPECT_TRUE(descriptor.is_assignable(round_trip));
+}
+
+TEST_F(TypeDescriptorTest, geo_descriptor_participates_in_type_identity) {
+    TypeDescriptor geography = TypeDescriptor::create_varbinary_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    geography.geo_type_desc = GeoTypeDescriptor{
+            .logical_type = TGeoLogicalType::GEOGRAPHY,
+            .coordinate_system = TGeoCoordinateSystem::SPHERICAL,
+            .edge_algorithm = TGeoEdgeAlgorithm::GEODESIC,
+            .crs = "OGC:CRS84",
+    };
+    geography.geo_storage_desc = GeoStorageDescriptor{
+            .encoding = TGeoEncoding::WKB,
+            .dimension = TGeoDimension::XY,
+            .validation_state = TGeoValidationState::STRUCTURALLY_VALIDATED,
+    };
+
+    TypeDescriptor geometry = geography;
+    geometry.geo_type_desc->logical_type = TGeoLogicalType::GEOMETRY;
+    geometry.geo_type_desc->coordinate_system = TGeoCoordinateSystem::CARTESIAN;
+    geometry.geo_type_desc->edge_algorithm = TGeoEdgeAlgorithm::LINEAR;
+
+    EXPECT_NE(geography, geometry);
+    EXPECT_FALSE(geography.is_assignable(geometry));
+
+    TypeDescriptor plain_varbinary = TypeDescriptor::create_varbinary_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    EXPECT_NE(geography, plain_varbinary);
+    EXPECT_FALSE(geography.is_assignable(plain_varbinary));
+}
+
+TEST_F(TypeDescriptorTest, absent_geo_descriptor_preserves_existing_scalar_contract) {
+    TypeDescriptor descriptor = TypeDescriptor::create_varbinary_type(128);
+
+    TypeDescriptor thrift_round_trip = TypeDescriptor::from_thrift(descriptor.to_thrift());
+    EXPECT_EQ(descriptor, thrift_round_trip);
+    EXPECT_FALSE(thrift_round_trip.geo_type_desc.has_value());
+    EXPECT_FALSE(thrift_round_trip.geo_storage_desc.has_value());
+
+    TypeDescriptor protobuf_round_trip = TypeDescriptor::from_protobuf(descriptor.to_protobuf());
+    EXPECT_EQ(descriptor, protobuf_round_trip);
+    EXPECT_FALSE(protobuf_round_trip.geo_type_desc.has_value());
+    EXPECT_FALSE(protobuf_round_trip.geo_storage_desc.has_value());
+}
+
 } // namespace starrocks

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -37,6 +37,59 @@ syntax = "proto2";
 package starrocks;
 option java_package = "com.starrocks.proto";
 
+enum PGeoLogicalType {
+    GEO_LOGICAL_TYPE_UNKNOWN = 0;
+    GEO_LOGICAL_TYPE_GEOGRAPHY = 1;
+    GEO_LOGICAL_TYPE_GEOMETRY = 2;
+}
+
+enum PGeoCoordinateSystem {
+    GEO_COORDINATE_SYSTEM_UNKNOWN = 0;
+    GEO_COORDINATE_SYSTEM_SPHERICAL = 1;
+    GEO_COORDINATE_SYSTEM_CARTESIAN = 2;
+}
+
+enum PGeoEdgeAlgorithm {
+    GEO_EDGE_ALGORITHM_UNKNOWN = 0;
+    GEO_EDGE_ALGORITHM_GEODESIC = 1;
+    GEO_EDGE_ALGORITHM_LINEAR = 2;
+}
+
+enum PGeoEncoding {
+    GEO_ENCODING_UNKNOWN = 0;
+    GEO_ENCODING_WKB = 1;
+}
+
+enum PGeoDimension {
+    GEO_DIMENSION_UNKNOWN = 0;
+    GEO_DIMENSION_XY = 1;
+    GEO_DIMENSION_XYZ = 2;
+    GEO_DIMENSION_XYM = 3;
+    GEO_DIMENSION_XYZM = 4;
+    GEO_DIMENSION_MIXED = 5;
+}
+
+enum PGeoValidationState {
+    GEO_VALIDATION_STATE_UNKNOWN = 0;
+    GEO_VALIDATION_STATE_UNVALIDATED = 1;
+    GEO_VALIDATION_STATE_STRUCTURALLY_VALIDATED = 2;
+    GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED = 3;
+}
+
+message PGeoTypeDesc {
+    optional PGeoLogicalType logical_type = 1;
+    optional PGeoCoordinateSystem coordinate_system = 2;
+    optional PGeoEdgeAlgorithm edge_algorithm = 3;
+    optional string crs = 4;
+    optional int32 srid = 5;
+}
+
+message PGeoStorageDesc {
+    optional PGeoEncoding encoding = 1;
+    optional PGeoDimension dimension = 2;
+    optional PGeoValidationState validation_state = 3;
+}
+
 message PScalarType {
     // TPrimitiveType, use int32 to avoid redefine Enum
     required int32 type = 1;
@@ -45,6 +98,9 @@ message PScalarType {
     // Only set for DECIMAL
     optional int32 precision = 3;
     optional int32 scale = 4;
+    // Only meaningful for native GEOGRAPHY/GEOMETRY values.
+    optional PGeoTypeDesc geo_type_desc = 5;
+    optional PGeoStorageDesc geo_storage_desc = 6;
 };
 
 // Represents a field in a STRUCT type.

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -115,6 +115,61 @@ enum TTypeNodeType {
     STRUCT
 }
 
+// Logical semantics for a native geo value. The WKB payload does not encode
+// this distinction, so it must be transported with the type descriptor.
+enum TGeoLogicalType {
+    UNKNOWN = 0,
+    GEOGRAPHY = 1,
+    GEOMETRY = 2
+}
+
+enum TGeoCoordinateSystem {
+    UNKNOWN = 0,
+    SPHERICAL = 1,
+    CARTESIAN = 2
+}
+
+enum TGeoEdgeAlgorithm {
+    UNKNOWN = 0,
+    GEODESIC = 1,
+    LINEAR = 2
+}
+
+enum TGeoEncoding {
+    UNKNOWN = 0,
+    WKB = 1
+}
+
+enum TGeoDimension {
+    UNKNOWN = 0,
+    XY = 1,
+    XYZ = 2,
+    XYM = 3,
+    XYZM = 4,
+    MIXED = 5
+}
+
+enum TGeoValidationState {
+    UNKNOWN = 0,
+    UNVALIDATED = 1,
+    STRUCTURALLY_VALIDATED = 2,
+    SEMANTICALLY_VALIDATED = 3
+}
+
+struct TGeoTypeDesc {
+    1: optional TGeoLogicalType logical_type
+    2: optional TGeoCoordinateSystem coordinate_system
+    3: optional TGeoEdgeAlgorithm edge_algorithm
+    4: optional string crs
+    5: optional i32 srid
+}
+
+struct TGeoStorageDesc {
+    1: optional TGeoEncoding encoding
+    2: optional TGeoDimension dimension
+    3: optional TGeoValidationState validation_state
+}
+
 struct TScalarType {
     1: required TPrimitiveType type
 
@@ -131,6 +186,11 @@ struct TScalarType {
     // UTC instant that must be shifted into the session timezone (Hive/Iceberg/Paimon LTZ);
     // Paimon TIMESTAMP sets it to true so the reader keeps the wall clock unshifted.
     5: optional bool datetime_is_ntz
+
+    // Only meaningful for native GEOGRAPHY/GEOMETRY values. These descriptors
+    // deliberately separate logical semantics from the canonical WKB payload.
+    6: optional TGeoTypeDesc geo_type_desc
+    7: optional TGeoStorageDesc geo_storage_desc
 }
 
 // Represents a field in a STRUCT type.

--- a/handbook/plans/active/2026-09-04-native-geo-contract.md
+++ b/handbook/plans/active/2026-09-04-native-geo-contract.md
@@ -1,0 +1,95 @@
+# Native Geo Contract
+
+- Status: active
+- Owner: ViktorGo86
+- Last Updated: 2026-09-04
+
+## Summary
+
+Introduce native geospatial support as a sequence of independently reviewable
+contracts. `GEOGRAPHY` and `GEOMETRY` remain distinct logical SQL types with no
+implicit conversion, while sharing a physical vectorized representation backed
+by canonical OGC WKB bytes.
+
+The first implementation step defines the descriptor and transport contract
+only. It does not expose SQL syntax, enable native-table persistence, or change
+legacy `VARCHAR` spatial functions and `GeoShape` payloads.
+
+## Contract Sequence
+
+1. Define `GeoTypeDesc` and `GeoStorageDesc`, including compatible Thrift and
+   protobuf representations and BE round-trip behavior.
+2. Introduce `GeoColumn`, backed by `BinaryColumn`, without embedding an
+   engine-specific geometry object in the persisted or exchanged payload.
+3. Propagate descriptors through FE types, expression results, exchange, spill,
+   intermediate materialization, and vectorized serde.
+4. Expose `GEOGRAPHY` with OGC:CRS84 longitude/latitude semantics and explicit
+   WKT/WKB boundaries.
+5. Add feature-gated native-table persistence and specify rolling-upgrade and
+   downgrade behavior.
+6. Add native spatial functions incrementally.
+7. Enable `GEOMETRY` after its planar semantics and GEOS execution contract are
+   agreed.
+
+## Descriptor Contract
+
+`GeoTypeDesc` separates semantic identity from physical representation:
+
+- logical type: `GEOGRAPHY` or `GEOMETRY`;
+- coordinate system: `SPHERICAL` or `CARTESIAN`;
+- edge algorithm: `GEODESIC` or `LINEAR`;
+- CRS identifier string;
+- optional parsed SRID.
+
+`GeoStorageDesc` describes the transported or persisted bytes:
+
+- encoding: canonical OGC WKB initially;
+- declared dimension: `UNKNOWN`, `XY`, `XYZ`, `XYM`, `XYZM`, or `MIXED`;
+- producer validation state: `UNKNOWN`, `UNVALIDATED`, structurally validated,
+  or semantically validated.
+
+Unknown enum values occupy ordinal zero. All newly added Thrift and protobuf
+fields are optional, use new ordinals, and must survive Thrift and protobuf
+round trips. Descriptor values participate in type identity so spherical and
+planar values cannot become assignable merely because their WKB bytes share the
+same physical layout.
+
+## Representation Invariants
+
+- Canonical WKB is the only initial persistent and interchange payload.
+- WKB bytes never determine whether a value has planar or spherical semantics.
+- S2, GEOS, H3, and legacy `GeoShape` internal bytes are never persisted as
+  native geo values.
+- Legacy spatial values are not implicitly reinterpreted as native geo values.
+- OGC:CRS84 is the initial `GEOGRAPHY` coordinate reference system: X is
+  longitude, Y is latitude, and edges are spherical.
+- EPSG:4326 or EWKB SRID 4326 may be accepted only at explicit SQL boundaries
+  and canonicalized to the native contract; authority-axis ambiguity must not
+  be silently propagated.
+
+## Upgrade And Downgrade Direction
+
+Native geo remains feature-gated until every participating FE, BE, and CN can
+preserve its descriptors. Before downgrading to a version without native geo,
+users must explicitly convert native values to canonical WKB in `VARBINARY`,
+remove remaining native-geo metadata, finish or cancel related schema changes,
+and create and synchronize a compatible FE metadata image.
+
+## Acceptance Criteria: Descriptor Contract
+
+- Thrift and protobuf schemas define semantic and storage descriptors using
+  optional fields without reusing existing ordinals.
+- BE `TypeDescriptor` preserves both descriptors through Thrift and protobuf
+  round trips.
+- Descriptor differences participate in equality and assignability.
+- Existing scalar descriptors without geo metadata retain their behavior.
+- Focused BE type tests pass.
+- Generated-schema compatibility and BE module-boundary checks pass.
+
+## Decision Log
+
+- 2026-09-04: Use separate logical types with one canonical WKB representation.
+- 2026-09-04: Deliver descriptor, column, transport, SQL, persistence, and
+  execution semantics as separate contracts.
+- 2026-09-04: Expose `GEOGRAPHY` first and keep `GEOMETRY` feature-gated until
+  its planar/GEOS contract is ready.

--- a/handbook/plans/index.md
+++ b/handbook/plans/index.md
@@ -5,6 +5,7 @@ Use this directory for repo-local execution plans that agents can read, update, 
 ## Active Plans
 
 - [Harness Engineering Roadmap](active/2026-03-27-harness-engineering-roadmap.md)
+- [Native Geo Contract](active/2026-09-04-native-geo-contract.md)
 
 ## Templates
 


### PR DESCRIPTION
## Why I'm doing:

The native geo prototype in #78381 demonstrated the need to separate logical semantics from the WKB payload. The same bytes must never implicitly determine whether a value is GEOGRAPHY or GEOMETRY.

The umbrella design and implementation tracker is #78693. Following discussion with @alvin-phoenix-ai, delivery is connector-first, with small, focused PRs for foundational contracts.

## What I'm doing:

### Current status and sequencing

This PR is an **in-progress starting point for Milestone 2, Contract 2.1**, not a completed implementation of the updated contract. Further code changes in this PR are deferred until **Milestone 1 — Iceberg/Parquet geo compatibility foundation** is completed.

This description has been aligned with the updated plan and review feedback. **The code has not yet been updated to address the findings below.** This PR should not be treated as ready to merge against the revised acceptance criteria.

### What the current diff contains

- `GeoTypeDesc` for logical kind, coordinate system, edge algorithm, CRS, and optional SRID.
- `GeoStorageDesc` for WKB encoding, declared dimension, and producer-validation state.
- Optional Thrift/protobuf fields with matching enum ordinals and compile-time parity checks.
- Initial BE `TypeDescriptor` integration and object-level round-trip/identity tests.
- A bundled implementation plan that still needs alignment with #78693.

The current integration and tests contain the contract issues identified in review; their presence does not establish compliance with the updated design.

### Required follow-up before this contract is complete

- [ ] Represent `SPHERICAL`, `VINCENTY`, `THOMAS`, `ANDOYER`, `KARNEY`, and `PLANAR` distinctly. Metadata transport must not collapse these into generic GEODESIC/LINEAR semantics. Preserving an algorithm does not enable its computation.
- [ ] Separate semantic identity from storage compatibility using named predicates. Producer-validation state must not affect SQL type identity or compatibility. Define explicit WKB encoding and UNKNOWN/MIXED/constrained-dimension assignment and pass-through rules.
- [ ] Remove premature native `TypeDescriptor` integration from the descriptor-only slice while native primitive types are deferred. Test descriptors independently; `VARBINARY` plus a geo descriptor is not a native geo type. The later integration slice must enforce primitive-type authority and reject non-geo attachments and inconsistent kind/coordinate/edge combinations.
- [ ] Preserve unknown numeric enum values during metadata transport or explicitly reject them before conversion. Never silently replace them with UNKNOWN or a supported default. Cover proto2 unknown-field behavior with serialized-wire tests, not only object-level round trips.
- [ ] Update the bundled plan to reference #78693 and the connector-first sequence. Downgrade/restore must preserve WKB **and** a companion semantic metadata manifest or explicit reconstruction parameters; WKB alone is insufficient.

### Non-goals of this PR

This descriptor-focused PR does not expose new SQL syntax, enable native geo execution or native-table persistence, introduce GeoColumn, add spatial functions, or change legacy VARCHAR spatial functions and GeoShape bytes.

## Incremental implementation plan:

1. **Milestone 1 — Iceberg/Parquet geo compatibility foundation:** recognize and preserve external geo metadata, parse Parquet annotations, validate schema conflicts, and retain unsupported/UNKNOWN_TYPE behavior. No native SQL type exposure, GeoColumn, GEOS/S2 execution, or native persistence.
2. **Milestone 2 — Shared native type and transport foundation:** resume this PR as the focused descriptor-contract slice of Contract 2.1, then implement native primitive-type integration, GeoColumn, and end-to-end transport/serde in reviewable slices.
3. **Milestone 3 — Native GEOGRAPHY for Iceberg:** separately gate reads, constructors/serializers, public result rendering, and the reviewed initial compute set: ST_X, ST_Y, ST_GEOMETRYTYPE, and POINT/POINT ST_DISTANCE.
4. **Later independently gated work:** native-table persistence, GEOMETRY/GEOS, nested fields, broader spatial functions, CRS transforms, H3, and Iceberg writes.

#78693 remains the source of truth for scope and acceptance criteria. A milestone does not automatically imply one PR.

ISO/OGC WKB is the canonical external payload contract; scans preserve valid source bytes without eager normalization. Native values require explicit logical type and descriptors. S2, GEOS, H3, and legacy GeoShape internal bytes are not native persistent payloads.

## Tests:

### Previously reported baseline

The original implementation reported `./run-be-ut.sh --build-target types_test --module types_test --without-java-ext` — **280/280 passed**, alongside generated-schema compatibility, BE module-boundary, generated AGENTS consistency, and diff checks.

Those results apply to the earlier implementation and **do not validate the revised contract**. No code tests were rerun for this description-only update.

### Required acceptance coverage for the follow-up

- Standalone Thrift/protobuf descriptor round trips for all six edge algorithms and optional fields.
- Serialized-wire unknown-enum cases for every enum field, with exact numeric preservation or explicit rejection.
- Compatibility unchanged by producer-validation state; explicit CRS/kind/edge, encoding, and dimension cases.
- No successful VARBINARY-as-native-geo proxy tests.
- Native primitive authority and mismatch rejection when integration is introduced.
- Focused BE tests, schema compatibility, formatting, and architecture checks rerun on the revised implementation.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my new feature
- [ ] This PR needs user documentation (no user-visible SQL feature is exposed in this contract PR)
- [ ] This is a backport PR