### PR TITLE
[BugFix] Keep global dict exprs when skew join v2 replaces the shuffle exchanges

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/SplitCastPlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SplitCastPlanFragment.java
@@ -43,6 +43,7 @@ public class SplitCastPlanFragment extends PlanFragment {
         this.children.addAll(planFragment.getChildren());
         this.setLoadGlobalDicts(planFragment.loadGlobalDicts);
         this.setQueryGlobalDicts(planFragment.queryGlobalDicts);
+        this.setQueryGlobalDictExprs(planFragment.queryGlobalDictExprs);
     }
 
     // get the list of destination fragments by exchange nodes

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSplitConsumeOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalSplitConsumeOperator.java
@@ -14,6 +14,8 @@
 package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.RowOutputInfo;
@@ -22,14 +24,21 @@ import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnDict;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class PhysicalSplitConsumeOperator extends PhysicalOperator {
     private final int splitId;
     private final List<ColumnRefOperator> outputColumnRefOp;
     private final ScalarOperator splitPredicate;
+    // Global dictionaries and derived-dictionary expressions the consuming fragment needs, carried over
+    // from the exchange this operator replaces (see SkewShuffleJoinEliminationRule). The low-cardinality
+    // rewrite attaches them to the exchange; the fragment built for this consumer must still receive them.
+    private List<Pair<Integer, ColumnDict>> globalDicts = Lists.newArrayList();
+    private Map<Integer, ScalarOperator> globalDictsExpr = Maps.newHashMap();
 
     public PhysicalSplitConsumeOperator(int splitId, ScalarOperator splitPredicate, DistributionSpec distributionSpec,
                                         List<ColumnRefOperator> outputColumnRefOp) {
@@ -46,6 +55,22 @@ public class PhysicalSplitConsumeOperator extends PhysicalOperator {
 
     public ScalarOperator getSplitPredicate() {
         return splitPredicate;
+    }
+
+    public List<Pair<Integer, ColumnDict>> getGlobalDicts() {
+        return globalDicts;
+    }
+
+    public void setGlobalDicts(List<Pair<Integer, ColumnDict>> globalDicts) {
+        this.globalDicts = globalDicts;
+    }
+
+    public Map<Integer, ScalarOperator> getGlobalDictsExpr() {
+        return globalDictsExpr;
+    }
+
+    public void setGlobalDictsExpr(Map<Integer, ScalarOperator> globalDictsExpr) {
+        this.globalDictsExpr = globalDictsExpr;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SkewShuffleJoinEliminationRule.java
@@ -119,7 +119,8 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             this.columnRefFactory = columnRefFactory;
         }
 
-        private record OutputExchangeTemplate(DistributionSpec distributionSpec, ColumnRefSet usedColumns) {
+        private record OutputExchangeTemplate(DistributionSpec distributionSpec, ColumnRefSet usedColumns,
+                                              PhysicalDistributionOperator exchangeOp) {
         }
 
         @Override
@@ -282,6 +283,11 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             if (requireOutputDistribution) {
                 PhysicalDistributionOperator newExchangeForBroadcastJoin =
                         new PhysicalDistributionOperator(outputExchangeTemplate.distributionSpec());
+                // the fragment above this exchange decodes the same dict columns as above the original
+                // join's exchanges, so it needs the same global dicts and derived-dict expressions
+                newExchangeForBroadcastJoin.setGlobalDicts(outputExchangeTemplate.exchangeOp().getGlobalDicts());
+                newExchangeForBroadcastJoin.setGlobalDictsExpr(
+                        outputExchangeTemplate.exchangeOp().getGlobalDictsExpr());
                 // we need add exchange node to make broadcast join's output distribution can be same as shuffle join's
                 rightChildOfConcatenate = OptExpression.builder().setOp(newExchangeForBroadcastJoin)
                         .setInputs(Collections.singletonList(skewBranch))
@@ -359,6 +365,13 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             PhysicalSplitConsumeOperator splitConsumerOptForBroadcastJoin =
                     new PhysicalSplitConsumeOperator(splitProduceOperator.getSplitId(), skewPredicate,
                             distributionSpecForBroadCastJoin, splitOutputColumns);
+            // Both consumers stand where the original exchange stood: the fragments built above them
+            // evaluate the same dict expressions the low-cardinality rewrite attached to that exchange.
+            for (PhysicalSplitConsumeOperator consumer : List.of(splitConsumerOptForShuffleJoin,
+                    splitConsumerOptForBroadcastJoin)) {
+                consumer.setGlobalDicts(exchangeOpOfOriginalShuffleJoin.getGlobalDicts());
+                consumer.setGlobalDictsExpr(exchangeOpOfOriginalShuffleJoin.getGlobalDictsExpr());
+            }
 
             OptExpression splitConsumerOptExpForShuffleJoin =
                     OptExpression.builder().setOp(splitConsumerOptForShuffleJoin).setInputs(Collections.emptyList())
@@ -432,7 +445,7 @@ public class SkewShuffleJoinEliminationRule implements TreeRewriteRule {
             OptExpression template = joinOpt.inputAt(1 - skewSideChildIndex);
             PhysicalDistributionOperator exchangeOp = template.getOp().cast();
             ColumnRefSet used = exchangeOp.getRowOutputInfo(template.getInputs()).getUsedColumnRefSet();
-            return new OutputExchangeTemplate(exchangeOp.getDistributionSpec(), used);
+            return new OutputExchangeTemplate(exchangeOp.getDistributionSpec(), used, exchangeOp);
         }
 
         private void addIdentityColumnsToProjectionIfMissing(Projection projection,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -4672,6 +4672,10 @@ public class PlanFragmentBuilder {
                     new PlanFragment(context.getNextFragmentId(), exchangeNode, dataPartition);
             splitConsumeFragment.setQueryGlobalDicts(splitProduceFragment.getQueryGlobalDicts());
             splitConsumeFragment.setQueryGlobalDictExprs(splitProduceFragment.getQueryGlobalDictExprs());
+            // plus what the exchange replaced by this consumer carried for the fragment above it
+            splitConsumeFragment.mergeQueryGlobalDicts(consumerOperator.getGlobalDicts());
+            splitConsumeFragment.mergeQueryDictExprs(
+                    getGlobalDictsExprs(consumerOperator.getGlobalDictsExpr(), context));
             splitConsumeFragment.setLoadGlobalDicts(splitProduceFragment.getLoadGlobalDicts());
 
             if (consumerOperator.hasLimit()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
@@ -300,6 +300,44 @@ public class SkewJoinV2Test extends PlanTestBase {
     }
 
     @Test
+    public void testSkewJoinV2KeepsDerivedDictExprs() throws Exception {
+        boolean oldMockDictManager = FeConstants.USE_MOCK_DICT_MANAGER;
+        boolean oldLowCardinality = connectContext.getSessionVariable().isEnableLowCardinalityOptimize();
+        boolean oldV2 = connectContext.getSessionVariable().isUseLowCardinalityOptimizeV2();
+        try {
+            FeConstants.USE_MOCK_DICT_MANAGER = true;
+            connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+            connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+
+            // t1.u is a DERIVED dict (upper over S_ADDRESS) defined below the shuffle that the skew
+            // rewrite replaces with split produce/consume; the fragments above must still receive its
+            // global dict expr, otherwise BE cannot build the dictionary to decode u.
+            String sql = "select ifnull(t1.u, 'x') v, s2.S_ADDRESS from " +
+                    "(select distinct upper(S_ADDRESS) u, S_SUPPKEY k from supplier) t1 " +
+                    "join[skew|t1.k(1,2)] supplier s2 on t1.k = s2.S_SUPPKEY";
+            String plan = getVerboseExplain(sql);
+            // the top fragment evaluates ifnull() as a DictMapping over the derived dict 21 ...
+            assertContains(plan, "18 <-> DictDecode([21: upper, INT, true], [ifnull[(<place-holder>, 'x')");
+            // ... so it must carry 21's global dict expr (it arrives through the split consumers)
+            assertContains(plan, "  RESULT SINK\n" +
+                    "\n" +
+                    "  Global Dict Exprs:\n" +
+                    "    21: DictDefine(19: S_ADDRESS, [upper(<place-holder>)])\n" +
+                    "\n" +
+                    "  13:Decode");
+            // and the split-producing fragment keeps the exprs of the fragment it was built from
+            assertContains(plan, "  Split expr: [1: S_SUPPKEY, INT, false] IN (1, 2)\n" +
+                    "\n" +
+                    "  Global Dict Exprs:\n" +
+                    "    21: DictDefine(19: S_ADDRESS, [upper(<place-holder>)])");
+        } finally {
+            FeConstants.USE_MOCK_DICT_MANAGER = oldMockDictManager;
+            connectContext.getSessionVariable().setEnableLowCardinalityOptimize(oldLowCardinality);
+            connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(oldV2);
+        }
+    }
+
+    @Test
     public void testSkewJoinV2WithComplexPredicate1() throws Exception {
         String sql = "select v2, v5 from t0 join[skew|t0.v1(1,2)] t1 on abs(v1) = abs(v4) ";
         String sqlPlan = getVerboseExplain(sql);

--- a/test/sql/test_skew_join/R/test_skew_join_v2_derived_dict
+++ b/test/sql/test_skew_join/R/test_skew_join_v2_derived_dict
@@ -1,0 +1,82 @@
+-- name: test_skew_join_v2_derived_dict
+set cbo_enable_low_cardinality_optimize = true;
+-- result:
+-- !result
+set low_cardinality_optimize_v2 = true;
+-- result:
+-- !result
+set enable_optimize_skew_join_v2 = true;
+-- result:
+-- !result
+CREATE TABLE `skew_fact` (
+  `id` int NULL,
+  `lot_state` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into skew_fact
+select
+    case when generate_series % 3 = 0 then 1 else generate_series end,
+    case
+        when generate_series % 4 = 0 then 'created'
+        when generate_series % 7 = 0 then null
+        else 'running'
+    end
+from TABLE(generate_series(1, 4096));
+-- result:
+-- !result
+CREATE TABLE `skew_dim` (
+  `id` int NULL,
+  `tag` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into skew_dim
+select generate_series, concat('t', generate_series % 5)
+from TABLE(generate_series(1, 4096));
+-- result:
+-- !result
+[UC] analyze full table skew_fact;
+function: wait_global_dict_ready('lot_state', 'skew_fact')
+-- result:
+
+-- !result
+function: assert_explain_verbose_contains('select ifnull(t.u, \'x\') v, count(*) c from (select distinct upper(lot_state) u, id from skew_fact) t join[skew|t.id(1)] skew_dim d on t.id = d.id group by v order by v', 'SplitCastDataSink', 'Decode')
+-- result:
+None
+-- !result
+[ORDER]select ifnull(t.u, 'x') v, count(*) c
+from (select distinct upper(lot_state) u, id from skew_fact) t
+join[skew|t.id(1)] skew_dim d on t.id = d.id
+group by v
+order by v;
+-- result:
+CREATED	684
+RUNNING	1756
+x	293
+-- !result
+function: assert_explain_verbose_contains('select t.u, d.tag from (select distinct upper(lot_state) u, id from skew_fact) t join[skew|t.id(1)] skew_dim d on t.id = d.id where d.id <= 3 order by 1, 2', 'SplitCastDataSink', 'Decode')
+-- result:
+None
+-- !result
+[ORDER]select t.u, d.tag
+from (select distinct upper(lot_state) u, id from skew_fact) t
+join[skew|t.id(1)] skew_dim d on t.id = d.id
+where d.id <= 3
+order by 1, 2;
+-- result:
+None	t1
+CREATED	t1
+RUNNING	t1
+RUNNING	t2
+-- !result

--- a/test/sql/test_skew_join/T/test_skew_join_v2_derived_dict
+++ b/test/sql/test_skew_join/T/test_skew_join_v2_derived_dict
@@ -1,0 +1,64 @@
+-- name: test_skew_join_v2_derived_dict
+
+set cbo_enable_low_cardinality_optimize = true;
+set low_cardinality_optimize_v2 = true;
+set enable_optimize_skew_join_v2 = true;
+
+CREATE TABLE `skew_fact` (
+  `id` int NULL,
+  `lot_state` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+-- every third row lands on id 1, the skewed join key
+insert into skew_fact
+select
+    case when generate_series % 3 = 0 then 1 else generate_series end,
+    case
+        when generate_series % 4 = 0 then 'created'
+        when generate_series % 7 = 0 then null
+        else 'running'
+    end
+from TABLE(generate_series(1, 4096));
+
+CREATE TABLE `skew_dim` (
+  `id` int NULL,
+  `tag` varchar(32) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into skew_dim
+select generate_series, concat('t', generate_series % 5)
+from TABLE(generate_series(1, 4096));
+
+[UC] analyze full table skew_fact;
+
+function: wait_global_dict_ready('lot_state', 'skew_fact')
+
+-- upper(lot_state) is a DERIVED dict defined below the shuffle that skew join v2 replaces with split
+-- produce/consume operators. ifnull() above the join is evaluated on that dict, so the fragments the
+-- rewrite creates must still carry the dict expr; it used to be dropped together with the exchange.
+function: assert_explain_verbose_contains('select ifnull(t.u, \'x\') v, count(*) c from (select distinct upper(lot_state) u, id from skew_fact) t join[skew|t.id(1)] skew_dim d on t.id = d.id group by v order by v', 'SplitCastDataSink', 'Decode')
+
+[ORDER]select ifnull(t.u, 'x') v, count(*) c
+from (select distinct upper(lot_state) u, id from skew_fact) t
+join[skew|t.id(1)] skew_dim d on t.id = d.id
+group by v
+order by v;
+
+-- the derived dict is also consumed directly (no expression on top) across the same split
+function: assert_explain_verbose_contains('select t.u, d.tag from (select distinct upper(lot_state) u, id from skew_fact) t join[skew|t.id(1)] skew_dim d on t.id = d.id where d.id <= 3 order by 1, 2', 'SplitCastDataSink', 'Decode')
+
+[ORDER]select t.u, d.tag
+from (select distinct upper(lot_state) u, id from skew_fact) t
+join[skew|t.id(1)] skew_dim d on t.id = d.id
+where d.id <= 3
+order by 1, 2;


### PR DESCRIPTION
## Why I'm doing:

SkewShuffleJoinEliminationRule runs after the low-cardinality rewrite and replaces the join's child PhysicalDistributionOperators with split produce/consume operators, and may add a new exchange under the concatenate. The low-cardinality rewrite had attached the global dictionaries and the derived-dictionary expressions the receiving fragment needs to exactly those exchanges, so the new operators carried none of it. On the planner side SplitCastPlanFragment copied the child fragment's dictionaries but not its dictionary expressions, and the split-consume fragment copied only from the produce fragment.

Base dictionaries still reached the receiving fragments (they come from the scan fragments), which is why pass-through dict columns worked. Any derived dictionary evaluated above the split, e.g. ifnull() over a distinct upper(...) column, or a nested derived dict decoded there, failed on BE with "Not found dict for cid" / "couldn't found dict cid" because the fragment had no expression to build the dictionary from.

Carry the replaced exchange's dictionaries and dict expressions on the PhysicalSplitConsumeOperators and merge them into the consume fragment, give the new broadcast-branch exchange the lists of the exchange it is modelled on, and make SplitCastPlanFragment copy the dict expressions along with the dictionaries. Add a SkewJoinV2Test case with a derived dict crossing the split (without the fix the top fragment prints no Global Dict Exprs at all) and a SQL test that runs ifnull() over a distinct upper(...) column through a hinted skew join; before the fix it fails on BE with "couldn't found dict cid".



## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
