### PR TITLE
[BugFix] Expand a constant data argument in the scalar _state combinator

### DIFF
--- a/be/src/exprs/agg/combinator/state_function.h
+++ b/be/src/exprs/agg/combinator/state_function.h
@@ -47,7 +47,10 @@ public:
         Columns new_columns;
         new_columns.reserve(columns.size());
         for (auto i = 0; i < columns.size(); i++) {
-            ASSIGN_OR_RETURN(ColumnPtr new_column, _convert_to_nullable_column(columns[i], _arg_nullables[i], false));
+            // Follow Aggregator::evaluate_agg_input_column: the data argument is expanded because the
+            // aggregate implementations down_cast it to a concrete data column, while the trailing
+            // arguments keep a constant column, which functions such as percentile_approx require.
+            ASSIGN_OR_RETURN(ColumnPtr new_column, _convert_to_nullable_column(columns[i], _arg_nullables[i], i == 0));
             new_columns.emplace_back(new_column);
         }
 

--- a/be/test/exprs/agg/agg_state_functions_test.cpp
+++ b/be/test/exprs/agg/agg_state_functions_test.cpp
@@ -18,6 +18,8 @@
 #include <cmath>
 #include <memory>
 
+#include "column/const_column.h"
+#include "column/fixed_length_column.h"
 #include "exprs/agg/aggregate_factory.h"
 #include "exprs/agg/base_aggregate_test.h"
 #include "exprs/agg/combinator/agg_state_combine.h"
@@ -827,6 +829,82 @@ TEST_F(AggStateFunctionsTest, test_state_function_avg) {
         test_state_function_empty_column<int32_t>(ctx, func, "avg", arg_type_descs, return_type_desc,
                                                   intermediate_type_desc, true);
     }
+}
+
+// StateFunction::execute must expand a const data argument before handing it to the
+// aggregate's convert_to_serialize_format: aggregate implementations down_cast the
+// input to a concrete data column, so a ConstColumn there silently yields corrupted
+// states, e.g. INSERT ... VALUES (..., avg_state(38)) that avg_merge later reads
+// back as garbage (or crashes the BE).
+TEST_F(AggStateFunctionsTest, test_state_function_const_column) {
+    TypeDescriptor return_type_desc = TypeDescriptor(TYPE_DOUBLE);
+    TypeDescriptor arg_type_desc = TypeDescriptor(TYPE_BIGINT);
+    TypeDescriptor intermediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    auto func = get_aggregate_function("avg", TYPE_BIGINT, TYPE_DOUBLE, false);
+    ASSERT_NE(func, nullptr);
+
+    AggStateDesc agg_state_desc("avg", return_type_desc, arg_type_descs, false, 1);
+    StateFunction state_func(agg_state_desc, intermediate_type_desc, {false});
+
+    // avg_state(38) evaluated over a 5-row chunk: the argument is a ConstColumn.
+    const size_t chunk_size = 5;
+    auto data_column = Int64Column::create();
+    data_column->append(38);
+    ColumnPtr const_column = ConstColumn::create(std::move(data_column), chunk_size);
+
+    Columns input_columns = {const_column};
+    auto result = state_func.execute(ctx, input_columns);
+    ASSERT_TRUE(result.ok());
+    ColumnPtr state_column = result.value();
+    ASSERT_EQ(chunk_size, state_column->size());
+
+    // Merging the per-row states back must reproduce avg(38, ..., 38) == 38.
+    auto merged = ManagedAggrState::create(ctx, func);
+    for (size_t i = 0; i < state_column->size(); ++i) {
+        func->merge(ctx, state_column.get(), merged->state(), i);
+    }
+    auto final_column = ColumnHelper::create_column(return_type_desc, false);
+    func->finalize_to_column(ctx, merged->state(), final_column.get());
+    ASSERT_EQ(1, final_column->size());
+    ASSERT_DOUBLE_EQ(38.0, final_column->get(0).get_double());
+}
+
+// Same for a const-NULL data argument (e.g. avg_state(NULL)): it must be expanded
+// into a nullable column instead of reaching the aggregate as a ConstColumn.
+TEST_F(AggStateFunctionsTest, test_state_function_const_null_column) {
+    TypeDescriptor return_type_desc = TypeDescriptor(TYPE_DOUBLE);
+    TypeDescriptor arg_type_desc = TypeDescriptor(TYPE_BIGINT);
+    TypeDescriptor intermediate_type_desc = TypeDescriptor(TYPE_VARBINARY);
+    std::vector<TypeDescriptor> arg_type_descs = {arg_type_desc};
+    auto utils = std::make_unique<FunctionUtils>(nullptr, return_type_desc, arg_type_descs);
+    auto ctx = utils->get_fn_ctx();
+
+    auto func = get_aggregate_function("avg", TYPE_BIGINT, TYPE_DOUBLE, true);
+    ASSERT_NE(func, nullptr);
+
+    AggStateDesc agg_state_desc("avg", return_type_desc, arg_type_descs, true, 1);
+    StateFunction state_func(agg_state_desc, intermediate_type_desc, {true});
+
+    const size_t chunk_size = 5;
+    Columns input_columns = {ColumnHelper::create_const_null_column(chunk_size)};
+    auto result = state_func.execute(ctx, input_columns);
+    ASSERT_TRUE(result.ok());
+    ColumnPtr state_column = result.value();
+    ASSERT_EQ(chunk_size, state_column->size());
+
+    // All-NULL input carries no state: merging it back must finalize to NULL.
+    auto merged = ManagedAggrState::create(ctx, func);
+    for (size_t i = 0; i < state_column->size(); ++i) {
+        func->merge(ctx, state_column.get(), merged->state(), i);
+    }
+    auto final_column = ColumnHelper::create_column(return_type_desc, true);
+    func->finalize_to_column(ctx, merged->state(), final_column.get());
+    ASSERT_EQ(1, final_column->size());
+    ASSERT_TRUE(final_column->is_null(0));
 }
 
 template <typename T>

