### PR TITLE
[BugFix] Fall back when one scan reads a JSON path at two types

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -272,8 +272,9 @@ public class JsonPathRewriteRule extends TransformationRule {
             LogicalMetaScanOperator metaScan = (LogicalMetaScanOperator) optExpr.inputAt(0).getOp();
 
             // Skip the JSON-path pushdown when two subfields of the same JSON column collide
-            // case-insensitively (e.g. 'Campaign' vs 'campaign'); see hasCaseCollidingJsonSubfields.
-            if (hasCaseCollidingJsonSubfields(new ArrayList<>(project.getColumnRefMap().values()), columnRefFactory,
+            // case-insensitively ('Campaign' vs 'campaign'), or read at two different types;
+            // see hasUnsupportedJsonSubfieldCollision.
+            if (hasUnsupportedJsonSubfieldCollision(new ArrayList<>(project.getColumnRefMap().values()), columnRefFactory,
                     null)) {
                 return optExpr;
             }
@@ -340,7 +341,8 @@ public class JsonPathRewriteRule extends TransformationRule {
             LogicalScanOperator scanOperator = (LogicalScanOperator) optExpr.getOp();
 
             // Skip the JSON-path pushdown when two subfields of the same JSON column collide
-            // case-insensitively (e.g. 'Campaign' vs 'campaign'); see hasCaseCollidingJsonSubfields.
+            // case-insensitively ('Campaign' vs 'campaign'), or read at two different types;
+            // see hasUnsupportedJsonSubfieldCollision.
             List<ScalarOperator> jsonRoots = new ArrayList<>();
             if (scanOperator.getPredicate() != null) {
                 jsonRoots.add(scanOperator.getPredicate());
@@ -348,7 +350,7 @@ public class JsonPathRewriteRule extends TransformationRule {
             if (scanOperator.getProjection() != null) {
                 jsonRoots.addAll(scanOperator.getProjection().getColumnRefMap().values());
             }
-            if (hasCaseCollidingJsonSubfields(jsonRoots, columnRefFactory, scanOperator.getTable())) {
+            if (hasUnsupportedJsonSubfieldCollision(jsonRoots, columnRefFactory, scanOperator.getTable())) {
                 return optExpr;
             }
 
@@ -421,9 +423,11 @@ public class JsonPathRewriteRule extends TransformationRule {
     }
 
     /**
-     * Returns true if any JSON column referenced by {@code roots} has two subfields whose access
-     * paths differ only by case, e.g. {@code get_json_string(c,'Campaign')} and
-     * {@code get_json_string(c,'campaign')}.
+     * Returns true if the JSON subfield reads in {@code roots} collide in a way the pushdown cannot
+     * express, in which case the caller must skip the rewrite for that scan. Two shapes qualify.
+     *
+     * <p><b>Case-differing paths.</b> Two subfields whose access paths differ only by case, e.g.
+     * {@code get_json_string(c,'Campaign')} and {@code get_json_string(c,'campaign')}.
      *
      * <p>JSON object keys are case-sensitive, so these are two distinct fields with distinct values.
      * The pushdown, however, materializes each as an extended {@link Column} whose name is the
@@ -434,14 +438,29 @@ public class JsonPathRewriteRule extends TransformationRule {
      * the query read the JSON column whole (identical to running with cbo_json_v2_rewrite=false),
      * which is correct — only the (rare) colliding query loses the subfield-pushdown optimization.
      *
+     * <p><b>One path read at two types.</b> {@code sum(coalesce(get_json_int(j,'$.v'),0))} next to
+     * {@code sum(coalesce(get_json_double(j,'$.v'),0))} in one scan. A scan keeps one {@code pathMap}
+     * entry per path, so the second read finds the first one's column ref under a different type and
+     * {@link JsonPathRewriteContext#getOrCreateColumn} throws. That exception is caught in
+     * {@link #transform}, which would be safe if nothing had happened yet — and by then something has:
+     * the rewrite runs through {@code ScalarOperatorRewriter}, which splices its results into the
+     * scalar tree in place with {@code setChild()}. The read that was rewritten first therefore keeps
+     * its extended column ref, while {@code setColRefToColumnMetaMap()} — placed after the loop that
+     * throws — never runs. Planning then dies in the statistics calculator with
+     * "missing statistic of col: N: j.v". Both reads must be materialized into the scan to reach
+     * this: bare subfields under an aggregate stay above it and never share a {@code pathMap}, which
+     * is why only scalar-wrapped reads ({@code length}, {@code upper}, {@code coalesce}) trip it.
+     *
      * <p>This is a side-effect-free pre-pass: it must run before any extended column is created,
      * because a partially-applied rewrite leaves dangling column refs that break later stages.
      */
-    private static boolean hasCaseCollidingJsonSubfields(List<ScalarOperator> roots, ColumnRefFactory factory,
-                                                         Table scanTable) {
+    private static boolean hasUnsupportedJsonSubfieldCollision(List<ScalarOperator> roots, ColumnRefFactory factory,
+                                                               Table scanTable) {
         // key: case-folded extended-column name -> the actual (case-sensitive) name that first claimed it.
         // Used for collisions WITHIN this scan; cross-scan collisions are caught against the table below.
         Map<String, String> claimed = Maps.newHashMap();
+        // key: extended-column name -> the value type the first read of that path asked for.
+        Map<String, Type> claimedTypes = Maps.newHashMap();
         Deque<ScalarOperator> stack = new ArrayDeque<>();
         for (ScalarOperator root : roots) {
             if (root != null) {
@@ -493,6 +512,18 @@ public class JsonPathRewriteRule extends TransformationRule {
             Table targetTable = scanTable != null ? scanTable : tableAndColumn.first;
             Column existing = targetTable.getColumn(name);
             if (existing != null && !existing.getName().equals(name)) {
+                return true;
+            }
+            // (c) one path read at two types within this scan. getOrCreateColumn() throws
+            // IllegalArgumentException on the second type and transform()'s catch-all swallows it, but the
+            // rewrite is not side-effect-free by then: ScalarOperatorRewriter splices its results into the
+            // scalar tree in place through setChild(), so whichever read was rewritten first keeps pointing
+            // at the synthesized extended column while setColRefToColumnMetaMap() -- which sits after the
+            // loop that throws -- never runs. The scan is then left carrying a column ref it does not know
+            // about, and StatisticsCalculator.computeOlapScanNode() kills the statement with
+            // "missing statistic of col: N: j.v".
+            Type priorType = claimedTypes.putIfAbsent(name, call.getType());
+            if (priorType != null && !priorType.equals(call.getType())) {
                 return true;
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -455,5 +455,52 @@ public class JsonPathRewriteTest extends PlanTestBase {
         }
     }
 
+    /**
+     * One scan reading a single path with two different types must fall back instead of planning at all.
+     *
+     * <p>getOrCreateColumn() throws on the second type, and transform()'s catch-all swallows that -- but the
+     * rewrite is not side-effect-free: ScalarOperatorRewriter mutates the scalar tree in place through
+     * setChild(), so the read that was rewritten first keeps pointing at the synthesized extended column
+     * while the scan's colRefToColumnMetaMap is never updated (that assignment lives past the throw). The
+     * statistics calculator then meets a column ref the scan does not know about and the query dies with
+     * "only found column statistics: {2: j}, but missing statistic of col: 7: j.v".
+     *
+     * <p>The wrapper around the get_json_* call matters: it is the parent's setChild() that makes the
+     * half-finished rewrite outlive the exception. A bare subfield under an aggregate stays above the scan
+     * and never shares a pathMap, which is why those shapes plan fine.
+     */
+    @Test
+    public void testSingleScanSamePathDifferentTypesFallBack() throws Exception {
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(false);
+        starRocksAssert.withTable(
+                "create table json_mixed_type (k int, j json) properties('replication_num'='1')");
+        try {
+            // int + double on '$.v', each wrapped in a scalar function.
+            String plan = getVerboseExplain(
+                    "select sum(coalesce(get_json_int(j, '$.v'), 0)), "
+                            + "sum(coalesce(get_json_double(j, '$.v'), 0)) from json_mixed_type");
+            assertNotContains(plan, "ExtendedColumnAccessPath");
+            assertContains(plan, "get_json_int");
+
+            // The same collision reached through length(), which is how it first showed up in production.
+            String stringPlan = getVerboseExplain(
+                    "select sum(length(get_json_string(j, '$.v'))), "
+                            + "sum(coalesce(get_json_int(j, '$.v'), 0)) from json_mixed_type");
+            assertNotContains(stringPlan, "ExtendedColumnAccessPath");
+
+            // Control: two different paths in the same shape are still pushed down.
+            String okPlan = getVerboseExplain(
+                    "select sum(coalesce(get_json_int(j, '$.v'), 0)), "
+                            + "sum(coalesce(get_json_double(j, '$.w'), 0)) from json_mixed_type");
+            assertContains(okPlan, "ExtendedColumnAccessPath");
+        } finally {
+            starRocksAssert.dropTable("json_mixed_type");
+            connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+            connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+        }
+    }
+
 }
 


### PR DESCRIPTION
## Why I'm doing:

Fixes #78702.

A single scan that reads one JSON subfield path at **two different types** fails planning outright. `cbo_json_v2_rewrite` defaults to true since 4.0, so no opt-in is needed to reach it. Three rows and a two-column table are enough — no `flat_json.*` property, no MV, no view, no join.

```sql
CREATE TABLE json_stat_repro (k int, j json) DUPLICATE KEY(k)
  DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES('replication_num'='1');
INSERT INTO json_stat_repro VALUES (1, parse_json('{"v":"abc"}')), (2, parse_json('{"v":"defg"}'));

SELECT sum(coalesce(get_json_int(j,'$.v'),0)),
       sum(coalesce(get_json_double(j,'$.v'),0)) FROM json_stat_repro;
```

```
ERROR 1064 (HY000): only found column statistics: {2: j}, but missing statistic of col: 7: j.v.
```

Deterministic, and the same statement succeeds on every attempt with `cbo_json_v2_rewrite = false`. `ANALYZE TABLE ... WITH SYNC MODE` does not help — the missing entry is for the *synthesized* extended column, which table statistics never cover. It is a loud error rather than a wrong answer, so no results are at risk.

### What actually goes wrong

The statistics code is not at fault; it is the first stage to notice the damage.

1. A scan keeps one `pathMap` entry per path. The second read finds the first one's column ref under a different type, so `getOrCreateColumn()` throws `IllegalArgumentException`.
2. `transform()` catches it and returns the original tree. That would be safe **if the rewrite were side-effect-free** — it is not.
3. `ScalarOperatorRewriter.applyRuleBottomUp()` splices its results into the scalar tree **in place** via `operator.setChild(i, ...)`. So the read that was rewritten first keeps pointing at the synthesized extended column even though the rewrite was abandoned.
4. `builder.setColRefToColumnMetaMap(...)` sits *after* the loop that throws, so it never runs — the scan's map still holds only the raw JSON column.
5. The scan therefore carries a column ref it does not know about, and the statistics calculator dies on it:

```
Statistics.getColumnStatistic(Statistics.java:145)
ExpressionStatisticCalculator$ExpressionStatisticVisitor.visitVariableReference(:111)
StatisticsCalculator.computeOlapScanNode(StatisticsCalculator.java:428)
StatisticsCalculator.visitLogicalOlapScan(StatisticsCalculator.java:348)
DeriveStatsTask.execute(DeriveStatsTask.java:63)
```

That mechanism also predicts exactly which shapes fail. Both reads have to be materialized **into the same scan**: a bare subfield under an aggregate stays above the scan and never shares a `pathMap`. Measured on `main`, all with the rewrite on:

| # | Projection | Result |
|---|---|---|
| A | `count(get_json_string(j,'$.v'))`, `sum(coalesce(get_json_int(j,'$.v'),0))` | OK |
| B | `count(get_json_string(...))`, `sum(length(get_json_string(...)))`, `sum(coalesce(get_json_int(...),0))` | **ERROR** |
| C | `sum(length(get_json_string(j,'$.v')))`, `sum(coalesce(get_json_int(j,'$.v'),0))` | **ERROR** |
| D | `sum(length(get_json_string(j,'$.v')))` alone | OK |
| E | `count(get_json_string(j,'$.v'))`, `sum(coalesce(get_json_int(j,'$.other'),0))` — **different** paths | OK |
| F | `count(upper(get_json_string(j,'$.v')))`, `sum(coalesce(get_json_int(j,'$.v'),0))` | **ERROR** |
| G | `sum(coalesce(get_json_int(j,'$.v'),0))`, `sum(coalesce(get_json_double(j,'$.v'),0))` | **ERROR** |

It needs two reads of one path at different types (E is fine), it does not need a string read (G is `int` + `double`), and it does not need `length()` specifically (F uses `upper()`). What every failing row shares is that the reads are wrapped in a scalar function rather than projected bare — which is the `setChild()` step above.

## What I'm doing:

`hasCaseCollidingJsonSubfields` is already the side-effect-free pre-pass for exactly this class of problem, and its own doc comment states the reason: *"it must run before any extended column is created, because a partially-applied rewrite leaves dangling column refs that break later stages."* This is another instance of that. So the collision is detected there, before anything mutates, and the rewrite is skipped for that scan — the same fallback its two case-collision branches already take. The helper is renamed to `hasUnsupportedJsonSubfieldCollision` because it now covers a third shape.

Skipping means the query reads the JSON column whole, identical to `cbo_json_v2_rewrite = false`, which is the reference answer. Only the rare colliding query loses the subfield pushdown.

The production change is four lines:

```java
// key: extended-column name -> the value type the first read of that path asked for.
Map<String, Type> claimedTypes = Maps.newHashMap();
...
Type priorType = claimedTypes.putIfAbsent(name, call.getType());
if (priorType != null && !priorType.equals(call.getType())) {
    return true;
}
```

Cross-scan reads of one path at two types are deliberately untouched: each scan builds its own `JsonPathRewriteContext`, so they never share a `pathMap` and each still gets its own extended column.

I considered making the rewrite transactional instead (deep-copying the scalars, or moving `setColRefToColumnMetaMap` before the loop) so that `transform()`'s catch-all would really be safe. That is the more general fix and would also protect against any other exception thrown mid-rewrite, but it is a much larger change to a hot planner path, and the only reachable trigger today is this collision. Happy to take it that way instead if you would prefer.

## Tests

`JsonPathRewriteTest#testSingleScanSamePathDifferentTypesFallBack` — three cases:

| Case | Expectation |
|---|---|
| `get_json_int` + `get_json_double` on one path | rewrite skipped |
| `length(get_json_string)` + `get_json_int` on one path | rewrite skipped |
| control — different paths `$.v` / `$.w` | still pushed down |

I ran it on a clean `main` checkout **before** touching the production file, and it fails there with the exact error from the report (`only found column statistics: {2: j}, but missing statistic of col: 7: j.v`), so the test is known to be load-bearing rather than vacuously green.

Regression on this branch, all passing: `JsonPathRewriteTest` (41), `LowCardinalityTest` (75), `LowCardinalityTest2` (112), `PruneComplexSubfieldTest` (63), `InsertPlanTest` (39), `JsonTypeTest` (6) — 336 tests.

Reproduced originally on a shared-data cluster, 3 FE / 6 CN, `4.1.4`. The failure is in planning, so it does not depend on the storage layer.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
