### PR TITLE
[Feature] Define Parquet geospatial annotation wire contract (Contract 1.2)

### DIFF
--- a/be/test/formats/CMakeLists.txt
+++ b/be/test/formats/CMakeLists.txt
@@ -16,6 +16,7 @@ set(FORMAT_CORE_TEST_FILES
     ../base/cxa_throw_wrap.cpp
     delta/deletion_vector_test.cpp
     disk_range_test.cpp
+    parquet/geo_annotation_wire_test.cpp
     file_input_stream_test.cpp
     io/async_flush_output_stream_test.cpp
     io/async_flush_stream_poller_test.cpp

--- a/be/test/formats/parquet/geo_annotation_wire_test.cpp
+++ b/be/test/formats/parquet/geo_annotation_wire_test.cpp
@@ -95,6 +95,41 @@ TEST(GeoAnnotationWireTest, OptionalDefaultsAndOrdinaryBinary) {
     EXPECT_EQ(field, decoded);
 }
 
+TEST(GeoAnnotationWireTest, BoundingBoxRequiresXYButNotZM) {
+    using namespace apache::thrift::protocol;
+    // Independently encode the upstream fields, omitting each required coordinate in turn.
+    for (int16_t omitted = 0; omitted <= 4; ++omitted) {
+        auto buffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+        TCompactProtocol protocol(buffer);
+        protocol.writeStructBegin("BoundingBox");
+        for (int16_t id = 1; id <= 4; ++id) {
+            if (id == omitted) {
+                continue;
+            }
+            protocol.writeFieldBegin("coordinate", T_DOUBLE, id);
+            protocol.writeDouble(id);
+            protocol.writeFieldEnd();
+        }
+        protocol.writeFieldStop();
+        protocol.writeStructEnd();
+        tparquet::BoundingBox bbox;
+        if (omitted != 0) {
+            EXPECT_THROW(bbox.read(&protocol), TProtocolException);
+        } else {
+            ASSERT_NO_THROW(bbox.read(&protocol));
+            EXPECT_EQ(1, bbox.xmin);
+            EXPECT_EQ(2, bbox.xmax);
+            EXPECT_EQ(3, bbox.ymin);
+            EXPECT_EQ(4, bbox.ymax);
+            EXPECT_FALSE(bbox.__isset.zmin);
+            EXPECT_FALSE(bbox.__isset.zmax);
+            EXPECT_FALSE(bbox.__isset.mmin);
+            EXPECT_FALSE(bbox.__isset.mmax);
+            EXPECT_EQ(bbox, round_trip(bbox));
+        }
+    }
+}
+
 TEST(GeoAnnotationWireTest, GeospatialStatisticsRemainMetadata) {
     tparquet::BoundingBox bbox;
     bbox.__set_xmin(-180);

--- a/be/test/formats/parquet/geo_annotation_wire_test.cpp
+++ b/be/test/formats/parquet/geo_annotation_wire_test.cpp
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <thrift/protocol/TCompactProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+
+#include "gen_cpp/parquet_types.h"
+
+namespace starrocks::parquet {
+namespace {
+template <typename T>
+T round_trip(const T& input) {
+    auto buffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+    apache::thrift::protocol::TCompactProtocol protocol(buffer);
+    input.write(&protocol);
+    T output;
+    output.read(&protocol);
+    return output;
+}
+} // namespace
+
+TEST(GeoAnnotationWireTest, StandardOrdinalsAndUnknownAlgorithms) {
+    // Write the external field IDs independently of generated Thrift writers.
+    for (int16_t kind : {17, 18}) {
+        for (int32_t algorithm : {0, 1, 2, 3, 4, 127}) {
+            auto buffer = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+            apache::thrift::protocol::TCompactProtocol protocol(buffer);
+            using namespace apache::thrift::protocol;
+            protocol.writeStructBegin("LogicalType");
+            protocol.writeFieldBegin("geo", T_STRUCT, kind);
+            protocol.writeStructBegin("Geo");
+            protocol.writeFieldBegin("crs", T_STRING, 1);
+            protocol.writeString("EPSG:4326");
+            protocol.writeFieldEnd();
+            if (kind == 18) {
+                protocol.writeFieldBegin("algorithm", T_I32, 2);
+                protocol.writeI32(algorithm);
+                protocol.writeFieldEnd();
+            }
+            protocol.writeFieldStop();
+            protocol.writeStructEnd();
+            protocol.writeFieldEnd();
+            protocol.writeFieldStop();
+            protocol.writeStructEnd();
+            tparquet::LogicalType decoded;
+            decoded.read(&protocol);
+            if (kind == 17) {
+                ASSERT_TRUE(decoded.__isset.GEOMETRY);
+                EXPECT_EQ("EPSG:4326", decoded.GEOMETRY.crs);
+            } else {
+                ASSERT_TRUE(decoded.__isset.GEOGRAPHY);
+                EXPECT_EQ("EPSG:4326", decoded.GEOGRAPHY.crs);
+                EXPECT_EQ(algorithm, decoded.GEOGRAPHY.algorithm);
+            }
+            EXPECT_EQ(decoded, round_trip(decoded));
+        }
+    }
+}
+
+TEST(GeoAnnotationWireTest, OptionalDefaultsAndOrdinaryBinary) {
+    tparquet::SchemaElement field;
+    field.__set_name("shape");
+    field.__set_type(tparquet::Type::BYTE_ARRAY);
+    field.__set_repetition_type(tparquet::FieldRepetitionType::OPTIONAL);
+    EXPECT_FALSE(round_trip(field).__isset.logicalType);
+
+    tparquet::LogicalType logical;
+    logical.__set_GEOGRAPHY(tparquet::GeographyType());
+    field.__set_logicalType(logical);
+    auto decoded = round_trip(field);
+    EXPECT_TRUE(decoded.logicalType.__isset.GEOGRAPHY);
+    EXPECT_FALSE(decoded.logicalType.GEOGRAPHY.__isset.crs);
+    EXPECT_FALSE(decoded.logicalType.GEOGRAPHY.__isset.algorithm);
+    // Preserve absence on the wire; the reader applies CRS84/SPHERICAL defaults.
+    EXPECT_EQ(field, decoded);
+
+    logical = tparquet::LogicalType();
+    logical.__set_GEOMETRY(tparquet::GeometryType());
+    field.__set_logicalType(logical);
+    decoded = round_trip(field);
+    EXPECT_TRUE(decoded.logicalType.__isset.GEOMETRY);
+    EXPECT_FALSE(decoded.logicalType.GEOMETRY.__isset.crs);
+    EXPECT_EQ(field, decoded);
+}
+
+TEST(GeoAnnotationWireTest, GeospatialStatisticsRemainMetadata) {
+    tparquet::BoundingBox bbox;
+    bbox.__set_xmin(-180);
+    bbox.__set_xmax(180);
+    bbox.__set_ymin(-90);
+    bbox.__set_ymax(90);
+    bbox.__set_zmin(-10);
+    bbox.__set_zmax(10);
+    bbox.__set_mmin(0);
+    bbox.__set_mmax(100);
+    tparquet::GeospatialStatistics stats;
+    stats.__set_bbox(bbox);
+    stats.__set_geospatial_types({1, 3, 7});
+    tparquet::ColumnMetaData column;
+    column.__set_type(tparquet::Type::BYTE_ARRAY);
+    column.__set_geospatial_statistics(stats);
+    EXPECT_EQ(column, round_trip(column));
+    // Recognition does not define pruning or decode any WKB payload.
+}
+} // namespace starrocks::parquet

--- a/build-support/check_gensrc_schema_compatibility.py
+++ b/build-support/check_gensrc_schema_compatibility.py
@@ -262,10 +262,8 @@ def compare_schema_path(repo_root: Path, repo_path: str, base: str | None) -> li
         ]
 
     unsupported_issues = _compare_unsupported_constructs(repo_path, base_schema, head_schema)
-    if unsupported_issues:
-        return unsupported_issues
-
-    return compare_schemas(repo_path, base_schema, head_schema)
+    # Unsupported constructs must not hide violations in independently parsed structs.
+    return unsupported_issues + compare_schemas(repo_path, base_schema, head_schema)
 
 
 def _compare_unsupported_constructs(
@@ -291,6 +289,17 @@ def _compare_unsupported_constructs(
         head_constructs = Counter(item.construct for item in head_items)
         if base_constructs == head_constructs:
             continue
+
+        # Narrow upstream exception, not general union parsing: only append these two
+        # exact alternatives to Parquet's existing LogicalType. All other edits fail closed.
+        if (repo_path == "gensrc/thrift/parquet.thrift" and key == ("thrift_union", "LogicalType")
+                and len(base_items) == len(head_items) == 1):
+            before = [" ".join(line.split()) for line in base_items[0].construct.splitlines()]
+            after = [" ".join(line.split()) for line in head_items[0].construct.splitlines()]
+            additions = ["17: GeometryType GEOMETRY", "18: GeographyType GEOGRAPHY"]
+            if (before and before[-1] == "}" and after == before[:-1] + additions + ["}"]
+                    and not any(re.match(r"(?:17|18)\s*:", line) for line in before)):
+                continue
 
         changed_items = _select_unsupported_constructs(head_items, head_constructs - base_constructs)
         if not changed_items:
@@ -955,9 +964,6 @@ def _is_proto_aggregate_option_line(line: str) -> bool:
 
 
 def _is_schema_path(path: str) -> bool:
-    # External Apache Parquet wire definitions follow upstream, not our RPC schema rules.
-    if path == "gensrc/thrift/parquet.thrift":
-        return False
     if not any(path.startswith(prefix) for prefix in SCHEMA_PREFIXES):
         return False
     return path.endswith(".proto") or path.endswith(".thrift")

--- a/build-support/check_gensrc_schema_compatibility.py
+++ b/build-support/check_gensrc_schema_compatibility.py
@@ -343,6 +343,17 @@ def compare_schemas(repo_path: str, base_schema: ParsedSchema | None, head_schem
         if container_decl is None:
             continue
 
+        before_container = base_schema.containers.get(container_name)
+        after_container = head_schema.containers.get(container_name)
+        if (before_container is not None and after_container is not None
+                and before_container.kind != after_container.kind):
+            issues.append(Violation(
+                path=repo_path, container=container_name, field_number=None, field_name="",
+                rule="container_kind_changed",
+                detail=f"container changed from {before_container.kind} to {after_container.kind}",
+                remediation="Keep the container kind stable; use a new definition for different semantics.",
+            ))
+
         common_numbers = set(base_fields) & set(head_fields)
         for number in sorted(common_numbers):
             before = base_fields[number]
@@ -450,36 +461,7 @@ def parse_thrift_schema(path: str, text: str) -> ParsedSchema:
         if not line:
             index += 1
             continue
-        union_match = re.match(r"union\s+([A-Za-z_]\w*)\s*\{", line)
-        if union_match:
-            union_name = union_match.group(1)
-            block_lines = [line]
-            unsupported.append(
-                UnsupportedConstruct(
-                    kind="thrift_union",
-                    scope=union_name,
-                    construct="",
-                    detail="thrift union parsing is not supported by the schema compatibility harness",
-                )
-            )
-            index += 1
-            while index < len(lines):
-                body_line = lines[index].strip()
-                if body_line:
-                    block_lines.append(body_line)
-                if body_line == "}":
-                    break
-                index += 1
-            unsupported[-1] = UnsupportedConstruct(
-                kind="thrift_union",
-                scope=union_name,
-                construct="\n".join(block_lines),
-                detail="thrift union parsing is not supported by the schema compatibility harness",
-            )
-            index += 1
-            continue
-
-        container_match = re.match(r"(struct|exception)\s+([A-Za-z_]\w*)\s*\{", line)
+        container_match = re.match(r"(struct|exception|union)\s+([A-Za-z_]\w*)\s*\{", line)
         if container_match:
             kind, name = container_match.groups()
             containers[name] = ContainerDecl(name=name, kind=kind)
@@ -674,7 +656,8 @@ def _parse_thrift_field_line(path: str, container: str, container_kind: str, raw
         number=int(number),
         name=name,
         type_repr=type_repr.strip(),
-        cardinality=cardinality or "unlabeled",
+        # Thrift union alternatives are implicitly optional, unlike struct fields.
+        cardinality=cardinality or ("optional" if container_kind == "union" else "unlabeled"),
         line=line_number,
     )
 

--- a/build-support/check_gensrc_schema_compatibility.py
+++ b/build-support/check_gensrc_schema_compatibility.py
@@ -343,17 +343,6 @@ def compare_schemas(repo_path: str, base_schema: ParsedSchema | None, head_schem
         if container_decl is None:
             continue
 
-        before_container = base_schema.containers.get(container_name)
-        after_container = head_schema.containers.get(container_name)
-        if (before_container is not None and after_container is not None
-                and before_container.kind != after_container.kind):
-            issues.append(Violation(
-                path=repo_path, container=container_name, field_number=None, field_name="",
-                rule="container_kind_changed",
-                detail=f"container changed from {before_container.kind} to {after_container.kind}",
-                remediation="Keep the container kind stable; use a new definition for different semantics.",
-            ))
-
         common_numbers = set(base_fields) & set(head_fields)
         for number in sorted(common_numbers):
             before = base_fields[number]
@@ -461,7 +450,36 @@ def parse_thrift_schema(path: str, text: str) -> ParsedSchema:
         if not line:
             index += 1
             continue
-        container_match = re.match(r"(struct|exception|union)\s+([A-Za-z_]\w*)\s*\{", line)
+        union_match = re.match(r"union\s+([A-Za-z_]\w*)\s*\{", line)
+        if union_match:
+            union_name = union_match.group(1)
+            block_lines = [line]
+            unsupported.append(
+                UnsupportedConstruct(
+                    kind="thrift_union",
+                    scope=union_name,
+                    construct="",
+                    detail="thrift union parsing is not supported by the schema compatibility harness",
+                )
+            )
+            index += 1
+            while index < len(lines):
+                body_line = lines[index].strip()
+                if body_line:
+                    block_lines.append(body_line)
+                if body_line == "}":
+                    break
+                index += 1
+            unsupported[-1] = UnsupportedConstruct(
+                kind="thrift_union",
+                scope=union_name,
+                construct="\n".join(block_lines),
+                detail="thrift union parsing is not supported by the schema compatibility harness",
+            )
+            index += 1
+            continue
+
+        container_match = re.match(r"(struct|exception)\s+([A-Za-z_]\w*)\s*\{", line)
         if container_match:
             kind, name = container_match.groups()
             containers[name] = ContainerDecl(name=name, kind=kind)
@@ -656,8 +674,7 @@ def _parse_thrift_field_line(path: str, container: str, container_kind: str, raw
         number=int(number),
         name=name,
         type_repr=type_repr.strip(),
-        # Thrift union alternatives are implicitly optional, unlike struct fields.
-        cardinality=cardinality or ("optional" if container_kind == "union" else "unlabeled"),
+        cardinality=cardinality or "unlabeled",
         line=line_number,
     )
 
@@ -938,6 +955,9 @@ def _is_proto_aggregate_option_line(line: str) -> bool:
 
 
 def _is_schema_path(path: str) -> bool:
+    # External Apache Parquet wire definitions follow upstream, not our RPC schema rules.
+    if path == "gensrc/thrift/parquet.thrift":
+        return False
     if not any(path.startswith(prefix) for prefix in SCHEMA_PREFIXES):
         return False
     return path.endswith(".proto") or path.endswith(".thrift")

--- a/build-support/schema_compatibility_waivers.json
+++ b/build-support/schema_compatibility_waivers.json
@@ -9,5 +9,46 @@
     "reason": "Reviewed compatibility exception after a multi-release deprecation window.",
     "owner": "engprod"
   },
-  "waivers": []
+  "waivers": [
+    {
+      "path": "gensrc/thrift/parquet.thrift",
+      "container_or_method": "BoundingBox",
+      "field_number": 1,
+      "field_name": "xmin",
+      "rule": "new_field_must_be_optional",
+      "base_signature": null,
+      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
+      "owner": "ViktorGo86"
+    },
+    {
+      "path": "gensrc/thrift/parquet.thrift",
+      "container_or_method": "BoundingBox",
+      "field_number": 2,
+      "field_name": "xmax",
+      "rule": "new_field_must_be_optional",
+      "base_signature": null,
+      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
+      "owner": "ViktorGo86"
+    },
+    {
+      "path": "gensrc/thrift/parquet.thrift",
+      "container_or_method": "BoundingBox",
+      "field_number": 3,
+      "field_name": "ymin",
+      "rule": "new_field_must_be_optional",
+      "base_signature": null,
+      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
+      "owner": "ViktorGo86"
+    },
+    {
+      "path": "gensrc/thrift/parquet.thrift",
+      "container_or_method": "BoundingBox",
+      "field_number": 4,
+      "field_name": "ymax",
+      "rule": "new_field_must_be_optional",
+      "base_signature": null,
+      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
+      "owner": "ViktorGo86"
+    }
+  ]
 }

--- a/build-support/test_check_gensrc_schema_compatibility.py
+++ b/build-support/test_check_gensrc_schema_compatibility.py
@@ -345,7 +345,14 @@ class CheckGensrcSchemaCompatibilityTest(unittest.TestCase):
             self.assertEqual("TSample", issues[0].container)
             self.assertEqual(2, issues[0].field_number)
 
-    def test_changed_mode_rejects_thrift_union_type_change(self) -> None:
+    def test_only_external_parquet_schema_is_exempt(self) -> None:
+        module = _load_module()
+        self.assertFalse(module._is_schema_path("gensrc/thrift/parquet.thrift"))
+        self.assertTrue(module._is_schema_path("gensrc/thrift/Descriptors.thrift"))
+        self.assertTrue(module._is_schema_path("gensrc/thrift/parquet_extra.thrift"))
+        self.assertTrue(module._is_schema_path("gensrc/proto/parquet.proto"))
+
+    def test_changed_mode_rejects_unsupported_thrift_union_change(self) -> None:
         module = _load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = Path(tmpdir)
@@ -375,25 +382,8 @@ class CheckGensrcSchemaCompatibilityTest(unittest.TestCase):
 
             issues = module.check_repo(repo, mode="changed", base="HEAD~1")
 
-            self.assertEqual(["field_type_changed"], [issue.rule for issue in issues])
+            self.assertEqual(["unsupported_syntax"], [issue.rule for issue in issues])
             self.assertEqual("TLegacyUnion", issues[0].container)
-
-    def test_union_evolution_checks(self) -> None:
-        module = _load_module()
-        path = "gensrc/thrift/geo.thrift"
-        base = module.parse_schema(path, "union LogicalType {\n1: string text\n}")
-        cases = [
-            ("union LogicalType {\n1: string text\n17: binary geometry\n18: binary geography\n}", []),
-            ("union LogicalType {\n1: string text\n17: required binary geometry\n}",
-             ["new_field_must_be_optional"]),
-            ("union LogicalType {\n2: string text\n}", ["field_renumbered"]),
-            ("union LogicalType {\n}", ["field_deleted"]),
-            ("struct LogicalType {\n1: optional string text\n}", ["container_kind_changed"]),
-        ]
-        for text, expected in cases:
-            with self.subTest(text=text):
-                head = module.parse_schema(path, text)
-                self.assertEqual(expected, [issue.rule for issue in module.compare_schemas(path, base, head)])
 
     def test_changed_mode_rejects_unsupported_proto_oneof_change(self) -> None:
         module = _load_module()

--- a/build-support/test_check_gensrc_schema_compatibility.py
+++ b/build-support/test_check_gensrc_schema_compatibility.py
@@ -345,12 +345,66 @@ class CheckGensrcSchemaCompatibilityTest(unittest.TestCase):
             self.assertEqual("TSample", issues[0].container)
             self.assertEqual(2, issues[0].field_number)
 
-    def test_only_external_parquet_schema_is_exempt(self) -> None:
+    def test_parquet_schema_remains_selected_and_checked(self) -> None:
         module = _load_module()
-        self.assertFalse(module._is_schema_path("gensrc/thrift/parquet.thrift"))
+        self.assertTrue(module._is_schema_path("gensrc/thrift/parquet.thrift"))
         self.assertTrue(module._is_schema_path("gensrc/thrift/Descriptors.thrift"))
         self.assertTrue(module._is_schema_path("gensrc/thrift/parquet_extra.thrift"))
         self.assertTrue(module._is_schema_path("gensrc/proto/parquet.proto"))
+        base = "union LogicalType {\n14: UUIDType UUID\n}\nstruct BoundingBox {\n1: required double xmin;\n}\n"
+        head = base.replace("14: UUIDType UUID", "14: UUIDType UUID\n17: GeometryType GEOMETRY\n"
+                            "18: GeographyType GEOGRAPHY")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            self._init_repo(repo)
+            path = repo / "gensrc/thrift/parquet.thrift"
+            path.write_text(base)
+            self._commit_all(repo, "base")
+            self._run_git(repo, "tag", "before-geo")
+            cases = [
+                (head, []),
+                (head.replace("required double xmin", "required i64 xmin"), ["field_type_changed"]),
+                (head.replace("1: required double xmin;", ""), ["field_deleted"]),
+                (head.replace("1: required double xmin", "2: required double xmin"), ["field_renumbered"]),
+                (head.replace("14: UUIDType UUID", "14: StringType UUID"), ["unsupported_syntax"]),
+                (head.replace("17: GeometryType", "14: GeometryType"), ["unsupported_syntax"]),
+                (head.replace("18: GeographyType GEOGRAPHY", ""), ["unsupported_syntax"]),
+                (head.replace("14: UUIDType UUID", "14: StringType UUID")
+                     .replace("required double xmin", "required i64 xmin"),
+                 ["field_type_changed", "unsupported_syntax"]),
+            ]
+            for content, expected in cases:
+                path.write_text(content)
+                self._commit_all(repo, "mutation")
+                for mode in ("changed", "full"):
+                    with self.subTest(mode=mode, content=content):
+                        self.assertIn("gensrc/thrift/parquet.thrift",
+                                      module.select_schema_paths(repo, mode, "before-geo"))
+                        self.assertEqual(expected, sorted(issue.rule for issue in
+                                                         module.check_repo(repo, mode=mode, base="before-geo")))
+            path.write_text(head)
+            self._commit_all(repo, "geo")
+            # Once present, the approved alternatives cannot be removed or changed.
+            for content in (base, head.replace("17: GeometryType", "17: StringType")):
+                path.write_text(content)
+                self.assertEqual(["unsupported_syntax"],
+                                 [issue.rule for issue in module.check_repo(repo, mode="full", base="HEAD")])
+
+    def test_parquet_required_field_waivers_are_narrow(self) -> None:
+        module = _load_module()
+        waivers = module.load_waivers(MODULE_PATH.parent / "schema_compatibility_waivers.json")
+        parquet_waivers = [w for w in waivers if w.path == "gensrc/thrift/parquet.thrift"]
+        self.assertEqual(4, len(parquet_waivers))
+        for number, name in enumerate(("xmin", "xmax", "ymin", "ymax"), 1):
+            issue = module.Violation(path="gensrc/thrift/parquet.thrift", container="BoundingBox",
+                                     field_number=number, field_name=name, rule="new_field_must_be_optional",
+                                     detail="", remediation="")
+            self.assertIsNotNone(module._match_waiver(issue, parquet_waivers))
+            for rule in ("field_deleted", "field_type_changed", "field_renumbered"):
+                issue = module.Violation(path="gensrc/thrift/parquet.thrift", container="BoundingBox",
+                                         field_number=number, field_name=name, rule=rule,
+                                         detail="", remediation="")
+                self.assertIsNone(module._match_waiver(issue, parquet_waivers))
 
     def test_changed_mode_rejects_unsupported_thrift_union_change(self) -> None:
         module = _load_module()

--- a/build-support/test_check_gensrc_schema_compatibility.py
+++ b/build-support/test_check_gensrc_schema_compatibility.py
@@ -345,7 +345,7 @@ class CheckGensrcSchemaCompatibilityTest(unittest.TestCase):
             self.assertEqual("TSample", issues[0].container)
             self.assertEqual(2, issues[0].field_number)
 
-    def test_changed_mode_rejects_unsupported_thrift_union_change(self) -> None:
+    def test_changed_mode_rejects_thrift_union_type_change(self) -> None:
         module = _load_module()
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = Path(tmpdir)
@@ -375,8 +375,25 @@ class CheckGensrcSchemaCompatibilityTest(unittest.TestCase):
 
             issues = module.check_repo(repo, mode="changed", base="HEAD~1")
 
-            self.assertEqual(["unsupported_syntax"], [issue.rule for issue in issues])
+            self.assertEqual(["field_type_changed"], [issue.rule for issue in issues])
             self.assertEqual("TLegacyUnion", issues[0].container)
+
+    def test_union_evolution_checks(self) -> None:
+        module = _load_module()
+        path = "gensrc/thrift/geo.thrift"
+        base = module.parse_schema(path, "union LogicalType {\n1: string text\n}")
+        cases = [
+            ("union LogicalType {\n1: string text\n17: binary geometry\n18: binary geography\n}", []),
+            ("union LogicalType {\n1: string text\n17: required binary geometry\n}",
+             ["new_field_must_be_optional"]),
+            ("union LogicalType {\n2: string text\n}", ["field_renumbered"]),
+            ("union LogicalType {\n}", ["field_deleted"]),
+            ("struct LogicalType {\n1: optional string text\n}", ["container_kind_changed"]),
+        ]
+        for text, expected in cases:
+            with self.subTest(text=text):
+                head = module.parse_schema(path, text)
+                self.assertEqual(expected, [issue.rule for issue in module.compare_schemas(path, base, head)])
 
     def test_changed_mode_rejects_unsupported_proto_oneof_change(self) -> None:
         module = _load_module()

--- a/gensrc/thrift/parquet.thrift
+++ b/gensrc/thrift/parquet.thrift
@@ -313,6 +313,42 @@ struct JsonType {
 struct BsonType {
 }
 
+// Apache Parquet geospatial annotations. Wire ordinals match parquet-format.
+enum EdgeInterpolationAlgorithm {
+  SPHERICAL = 0;
+  VINCENTY = 1;
+  THOMAS = 2;
+  ANDOYER = 3;
+  KARNEY = 4;
+}
+
+// ISO/OGC WKB in BYTE_ARRAY; absent CRS means OGC:CRS84.
+struct GeometryType {
+  1: optional string crs;
+}
+
+struct GeographyType {
+  1: optional string crs;
+  2: optional EdgeInterpolationAlgorithm algorithm;
+}
+
+// Retained as metadata only. Spatial pruning is not enabled.
+struct BoundingBox {
+  1: optional double xmin;
+  2: optional double xmax;
+  3: optional double ymin;
+  4: optional double ymax;
+  5: optional double zmin;
+  6: optional double zmax;
+  7: optional double mmin;
+  8: optional double mmax;
+}
+
+struct GeospatialStatistics {
+  1: optional BoundingBox bbox;
+  2: optional list<i32> geospatial_types;
+}
+
 /**
  * LogicalType annotations to replace ConvertedType.
  *
@@ -342,6 +378,9 @@ union LogicalType {
   12: JsonType JSON           // use ConvertedType JSON
   13: BsonType BSON           // use ConvertedType BSON
   14: UUIDType UUID           // no compatible ConvertedType
+  // 15 and 16 belong to FLOAT16 and VARIANT in upstream parquet-format.
+  17: GeometryType GEOMETRY
+  18: GeographyType GEOGRAPHY
 }
 
 /**
@@ -759,6 +798,8 @@ struct ColumnMetaData {
   14: optional i64 bloom_filter_offset;
 
   15: optional i32 bloom_filter_length;
+  // 16 is reserved for upstream SizeStatistics.
+  17: optional GeospatialStatistics geospatial_statistics;
 }
 
 struct EncryptionWithFooterKey {

--- a/gensrc/thrift/parquet.thrift
+++ b/gensrc/thrift/parquet.thrift
@@ -415,8 +415,8 @@ union LogicalType {
   13: BsonType BSON           // use ConvertedType BSON
   14: UUIDType UUID           // no compatible ConvertedType
   // 15 and 16 belong to FLOAT16 and VARIANT in upstream parquet-format.
-  17: GeometryType GEOMETRY
-  18: GeographyType GEOGRAPHY
+  17: GeometryType GEOMETRY   // no compatible ConvertedType
+  18: GeographyType GEOGRAPHY // no compatible ConvertedType
 }
 
 /**
@@ -835,6 +835,7 @@ struct ColumnMetaData {
 
   15: optional i32 bloom_filter_length;
   // 16 is reserved for upstream SizeStatistics.
+  /** Optional statistics specific for Geometry and Geography logical types */
   17: optional GeospatialStatistics geospatial_statistics;
 }
 

--- a/gensrc/thrift/parquet.thrift
+++ b/gensrc/thrift/parquet.thrift
@@ -313,7 +313,7 @@ struct JsonType {
 struct BsonType {
 }
 
-// Apache Parquet geospatial annotations. Wire ordinals match parquet-format.
+/** Edge interpolation algorithm for Geography logical type */
 enum EdgeInterpolationAlgorithm {
   SPHERICAL = 0;
   VINCENTY = 1;
@@ -322,30 +322,66 @@ enum EdgeInterpolationAlgorithm {
   KARNEY = 4;
 }
 
-// ISO/OGC WKB in BYTE_ARRAY; absent CRS means OGC:CRS84.
+/**
+ * Embedded Geometry logical type annotation
+ *
+ * Geospatial features in the Well-Known Binary (WKB) format and `edges` interpolation
+ * is always linear/planar.
+ *
+ * A custom CRS can be set by the crs field. If unset, it defaults to "OGC:CRS84",
+ * which means that the geometries must be stored in longitude, latitude based on
+ * the WGS84 datum.
+ *
+ * Allowed for physical type: BYTE_ARRAY.
+ *
+ * See Geospatial.md for details.
+ */
 struct GeometryType {
   1: optional string crs;
 }
 
+/**
+ * Embedded Geography logical type annotation
+ *
+ * Geospatial features in the WKB format with an explicit (non-linear/non-planar)
+ * `edges` interpolation algorithm.
+ *
+ * A custom geographic CRS can be set by the crs field, where longitudes are
+ * bound by [-180, 180] and latitudes are bound by [-90, 90]. If unset, the CRS
+ * defaults to "OGC:CRS84".
+ *
+ * An optional algorithm can be set to correctly interpret `edges` interpolation
+ * of the geometries. If unset, the algorithm defaults to SPHERICAL.
+ *
+ * Allowed for physical type: BYTE_ARRAY.
+ *
+ * See Geospatial.md for details.
+ */
 struct GeographyType {
   1: optional string crs;
   2: optional EdgeInterpolationAlgorithm algorithm;
 }
 
-// Retained as metadata only. Spatial pruning is not enabled.
+/**
+ * Bounding box for GEOMETRY or GEOGRAPHY type in the representation of min/max
+ * value pair of coordinates from each axis.
+ */
 struct BoundingBox {
-  1: optional double xmin;
-  2: optional double xmax;
-  3: optional double ymin;
-  4: optional double ymax;
+  1: required double xmin;
+  2: required double xmax;
+  3: required double ymin;
+  4: required double ymax;
   5: optional double zmin;
   6: optional double zmax;
   7: optional double mmin;
   8: optional double mmax;
 }
 
+/** Statistics specific to Geometry and Geography logical types */
 struct GeospatialStatistics {
+  /** A bounding box of geospatial instances */
   1: optional BoundingBox bbox;
+  /** Geospatial type codes of all instances, or an empty list if not known */
   2: optional list<i32> geospatial_types;
 }
 

--- a/handbook/architecture/schema-compatibility-harness.md
+++ b/handbook/architecture/schema-compatibility-harness.md
@@ -25,3 +25,17 @@ python3 build-support/check_gensrc_schema_compatibility.py --mode full --base or
 - Field-number changes, type changes, and cardinality changes fail the harness.
 - Field deletions require a checked-in waiver entry with matching signature, rationale, and owner.
 - Remove stale waivers as soon as the compatibility exception is no longer needed.
+
+## External Parquet Definitions
+
+`gensrc/thrift/parquet.thrift` remains selected in both changed and full checks.
+The checker permits only the exact append of upstream `LogicalType` alternatives
+17 (`GeometryType GEOMETRY`) and 18 (`GeographyType GEOGRAPHY`), without changing
+the pre-existing union body. This is not general Thrift union support: other union
+edits still fail closed, and parsed structs are checked independently even when
+an unsupported construct changes.
+
+The four upstream-required `BoundingBox` X/Y fields have field-specific
+`new_field_must_be_optional` waivers. These do not waive deletion, renumbering, or
+type changes. Remove these addition waivers once the comparison base contains the
+fields, as required by the stale-waiver check.


### PR DESCRIPTION
## Why I'm doing:

Related to #78693, Milestone 1 / Contract 1.2 (wire-definition foundation).

The local Parquet Thrift definition lacks the standard GEOMETRY/GEOGRAPHY logical annotations and geospatial statistics. We need a stable, independently reviewable external metadata contract before integrating native geo readers.

This PR follows the connector-first sequencing and small foundational contract PRs discussed with Alvin in #78693. It does not imply approval of this implementation.

## What I'm doing:

- Add standard LogicalType field IDs 17 (GEOMETRY) and 18 (GEOGRAPHY), preserving existing IDs and the upstream-reserved gaps.
- Represent CRS and all five geography edge algorithms distinctly: SPHERICAL, VINCENTY, THOMAS, ANDOYER, and KARNEY.
- Define ISO/OGC WKB in BYTE_ARRAY as the external payload contract; retain geospatial statistics as metadata only.
- Match upstream geospatial definitions and comments: BoundingBox X/Y extrema are required; Z/M extrema and the bounding-box/statistics containers remain optional. No pruning or WKB decoding is enabled.
- Keep `gensrc/thrift/parquet.thrift` selected in both changed and full compatibility checks. Allow only the exact append of upstream LogicalType alternatives 17/18 without altering the existing union body; other union edits fail closed. Four field-specific addition waivers cover the upstream-required BoundingBox X/Y bounds. Deletion, renumbering, and type checks remain active, including when unsupported union edits occur simultaneously. No general union parser is introduced.
- Add independently encoded serialized-wire tests for standard ordinals, explicit/absent parameters, ordinary unannotated binary, statistics, and unknown numeric algorithms. Unknown values survive round trips instead of becoming a default.

### Scope and follow-ups

This PR is intentionally limited to wire definitions and their tests; it does not change scan execution or claim that Contract 1.3 is implemented. Physical-type and Iceberg/Parquet conflict validation, disabled geo projection, and pruning/read guards belong to the separate Contract 1.3 integration PR. Native feature exposure remains off; no native SQL types, GeoColumn, spatial functions, storage, or writes are introduced.

The Iceberg schema metadata PR is independent. Neither foundational PR alone completes Milestone 1, and this PR must not close #78693. No new public feature documentation or backport is requested for this internal contract-only change.

### Validation

- **4 isolated GeoAnnotationWireTest cases passed under ASAN**, compiled using only generated parquet_types.cpp, Thrift and GoogleTest (no dependency on Iceberg or reader integration changes).
- **35 schema-checker unit tests passed**, including changed/full selection and negative deletion/type/ordinal/union mutation cases.
- Changed and full schema compatibility checks passed with four narrowly scoped BoundingBox addition waivers; there is no file-wide exclusion. Earlier BE module-boundary and C++ formatting checks passed. This latest checker-only revision does not change Thrift or C++ runtime code.
- The local Windows handbook check is blocked by the existing CLAUDE.md symlink being checked out as a plain-text link target; no handbook-link files were changed.
- Negative wire tests reject a bounding box missing any required X/Y coordinate; valid 2D boxes preserve absent Z/M fields.
- The wire tests are also registered in format_test for CI.

```bash
./run-be-ut.sh -j 6 --build-target format_test --module format_test --without-java-ext
python3 -m unittest discover -s build-support -p test_check_gensrc_schema_compatibility.py
python3 build-support/check_gensrc_schema_compatibility.py --mode full --base origin/main
```

Before these review fixes, the combined Milestone 1 validation passed 375 format tests and 226 connector tests under ASAN. Those broader suites were not rerun for this wire-only revision; the four isolated ASAN wire tests above were rebuilt and rerun against the updated definitions. The broader integration changes are intentionally not part of this PR. Live external-catalog testing remains a separate integration step.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5