--- a/test/sql/test_agg_state/R/test_agg_state_const_arg.sql
+++ b/test/sql/test_agg_state/R/test_agg_state_const_arg.sql
@@ -1,0 +1,104 @@
+-- name: test_agg_state_const_arg
+CREATE TABLE t_agg_state_const (
+  k1 VARCHAR(10),
+  v_avg avg(bigint),
+  v_sum sum(bigint),
+  v_min min(bigint),
+  v_max max(bigint),
+  v_count count(bigint)
+)
+AGGREGATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_agg_state_const VALUES
+  ('a', avg_state(cast(38 as bigint)), sum_state(cast(38 as bigint)), min_state(cast(38 as bigint)), max_state(cast(38 as bigint)), count_state(cast(38 as bigint))),
+  ('b', avg_state(cast(50 as bigint)), sum_state(cast(50 as bigint)), min_state(cast(50 as bigint)), max_state(cast(50 as bigint)), count_state(cast(50 as bigint)));
+-- result:
+-- !result
+SELECT k1, avg_merge(v_avg), sum_merge(v_sum), min_merge(v_min), max_merge(v_max), count_merge(v_count)
+FROM t_agg_state_const GROUP BY k1 ORDER BY k1;
+-- result:
+a	38.0	38	38	38	1
+b	50.0	50	50	50	1
+-- !result
+CREATE TABLE t_src (k1 VARCHAR(10), pv BIGINT)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_src VALUES ('a', 38), ('b', 50);
+-- result:
+-- !result
+CREATE TABLE t_agg_state_col (
+  k1 VARCHAR(10),
+  v_avg avg(bigint),
+  v_sum sum(bigint),
+  v_min min(bigint),
+  v_max max(bigint),
+  v_count count(bigint)
+)
+AGGREGATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_agg_state_col
+SELECT k1, avg_state(pv), sum_state(pv), min_state(pv), max_state(pv), count_state(pv) FROM t_src;
+-- result:
+-- !result
+SELECT k1, avg_merge(v_avg), sum_merge(v_sum), min_merge(v_min), max_merge(v_max), count_merge(v_count)
+FROM t_agg_state_col GROUP BY k1 ORDER BY k1;
+-- result:
+a	38.0	38	38	38	1
+b	50.0	50	50	50	1
+-- !result
+SELECT avg_merge(avg_state(cast(38 as bigint))), sum_merge(sum_state(cast(38 as bigint))), min_merge(min_state(cast(38 as bigint))), max_merge(max_state(cast(38 as bigint))), count_merge(count_state(cast(38 as bigint)));
+-- result:
+38.0	38	38	38	1
+-- !result
+SELECT avg_merge(avg_state(cast(NULL as bigint)));
+-- result:
+None
+-- !result
+SELECT avg_merge(avg_state(cast(38 as bigint))), count_merge(count_state(cast(38 as bigint))) FROM t_src;
+-- result:
+38.0	2
+-- !result
+SELECT percentile_approx_merge(percentile_approx_state(cast(38 as double), 0.5)), percentile_approx_merge(percentile_approx_state(pv, 0.5)) FROM t_src;
+-- result:
+38.0	44.0
+-- !result
+CREATE TABLE t_agg_state_percentile (
+  k1 VARCHAR(10),
+  v_col percentile_approx(double, double),
+  v_const percentile_approx(double, double),
+  v_weighted percentile_approx_weighted(double, bigint, double)
+)
+AGGREGATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_agg_state_percentile
+SELECT k1,
+       percentile_approx_state(cast(pv as double), 0.5),
+       percentile_approx_state(cast(38 as double), 0.5),
+       percentile_approx_weighted_state(cast(pv as double), 1, 0.5)
+FROM t_src;
+-- result:
+-- !result
+INSERT INTO t_agg_state_percentile VALUES
+  ('c', percentile_approx_state(cast(38 as double), 0.5), percentile_approx_state(cast(50 as double), 0.5),
+        percentile_approx_weighted_state(cast(38 as double), 1, 0.5));
+-- result:
+-- !result
+SELECT k1, percentile_approx_merge(v_col), percentile_approx_merge(v_const), percentile_approx_weighted_merge(v_weighted)
+FROM t_agg_state_percentile GROUP BY k1 ORDER BY k1;
+-- result:
+a	38.0	38.0	38.0
+b	50.0	38.0	50.0
+c	38.0	50.0	38.0
+-- !result

