### PR TITLE
[BugFix] Honour hive.metastore.warehouse.dir from Iceberg catalog properties

### DIFF
--- a/docs/en/data_source/catalog/iceberg/iceberg.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg.md
@@ -182,6 +182,10 @@ The following table describes the parameter you need to configure in `MetastoreP
   - Required: Yes
   - Description: The URI of your Hive metastore. Format: `thrift://<metastore_IP_address>:<metastore_port>`.<br />If high availability (HA) is enabled for your Hive metastore, you can specify multiple metastore URIs and separate them with commas (`,`), for example, `"thrift://<metastore_IP_address_1>:<metastore_port_1>,thrift://<metastore_IP_address_2>:<metastore_port_2>,thrift://<metastore_IP_address_3>:<metastore_port_3>"`. 
 
+- `hive.metastore.warehouse.dir`
+  - Required: No
+  - Description: The warehouse directory under which StarRocks creates databases and tables in this catalog when no location is given explicitly. Specify it if your Hive metastore uses a warehouse directory other than the default `/user/hive/warehouse`, for example, `"hive.metastore.warehouse.dir" = "s3://my-bucket/warehouse"`.<br />Precedence: a `location` property given in `CREATE DATABASE` wins over this parameter, and this parameter wins over the built-in default. Because the value is read from the catalog properties, it does not need to be present in your `hive-site.xml`. 
+
 </TabItem>
 
 <TabItem value="GLUE" label="AWS Glue">

--- a/docs/zh/data_source/catalog/iceberg/iceberg.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg.md
@@ -183,6 +183,11 @@ Iceberg catalog 的描述。此参数是可选的。
 必需：是
 描述：Hive metastore 的 URI。格式：`thrift://<metastore_IP_address>:<metastore_port>`。<br />如果 Hive metastore 启用了高可用性（HA），您可以指定多个 metastore URI，并用逗号（`,`）分隔，例如 `"thrift://<metastore_IP_address_1>:<metastore_port_1>,thrift://<metastore_IP_address_2>:<metastore_port_2>,thrift://<metastore_IP_address_3>:<metastore_port_3>"`。
 
