### PR TITLE
[BugFix] Fill the caller's groups into authorization contexts rebuilt from Thrift

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/LDAPGroupProvider.java
@@ -144,6 +144,11 @@ public class LDAPGroupProvider extends GroupProvider {
             // When using distinguished name, normalize it for case-insensitive matching
             lookupKey = LDAPAuthProvider.normalizeUsername(distinguishedName);
         }
+        if (lookupKey == null) {
+            // The cache is a ConcurrentHashMap, which rejects a null key with an NPE instead of reporting
+            // a miss - so a caller with nothing to look up has to be answered here.
+            return Set.of();
+        }
         return userToGroupCache.getOrDefault(lookupKey, Set.of());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserIdentityUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserIdentityUtils.java
@@ -17,6 +17,7 @@ package com.starrocks.authentication;
 import com.google.common.base.Strings;
 import com.starrocks.authorization.PrivilegeException;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TAuthInfo;
@@ -76,10 +77,23 @@ public class UserIdentityUtils {
         if (authInfo.isSetCurrent_user_ident()) {
             setAuthInfoFromThrift(context, authInfo.getCurrent_user_ident());
         } else {
-            UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(authInfo.user, authInfo.user_ip);
-            context.setCurrentUserIdentity(userIdentity);
-            context.setCurrentRoleIds(userIdentity);
+            setAuthInfoFromThrift(context, authInfo.user, authInfo.user_ip);
         }
+    }
+
+    /**
+     * Fallback for Thrift requests that carry a bare user name and IP instead of a full identity.
+     *
+     * <p>Several request types (TGetTablesParams, TGetTasksParams, ...) declare the same
+     * {@code user}/{@code user_ip}/{@code current_user_ident} triple without sharing a Thrift struct, so
+     * each of their handlers inlined this block. Sharing it here keeps them from drifting apart - notably
+     * over the group resolution below, which every one of them needs.
+     */
+    public static void setAuthInfoFromThrift(ConnectContext context, String user, String userIp) {
+        UserIdentity userIdentity = UserIdentity.createAnalyzedUserIdentWithIp(user, userIp);
+        context.setCurrentUserIdentity(userIdentity);
+        context.setCurrentRoleIds(userIdentity);
+        setGroupsIfAbsent(context, userIdentity);
     }
 
     public static void setAuthInfoFromThrift(ConnectContext context, TUserIdentity tUserIdent) {
@@ -99,6 +113,70 @@ public class UserIdentityUtils {
         } else {
             context.setCurrentRoleIds(userIdentity);
         }
+        setGroupsIfAbsent(context, userIdentity);
     }
 
