### PR TITLE
[BugFix] Let a temporary partition adopt the bounds of the partition it overwrites

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -149,6 +149,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1874,6 +1875,12 @@ public class AnalyzerUtils {
 
         List<PartitionDesc> partitionDescs = Lists.newArrayList();
         List<String> partitionNames = Lists.newArrayList();
+        // Built once per clause, not once per value: the defaults allow 4096 values per load and
+        // 100000 partitions per table, so a scan per value is hundreds of millions of range checks
+        // while FrontendServiceImpl.parseAddPartitionClause holds the table READ lock.
+        CoveringPartitionIndex coveringIndex = adoptCoveringPartition
+                ? CoveringPartitionIndex.of(olapTable, expressionRangePartitionInfo)
+                : null;
         for (List<String> partitionValue : partitionValues) {
             if (partitionValue.size() != 1) {
                 throw new AnalysisException("automatic partition only support single column for range partition.");
@@ -1924,9 +1931,9 @@ public class AnalyzerUtils {
                 // scoped by BETWEEN, deliberately leaves the expression alone. A temporary partition is
                 // swapped into this table afterwards, so computing its bounds from the expression would
                 // re-introduce the finer partitions the merge had removed.
-                if (adoptCoveringPartition) {
+                if (coveringIndex != null) {
                     Pair<String, PartitionKeyDesc> covering =
-                            findCoveringPartition(olapTable, expressionRangePartitionInfo, partitionItem);
+                            coveringIndex.find(olapTable, expressionRangePartitionInfo, partitionItem);
                     if (covering != null) {
                         partitionName = covering.first;
                         partitionKeyDesc = covering.second;
@@ -1966,27 +1973,67 @@ public class AnalyzerUtils {
      * request may fall into the same covering partition, and they must collapse into a single
      * partition desc instead of producing overlapping ranges under different names.
      */
-    private static Pair<String, PartitionKeyDesc> findCoveringPartition(
-            OlapTable olapTable, ExpressionRangePartitionInfo partitionInfo, String partitionItem) {
-        try {
-            PartitionKey key = PartitionKey.createPartitionKey(
-                    Collections.singletonList(new PartitionValue(partitionItem)),
-                    partitionInfo.getPartitionColumns(olapTable.getIdToColumn()));
-            for (Map.Entry<Long, Range<PartitionKey>> entry : partitionInfo.getIdToRange(false).entrySet()) {
+    private static final class CoveringPartitionIndex {
+        // Sorted by lower endpoint. Range partitions are disjoint, so the only candidate for a key is
+        // the last range whose lower endpoint does not exceed it — found by binary search.
+        private final List<Map.Entry<Long, Range<PartitionKey>>> byLowerBound;
+
+        private CoveringPartitionIndex(List<Map.Entry<Long, Range<PartitionKey>>> byLowerBound) {
+            this.byLowerBound = byLowerBound;
+        }
+
+        static CoveringPartitionIndex of(OlapTable olapTable, ExpressionRangePartitionInfo partitionInfo) {
+            List<Map.Entry<Long, Range<PartitionKey>>> sorted =
+                    Lists.newArrayList(partitionInfo.getIdToRange(false).entrySet());
+            // Drop ids the table no longer has here rather than per lookup, so a dropped partition
+            // cannot shadow a live one that also covers the value.
+            sorted.removeIf(e -> olapTable.getPartition(e.getKey()) == null);
+            sorted.sort(Comparator.comparing(e -> e.getValue().lowerEndpoint()));
+            return new CoveringPartitionIndex(sorted);
+        }
+
+        Pair<String, PartitionKeyDesc> find(
+                OlapTable olapTable, ExpressionRangePartitionInfo partitionInfo, String partitionItem) {
+            if (byLowerBound.isEmpty()) {
+                return null;
+            }
+            try {
+                PartitionKey key = PartitionKey.createPartitionKey(
+                        Collections.singletonList(new PartitionValue(partitionItem)),
+                        partitionInfo.getPartitionColumns(olapTable.getIdToColumn()));
+                // Greatest lower endpoint <= key.
+                int lo = 0;
+                int hi = byLowerBound.size() - 1;
+                int candidate = -1;
+                while (lo <= hi) {
+                    int mid = (lo + hi) >>> 1;
+                    if (byLowerBound.get(mid).getValue().lowerEndpoint().compareTo(key) <= 0) {
+                        candidate = mid;
+                        lo = mid + 1;
+                    } else {
+                        hi = mid - 1;
+                    }
+                }
+                if (candidate < 0) {
+                    return null;
+                }
+                Map.Entry<Long, Range<PartitionKey>> entry = byLowerBound.get(candidate);
+                // The lower endpoint fits by construction; the upper one still has to be checked,
+                // because a value can fall in the gap between two partitions.
                 if (!entry.getValue().contains(key)) {
-                    continue;
+                    return null;
                 }
                 Partition partition = olapTable.getPartition(entry.getKey());
                 if (partition == null) {
-                    continue;
+                    return null;
                 }
                 return Pair.create(partition.getName(), toPartitionKeyDesc(entry.getValue()));
+            } catch (AnalysisException e) {
+                // Not fatal: fall back to the partition expression, which is what this path did before.
+                LOG.warn("failed to look up the partition covering value {}", partitionItem, e);
+                return null;
             }
-        } catch (AnalysisException e) {
-            // Not fatal: fall back to the partition expression, which is what this path did before.
-            LOG.warn("failed to look up the partition covering value {}", partitionItem, e);
         }
-        return null;
     }
 
     private static PartitionKeyDesc toPartitionKeyDesc(Range<PartitionKey> range) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.authorization.AccessDeniedException;
 import com.starrocks.authorization.ObjectType;
@@ -42,6 +43,7 @@ import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PaimonTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
@@ -1718,8 +1720,10 @@ public class AnalyzerUtils {
             ExpressionPartitionDesc expressionPartitionDesc = (ExpressionPartitionDesc) partitionDesc;
             PartitionMeasure measure = checkAndGetPartitionMeasure(expressionPartitionDesc.getExpr());
             PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+            // The caller supplies the granularity here (partition merge builds its target partition this
+            // way), so the existing partitions are exactly what it intends to replace — never adopt them.
             return getAddPartitionClauseForRangePartition(olapTable, partitionValues, isTemp, partitionNamePrefix, measure,
-                    distributionDesc, (ExpressionRangePartitionInfo) partitionInfo);
+                    distributionDesc, (ExpressionRangePartitionInfo) partitionInfo, false);
         } else {
             PartitionInfo partitionInfo = olapTable.getPartitionInfo();
             throw new AnalysisException("Unsupported partition type " + partitionInfo.getType());
@@ -1740,8 +1744,11 @@ public class AnalyzerUtils {
             }
             Expr expr = partitionExprs.get(0);
             PartitionMeasure measure = checkAndGetPartitionMeasure(expr);
+            // Granularity comes from the table's own expression, so an existing partition may legitimately
+            // be coarser than it (partition merge is scoped by BETWEEN and leaves the expression alone).
+            // A temporary partition is swapped into this table, so it must not contradict what is there.
             return getAddPartitionClauseForRangePartition(olapTable, partitionValues, isTemp, partitionNamePrefix, measure,
-                    null, expressionRangePartitionInfo);
+                    null, expressionRangePartitionInfo, isTemp);
         } else if (partitionInfo instanceof ListPartitionInfo) {
             Short replicationNum = olapTable.getTableProperty().getReplicationNum();
             DistributionDesc distributionDesc = olapTable.getDefaultDistributionInfo()
@@ -1853,7 +1860,8 @@ public class AnalyzerUtils {
             String partitionPrefix,
             PartitionMeasure measure,
             DistributionDesc distributionDesc,
-            ExpressionRangePartitionInfo expressionRangePartitionInfo) throws AnalysisException {
+            ExpressionRangePartitionInfo expressionRangePartitionInfo,
+            boolean adoptCoveringPartition) throws AnalysisException {
         String granularity = measure.getGranularity();
         long interval = measure.getInterval();
         Type firstPartitionColumnType = expressionRangePartitionInfo.getPartitionColumns(olapTable.getIdToColumn())
@@ -1911,6 +1919,20 @@ public class AnalyzerUtils {
                 PartitionKeyDesc partitionKeyDesc =
                         createPartitionKeyDesc(firstPartitionColumnType, beginTime, endTime);
 
+                // A partition may be coarser than the table's partition expression: ALTER TABLE ...
+                // PARTITION BY <coarser expr> BETWEEN a AND b merges a range of partitions and, being
+                // scoped by BETWEEN, deliberately leaves the expression alone. A temporary partition is
+                // swapped into this table afterwards, so computing its bounds from the expression would
+                // re-introduce the finer partitions the merge had removed.
+                if (adoptCoveringPartition) {
+                    Pair<String, PartitionKeyDesc> covering =
+                            findCoveringPartition(olapTable, expressionRangePartitionInfo, partitionItem);
+                    if (covering != null) {
+                        partitionName = covering.first;
+                        partitionKeyDesc = covering.second;
+                    }
+                }
+
                 if (partitionPrefix != null) {
                     if (partitionPrefix.contains(PARTITION_NAME_PREFIX_SPLIT)) {
                         throw new AnalysisException("partition name prefix can not contain " + PARTITION_NAME_PREFIX_SPLIT);
@@ -1934,6 +1956,48 @@ public class AnalyzerUtils {
         rangePartitionDesc.setPartitionNames(partitionNames);
         rangePartitionDesc.setSystem(true);
         return new AddPartitionClause(rangePartitionDesc, distributionDesc, partitionProperties, isTemp);
+    }
+
+    /**
+     * The existing (non-temporary) partition whose range covers {@code partitionItem}, as
+     * (partition name, its bounds), or null when no partition covers the value.
+     *
+     * <p>Returning the partition's own name matters as much as its bounds: several values in one
+     * request may fall into the same covering partition, and they must collapse into a single
+     * partition desc instead of producing overlapping ranges under different names.
+     */
+    private static Pair<String, PartitionKeyDesc> findCoveringPartition(
+            OlapTable olapTable, ExpressionRangePartitionInfo partitionInfo, String partitionItem) {
+        try {
+            PartitionKey key = PartitionKey.createPartitionKey(
+                    Collections.singletonList(new PartitionValue(partitionItem)),
+                    partitionInfo.getPartitionColumns(olapTable.getIdToColumn()));
+            for (Map.Entry<Long, Range<PartitionKey>> entry : partitionInfo.getIdToRange(false).entrySet()) {
+                if (!entry.getValue().contains(key)) {
+                    continue;
+                }
+                Partition partition = olapTable.getPartition(entry.getKey());
+                if (partition == null) {
+                    continue;
+                }
+                return Pair.create(partition.getName(), toPartitionKeyDesc(entry.getValue()));
+            }
+        } catch (AnalysisException e) {
+            // Not fatal: fall back to the partition expression, which is what this path did before.
+            LOG.warn("failed to look up the partition covering value {}", partitionItem, e);
+        }
+        return null;
+    }
+
+    private static PartitionKeyDesc toPartitionKeyDesc(Range<PartitionKey> range) {
+        PartitionKey upper = range.upperEndpoint();
+        PartitionValue upperValue = upper.isMaxValue()
+                ? PartitionValue.MAX_VALUE
+                : new PartitionValue(upper.getKeys().get(0).getStringValue());
+        return new PartitionKeyDesc(
+                Collections.singletonList(
+                        new PartitionValue(range.lowerEndpoint().getKeys().get(0).getStringValue())),
+                Collections.singletonList(upperValue));
     }
 
     private static PartitionKeyDesc createPartitionKeyDesc(Type partitionType, LocalDateTime beginTime,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTempPartitionOnMergedTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTempPartitionOnMergedTest.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.persist.ColumnIdExpr;
+import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.KeysType;
+import com.starrocks.sql.ast.PartitionKeyDesc;
+import com.starrocks.sql.ast.PartitionValue;
+import com.starrocks.sql.ast.RangePartitionDesc;
+import com.starrocks.sql.ast.SingleRangePartitionDesc;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.type.DateType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Automatic partitions created at load time must not contradict the partitions the table already has.
+ *
+ * <p>A table can hold partitions coarser than its own partition expression: {@code ALTER TABLE t
+ * PARTITION BY date_trunc('month', dt) BETWEEN ...} merges a range of daily partitions into one
+ * monthly partition and — by design, since the merge is scoped by BETWEEN — leaves the table's
+ * partition expression at {@code date_trunc('day', dt)}. That state is reachable only through the
+ * merge job (a table with automatic partitioning rejects a manual ADD PARTITION), so these tests
+ * build it directly on the metadata.
+ *
+ * <p>Ordinary loads are unaffected: the sink resolves a row against the existing ranges and only
+ * asks the FE for a partition when no range covers it. Dynamic overwrite is different — it creates
+ * a *temporary* partition per written partition at load time and swaps it in afterwards, so a
+ * temporary partition computed from the expression granularity instead of the covering partition
+ * re-introduces the daily partitions the merge had removed.
+ */
+public class AnalyzerUtilsTempPartitionOnMergedTest {
+
+    private static final long MERGED_PARTITION_ID = 10001L;
+
+    /** A day-partitioned table that already holds one monthly partition, as a merge would leave it. */
+    private static OlapTable mergedTable() throws Exception {
+        Column dt = new Column("dt", DateType.DATE);
+        List<Column> schema = Lists.newArrayList(dt);
+
+        Expr dayExpr = new FunctionCallExpr("date_trunc",
+                Lists.newArrayList(new StringLiteral("day"), new SlotRef(null, "dt")));
+        ExpressionRangePartitionInfo partitionInfo = new ExpressionRangePartitionInfo(
+                Lists.newArrayList(ColumnIdExpr.create(dayExpr)), schema, PartitionType.EXPR_RANGE);
+
+        HashDistributionInfo distributionInfo = new HashDistributionInfo(1, schema);
+        OlapTable table = new OlapTable(1L, "merged_day_tbl", schema, KeysType.DUP_KEYS,
+                partitionInfo, distributionInfo);
+        table.setTableProperty(new TableProperty(ImmutableMap.of("replication_num", "1")));
+
+        Range<PartitionKey> january = Range.closedOpen(
+                PartitionKey.createPartitionKey(
+                        Collections.singletonList(new PartitionValue("2026-01-01")), schema),
+                PartitionKey.createPartitionKey(
+                        Collections.singletonList(new PartitionValue("2026-02-01")), schema));
+        partitionInfo.setRange(MERGED_PARTITION_ID, false, january);
+        partitionInfo.setReplicationNum(MERGED_PARTITION_ID, (short) 1);
+        table.addPartition(new Partition(MERGED_PARTITION_ID, "p202601", distributionInfo));
+        return table;
+    }
+
+    private static List<List<String>> values(String partitionValue) {
+        return Collections.singletonList(Collections.singletonList(partitionValue));
+    }
+
+    private static PartitionKeyDesc onlyKeyDesc(AddPartitionClause clause) {
+        RangePartitionDesc rangeDesc = (RangePartitionDesc) clause.getPartitionDesc();
+        List<SingleRangePartitionDesc> descs = rangeDesc.getSingleRangePartitionDescs();
+        Assertions.assertEquals(1, descs.size(), "expected exactly one partition desc");
+        return descs.get(0).getPartitionKeyDesc();
+    }
+
+    /**
+     * Trigger: a temporary partition for a value already covered by the merged monthly partition
+     * must adopt that partition's bounds, not the daily bounds of the partition expression.
+     */
+    @Test
+    public void tempPartitionAdoptsCoveringPartitionBounds() throws Exception {
+        AddPartitionClause clause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
+                mergedTable(), values("2026-01-05"), true, "txn1");
+        PartitionKeyDesc keyDesc = onlyKeyDesc(clause);
+        Assertions.assertEquals("2026-01-01",
+                keyDesc.getLowerValues().get(0).getStringValue(),
+                "temporary partition must start where the covering partition starts");
+        Assertions.assertEquals("2026-02-01",
+                keyDesc.getUpperValues().get(0).getStringValue(),
+                "temporary partition must end where the covering partition ends");
+    }
+
+    /**
+     * Trigger: two values inside the same covering partition must collapse into one partition desc,
+     * otherwise the load would ask for two temporary partitions with identical, overlapping ranges.
+     */
+    @Test
+    public void valuesInsideOneCoveringPartitionCollapse() throws Exception {
+        List<List<String>> twoDays = Lists.newArrayList(
+                Collections.singletonList("2026-01-05"),
+                Collections.singletonList("2026-01-06"));
+        AddPartitionClause clause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
+                mergedTable(), twoDays, true, "txn1");
+        RangePartitionDesc rangeDesc = (RangePartitionDesc) clause.getPartitionDesc();
+        Assertions.assertEquals(1, rangeDesc.getSingleRangePartitionDescs().size(),
+                "both values fall in the same covering partition, so one desc is expected");
+    }
+
+    /** Control: a value outside every existing partition still follows the partition expression. */
+    @Test
+    public void tempPartitionOutsideCoverageKeepsExpressionGranularity() throws Exception {
+        AddPartitionClause clause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
+                mergedTable(), values("2026-03-07"), true, "txn1");
+        PartitionKeyDesc keyDesc = onlyKeyDesc(clause);
+        Assertions.assertEquals("2026-03-07", keyDesc.getLowerValues().get(0).getStringValue());
+        Assertions.assertEquals("2026-03-08", keyDesc.getUpperValues().get(0).getStringValue());
+    }
+
+    /** Control: ordinary (non-temporary) automatic partitioning is untouched by this rule. */
+    @Test
+    public void ordinaryAutoPartitionKeepsExpressionGranularity() throws Exception {
+        AddPartitionClause clause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(
+                mergedTable(), values("2026-01-05"), false, null);
+        PartitionKeyDesc keyDesc = onlyKeyDesc(clause);
+        Assertions.assertEquals("2026-01-05", keyDesc.getLowerValues().get(0).getStringValue());
+        Assertions.assertEquals("2026-01-06", keyDesc.getUpperValues().get(0).getStringValue());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

After merging daily partitions into a monthly one, `dynamic_overwrite` re-creates the daily
partitions the merge had just removed:

```sql
-- day-partitioned table with p20260101 / p20260102 / p20260103 / p20260203
ALTER TABLE test_partition PARTITION BY date_trunc('month', statistical_date)
BETWEEN '2026-01-01' AND '2026-01-31';           -- -> p202601 / p20260203

SET dynamic_overwrite = true;
INSERT OVERWRITE test_partition VALUES ('2026-01-01',12), ...;
SHOW PARTITIONS FROM test_partition;
-- p20260101 / p202601 / p20260102 / p20260103 / p20260203   <-- daily partitions are back
```

Reproduced on a live cluster while investigating #78145.

The merge is scoped by `BETWEEN`, so it deliberately leaves the table's partition expression at
`date_trunc('day', dt)` — changing it would misdescribe the partitions outside the merged range.
A table therefore legitimately holds partitions **coarser than its own partition expression**.

`dynamic_overwrite` creates one temporary partition per written partition at load time and swaps
them in afterwards. Those temporary partitions were built from the partition expression, so on such
a table they contradict the partitions already there.

Isolating which write path is at fault:

| write | partition written into | correct? |
|---|---|---|
| `INSERT` | reuses `p202601` | ✅ the sink only asks the FE for a partition when no range covers the row |
| `INSERT OVERWRITE` (`dynamic_overwrite=false`) | reuses `p202601` | ✅ temporary partitions come from `job.getSourcePartitionIds()`, so they inherit the existing bounds |
| `INSERT OVERWRITE` (`dynamic_overwrite=true`) | creates `p20260101…` | ❌ `createTempPartitions()` returns early, and the temporary partitions are created at load time from the expression granularity |

## What I'm doing:

When building an automatic partition **for a temporary partition**, adopt the bounds — and the name —
of the existing partition that covers the value, if there is one. Reusing the name matters as much as
the bounds: several values in one request can fall into the same covering partition and must collapse
into a single desc rather than produce overlapping ranges.

`getAddPartitionClauseFromPartitionValues` has two overloads and both pass `isTemp=true`, so the new
behaviour is opt-in per overload:

- the overload that derives granularity from the **table's own expression** (automatic partitioning at
  load time) adopts the covering partition;
- the overload that takes a `PartitionDesc` from the **caller** must not — partition merge itself uses
  it to build the coarser target partition, and adopting the partitions it is about to replace would
  defeat the merge.

Tests cover the adopting case, the collapse of two values into one covering partition, a value outside
any existing partition, and ordinary (non-temporary) automatic partitioning. The first two fail before
this change and pass after it.

Fixes #78145

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

The three branches were checked individually: each carries `MergePartitionJob`, the same early return
for dynamic overwrite in `InsertOverwriteJobRunner.createTempPartitions()`, and the same
`getAddPartitionClauseForRangePartition`, so all three are affected.
