### PR TITLE
[BugFix] Reclaim tablet metadata by dropping delete_predicate on compaction and replication archival (backport #76870)

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -579,6 +579,10 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
             }
             // Collect del files.
             _collect_del_files_above_rebuild_point(&(*it), &collect_del_files);
+            // Drop the delete_predicate before archiving the input rowset into compaction_inputs.
+            // compaction_inputs is consumed only by vacuum/file cleanup, never by readers, so the
+            // predicate is pure metadata bloat once the rowset is compacted away.
+            (*it).clear_delete_predicate();
             _tablet_meta->mutable_compaction_inputs()->Add(std::move(*it));
             it = _tablet_meta->mutable_rowsets()->erase(it);
             deleted_input_rowset_cnt++;

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -763,6 +763,10 @@ private:
                 }
                 for (auto&& old_rowset : old_rowsets) {
                     if (new_rowset_ids.count(old_rowset.id()) == 0) {
+                        // Drop the delete_predicate before archiving into compaction_inputs; it is
+                        // consumed only by vacuum/file cleanup, never by readers, so it is pure
+                        // metadata bloat here (same rationale as the compaction archival paths).
+                        old_rowset.clear_delete_predicate();
                         _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
                     }
                 }
@@ -793,6 +797,11 @@ private:
                 apply_replication_dcg_meta(op_replication, old_next_rowset_id, _metadata.get());
                 _metadata->set_next_rowset_id(new_next_rowset_id);
                 old_rowsets.Swap(_metadata->mutable_compaction_inputs());
+                // Drop delete_predicate on the archived inputs; compaction_inputs is consumed only
+                // by vacuum/file cleanup, never by readers, so the predicate is pure metadata bloat.
+                for (auto& archived : *_metadata->mutable_compaction_inputs()) {
+                    archived.clear_delete_predicate();
+                }
             }
 
             _metadata->set_cumulative_point(0);
@@ -1164,9 +1173,13 @@ private:
         const auto end_input_pos = pre_input_pos + 1;
         for (auto iter = first_input_pos; iter != end_input_pos; ++iter) {
             if (iter != last_input_pos) {
+                // Drop the delete_predicate before archiving into compaction_inputs; it is consumed
+                // only by vacuum/file cleanup, never by readers, so it is pure metadata bloat here.
+                (*iter).clear_delete_predicate();
                 _metadata->mutable_compaction_inputs()->Add(std::move(*iter));
             } else {
                 // might be a partial compaction, use real last input rowset
+                last_input_rowset.clear_delete_predicate();
                 _metadata->mutable_compaction_inputs()->Add(std::move(last_input_rowset));
             }
         }
@@ -1322,6 +1335,10 @@ private:
                 }
                 for (auto&& old_rowset : old_rowsets) {
                     if (new_rowset_ids.count(old_rowset.id()) == 0) {
+                        // Drop the delete_predicate before archiving into compaction_inputs; it is
+                        // consumed only by vacuum/file cleanup, never by readers, so it is pure
+                        // metadata bloat here (same rationale as the compaction archival paths).
+                        old_rowset.clear_delete_predicate();
                         _metadata->mutable_compaction_inputs()->Add(std::move(old_rowset));
                     }
                 }
@@ -1333,6 +1350,11 @@ private:
                 }
                 apply_replication_dcg_meta(op_replication, rssid_remap, _metadata.get());
                 old_rowsets.Swap(_metadata->mutable_compaction_inputs());
+                // Drop delete_predicate on the archived inputs; compaction_inputs is consumed only
+                // by vacuum/file cleanup, never by readers, so the predicate is pure metadata bloat.
+                for (auto& archived : *_metadata->mutable_compaction_inputs()) {
+                    archived.clear_delete_predicate();
+                }
             }
             std::unordered_set<std::string> new_referenced_files;
             for (const auto& [_, dcg] : _metadata->dcg_meta().dcgs()) {

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -752,6 +752,56 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
     }
 }
 