--- a/test/sql/test_agg_state/T/test_agg_state_const_arg.sql
+++ b/test/sql/test_agg_state/T/test_agg_state_const_arg.sql
@@ -1,0 +1,95 @@
+-- name: test_agg_state_const_arg
+-- Regression for *_state(<literal>) producing a corrupted aggregate state.
+-- The scalar StateFunction passed its input columns to the aggregate's
+-- convert_to_serialize_format() as-is, so a literal argument arrived as a ConstColumn while
+-- every aggregate implementation down_casts it to a concrete data column. The states were
+-- silently wrong (avg_merge read 38 back as -24) or the BE crashed with SIGSEGV in
+-- StateFunction::execute. The aggregate-driven *_state(<column>) form was unaffected, because
+-- Aggregator::evaluate_agg_input_column already expands a constant data argument.
+CREATE TABLE t_agg_state_const (
+  k1 VARCHAR(10),
+  v_avg avg(bigint),
+  v_sum sum(bigint),
+  v_min min(bigint),
+  v_max max(bigint),
+  v_count count(bigint)
+)
+AGGREGATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- The *_state arguments are literals, so the BE evaluates them over ConstColumns.
+INSERT INTO t_agg_state_const VALUES
+  ('a', avg_state(cast(38 as bigint)), sum_state(cast(38 as bigint)), min_state(cast(38 as bigint)), max_state(cast(38 as bigint)), count_state(cast(38 as bigint))),
+  ('b', avg_state(cast(50 as bigint)), sum_state(cast(50 as bigint)), min_state(cast(50 as bigint)), max_state(cast(50 as bigint)), count_state(cast(50 as bigint)));
+
+SELECT k1, avg_merge(v_avg), sum_merge(v_sum), min_merge(v_min), max_merge(v_max), count_merge(v_count)
+FROM t_agg_state_const GROUP BY k1 ORDER BY k1;
+
+-- The same states built from a column must merge back to exactly the same results.
+CREATE TABLE t_src (k1 VARCHAR(10), pv BIGINT)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_src VALUES ('a', 38), ('b', 50);
+
+CREATE TABLE t_agg_state_col (
+  k1 VARCHAR(10),
+  v_avg avg(bigint),
+  v_sum sum(bigint),
+  v_min min(bigint),
+  v_max max(bigint),
+  v_count count(bigint)
+)
+AGGREGATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_agg_state_col
+SELECT k1, avg_state(pv), sum_state(pv), min_state(pv), max_state(pv), count_state(pv) FROM t_src;
+
+SELECT k1, avg_merge(v_avg), sum_merge(v_sum), min_merge(v_min), max_merge(v_max), count_merge(v_count)
+FROM t_agg_state_col GROUP BY k1 ORDER BY k1;
+
+-- Pure query form, no storage involved.
+SELECT avg_merge(avg_state(cast(38 as bigint))), sum_merge(sum_state(cast(38 as bigint))), min_merge(min_state(cast(38 as bigint))), max_merge(max_state(cast(38 as bigint))), count_merge(count_state(cast(38 as bigint)));
+
+-- A constant NULL argument must be expanded into a nullable column as well.
+SELECT avg_merge(avg_state(cast(NULL as bigint)));
+
+-- Constant argument evaluated over a multi-row chunk.
+SELECT avg_merge(avg_state(cast(38 as bigint))), count_merge(count_state(cast(38 as bigint))) FROM t_src;
+
+-- Guard: the quantile of percentile_approx must stay a constant column, so only the data
+-- argument is expanded. Both the constant and the column form have to keep working.
+SELECT percentile_approx_merge(percentile_approx_state(cast(38 as double), 0.5)), percentile_approx_merge(percentile_approx_state(pv, 0.5)) FROM t_src;
+
+-- The same guard on the load path, where the states are serialized into storage rather than
+-- consumed by the query itself. percentile_approx keeps its quantile as a constant column and
+-- percentile_approx_weighted keeps both its weight and its quantile, so expanding every
+-- argument instead of only the data argument would corrupt these states on the way in.
+-- v_col is the form that already worked before the fix and must keep its exact values.
+CREATE TABLE t_agg_state_percentile (
+  k1 VARCHAR(10),
+  v_col percentile_approx(double, double),
+  v_const percentile_approx(double, double),
+  v_weighted percentile_approx_weighted(double, bigint, double)
+)
+AGGREGATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_agg_state_percentile
+SELECT k1,
+       percentile_approx_state(cast(pv as double), 0.5),
+       percentile_approx_state(cast(38 as double), 0.5),
+       percentile_approx_weighted_state(cast(pv as double), 1, 0.5)
+FROM t_src;
+
+INSERT INTO t_agg_state_percentile VALUES
+  ('c', percentile_approx_state(cast(38 as double), 0.5), percentile_approx_state(cast(50 as double), 0.5),
+        percentile_approx_weighted_state(cast(38 as double), 1, 0.5));
+
+SELECT k1, percentile_approx_merge(v_col), percentile_approx_merge(v_const), percentile_approx_weighted_merge(v_weighted)
+FROM t_agg_state_percentile GROUP BY k1 ORDER BY k1;


