### PR TITLE
[BugFix] Let the ANN distance column tolerate a reused scan chunk

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -175,13 +175,23 @@ void Chunk::append_column(const ColumnPtr& column, const FieldPtr& field) {
     check_or_die();
 }
 
-void Chunk::append_vector_column(ColumnPtr&& column, const FieldPtr& field, SlotId slot_id) {
-    DCHECK(!_cid_to_index.contains(field->id()));
-    _cid_to_index[field->id()] = _columns.size();
-    _slot_id_to_index[slot_id] = _columns.size();
-    _append_column_checked(_columns.size(), std::move(column));
-    _schema->append(field);
-    check_or_die();
+void Chunk::append_or_update_column(ColumnPtr&& column, const FieldPtr& field, SlotId slot_id) {
+    if (auto it = _cid_to_index.find(field->id()); it != _cid_to_index.end()) {
+        // The column id is already present -- e.g. the synthetic ANN distance column re-emitted across a
+        // `do { _do_get_next(chunk); } while (chunk->num_rows() == 0)` scan-loop iteration whose chunk
+        // survived reset() (reset clears rows, not _cid_to_index/_columns/_schema). Update it in place;
+        // the cid/slot/schema entries already point at this column. (_update_column_checked only does
+        // the shared-pointer bookkeeping, so verify row-count consistency explicitly.)
+        _update_column_checked(it->second, std::move(column));
+        check_or_die();
+    } else {
+        _cid_to_index[field->id()] = _columns.size();
+        _slot_id_to_index[slot_id] = _columns.size();
+        _append_column_checked(_columns.size(), std::move(column));
+        _schema->append(field);
+        // only check it when append a new column
+        check_or_die();
+    }
 }
 
 void Chunk::append_column(ColumnPtr&& column, SlotId slot_id) {
@@ -714,13 +724,20 @@ void MutableChunk::append_column(MutableColumnPtr&& column, const FieldPtr& fiel
     check_or_die();
 }
 
-void MutableChunk::append_vector_column(MutableColumnPtr&& column, const FieldPtr& field, SlotId slot_id) {
-    DCHECK(!_cid_to_index.contains(field->id()));
-    _cid_to_index[field->id()] = _columns.size();
-    _slot_id_to_index[slot_id] = _columns.size();
-    _columns.emplace_back(std::move(column));
-    _schema->append(field);
-    check_or_die();
+void MutableChunk::append_or_update_column(MutableColumnPtr&& column, const FieldPtr& field, SlotId slot_id) {
+    if (auto it = _cid_to_index.find(field->id()); it != _cid_to_index.end()) {
+        // See Chunk::append_or_update_column: update an already-present column in place rather than
+        // appending a duplicate (the reused-chunk scan loop can re-emit the same synthetic cid).
+        _columns[it->second] = std::move(column);
+        check_or_die();
+    } else {
+        _cid_to_index[field->id()] = _columns.size();
+        _slot_id_to_index[slot_id] = _columns.size();
+        _columns.emplace_back(std::move(column));
+        _schema->append(field);
+        // only check it when append a new column
+        check_or_die();
+    }
 }
 
 void MutableChunk::append_column(MutableColumnPtr&& column, SlotId slot_id) {

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -146,7 +146,10 @@ public:
     void update_column(ColumnPtr& column, SlotId slot_id);
     void append_column(const ColumnPtr& column, ColumnId column_id, [[maybe_unused]] bool is_column_id);
 
-    void append_vector_column(ColumnPtr&& column, const FieldPtr& field, SlotId slot_id);
+    // Appends `column` under `field`/`slot_id`, or -- if a column with the same field id is already
+    // present (a reused chunk that survived reset()) -- updates that column in place. Used for the
+    // synthetic ANN distance column, which the scan loop can re-emit onto the same chunk.
+    void append_or_update_column(ColumnPtr&& column, const FieldPtr& field, SlotId slot_id);
     void update_column_by_index(ColumnPtr&& column, size_t idx);
     void append_or_update_column(ColumnPtr&& column, SlotId slot_id);
 
@@ -540,7 +543,7 @@ public:
 
     // schema must exist and will be updated.
     void append_column(MutableColumnPtr&& column, const FieldPtr& field);
-    void append_vector_column(MutableColumnPtr&& column, const FieldPtr& field, SlotId slot_id);
+    void append_or_update_column(MutableColumnPtr&& column, const FieldPtr& field, SlotId slot_id);
     void append_column(MutableColumnPtr&& column, SlotId slot_id);
     void insert_column(size_t idx, MutableColumnPtr&& column, const FieldPtr& field);
     void update_column(MutableColumnPtr&& column, SlotId slot_id);

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3168,8 +3168,14 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         }
 
         // TODO: plan vector column in FE Planner
-        chunk->append_vector_column(std::move(distance_column), _make_field(_vector_index_ctx->vector_column_id),
-                                    _vector_index_ctx->vector_slot_id);
+        // The distance column reuses vector_column_id as its column id because the FE does not yet
+        // allocate a distinct one. The scan loop `do { _do_get_next(chunk); } while (chunk->num_rows()
+        // == 0)` re-invokes _do_get_next on the same chunk whenever a batch is fully filtered (e.g. the
+        // vector_range predicate dropped every row), and Chunk::reset() keeps the appended column in
+        // _cid_to_index. append_or_update_column tolerates that by updating the distance column in place
+        // instead of appending a duplicate.
+        chunk->append_or_update_column(std::move(distance_column), _make_field(_vector_index_ctx->vector_column_id),
+                                       _vector_index_ctx->vector_slot_id);
     } else if (_vector_index_ctx && _vector_index_ctx->use_brute_force) {
         // Brute-force fallback: compute distances from the raw vector column. It lives in `chunk` when
         // FE kept it (swapped in by _build_final_chunk), or in _dict_chunk when FE pruned it and
@@ -3533,8 +3539,11 @@ FloatColumn::MutablePtr SegmentIterator::_brute_force_distance_column(const Colu
 }
 
 void SegmentIterator::_compute_brute_force_distances(const Column* vector_column, Chunk* chunk) {
-    chunk->append_vector_column(_brute_force_distance_column(vector_column),
-                                _make_field(_vector_index_ctx->vector_column_id), _vector_index_ctx->vector_slot_id);
+    // append_or_update_column tolerates the scan loop re-emitting the distance column onto a reused
+    // chunk (see the ANN path in _do_get_next).
+    chunk->append_or_update_column(_brute_force_distance_column(vector_column),
+                                   _make_field(_vector_index_ctx->vector_column_id),
+                                   _vector_index_ctx->vector_slot_id);
 }
 
 // Exact distance rescan over a candidate bitmap. Reached only when the HNSW filtered search returned

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -3542,8 +3542,7 @@ void SegmentIterator::_compute_brute_force_distances(const Column* vector_column
     // append_or_update_column tolerates the scan loop re-emitting the distance column onto a reused
     // chunk (see the ANN path in _do_get_next).
     chunk->append_or_update_column(_brute_force_distance_column(vector_column),
-                                   _make_field(_vector_index_ctx->vector_column_id),
-                                   _vector_index_ctx->vector_slot_id);
+                                   _make_field(_vector_index_ctx->vector_column_id), _vector_index_ctx->vector_slot_id);
 }
 
 // Exact distance rescan over a candidate bitmap. Reached only when the HNSW filtered search returned

--- a/be/src/storage_primitive/projection_iterator.cpp
+++ b/be/src/storage_primitive/projection_iterator.cpp
@@ -109,7 +109,7 @@ Status ProjectionIterator::do_get_next(Chunk* chunk) {
                 // does not deref a moved-from ColumnPtr.
                 ColumnPtr empty = input_columns[k]->clone_empty();
                 if (sid >= 0) {
-                    chunk->append_vector_column(std::move(input_columns[k]), f, sid);
+                    chunk->append_or_update_column(std::move(input_columns[k]), f, sid);
                 } else {
                     chunk->append_column(std::move(input_columns[k]), f);
                 }


### PR DESCRIPTION
## Why I'm doing:

```
*** Aborted at 1788451805 (unix time) try "date -d @1788451805" if you are using GNU date ***
[1788451805.998][thread: 139791705130688] je_mallctl execute purge success
[1788451805.998][thread: 139791705130688] je_mallctl execute dontdump success
[1788451805.998][thread: 139790239094464] je_mallctl execute purge success
[1788451805.998][thread: 139790239094464] je_mallctl execute dontdump success
PC: @     0x7f2708b48b2c pthread_kill
*** SIGABRT (@0x74f89) received by PID 479113 (TID 0x7f238cae86c0) LWP(479905) from PID 479113; stack trace: ***
    @         0x33541647 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f2708b4bed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x33540e46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f2708aef330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f2708b48b2c pthread_kill
    @     0x7f2708aef27e gsignal
    @     0x7f2708ad28ff abort
    @         0x1d013d4a starrocks::failure_function()
    @         0x33534f5d google::LogMessage::Fail()
    @         0x33536044 google::LogMessageFatal::~LogMessageFatal()
    @         0x2dede32c starrocks::Chunk::append_vector_column(starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column>&&, std::shared_ptr<starrocks::Field> const&, int)
    @         0x21bfc63e starrocks::SegmentIterator::_compute_brute_force_distances(starrocks::Column const*, starrocks::Chunk*)
    @         0x21bf599c starrocks::SegmentIterator::_do_get_next(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*)
    @         0x21bf1646 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)
    @         0x1d1ce73f starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x22f984f0 starrocks::SegmentIteratorWrapper::do_get_next(starrocks::Chunk*)
    @         0x1d1ce73f starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x247b6940 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @         0x1d1ce73f starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x24e1f91b starrocks::UnionIterator::do_get_next(starrocks::Chunk*)
    @         0x1d1ce73f starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x2242f1b2 starrocks::TabletReader::do_get_next(starrocks::Chunk*)
    @         0x1d1ce73f starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x1ec32033 starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage(starrocks::RuntimeState*, starrocks::Chunk*)
    @         0x1ec30945 starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x1ec0dbe1 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @         0x1ebf13da auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const
    @         0x1ebf8af9 void std::__invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(std::__invoke_other, starrocks
::pipeline::ScanOperator::_trigger_next_scan(starro@
    @         0x1ebf8750 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>, void>::type std::__in
voke_r<void, starrocks::pipeline::ScanOperator::_tr@
    @         0x1ebf815f std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const
&, starrocks::workgroup::YieldContext&)
```

The vector distance column reuses the synthetic column id num_columns() because the FE does not yet allocate a distinct one. The segment scan loop `do { _do_get_next(chunk); } while (chunk->num_rows() == 0)` re-invokes _do_get_next on the same chunk whenever a batch is fully filtered (e.g. the vector_range predicate drops every row). Chunk::reset() clears the rows but not _cid_to_index, and _final_chunk is cycled back through swap_chunk, so the distance column appended by an earlier iteration is still present when a later iteration appends it again -- tripping append_vector_column's DCHECK(!_cid_to_index.contains(field->id())) under fault injection / ASan and corrupting the cid->index map in release. A single-threaded query such as

    SELECT id FROM t WHERE approx_l2_distance(v, [..]) <= <tiny>
    ORDER BY approx_l2_distance(v, [..]) LIMIT k

whose range predicate filters whole batches to zero rows reproduces it deterministically on both the ANN-index and brute-force fallback paths.

Rename Chunk/MutableChunk::append_vector_column to append_or_update_column and make it idempotent: when a column with the same field id is already present, update it in place instead of appending a duplicate. This mirrors the existing Chunk::append_or_update_column(ColumnPtr&&, SlotId) overload, lets the scan loop re-emit the distance column safely, and removes the now-unnecessary DCHECK. The update branch still runs check_or_die() so a row-count mismatch is caught in debug/ASan.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