+##### hive.metastore.warehouse.dir
+
+必需：否
+描述：未显式指定 location 时，StarRocks 在该 Catalog 中创建数据库和表所使用的 warehouse 目录。如果 Hive metastore 使用的不是默认的 `/user/hive/warehouse`，请指定该参数，例如 `"hive.metastore.warehouse.dir" = "s3://my-bucket/warehouse"`。<br />优先级：`CREATE DATABASE` 中显式给出的 `location` 属性高于该参数，该参数高于内置默认值。该取值从 Catalog 属性中读取，因此无需出现在 `hive-site.xml` 中。
+
 </TabItem>
 
 <TabItem value="GLUE" label="AWS Glue">

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -76,7 +76,14 @@ public class IcebergHiveCatalog implements IcebergCatalog {
         String hmsTimeout = properties.getOrDefault(HIVE_METASTORE_TIMEOUT, String.valueOf(Config.hive_meta_store_timeout_s));
         this.conf.set(MetastoreConf.ConfVars.CLIENT_SOCKET_TIMEOUT.getHiveName(), hmsTimeout);
         if (conf.get(METASTOREWAREHOUSE.varname) == null) {
-            this.conf.set(METASTOREWAREHOUSE.varname, METASTOREWAREHOUSE.getDefaultValue());
+            // The Configuration comes from HdfsEnvironment, which only applies cloud-storage
+            // credentials to it — catalog properties are not propagated. So "absent from the
+            // Configuration" does not mean "the user did not configure it": fall back to the default
+            // only after the catalog properties have been consulted, otherwise a configured
+            // warehouse dir is silently replaced and CREATE DATABASE fails against a path nobody asked for.
+            String warehouseDir = properties.get(METASTOREWAREHOUSE.varname);
+            this.conf.set(METASTOREWAREHOUSE.varname,
+                    warehouseDir != null ? warehouseDir : METASTOREWAREHOUSE.getDefaultValue());
         }
 
         Map<String, String> copiedProperties = Maps.newHashMap(properties);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogWarehouseDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogWarehouseDirTest.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import mockit.Mocked;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.hive.HiveCatalog;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREWAREHOUSE;
+
+/**
+ * {@code hive.metastore.warehouse.dir} given in the catalog properties must reach the Hadoop
+ * Configuration the Hive catalog is built with.
+ *
+ * <p>The Configuration is built by {@code IcebergConnector} via {@code HdfsEnvironment}, which only
+ * applies cloud-storage credentials to it — catalog properties such as the warehouse directory are
+ * not propagated. So the constructor cannot treat "absent from the Configuration" as "the user did
+ * not configure it", or a configured warehouse dir is silently replaced by the built-in default and
+ * CREATE DATABASE fails against a path the user never asked for.
+ */
+public class IcebergHiveCatalogWarehouseDirTest {
+
+    private static Map<String, String> properties(String warehouseDir) {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("hive.metastore.uris", "thrift://129.1.2.3:9876");
+        if (warehouseDir != null) {
+            properties.put(METASTOREWAREHOUSE.varname, warehouseDir);
+        }
+        return properties;
+    }
+
+    /** Trigger: configured in the catalog properties, absent from the Configuration. */
+    @Test
+    public void warehouseDirFromCatalogProperties(@Mocked HiveCatalog hiveCatalog) {
+        Configuration conf = new Configuration();
+        new IcebergHiveCatalog("iceberg_hive", conf, properties("hdfs://ns1/iceberg"));
+        Assertions.assertEquals("hdfs://ns1/iceberg", conf.get(METASTOREWAREHOUSE.varname));
+    }
+
+    /** Control: nothing configured anywhere still falls back to the default. */
+    @Test
+    public void warehouseDirFallsBackToDefault(@Mocked HiveCatalog hiveCatalog) {
+        Configuration conf = new Configuration();
+        new IcebergHiveCatalog("iceberg_hive", conf, properties(null));
+        Assertions.assertEquals(METASTOREWAREHOUSE.getDefaultValue(), conf.get(METASTOREWAREHOUSE.varname));
+    }
+
+    /** Control: a value already on the Configuration keeps precedence. */
+    @Test
+    public void warehouseDirOnConfigurationWins(@Mocked HiveCatalog hiveCatalog) {
+        Configuration conf = new Configuration();
+        conf.set(METASTOREWAREHOUSE.varname, "hdfs://ns1/from-configuration");
+        new IcebergHiveCatalog("iceberg_hive", conf, properties("hdfs://ns1/from-properties"));
+        Assertions.assertEquals("hdfs://ns1/from-configuration", conf.get(METASTOREWAREHOUSE.varname));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`hive.metastore.warehouse.dir` set in `CREATE EXTERNAL CATALOG` is accepted and then ignored:

```sql
CREATE EXTERNAL CATALOG iceberg_hive PROPERTIES (
    "type" = "iceberg",
    "iceberg.catalog.type" = "hive",
    "hive.metastore.uris" = "thrift://<hms_host>:9083",
    "hive.metastore.warehouse.dir" = "s3a://iceberg/"
);
CREATE DATABASE iceberg_hive.iceberg_test;
-- ERROR 1064 (HY000): Unable to create database path file:/user/hive/warehouse/iceberg_test.db
```

`IcebergHiveCatalog` falls back to the built-in default whenever the Hadoop `Configuration` does not
already carry the key:

```java
if (conf.get(METASTOREWAREHOUSE.varname) == null) {
    this.conf.set(METASTOREWAREHOUSE.varname, METASTOREWAREHOUSE.getDefaultValue());
}
```

That `Configuration` is built by `IcebergConnector` through `HdfsEnvironment`, which applies only the
cloud-storage credentials (`cloudConfiguration.applyToConfiguration(...)`) and never propagates catalog
properties. The key is therefore *always* absent, so the branch reads "the user did not configure it"
when the truth is "this Configuration was never given catalog properties in the first place".

Reported in #76737, with the same root cause identified there.

## What I'm doing:

Consult the catalog properties before falling back to the default. A value already present on the
`Configuration` still wins, so the existing precedence is unchanged — only the case that used to be
silently overwritten now works.

Tests cover all three: value from catalog properties, value already on the Configuration, and neither.

Fixes #76737

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

All three branches carry the same fallback in the same constructor; the reporter also observed it on
3.5.19 and on `main`.