### PR DESCRIPTION
## Why I'm doing:

`StateFunction::execute()` (the scalar `*_state` combinator) passed its input columns straight to the wrapped aggregate's `convert_to_serialize_format()`:

```cpp
ASSIGN_OR_RETURN(ColumnPtr new_column, _convert_to_nullable_column(columns[i], _arg_nullables[i], false));
```

A literal argument such as `avg_state(38)` is a `ConstColumn`, but every aggregate implementation `down_cast`s the data argument to a concrete data column and indexes it per row — `AvgAggregateFunction::convert_to_serialize_format` does `down_cast<const InputColumnType*>(src[0].get())` followed by `immutable_data()[i]`. So the constant column was reinterpreted as a numeric column. In a debug build the `down_cast` assertion fires; in a release build `down_cast` is a plain `static_cast`, i.e. undefined behaviour that silently serialized a corrupted state.

The user-visible result is a data-correctness bug: `INSERT INTO <agg table> VALUES (..., avg_state(38))` succeeded and `avg_merge` read the value back as `-24` on 3.5.18, while on 4.1.1 the same statement reliably SIGSEGV'd the BE (surfacing as `Backend node not found`). The corrupted states are persisted, so affected data has to be reloaded. `*_state(<column>)` was never affected, and `CAST(38 AS BIGINT)` is not a workaround because it is still a constant column.

The aggregate-driven path never had this problem: `Aggregator::evaluate_agg_input_column` already expands a constant **data** argument and deliberately keeps only the **trailing** arguments constant, because functions such as `percentile_approx` require them to stay constant — `PercentileApproxAggregateFunction::convert_to_serialize_format` reads `src[0]` via `down_cast<const DoubleColumn*>(...)->immutable_data()[i]` but asserts `DCHECK(src[1]->is_constant())` for the quantile. The scalar combinator simply never adopted that rule.

## What I'm doing:

Make the scalar combinator follow the same rule as the aggregate path: expand the data argument, leave the trailing arguments untouched.

```cpp
ASSIGN_OR_RETURN(ColumnPtr new_column, _convert_to_nullable_column(columns[i], _arg_nullables[i], i == 0));
```

`_convert_to_nullable_column` already had the `is_unpack_column` switch and the two other scalar combinators (`StateMergeFunction`, `StateUnionFunction`) already pass `true`; only `StateFunction` passed `false` for every argument.

Two BE unit tests are added to `AggStateFunctionsTest`, covering a constant argument and a constant `NULL` argument over a multi-row chunk, and asserting that the resulting states merge back to the same values as an equivalent data column. Both fail before the change — the first one aborts in `down_cast` inside `AvgAggregateFunction::convert_to_serialize_format`, which is the debug-build form of the corruption reported above — and pass after it.

A SQL regression test (`test_agg_state/T,R/test_agg_state_const_arg`) covers both directions.

*The reported case works again*: an aggregate table written with `INSERT... VALUES (..., avg_state(38))` has to merge back to exactly the same values as the equivalent states built from a column, plus the pure-query, constant-`NULL` and multi-row-chunk forms.

*Nothing else broke on the load path*: the case also loads `percentile_approx(double, double)` and `percentile_approx_weighted(double, bigint, double)` states into an aggregate table, through both `INSERT... SELECT` and `INSERT... VALUES`, with the data argument given as a column and as a literal. Those are the functions whose trailing arguments must stay constant — `percentile_approx` for its quantile, `percentile_approx_weighted` for both its weight and its quantile — so a fix that expanded *every* argument rather than only the data argument would corrupt exactly these states on the way into storage.

### Verification

Run against a locally built cluster and a debug BE unit-test binary:

* BE UT — before the change `AggStateFunctionsTest.test_state_function_const_column` aborts with `down_cast` assertion `f == NULL || dynamic_cast<To>(f)!= NULL` under `AvgAggregateFunction::convert_to_serialize_format`; after it, all 41 `AggStateFunctionsTest` cases pass, and the `AggregateTest` percentile cases are unaffected.
* SQL-Tester — on a BE without the fix the recorded case fails with `Backend node not found`, the BE having crashed in `Aggregator::_evaluate_const_columns → Expr::evaluate_const → StateFunction::execute → AvgAggregateFunction::convert_to_serialize_format`, which is the same stack reported on 4.1.1. With the fix the case passes 3/3, and `SELECT avg_merge(v_avg)...` returns `38.0` for the row that previously read back as `-24`.
* No regression on the paths that already worked — the column form of the percentile load was run against the same cluster on a BE with and without the fix, using identical statements, and merges back to identical values (`38.0` / `50.0`) in both. The literal form of the same load crashes the BE without the fix, so these statements do discriminate rather than merely pass.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5