### PR TITLE
[Refactor] Silence phmap btree -Warray-bounds false positive

### DIFF
--- a/be/src/base/phmap/btree.h
+++ b/be/src/base/phmap/btree.h
@@ -1082,6 +1082,10 @@ public:
     reference value(size_type i) { return params_type::element(slot(i)); }
     const_reference value(size_type i) const { return params_type::element(slot(i)); }
 
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     // Getters/setter for the child at position i in the node.
     btree_node* child(size_type i) const { return GetField<3>()[i]; }
     btree_node*& mutable_child(size_type i) { return GetField<3>()[i]; }
@@ -1091,6 +1095,9 @@ public:
         mutable_child(i) = c;
         c->set_position((field_type)i);
     }
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
     void init_child(int i, btree_node* c) {
         set_child(i, c);
         c->set_parent(this);


### PR DESCRIPTION
## Why I'm doing:

GCC 12+ emits a `-Warray-bounds` false positive inside phmap's `btree_node` child
accessors. It shows up when building `be/src/storage/lake/persistent_index_memtable.cpp`
(whose `_map` is a `phmap::btree_map<std::string, IndexValueWithVer, std::less<>>`), and
each occurrence dumps ~40 lines of inlining context, which drowns out real warnings:

```
be/src/base/phmap/btree.h:1091:26: warning: array subscript [33, 287] is outside array
bounds of 'phmap::priv::Allocate<8, ...>::M [32]' [-Warray-bounds=]
 1091 |         mutable_child(i) = c;
new_allocator.h:151:55: note: at offset [264, 2296] into object of size [112, 256]
allocated by 'operator new'
```

**Why it is a false positive.** GCC inlines `btree<P>::internal_emplace()`, which
allocates a *leaf* node with `new_leaf_root_node()` (`btree.h:2850`, the `[112, 256]`
object in the note) and then calls `btree_node::swap()` (`btree.h:2851`). The
child-pointer writes GCC flags sit inside `swap()`'s `if (!leaf())` block
(`btree.h:2155`), which is unreachable for a node `init_leaf()` has just created;
`swap()` additionally asserts `leaf() == x->leaf()`. `-Warray-bounds` runs after
inlining and is path-insensitive, so it cannot correlate the allocation site with the
guard, because `leaf()` is a runtime flag stored in the node itself
(`GetField<1>()[3] != kInternalNodeMaxCount`, `btree.h:1052`).

Compounding it, `phmap::priv::Allocate<Alignment>()` (`phmap_base.h:4067`) allocates
nodes as an array of an empty `struct alignas(Alignment) M {}` and the result is
`reinterpret_cast` to `btree_node`, whose real layout is computed at runtime by
`GetField<N>()`. GCC only sees the declared `M[32]`, so any child-slot index past
element 32 looks out of bounds.

## What I'm doing:

Taking the upstream fix verbatim. parallel-hashmap commit
[`8650bcc`](https://github.com/greg7mdp/parallel-hashmap/commit/8650bcc503ea40523f8ac7cab8ca9f51ec868038)
("Fix compiler warning in btree - issue #156", 2022-07-22) wraps the four child
accessors — `child()`, `mutable_child()`, `clear_child()`, `set_child()` — in a
`#pragma GCC diagnostic push` / `ignored "-Warray-bounds"` / `pop` block, and
[upstream master](https://github.com/greg7mdp/parallel-hashmap/blob/master/parallel_hashmap/btree.h)
still carries it. Our vendored copy predates that commit, which is also visible in
`internal_verify()` still returning `int` instead of `size_type`.

The pragma covers exactly the two locations GCC reports here, `btree.h:1086`
(`child()`) and `btree.h:1091` (inside `set_child()`).

Alternatives considered and rejected:
- Global `-Wno-array-bounds`: this warning does catch real problems in our own code, so
  disabling it project-wide would be a net loss.
- Marking `be/src/base/phmap` as a SYSTEM include: unreliable here, since
  `-Warray-bounds` is a middle-end diagnostic. Observed in this build:
  `/opt/gcc-toolset-14/.../include/emmintrin.h` is already a system header yet still
  produced an `-Warray-bounds` warning.
- Upgrading the vendored phmap (upstream is now v2.0.0): larger win, but
  `be/src/base/phmap/` is depended on across the whole BE and warrants its own PR with
  full regression testing.

Verification:
- `-fsyntax-only` on a TU instantiating `phmap::btree_map<std::string, std::pair<long, IndexValue>, std::less<>>`
  (the same shape as `persistent_index_memtable.h`) passes; `push`/`pop` are balanced 1:1.
- `clang-format -style=file` reports no change for the file.
- `python3 build-support/check_be_module_boundaries.py --mode full` → OK.
- `python3 build-support/render_be_agents.py --check` → OK.

Observability: no change. This touches only compiler diagnostics — no logs, metrics,
profile counters, or generated code are affected, and no existing signal on the
persistent-index path is altered.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
  - Not applicable: the change only suppresses a compiler diagnostic and generates no
    different code, so there is no runtime behavior to assert on. It is verified by the
    warning disappearing from the build.
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
