### PR TITLE
[BugFix] Serialize dictionary_get keys by keySize, not by children count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprExplainVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/ExprExplainVisitor.java
@@ -557,7 +557,20 @@ public class ExprExplainVisitor implements AstVisitorExtendInterface<String, Voi
     @Override
     public String visitDictionaryGetExpr(DictionaryGetExpr node, Void context) {
         String message = "DICTIONARY_GET(";
-        int size = (node.getChildren().size() == 3) ? node.getChildren().size() - 1 : node.getChildren().size();
+        // children = [dictionary name, key..., optional null_if_not_exist literal], and
+        // nullIfNotExist is kept as a field of its own. So the flag would be printed twice if
+        // the optional child were included here, and a key would be dropped if it were mistaken
+        // for that child.
+        //
+        // ExpressionAnalyzer sets keySize from the dictionary metadata, which is exactly where
+        // the keys end — the children count is not, because a call with N keys and no explicit
+        // flag has the same shape as one with N-1 keys and a flag. Unanalyzed expressions carry
+        // no keySize (0) and no reliable flag either, so they keep the previous behaviour rather
+        // than guessing differently.
+        int keySize = node.getKeySize();
+        int size = keySize > 0
+                ? Math.min(keySize + 1, node.getChildren().size())
+                : (node.getChildren().size() == 3 ? node.getChildren().size() - 1 : node.getChildren().size());
         message += node.getChildren().stream().limit(size)
                 .map(this::visit)
                 .collect(Collectors.joining(", "));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToSqlDictionaryGetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToSqlDictionaryGetTest.java
@@ -1,0 +1,111 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast.expression;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Round-trip serialization of {@code dictionary_get}.
+ *
+ * <p>The serialized form is re-parsed and re-analyzed by features that rebuild a query from an
+ * expression tree — {@code partition_retention_condition} is one, and it queries
+ * {@code information_schema.partitions_meta} with the reconstructed predicate. If the printer
+ * emits a different number of arguments than the analyzer accepts, that internal query fails
+ * analysis and the feature silently stops working.
+ *
+ * <p>An analyzed {@link DictionaryGetExpr} carries {@code keySize} (the dictionary's key count)
+ * and {@code nullIfNotExist} as fields, while the optional boolean argument also stays in the
+ * children list. The printer must therefore take the key count from {@code keySize} rather than
+ * guessing it from {@code children.size()}.
+ */
+public class ExprToSqlDictionaryGetTest {
+
+    private static DictionaryGetExpr dictGet(int keySize, boolean nullIfNotExist, boolean explicitFlagChild) {
+        List<Expr> params = Lists.newArrayList();
+        params.add(new StringLiteral("dict"));
+        for (int i = 1; i <= keySize; i++) {
+            params.add(new StringLiteral("k" + i));
+        }
+        if (explicitFlagChild) {
+            params.add(new BoolLiteral(nullIfNotExist));
+        }
+        DictionaryGetExpr expr = new DictionaryGetExpr(params, NodePosition.ZERO);
+        expr.setKeySize(keySize);              // set by ExpressionAnalyzer from the dictionary metadata
+        expr.setNullIfNotExist(nullIfNotExist);
+        expr.setType(IntegerType.INT);
+        expr.setOriginType(IntegerType.INT);
+        return expr;
+    }
+
+    /** Top-level arguments of {@code NAME(a, b, c)}; every argument here is a literal. */
+    private static List<String> args(String sql) {
+        String inner = sql.substring(sql.indexOf('(') + 1, sql.lastIndexOf(')'));
+        return Arrays.asList(inner.split(",\\s*"));
+    }
+
+    private static void assertArgs(int keySize, boolean nullIfNotExist, boolean explicitFlagChild) {
+        String sql = ExprToSql.toSql(dictGet(keySize, nullIfNotExist, explicitFlagChild));
+        List<String> args = args(sql);
+        // dictionary name + keySize keys + exactly one null_if_not_exist flag
+        Assertions.assertEquals(keySize + 2, args.size(),
+                "wrong argument count in " + sql);
+        for (int i = 1; i <= keySize; i++) {
+            Assertions.assertTrue(args.get(i).contains("k" + i),
+                    "key " + i + " missing or misplaced in " + sql);
+        }
+        Assertions.assertEquals(nullIfNotExist ? "true" : "false", args.get(args.size() - 1),
+                "null_if_not_exist flag not serialized exactly once in " + sql);
+    }
+
+    // ---- control: single-key calls have always been serialized correctly ------------------
+
+    @Test
+    public void oneKeyWithExplicitFlag() {
+        assertArgs(1, true, true);
+    }
+
+    @Test
+    public void oneKeyWithoutExplicitFlag() {
+        assertArgs(1, false, false);
+    }
+
+    // ---- trigger: multi-key calls ----------------------------------------------------------
+
+    @Test
+    public void twoKeysWithExplicitFlag() {
+        // children = [dict, k1, k2, TRUE] -> printing all four and then appending the flag
+        // yields five arguments, and re-analysis rejects it.
+        assertArgs(2, true, true);
+    }
+
+    @Test
+    public void twoKeysWithoutExplicitFlag() {
+        // children = [dict, k1, k2] -> the size==3 heuristic mistakes the second key for the
+        // optional flag and drops it. Silent, and worse than the loud failure above.
+        assertArgs(2, false, false);
+    }
+
+    @Test
+    public void threeKeysWithExplicitFlag() {
+        assertArgs(3, false, true);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`ExprExplainVisitor.visitDictionaryGetExpr` decides how many children are dictionary keys from
`children.size()`:

```java
int size = (node.getChildren().size() == 3) ? node.getChildren().size() - 1 : node.getChildren().size();
```

That only holds for single-key dictionaries. A call with N keys and no explicit `null_if_not_exist`
has exactly the same shape as one with N-1 keys and the flag, so the heuristic breaks both ways:

| keys | explicit flag | children | printed today | correct |
|---|---|---|---|---|
| 1 | no / yes | 2 / 3 | ok | ok |
| **2** | **no** | 3 | `dict, k1, false` — **k2 dropped** | `dict, k1, k2, false` |
| **2** | **yes** | 4 | `dict, k1, k2, TRUE, true` — **flag twice** | `dict, k1, k2, true` |
| 3 | yes | 5 | flag twice | `dict, k1, k2, k3, true` |

The serialized form is re-parsed and re-analyzed by features that rebuild a query from an expression
tree. With `partition_retention_condition`, the internal query against
`information_schema.partitions_meta` then fails analysis with

```
dictionary: <name> has expected keys size: 2 keys: [table_key, tenant] plus null_if_not_exist flag(optional) but param given: 4
```

so expired partitions are never dropped while the trigger API still returns `Success` — a silent
data-retention failure. The dropped-key variant is worse: it produces a *valid* query against the
wrong key.

Reported in #78417 with a full reproducer.

## What I'm doing:

`ExpressionAnalyzer` already records the dictionary's key count on the expression
(`node.setKeySize(dictionary.getKeys().size())`), and `BaseScalarOperatorShuttle` already uses
`getKeySize() + 2` for the same kind of arithmetic. This path was simply not updated: use `keySize`
to find where the keys end, then append the flag exactly once.

Unanalyzed expressions carry no `keySize` (0) and no reliable flag either, so they keep the previous
behaviour rather than guessing differently — the analyzed path is the one these features use.

Tests cover the round-trip contract for one/two/three keys with the flag omitted and present; the
two- and three-key cases fail before this change and pass after it.

Fixes #78417

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

Note for the backports: `branch-4.1` carries the same code in
`sql/formatter/ExprExplainVisitor.java`, but on `branch-4.0` and `branch-3.5` the identical logic
lives in `DictionaryGetExpr.toSqlImpl()` (`sql/ast/DictionaryGetExpr.java`), so the cherry-picks to
those two branches will conflict and need the equivalent change applied by hand.