+    /**
+     * Resolve the caller's groups into a context that was rebuilt from a Thrift request.
+     *
+     * <p>TAuthInfo/TUserIdentity carry the identity and the role ids but no group membership, so a context
+     * built from them starts with an empty group set. The handlers that serve {@code information_schema}
+     * and the {@code sys} tables construct one per request and hand it to
+     * {@link com.starrocks.sql.analyzer.Authorizer}, which passes {@code context.getGroups()} straight to
+     * the external access controller - Ranger then receives an empty group list and no policy item whose
+     * subject is a group can match. The visible effect is that a user who holds access purely through a
+     * group sees those tables as empty while {@code SHOW TABLES} and {@code SELECT} on the very same
+     * objects succeed, because those run on the session context where the groups were resolved at login.
+     *
+     * <p>The groups are re-resolved here rather than carried over Thrift on purpose. Role ids can be
+     * shipped because the receiver can check them against the ones the user actually holds - which is what
+     * the {@code retainAll} above does. Group membership has no such check available: the only authority
+     * on it is the group provider, so a group list arriving over Thrift would have to be trusted as sent,
+     * and anything able to shape that request could claim membership and pick up whatever a policy grants
+     * it. Asking the providers keeps the answer coming from the same place the login path got it from, and
+     * it is a cache read there rather than directory traffic.
+     *
+     * <p>Only fills an empty set. Some callers pass a live session context that already carries the groups
+     * resolved at login - possibly through a security integration's own provider, which this path cannot
+     * see - and those must not be overwritten with a global-provider answer.
+     *
+     * <p>A failure here leaves the context with no groups, which denies rather than grants, so it is
+     * logged and swallowed instead of failing the metadata scan outright. This mirrors
+     * {@code ExecuteAsExecutor.refreshGroupsAndRoles()}.
+     */
+    private static void setGroupsIfAbsent(ConnectContext context, UserIdentity userIdentity) {
+        if (!context.getGroups().isEmpty()) {
+            return;
+        }
+
+        try {
+            Set<String> groups = AuthenticationHandler.getGroups(
+                    userIdentity, groupProviderLookupKey(userIdentity), List.of(Config.group_provider));
+            if (!groups.isEmpty()) {
+                context.setGroups(groups);
+            }
+        } catch (Exception e) {
+            LOG.warn("Failed to resolve groups for user {}: {}", userIdentity, e.getMessage());
+        }
+    }
+
+    /**
+     * The key the group providers look a user up by. {@link AuthenticationHandler} passes the session's
+     * distinguished name in this position at login; this path has none to pass.
+     *
+     * <p>The DN is produced by the LDAP bind and only the authenticating session holds it - neither
+     * TAuthInfo nor TUserIdentity carries it, and re-deriving it would mean a directory search per
+     * metadata request, which is exactly the cost this fix sets out to avoid. The user name is what
+     * remains, and it is the right key for every provider that caches under it: {@code file} and
+     * {@code unix} always do, and {@code ldap} does when {@code ldap_user_search_attr} is set, which
+     * makes {@link LDAPGroupProvider} cache each member under the value that attribute pulls out of the
+     * member DN - the same string the user logs in with.
+     *
+     * <p>An {@code ldap} provider without that property caches under the full member DN instead and will
+     * not match a user name. Such a configuration resolves to no groups here, which denies rather than
+     * grants, and leaves those tables looking the way they do today.
+     */
+    private static String groupProviderLookupKey(UserIdentity userIdentity) {
+        return userIdentity.getUser();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.CaseSensibility;
@@ -244,9 +243,7 @@ public class MaterializedViewsSystemTable extends SystemTable {
         if (params.isSetCurrent_user_ident()) {
             UserIdentityUtils.setAuthInfoFromThrift(context, params.getCurrent_user_ident());
         } else {
-            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.user, params.user_ip);
         }
         Preconditions.checkState(params.isSetType() && MATERIALIZED_VIEW.equals(params.getType()));
         return listMaterializedViewStatus(limit, matcher, context, params);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -251,9 +251,7 @@ public class ViewsSystemTable extends SystemTable {
         if (params.isSetCurrent_user_ident()) {
             UserIdentityUtils.setAuthInfoFromThrift(context, params.getCurrent_user_ident());
         } else {
-            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.user, params.user_ip);
         }
         String tableNameParam = params.isSetTable_name() ? params.getTable_name() : null;
         boolean listingViews = params.isSetType() && TTableType.VIEW.equals(params.getType());

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -506,11 +506,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         ConnectContext context = new ConnectContext();
         if (params.isSetCurrent_user_ident()) {
-            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.getCurrent_user_ident());
         } else {
-            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.user, params.user_ip);
         }
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
@@ -561,11 +559,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         ConnectContext context = new ConnectContext();
         if (params.isSetCurrent_user_ident()) {
-            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.getCurrent_user_ident());
         } else {
-            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.user, params.user_ip);
         }
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
@@ -925,11 +921,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         // database privs should be checked in analysis phrase
         ConnectContext context = new ConnectContext();
         if (params.isSetCurrent_user_ident()) {
-            UserIdentityUtils.setAuthInfoFromThrift(context, params.current_user_ident);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.getCurrent_user_ident());
         } else {
-            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(params.user, params.user_ip);
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
+            UserIdentityUtils.setAuthInfoFromThrift(context, params.user, params.user_ip);
         }
 
         long limit = params.isSetLimit() ? params.getLimit() : -1;

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -121,13 +121,7 @@ public class InformationSchemaDataSource {
         }
 
         ConnectContext context = new ConnectContext();
-        if (authInfo.isSetCurrent_user_ident()) {
-            UserIdentityUtils.setAuthInfoFromThrift(context, authInfo.getCurrent_user_ident());
-        } else {
-            UserIdentity currentUser = UserIdentity.createAnalyzedUserIdentWithIp(authInfo.user, authInfo.user_ip);
-            context.setCurrentUserIdentity(currentUser);
-            context.setCurrentRoleIds(currentUser);
-        }
+        UserIdentityUtils.setAuthInfoFromThrift(context, authInfo);
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
         List<String> dbNames = metadataMgr.listDbNames(context, catalogName);