+TEST_F(MetaFileTest, test_clear_delete_predicate_when_compact) {
+    // Regression for the metadata-reclaim change: when compaction archives its input
+    // rowsets into compaction_inputs, the (potentially large) delete_predicate must be
+    // dropped from the archived copy. compaction_inputs is consumed only by vacuum/file
+    // cleanup, never by readers, so the predicate is pure metadata bloat once moved.
+    const int64_t tablet_id = 10007;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(112);
+
+    // Two live rowsets, each carrying a delete_predicate.
+    auto* r0 = metadata->add_rowsets();
+    r0->set_id(110);
+    r0->set_overlapped(false);
+    r0->set_num_rows(10);
+    r0->set_data_size(100);
+    r0->add_segment_metas()->set_filename("aaa.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = metadata->add_rowsets();
+    r1->set_id(111);
+    r1->set_overlapped(false);
+    r1->set_num_rows(20);
+    r1->set_data_size(200);
+    r1->add_segment_metas()->set_filename("bbb.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+
+    // Pre-condition: both live rowsets currently carry the predicate.
+    ASSERT_TRUE(metadata->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(metadata->rowsets(1).has_delete_predicate());
+
+    // Compact 110 + 111 -> archived into compaction_inputs.
+    metadata->set_version(11);
+    MetaFileBuilder builder(*tablet, metadata);
+    TxnLogPB_OpCompaction op_compaction;
+    op_compaction.add_input_rowsets(110);
+    op_compaction.add_input_rowsets(111);
+    RowsetMetadataPB output_rowset;
+    output_rowset.add_segment_metas()->set_filename("ccc.dat");
+    op_compaction.mutable_output_rowset()->CopyFrom(output_rowset);
+    op_compaction.set_compact_version(11);
+    builder.apply_opcompaction(op_compaction, 111, 0);
+
+    // The archived compaction_inputs must NOT retain the delete_predicate.
+    ASSERT_EQ(2, metadata->compaction_inputs_size());
+    EXPECT_FALSE(metadata->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(metadata->compaction_inputs(1).has_delete_predicate());
+}
+
 TEST_F(MetaFileTest, test_compaction_conflict_checker_with_sparse_segment_id) {
     const int64_t tablet_id = 32001;
     auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -1129,5 +1129,233 @@ TEST(TxnLogApplierBatchTest, NonPKIncrementalReplicationWithDcg) {
     EXPECT_EQ("dcg_77.cols", meta->dcg_meta().dcgs().at(77).column_files(0));
 }
 
+// Regression for the metadata-reclaim change on the non-PK path: when
+// NonPrimaryKeyTxnLogApplier archives compaction input rowsets into
+// compaction_inputs, the delete_predicate must be dropped from the archived copy
+// (covers both the std::move(*iter) branch and the last_input_rowset branch).
+TEST(TxnLogApplierCompactionTest, NonPKCompactionDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40050);
+    auto meta = build_non_pk_metadata(40050);
+    meta->set_next_rowset_id(10);
+
+    // Two adjacent live rowsets, each carrying a delete_predicate.
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_overlapped(false);
+    r0->set_num_rows(10);
+    r0->set_data_size(100);
+    r0->add_segment_metas()->set_filename("seg0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_overlapped(false);
+    r1->set_num_rows(20);
+    r1->set_data_size(200);
+    r1->add_segment_metas()->set_filename("seg1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40050);
+    log->set_txn_id(200);
+    auto* op_compaction = log->mutable_op_compaction();
+    op_compaction->add_input_rowsets(1);
+    op_compaction->add_input_rowsets(2);
+    auto* output = op_compaction->mutable_output_rowset();
+    output->set_num_rows(30);
+    output->set_data_size(300);
+    output->add_segment_metas()->set_filename("out.dat");
+    op_compaction->set_compact_version(2);
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // Input rowsets archived into compaction_inputs must NOT retain delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
+// Regression: non-PK LAKE replication (full snapshot with tablet_metadata) archives superseded old
+// rowsets into compaction_inputs via the Add path — delete_predicate must be dropped there too.
+TEST(TxnLogApplierCompactionTest, NonPKLakeReplicationDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40060);
+    auto meta = build_non_pk_metadata(40060);
+    meta->set_next_rowset_id(10);
+    // Existing (soon-to-be-superseded) rowsets carrying delete_predicate.
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_num_rows(10);
+    r0->add_segment_metas()->set_filename("old0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_num_rows(20);
+    r1->add_segment_metas()->set_filename("old1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40060);
+    log->set_txn_id(300);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(300);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+    txn_meta->set_incremental_snapshot(false); // full snapshot -> else branch
+    // Lake replication: provide tablet_metadata with NEW rowset ids, so the old ids (1,2) are archived.
+    auto* tm = op_rep->mutable_tablet_metadata();
+    tm->set_id(40060);
+    tm->set_next_rowset_id(20);
+    auto* nr = tm->add_rowsets();
+    nr->set_id(15);
+    nr->set_num_rows(30);
+    nr->add_segment_metas()->set_filename("new0.dat");
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // The superseded old rowsets are archived into compaction_inputs without their delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
+// Regression: non-PK NON-LAKE replication (full snapshot, no tablet_metadata) swaps all superseded
+// old rowsets into compaction_inputs — delete_predicate must be dropped across the Swap too.
+TEST(TxnLogApplierCompactionTest, NonPKNonLakeReplicationDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40061);
+    auto meta = build_non_pk_metadata(40061);
+    meta->set_next_rowset_id(10);
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_num_rows(10);
+    r0->add_segment_metas()->set_filename("old0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_num_rows(20);
+    r1->add_segment_metas()->set_filename("old1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40061);
+    log->set_txn_id(301);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(301);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+    txn_meta->set_incremental_snapshot(false); // full snapshot, no tablet_metadata -> non-lake Swap path
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // All superseded old rowsets are swapped into compaction_inputs without their delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
+// Regression: PK LAKE replication (full snapshot with tablet_metadata) archives superseded old rowsets
+// into compaction_inputs via the Add path — delete_predicate must be dropped there too.
+TEST(TxnLogApplierCompactionTest, PKLakeReplicationDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40070);
+    auto meta = build_pk_metadata(40070);
+    meta->set_next_rowset_id(10);
+    // Existing (soon-to-be-superseded) rowsets carrying delete_predicate.
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_num_rows(10);
+    r0->add_segment_metas()->set_filename("old0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_num_rows(20);
+    r1->add_segment_metas()->set_filename("old1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40070);
+    log->set_txn_id(400);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(400);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+    txn_meta->set_incremental_snapshot(false); // full snapshot -> else branch
+    // Lake replication: provide tablet_metadata with NEW rowset ids, so the old ids (1,2) are archived.
+    auto* tm = op_rep->mutable_tablet_metadata();
+    tm->set_id(40070);
+    tm->set_next_rowset_id(20);
+    auto* nr = tm->add_rowsets();
+    nr->set_id(15);
+    nr->set_num_rows(30);
+    nr->add_segment_metas()->set_filename("new0.dat");
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // The superseded old rowsets are archived into compaction_inputs without their delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
+// Regression: PK NON-LAKE replication (full snapshot, no tablet_metadata) swaps all superseded old
+// rowsets into compaction_inputs — delete_predicate must be dropped across the Swap too.
+TEST(TxnLogApplierCompactionTest, PKNonLakeReplicationDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40071);
+    auto meta = build_pk_metadata(40071);
+    meta->set_next_rowset_id(10);
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_num_rows(10);
+    r0->add_segment_metas()->set_filename("old0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_num_rows(20);
+    r1->add_segment_metas()->set_filename("old1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false, true);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40071);
+    log->set_txn_id(401);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(401);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+    txn_meta->set_incremental_snapshot(false); // full snapshot, no tablet_metadata -> non-lake Swap path
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // All superseded old rowsets are swapped into compaction_inputs without their delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
 } // namespace lake
 } // namespace starrocks


### PR DESCRIPTION
Backport of #76870 to `branch-4.1`. Original PR merged to main as `577c87c`.
Replaces the mergify auto-backport #78648, which cherry-picked cleanly but does not compile
on this branch.

## Why this is a manual backport

The backported unit tests construct `Tablet` via
`StorageEnv::GetInstance()->lake_tablet_manager()`. `StorageEnv` is a newer refactor that only
exists on main; on `branch-4.1` the lake tablet manager is still reached through `ExecEnv`. The
five new test call sites were adapted to `ExecEnv::GetInstance()->lake_tablet_manager()`, matching
every pre-existing test in the same file on this branch. Everything else is identical to #76870.

## Fix summary (unchanged from #76870)

When compaction (or replication) retires an input rowset, it is archived into
`TabletMetadataPB.compaction_inputs` and kept there until vacuum/file cleanup. `compaction_inputs`
is never read by readers, so any `delete_predicate` carried by the archived rowset is pure metadata
bloat. This change clears the predicate at every archival site (non-PK and PK compaction appliers,
`MetaFileBuilder::apply_opcompaction`, and the replication paths), shrinking oversized
per-partition tablet metadata at its source.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr


