### PR TITLE
[Feature] Preserve Iceberg geo schema metadata (Contract 1.1)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -935,6 +935,11 @@ public class ColumnTypeConverter {
             case VARIANT:
                 return VariantType.VARIANT;
             case FIXED:
+            case GEOGRAPHY:
+            case GEOMETRY:
+                // External geo metadata is transported separately by IcebergApiConverter.
+                // Recognition must not expose WKB as ordinary SQL binary values.
+                return UnknownType.UNKNOWN_TYPE;
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -37,6 +37,7 @@ import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.thrift.TIcebergColumnStats;
 import com.starrocks.thrift.TIcebergDataFile;
+import com.starrocks.thrift.TIcebergGeoMetadata;
 import com.starrocks.thrift.TIcebergSchema;
 import com.starrocks.thrift.TIcebergSchemaField;
 import com.starrocks.type.ArrayType;
@@ -569,6 +570,20 @@ public class IcebergApiConverter {
         tIcebergSchemaField.setField_id(nestedField.fieldId());
         tIcebergSchemaField.setName(nestedField.name());
         tIcebergSchemaField.setIs_optional(nestedField.isOptional());
+        tIcebergSchemaField.setIceberg_type(nestedField.type().typeId().name());
+        // Preserve external semantics even while SQL conversion remains UNKNOWN_TYPE.
+        // Do not infer these parameters from WKB or map these fields to VARBINARY.
+        if (nestedField.type().typeId() == org.apache.iceberg.types.Type.TypeID.GEOGRAPHY) {
+            Types.GeographyType geography = (Types.GeographyType) nestedField.type();
+            tIcebergSchemaField.setGeo_metadata(new TIcebergGeoMetadata()
+                    .setKind("GEOGRAPHY").setCrs(geography.crs() == null ? "OGC:CRS84" : geography.crs())
+                    .setEdge_algorithm(geography.algorithm() == null ? "SPHERICAL" : geography.algorithm().name()));
+        } else if (nestedField.type().typeId() == org.apache.iceberg.types.Type.TypeID.GEOMETRY) {
+            Types.GeometryType geometry = (Types.GeometryType) nestedField.type();
+            tIcebergSchemaField.setGeo_metadata(new TIcebergGeoMetadata()
+                    .setKind("GEOMETRY").setCrs(geometry.crs() == null ? "OGC:CRS84" : geometry.crs())
+                    .setEdge_algorithm("PLANAR"));
+        }
         if (nestedField.type().isNestedType()) {
             List<TIcebergSchemaField> children = new ArrayList<>(nestedField.type().asNestedType().fields().size());
             for (Types.NestedField child : nestedField.type().asNestedType().fields()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -37,6 +37,7 @@ import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.thrift.TIcebergColumnStats;
 import com.starrocks.thrift.TIcebergDataFile;
+import com.starrocks.thrift.TIcebergGeoKind;
 import com.starrocks.thrift.TIcebergGeoMetadata;
 import com.starrocks.thrift.TIcebergSchema;
 import com.starrocks.thrift.TIcebergSchemaField;
@@ -576,12 +577,12 @@ public class IcebergApiConverter {
         if (nestedField.type().typeId() == org.apache.iceberg.types.Type.TypeID.GEOGRAPHY) {
             Types.GeographyType geography = (Types.GeographyType) nestedField.type();
             tIcebergSchemaField.setGeo_metadata(new TIcebergGeoMetadata()
-                    .setKind("GEOGRAPHY").setCrs(geography.crs() == null ? "OGC:CRS84" : geography.crs())
+                    .setKind(TIcebergGeoKind.GEOGRAPHY).setCrs(geography.crs() == null ? "OGC:CRS84" : geography.crs())
                     .setEdge_algorithm(geography.algorithm() == null ? "SPHERICAL" : geography.algorithm().name()));
         } else if (nestedField.type().typeId() == org.apache.iceberg.types.Type.TypeID.GEOMETRY) {
             Types.GeometryType geometry = (Types.GeometryType) nestedField.type();
             tIcebergSchemaField.setGeo_metadata(new TIcebergGeoMetadata()
-                    .setKind("GEOMETRY").setCrs(geometry.crs() == null ? "OGC:CRS84" : geometry.crs())
+                    .setKind(TIcebergGeoKind.GEOMETRY).setCrs(geometry.crs() == null ? "OGC:CRS84" : geometry.crs())
                     .setEdge_algorithm("PLANAR"));
         }
         if (nestedField.type().isNestedType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -571,7 +571,6 @@ public class IcebergApiConverter {
         tIcebergSchemaField.setField_id(nestedField.fieldId());
         tIcebergSchemaField.setName(nestedField.name());
         tIcebergSchemaField.setIs_optional(nestedField.isOptional());
-        tIcebergSchemaField.setIceberg_type(nestedField.type().typeId().name());
         // Preserve external semantics even while SQL conversion remains UNKNOWN_TYPE.
         // Do not infer these parameters from WKB or map these fields to VARBINARY.
         if (nestedField.type().typeId() == org.apache.iceberg.types.Type.TypeID.GEOGRAPHY) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGeoMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGeoMetadataTest.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.connector.ColumnTypeConverter;
+import com.starrocks.thrift.TIcebergGeoMetadata;
+import com.starrocks.thrift.TIcebergSchema;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarbinaryType;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.types.EdgeAlgorithm;
+import org.apache.iceberg.types.Types;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class IcebergGeoMetadataTest {
+    @Test
+    public void geographyAlgorithmsSurviveSchemaAndWireRoundTrips() throws Exception {
+        for (EdgeAlgorithm edge : EdgeAlgorithm.values()) {
+            for (String crs : new String[] {"OGC:CRS84", "EPSG:4326", "srid:4326"}) {
+                Types.GeographyType type = Types.GeographyType.of(crs, edge);
+                Schema schema = new Schema(Types.NestedField.optional(1, "shape", type));
+                Schema restored = SchemaParser.fromJson(SchemaParser.toJson(schema));
+                TIcebergSchema wire = IcebergApiConverter.getTIcebergSchema(restored);
+                TIcebergSchema decoded = new TIcebergSchema();
+                new TDeserializer(new TCompactProtocol.Factory()).deserialize(decoded,
+                        new TSerializer(new TCompactProtocol.Factory()).serialize(wire));
+                Assertions.assertEquals(wire, decoded);
+                TIcebergGeoMetadata geo = decoded.getFields().get(0).getGeo_metadata();
+                Assertions.assertEquals("GEOGRAPHY", geo.getKind());
+                Assertions.assertEquals(crs, geo.getCrs());
+                Assertions.assertEquals(edge.name(), geo.getEdge_algorithm());
+                Assertions.assertTrue(ColumnTypeConverter.fromIcebergType(type).isUnknown());
+            }
+        }
+    }
+
+    @Test
+    public void defaultsGeometryAndOrdinaryBinaryRemainDistinct() {
+        Schema schema = new Schema(
+                Types.NestedField.optional(1, "geog", Types.GeographyType.crs84()),
+                Types.NestedField.optional(2, "geom", Types.GeometryType.of("EPSG:3857")),
+                Types.NestedField.optional(3, "bytes", Types.BinaryType.get()),
+                Types.NestedField.required(4, "id", Types.IntegerType.get()));
+        TIcebergSchema wire = IcebergApiConverter.getTIcebergSchema(schema);
+        Assertions.assertEquals("OGC:CRS84", wire.getFields().get(0).getGeo_metadata().getCrs());
+        Assertions.assertEquals("SPHERICAL", wire.getFields().get(0).getGeo_metadata().getEdge_algorithm());
+        Assertions.assertEquals("GEOMETRY", wire.getFields().get(1).getGeo_metadata().getKind());
+        Assertions.assertEquals("EPSG:3857", wire.getFields().get(1).getGeo_metadata().getCrs());
+        Assertions.assertEquals("PLANAR", wire.getFields().get(1).getGeo_metadata().getEdge_algorithm());
+        Assertions.assertFalse(wire.getFields().get(2).isSetGeo_metadata());
+        Assertions.assertEquals("BINARY", wire.getFields().get(2).getIceberg_type());
+        Assertions.assertFalse(wire.getFields().get(3).isSetGeo_metadata());
+        Assertions.assertTrue(ColumnTypeConverter.fromIcebergType(Types.GeometryType.crs84()).isUnknown());
+        Assertions.assertEquals(VarbinaryType.VARBINARY, ColumnTypeConverter.fromIcebergType(Types.BinaryType.get()));
+        Assertions.assertEquals(IntegerType.INT, ColumnTypeConverter.fromIcebergType(Types.IntegerType.get()));
+    }
+
+    @Test
+    public void nestedMetadataIsPreservedWithoutEnablingNestedGeo() {
+        Schema schema = new Schema(Types.NestedField.optional(1, "shapes",
+                Types.ListType.ofOptional(2, Types.GeometryType.crs84())));
+        TIcebergSchema wire = IcebergApiConverter.getTIcebergSchema(schema);
+        Assertions.assertFalse(wire.getFields().get(0).isSetGeo_metadata());
+        Assertions.assertEquals("GEOMETRY",
+                wire.getFields().get(0).getChildren().get(0).getGeo_metadata().getKind());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGeoMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGeoMetadataTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg;
 
 import com.starrocks.connector.ColumnTypeConverter;
+import com.starrocks.thrift.TIcebergGeoKind;
 import com.starrocks.thrift.TIcebergGeoMetadata;
 import com.starrocks.thrift.TIcebergSchema;
 import com.starrocks.type.IntegerType;
@@ -26,6 +27,9 @@ import org.apache.iceberg.types.Types;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TField;
+import org.apache.thrift.protocol.TType;
+import org.apache.thrift.transport.TMemoryInputTransport;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +47,7 @@ public class IcebergGeoMetadataTest {
                         new TSerializer(new TCompactProtocol.Factory()).serialize(wire));
                 Assertions.assertEquals(wire, decoded);
                 TIcebergGeoMetadata geo = decoded.getFields().get(0).getGeo_metadata();
-                Assertions.assertEquals("GEOGRAPHY", geo.getKind());
+                Assertions.assertEquals(TIcebergGeoKind.GEOGRAPHY, geo.getKind());
                 Assertions.assertEquals(crs, geo.getCrs());
                 Assertions.assertEquals(edge.name(), geo.getEdge_algorithm());
                 Assertions.assertTrue(ColumnTypeConverter.fromIcebergType(type).isUnknown());
@@ -61,7 +65,7 @@ public class IcebergGeoMetadataTest {
         TIcebergSchema wire = IcebergApiConverter.getTIcebergSchema(schema);
         Assertions.assertEquals("OGC:CRS84", wire.getFields().get(0).getGeo_metadata().getCrs());
         Assertions.assertEquals("SPHERICAL", wire.getFields().get(0).getGeo_metadata().getEdge_algorithm());
-        Assertions.assertEquals("GEOMETRY", wire.getFields().get(1).getGeo_metadata().getKind());
+        Assertions.assertEquals(TIcebergGeoKind.GEOMETRY, wire.getFields().get(1).getGeo_metadata().getKind());
         Assertions.assertEquals("EPSG:3857", wire.getFields().get(1).getGeo_metadata().getCrs());
         Assertions.assertEquals("PLANAR", wire.getFields().get(1).getGeo_metadata().getEdge_algorithm());
         Assertions.assertFalse(wire.getFields().get(2).isSetGeo_metadata());
@@ -78,7 +82,32 @@ public class IcebergGeoMetadataTest {
                 Types.ListType.ofOptional(2, Types.GeometryType.crs84())));
         TIcebergSchema wire = IcebergApiConverter.getTIcebergSchema(schema);
         Assertions.assertFalse(wire.getFields().get(0).isSetGeo_metadata());
-        Assertions.assertEquals("GEOMETRY",
+        Assertions.assertEquals(TIcebergGeoKind.GEOMETRY,
                 wire.getFields().get(0).getChildren().get(0).getGeo_metadata().getKind());
+    }
+
+    @Test
+    public void geoKindUsesStableEnumWireValues() throws Exception {
+        Assertions.assertEquals(0, TIcebergGeoKind.UNKNOWN.getValue());
+        Assertions.assertEquals(1, TIcebergGeoKind.GEOGRAPHY.getValue());
+        Assertions.assertEquals(2, TIcebergGeoKind.GEOMETRY.getValue());
+        for (TIcebergGeoKind kind : TIcebergGeoKind.values()) {
+            TIcebergGeoMetadata metadata = new TIcebergGeoMetadata().setKind(kind);
+            byte[] bytes = new TSerializer(new TCompactProtocol.Factory()).serialize(metadata);
+            TCompactProtocol protocol = new TCompactProtocol(new TMemoryInputTransport(bytes));
+            protocol.readStructBegin();
+            TField field = protocol.readFieldBegin();
+            Assertions.assertEquals(1, field.id);
+            Assertions.assertEquals(TType.I32, field.type);
+            Assertions.assertEquals(kind.getValue(), protocol.readI32());
+            TIcebergGeoMetadata decoded = new TIcebergGeoMetadata();
+            new TDeserializer(new TCompactProtocol.Factory()).deserialize(decoded, bytes);
+            Assertions.assertEquals(kind, decoded.getKind());
+        }
+        TIcebergGeoMetadata absent = new TIcebergGeoMetadata();
+        byte[] bytes = new TSerializer(new TCompactProtocol.Factory()).serialize(absent);
+        TIcebergGeoMetadata decoded = new TIcebergGeoMetadata();
+        new TDeserializer(new TCompactProtocol.Factory()).deserialize(decoded, bytes);
+        Assertions.assertFalse(decoded.isSetKind());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGeoMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGeoMetadataTest.java
@@ -69,7 +69,6 @@ public class IcebergGeoMetadataTest {
         Assertions.assertEquals("EPSG:3857", wire.getFields().get(1).getGeo_metadata().getCrs());
         Assertions.assertEquals("PLANAR", wire.getFields().get(1).getGeo_metadata().getEdge_algorithm());
         Assertions.assertFalse(wire.getFields().get(2).isSetGeo_metadata());
-        Assertions.assertEquals("BINARY", wire.getFields().get(2).getIceberg_type());
         Assertions.assertFalse(wire.getFields().get(3).isSetGeo_metadata());
         Assertions.assertTrue(ColumnTypeConverter.fromIcebergType(Types.GeometryType.crs84()).isUnknown());
         Assertions.assertEquals(VarbinaryType.VARBINARY, ColumnTypeConverter.fromIcebergType(Types.BinaryType.get()));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -241,13 +241,15 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                 new Column("id", IntegerType.INT, true),
                 new Column("data", StringType.STRING, true),
                 new Column("geo_col", UnknownType.UNKNOWN_TYPE, true),
+                new Column("geography_col", UnknownType.UNKNOWN_TYPE, true),
                 new Column("ts_nano_col", UnknownType.UNKNOWN_TYPE, true));
         schemas = addMetaColumns(schemas);
 
         Schema schema = new Schema(
                 required(3, "id", Types.IntegerType.get()),
                 required(4, "data", Types.StringType.get()),
-                required(5, "geo_col", Types.StringType.get()),
+                required(5, "geo_col", Types.GeometryType.crs84()),
+                required(7, "geography_col", Types.GeographyType.crs84()),
                 required(6, "ts_nano_col", Types.StringType.get()));
         PartitionSpec spec = PartitionSpec.builderFor(schema).build();
         TestTables.TestTable baseTable = TestTables.create(
@@ -255,7 +257,8 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                         MOCKED_UNKNOWN_TYPE_TABLE_NAME), MOCKED_UNKNOWN_TYPE_TABLE_NAME,
                 schema, spec, 3);
 
-        MockIcebergTable mockIcebergTable = new MockIcebergTable(2, MOCKED_UNKNOWN_TYPE_TABLE_NAME,
+        MockIcebergTable mockIcebergTable = new MockIcebergTable(MOCKED_UNKNOWN_TYPE_TABLE_NAME.hashCode(),
+                MOCKED_UNKNOWN_TYPE_TABLE_NAME,
                 MOCKED_ICEBERG_CATALOG_NAME, null, MOCKED_UNPARTITIONED_DB_NAME,
                 MOCKED_UNKNOWN_TYPE_TABLE_NAME, schemas, baseTable, null, "");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergUnsupportedTypeQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/IcebergUnsupportedTypeQueryTest.java
@@ -28,6 +28,17 @@ import java.io.File;
  * while querying supported columns on the same table works fine.
  */
 public class IcebergUnsupportedTypeQueryTest extends ConnectorPlanTestBase {
+    @Test
+    public void testGeographyProjectionAndPredicatesFail() {
+        for (String sql : new String[] {
+                "SELECT geography_col FROM iceberg0.unpartitioned_db.t_unknown_types",
+                "SELECT id FROM iceberg0.unpartitioned_db.t_unknown_types WHERE geography_col IS NULL",
+                "SELECT CAST(geo_col AS VARBINARY) FROM iceberg0.unpartitioned_db.t_unknown_types"}) {
+            SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+            Assertions.assertTrue(ex.getMessage().contains("not supported"), ex.getMessage());
+        }
+    }
+
     @TempDir
     public static File temp;
 
@@ -42,6 +53,12 @@ public class IcebergUnsupportedTypeQueryTest extends ConnectorPlanTestBase {
                 getFragmentPlan("SELECT geo_col FROM iceberg0.unpartitioned_db.t_unknown_types"));
         Assertions.assertTrue(ex.getMessage().contains("not supported"),
                 "Expected 'not supported' error, got: " + ex.getMessage());
+    }
+
+    @Test
+    public void testSupportedProjectionStillWorks() throws Exception {
+        String plan = getFragmentPlan("SELECT id FROM iceberg0.unpartitioned_db.t_unknown_types");
+        Assertions.assertTrue(plan.contains("IcebergScanNode"));
     }
 
     @Test

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -580,6 +580,14 @@ struct TTableFunctionTable {
     14: optional i8 csv_escape
 }
 
+// External schema metadata only; this does not declare a native SQL type.
+// Strings preserve the source vocabulary without coupling it to native enums.
+struct TIcebergGeoMetadata {
+    1: optional string kind
+    2: optional string crs
+    3: optional string edge_algorithm
+}
+
 struct TIcebergSchemaField {
     // Refer to field id in iceberg schema
     1: optional i32 field_id
@@ -590,6 +598,11 @@ struct TIcebergSchemaField {
     // Mirrors Types.NestedField#isOptional(). Unset means optional: never enforce
     // NOT NULL without an explicit signal from the Iceberg schema.
     3: optional bool is_optional
+
+    4: optional TIcebergGeoMetadata geo_metadata
+
+    // Source schema identity, not a StarRocks SQL primitive. Absent on older FEs.
+    5: optional string iceberg_type
 
     // You can fill other field properties here if you needed
     // .......

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -580,10 +580,16 @@ struct TTableFunctionTable {
     14: optional i8 csv_escape
 }
 
-// External schema metadata only; this does not declare a native SQL type.
-// Strings preserve the source vocabulary without coupling it to native enums.
+// External Iceberg schema identity, not a native StarRocks SQL type.
+enum TIcebergGeoKind {
+    UNKNOWN = 0,
+    GEOGRAPHY = 1,
+    GEOMETRY = 2
+}
+
+// CRS and edge algorithm retain the source vocabulary as strings.
 struct TIcebergGeoMetadata {
-    1: optional string kind
+    1: optional TIcebergGeoKind kind
     2: optional string crs
     3: optional string edge_algorithm
 }
@@ -599,13 +605,13 @@ struct TIcebergSchemaField {
     // NOT NULL without an explicit signal from the Iceberg schema.
     3: optional bool is_optional
 
+    // You can fill other field properties here if you needed
+    // .......
+
     4: optional TIcebergGeoMetadata geo_metadata
 
     // Source schema identity, not a StarRocks SQL primitive. Absent on older FEs.
     5: optional string iceberg_type
-
-    // You can fill other field properties here if you needed
-    // .......
 
     // Children fields for struct, map and list(array)
     100: optional list<TIcebergSchemaField> children

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -610,9 +610,6 @@ struct TIcebergSchemaField {
 
     4: optional TIcebergGeoMetadata geo_metadata
 
-    // Source schema identity, not a StarRocks SQL primitive. Absent on older FEs.
-    5: optional string iceberg_type
-
     // Children fields for struct, map and list(array)
     100: optional list<TIcebergSchemaField> children
 }


### PR DESCRIPTION
## Why I'm doing:

Related to #78693, Milestone 1 / Contract 1.1.

Iceberg v3 geography and geometry carry semantic metadata that must survive schema conversion even while StarRocks does not expose native geo SQL types. Discarding CRS or edge algorithms would prevent later readers from distinguishing incompatible data correctly.

This is a focused foundational PR following the connector-first sequencing and smaller contract PRs discussed with Alvin in #78693. It does not imply approval of this implementation.

## What I'm doing:

- Preserve Iceberg logical kind as TIcebergGeoKind (UNKNOWN/GEOGRAPHY/GEOMETRY), exact CRS identifier, and edge algorithm in optional Thrift scan-schema fields, recursively including nested fields.
- Restore Iceberg's omitted defaults as OGC:CRS84 and SPHERICAL; retain explicit CRS strings and all five geography edge algorithms without coercion.
- Keep GEOGRAPHY and GEOMETRY mapped to UNKNOWN_TYPE. Ordinary binary is unchanged.
- Add Iceberg JSON/Thrift round-trip tests and FE query tests: supported-column projection succeeds; geo projection, SELECT *, predicates, and binary casts remain unsupported.

No native SQL types, GeoColumn, spatial compute, native persistence, implicit binary fallback, or capability enablement are introduced. Legacy spatial functions remain unchanged. This is internal metadata plumbing, so no new public feature documentation or backport is requested.

### Scope and follow-ups

The Parquet annotation wire contract is an independent PR. Contract 1.3 will consume both metadata contracts to validate schema conflicts and enforce disabled-read behavior through native and Arrow readers. PR #78667 remains deferred Milestone 2 work and is not modified here. This PR must not close the umbrella issue.

### Validation

The targeted FE suite passed: **66 tests, zero failures/errors/skips** across IcebergGeoMetadataTest, IcebergUnsupportedTypeQueryTest, IcebergApiConverterTest, and ColumnTypeConverterTest, using JDK 21. The suite was rerun after removing the unused `iceberg_type` field, its converter assignment, and the corresponding assertion, including an independent compact-protocol check of enum wire ordinals and absent-kind handling. The Linux build copy includes the combined Milestone 1 sources; this PR contains only the FE/Iceberg slice.

```bash
./run-fe-ut.sh -j 2 --test IcebergGeoMetadataTest,IcebergUnsupportedTypeQueryTest,IcebergApiConverterTest,ColumnTypeConverterTest
python3 build-support/check_gensrc_schema_compatibility.py --mode changed --base origin/main
```

Schema compatibility passed without waivers; existing Thrift field numbers are unchanged. A live external Iceberg catalog integration run has not been performed.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5