@@ -232,6 +226,10 @@ public class InformationSchemaDataSource {
             ConnectContext context = new ConnectContext();
             context.setCurrentUserIdentity(authContext.getCurrentUserIdentity());
             context.setCurrentRoleIds(authContext.getCurrentRoleIds());
+            // Carried over with the identity and the roles: the per-table authorization below hands these
+            // to the external access controller, and dropping them here would deny every group-granted
+            // table even though the database-level pass above already accepted the same groups.
+            context.setGroups(authContext.getGroups());
             return context;
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/UserIdentityUtilsGroupLookupKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/UserIdentityUtilsGroupLookupKeyTest.java
@@ -1,0 +1,187 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TUserIdentity;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Which LDAP group provider configurations the Thrift-rebuilt authorization context can resolve groups for.
+ *
+ * <p>{@code UserIdentityUtils.setGroupsIfAbsent} re-resolves the groups that TAuthInfo/TUserIdentity do not
+ * carry, and it has no distinguished name to look them up by: the DN is produced by the LDAP bind and only
+ * the authenticating session holds it. So it passes the user name, and whether that resolves is decided
+ * entirely by {@code ldap_user_search_attr}. Both halves are pinned here because the two configurations
+ * behave oppositely and only one of them is the deployed one.
+ */
+public class UserIdentityUtilsGroupLookupKeyTest {
+    /** The name a user logs in with, and the CN inside that user's member DN. */
+    private static final String USER = "someone";
+    private static final String USER_DN = "cn=someone,ou=ldapusers,ou=woowahan,dc=woowahan,dc=in";
+    private static final Set<String> GROUPS = Set.of("zeppelin-public", "dataservice");
+
+    /** The deployed value of {@code ldap_user_search_attr}: a regex whose capture group is the user name. */
+    private static final String USER_SEARCH_ATTR = "CN=([^,]+)";
+
+    private String[] savedGroupProvider;
+    /**
+     * Surefire runs a module's test classes in one JVM (the default {@code forkCount=1},
+     * {@code reuseForks=true}), so the manager {@link #registerLdapGroupProvider} swaps in would otherwise
+     * outlive this class and serve whatever runs next - a manager holding one throwaway group provider and
+     * no users.
+     */
+    private AuthenticationMgr savedAuthenticationMgr;
+
+    @BeforeEach
+    public void setUp() {
+        savedGroupProvider = Config.group_provider;
+        savedAuthenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
+
+        new MockUp<LDAPGroupProvider>() {
+            @Mock
+            public void init() throws DdlException {
+                // No directory to reach and no refresh thread to start - the tests set the cache directly.
+            }
+        };
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.group_provider = savedGroupProvider;
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(savedAuthenticationMgr);
+    }
+
+    /**
+     * Registers a single ldap group provider and makes it the global one, so
+     * {@code setGroupsIfAbsent}'s {@code List.of(Config.group_provider)} finds exactly it.
+     *
+     * <p>Swaps in a manager of its own rather than adding to the shared one, so the providers registered
+     * here leave nothing behind. {@link #tearDown} puts the original back.
+     */
+    private static LDAPGroupProvider registerLdapGroupProvider(String name, Map<String, String> extraProperties)
+            throws DdlException {
+        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
+
+        Map<String, String> properties = new HashMap<>(extraProperties);
+        properties.put(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "ldap");
+        authenticationMgr.replayCreateGroupProvider(name, properties);
+
+        Config.group_provider = new String[] {name};
+        return (LDAPGroupProvider) authenticationMgr.getGroupProvider(name);
+    }
+
+    private static TUserIdentity thriftIdentity(String user) {
+        TUserIdentity tUserIdent = new TUserIdentity();
+        tUserIdent.setUsername(user);
+        tUserIdent.setHost("%");
+        tUserIdent.setIs_domain(false);
+        return tUserIdent;
+    }
+
+    /**
+     * The deployed configuration. With {@code ldap_user_search_attr} set, a refresh pulls the user name out
+     * of each member DN and caches under it, so the user name is the correct - and only needed - key.
+     */
+    @Test
+    public void testUserNameKeyedProviderResolvesGroups() throws DdlException {
+        LDAPGroupProvider provider = registerLdapGroupProvider("user_name_keyed_provider",
+                Map.of(LDAPGroupProvider.LDAP_USER_SEARCH_ATTR, USER_SEARCH_ATTR));
+        provider.setUserToGroupCache(Map.of(USER, GROUPS));
+
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, thriftIdentity(USER));
+
+        Assertions.assertEquals(GROUPS, context.getGroups());
+    }
+
+    /**
+     * The gap the review asked about. Without {@code ldap_user_search_attr} the cache is keyed by the full
+     * member DN, which no Thrift request carries, so this path resolves nothing.
+     *
+     * <p>Asserted rather than fixed on purpose: empty groups deny rather than grant, and closing it means
+     * carrying the DN or the groups themselves over Thrift plus a BE built against the widened schema.
+     * If a deployment ever drops {@code ldap_user_search_attr}, this test is what says what it costs.
+     */
+    @Test
+    public void testDnKeyedProviderResolvesNoGroupsFromThrift() throws DdlException {
+        LDAPGroupProvider provider = registerLdapGroupProvider("dn_keyed_provider", Map.of());
+        provider.setUserToGroupCache(Map.of(USER_DN, GROUPS));
+
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, thriftIdentity(USER));
+
+        Assertions.assertTrue(context.getGroups().isEmpty());
+        // The identity still has to be usable: the metadata scan runs, it just sees less.
+        Assertions.assertEquals(USER, context.getCurrentUserIdentity().getUser());
+        Assertions.assertNotNull(context.getCurrentRoleIds());
+    }
+
+    /**
+     * The other side of the test above: the very same DN-keyed provider does resolve for the caller that
+     * holds the DN. That is the login path, and it is why the configuration works at all despite the above.
+     */
+    @Test
+    public void testDnKeyedProviderResolvesForTheAuthenticatedSession() throws DdlException {
+        LDAPGroupProvider provider = registerLdapGroupProvider("dn_keyed_provider_at_login", Map.of());
+        provider.setUserToGroupCache(Map.of(USER_DN, GROUPS));
+
+        Set<String> groups = AuthenticationHandler.getGroups(
+                UserIdentity.createEphemeralUserIdent(USER, "%"), USER_DN,
+                List.of("dn_keyed_provider_at_login"));
+
+        Assertions.assertEquals(GROUPS, groups);
+    }
+
+    /**
+     * A DN-keyed provider handed no DN must answer empty. The cache is frozen with {@code Map.copyOf}, and
+     * an immutable map throws on a null key rather than reporting a miss - which would surface as a
+     * resolution failure rather than as an empty group set.
+     */
+    @Test
+    public void testDnKeyedProviderToleratesAMissingDn() throws DdlException {
+        LDAPGroupProvider provider = registerLdapGroupProvider("dn_keyed_provider_null_dn", Map.of());
+        provider.setUserToGroupCache(Map.of(USER_DN, GROUPS));
+
+        Set<String> groups = provider.getGroup(UserIdentity.createEphemeralUserIdent(USER, "%"), null);
+
+        Assertions.assertTrue(groups.isEmpty());
+    }
+
+    /** Same for a provider whose cache a failed first refresh left empty. */
+    @Test
+    public void testDnKeyedProviderToleratesAMissingDnOnAnEmptyCache() throws DdlException {
+        LDAPGroupProvider provider = registerLdapGroupProvider("dn_keyed_provider_empty_cache", Map.of());
+
+        Set<String> groups = provider.getGroup(UserIdentity.createEphemeralUserIdent(USER, "%"), null);
+
+        Assertions.assertTrue(groups.isEmpty());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/UserIdentityUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/UserIdentityUtilsTest.java
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TUserIdentity;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A context rebuilt from Thrift must carry the caller's groups.
+ *
+ * <p>TAuthInfo/TUserIdentity ship the identity and the role ids but no group membership, and the handlers
+ * that serve information_schema and the sys tables build a fresh ConnectContext from them before calling the
+ * authorizer. When the group set stayed empty, the external access controller (Ranger) received no groups and
+ * refused every policy item whose subject is a group - a user holding access purely through a group saw those
+ * tables as empty while SHOW TABLES and SELECT on the same objects succeeded.
+ */
+public class UserIdentityUtilsTest {
+    private static final String GROUP_PROVIDER_NAME = "file_group_provider";
+    /** Present in test resource auth/file_group as a member of both group1 and group2. */
+    private static final String USER_IN_GROUPS = "harbor";
+
+    private String[] savedGroupProvider;
+    /**
+     * Surefire runs a module's test classes in one JVM (the default {@code forkCount=1},
+     * {@code reuseForks=true}), so a provider registered into the shared manager would outlive this class
+     * and stay visible to whatever runs next. The manager installed below is this class's own; this holds
+     * the original so {@link #tearDown} can put it back.
+     */
+    private AuthenticationMgr savedAuthenticationMgr;
+
+    @BeforeEach
+    public void setUp() throws DdlException {
+        savedGroupProvider = Config.group_provider;
+        savedAuthenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
+
+        new MockUp<FileGroupProvider>() {
+            @Mock
+            public InputStream getPath(String groupFileUrl) throws IOException {
+                String path = ClassLoader.getSystemClassLoader().getResource("auth").getPath() + "/" + "file_group";
+                return new FileInputStream(path);
+            }
+        };
+
+        AuthenticationMgr authenticationMgr = new AuthenticationMgr();
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
+        authenticationMgr.replayCreateGroupProvider(GROUP_PROVIDER_NAME,
+                Map.of(GroupProvider.GROUP_PROVIDER_PROPERTY_TYPE_KEY, "file",
+                        FileGroupProvider.GROUP_FILE_URL, "file_group"));
+        Config.group_provider = new String[] {GROUP_PROVIDER_NAME};
+    }
+
+    @AfterEach
+    public void tearDown() {
+        Config.group_provider = savedGroupProvider;
+        GlobalStateMgr.getCurrentState().setAuthenticationMgr(savedAuthenticationMgr);
+    }
+
+    private static TUserIdentity thriftIdentity(String user) {
+        TUserIdentity tUserIdent = new TUserIdentity();
+        tUserIdent.setUsername(user);
+        tUserIdent.setHost("%");
+        tUserIdent.setIs_domain(false);
+        return tUserIdent;
+    }
+
+    @Test
+    public void testGroupsResolvedFromTUserIdentity() {
+        ConnectContext context = new ConnectContext();
+        Assertions.assertTrue(context.getGroups().isEmpty());
+
+        UserIdentityUtils.setAuthInfoFromThrift(context, thriftIdentity(USER_IN_GROUPS));
+
+        Assertions.assertEquals(Set.of("group1", "group2"), context.getGroups());
+        Assertions.assertEquals(USER_IN_GROUPS, context.getCurrentUserIdentity().getUser());
+    }
+
+    @Test
+    public void testGroupsResolvedFromTAuthInfoWithIdentity() {
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setCurrent_user_ident(thriftIdentity(USER_IN_GROUPS));
+
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, authInfo);
+
+        Assertions.assertEquals(Set.of("group1", "group2"), context.getGroups());
+    }
+
+    /**
+     * The fallback branch, taken when the request carries only a user name and an IP. It used to be inlined
+     * in every handler, so it was the copy most likely to be missed.
+     */
+    @Test
+    public void testGroupsResolvedFromTAuthInfoWithoutIdentity() {
+        TAuthInfo authInfo = new TAuthInfo();
+        authInfo.setUser(USER_IN_GROUPS);
+        authInfo.setUser_ip("127.0.0.1");
+
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, authInfo);
+
+        Assertions.assertEquals(Set.of("group1", "group2"), context.getGroups());
+    }
+
+    @Test
+    public void testGroupsResolvedFromUserAndIpOverload() {
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, USER_IN_GROUPS, "127.0.0.1");
+
+        Assertions.assertEquals(Set.of("group1", "group2"), context.getGroups());
+    }
+
+    /**
+     * Some callers pass a live session context whose groups were resolved at login, possibly through a
+     * security integration's own provider that this code path cannot see. Those must survive untouched.
+     */
+    @Test
+    public void testExistingGroupsAreNotOverwritten() {
+        ConnectContext context = new ConnectContext();
+        context.setGroups(Set.of("groups-from-the-session"));
+
+        UserIdentityUtils.setAuthInfoFromThrift(context, thriftIdentity(USER_IN_GROUPS));
+
+        Assertions.assertEquals(Set.of("groups-from-the-session"), context.getGroups());
+    }
+
+    @Test
+    public void testUserInNoGroupLeavesGroupsEmpty() {
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, thriftIdentity("user_that_is_in_no_group"));
+
+        Assertions.assertTrue(context.getGroups().isEmpty());
+    }
+
+    /**
+     * Resolution must not be able to fail the request it decorates: no groups denies rather than grants, so a
+     * broken provider has to leave the identity usable rather than propagate out of the metadata scan.
+     */
+    @Test
+    public void testProviderFailureLeavesIdentityIntact() {
+        new MockUp<AuthenticationHandler>() {
+            @Mock
+            public Set<String> getGroups(UserIdentity userIdentity, String distinguishedName,
+                                         java.util.List<String> groupProviderList) {
+                throw new RuntimeException("group provider is down");
+            }
+        };
+
+        ConnectContext context = new ConnectContext();
+        UserIdentityUtils.setAuthInfoFromThrift(context, thriftIdentity(USER_IN_GROUPS));
+
+        Assertions.assertTrue(context.getGroups().isEmpty());
+        Assertions.assertEquals(USER_IN_GROUPS, context.getCurrentUserIdentity().getUser());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

A user who holds access purely through a **group** sees `information_schema` as empty, while `SHOW TABLES` and `SELECT` on the very same objects succeed **in the same session**.

The handlers that serve `information_schema` and the `sys` tables build a fresh `ConnectContext` out of a Thrift request. `TAuthInfo`/`TUserIdentity` carry the identity and the role ids but **no group membership**, so that context starts — and stays — with an empty group set. `Authorizer` passes `context.getGroups()` straight to the external access controller, so Ranger receives an empty group list and **no policy item whose subject is a group can match**. `SHOW TABLES` and `SELECT` are unaffected because they run on the session context, where the groups were resolved at login.

```java
// InformationSchemaDataSource.getAuthDbRequestResult() — before
ConnectContext context = new ConnectContext();
context.setCurrentUserIdentity(currentUser);
context.setCurrentRoleIds(currentUser);
// no setGroups() → context.getGroups() stays empty
```

This is the **group half of #69233**, which fixed the same code path for roles:

> the information_schema code path (`TablesSystemTable` → `InformationSchemaDataSource`) serializes only the user identity into `TAuthInfo`, then creates a brand-new `ConnectContext` that recalculates roles from defaults.

`AuthDbRequestResult.buildConnectContext()` that #69233 introduced is one of the places corrected here.

### Affected

Empty for a group-only caller: `schemata`, `tables`, `tables_config`, `partitions_meta`, `columns`, `tasks`, `task_runs`, `analyze_status`, `materialized_view_refresh_jobs`.

`views` and `materialized_views` are **not** affected — their handlers receive the session context instead of building one. That split is what pinned the cause.

## What I'm doing:

Resolve the caller's groups in `UserIdentityUtils.setAuthInfoFromThrift`, which every one of these handlers already goes through.

The groups are **re-resolved from the configured providers rather than carried over Thrift**, on purpose. Role ids can be shipped because the receiver can check them against the ones the user actually holds — that is what the existing `retainAll` does:

```java
Set<Long> actualRoleIds = ...getRoleIdsByUser(userIdentity);
requestedRoleIds.retainAll(actualRoleIds);
```

Group membership has no such check available: the only authority on it is the group provider, so a group list arriving over Thrift would have to be **trusted as sent**, and anything able to shape that request could claim membership and pick up whatever a policy grants it. Asking the providers keeps the answer coming from the same place the login path got it from, and it is a cache read there rather than directory traffic.

Two guards:

- **Only an empty group set is filled.** Some callers pass a live session context whose groups may have come from a security integration's own provider, which this path cannot see, and those must not be overwritten.
- **A resolution failure is logged and swallowed.** No groups denies rather than grants, so that is safer than failing the metadata scan outright. This mirrors `ExecuteAsExecutor.refreshGroupsAndRoles()`.

### Also in this change

- The `user`/`user_ip` fallback block was duplicated across **six** handlers, which is why the omission could exist in one place and not another. They now share one overload.
- `LDAPGroupProvider.getGroup` reached `ConcurrentHashMap.getOrDefault` with a possibly-null key, which throws instead of reporting a miss. It now answers `Set.of()`.

## Known limitation

The lookup key this path can offer is the **user name**; the distinguished name is produced by the LDAP bind and only the authenticating session holds it — neither `TAuthInfo` nor `TUserIdentity` carries it, and re-deriving it would mean a directory search per metadata request.

That is the right key for `file` and `unix` providers, and for `ldap` when `ldap_user_search_attr` is set (the cache is then keyed by the value that attribute pulls out of each member DN — the same string the user logs in with). An `ldap` provider **without** that property keys its cache on the full member DN and will still resolve to no groups here, which denies rather than grants and leaves those tables as they are today.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Behavior change details**: `information_schema` and `sys` tables now honour group-based policies of the external access controller. Previously only user-subject policy items matched on those tables, so objects granted to a group were invisible there.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
