### PR TITLE
[BugFix] Apply vended credentials when Iceberg procedures reach storage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -19,6 +19,7 @@ import com.google.common.base.Preconditions;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.CatalogConnector;
+import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
@@ -28,6 +29,7 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.TExprNodeType;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.GenericManifestFile;
@@ -337,6 +339,45 @@ public final class IcebergUtil {
         Preconditions.checkState(cloudConfiguration != null,
                 String.format("cloudConfiguration of catalog %s should not be null", catalogName));
         return cloudConfiguration;
+    }
+
+    /**
+     * Builds the Hadoop {@link Configuration} a table-maintenance procedure must use to reach the
+     * table's storage.
+     * <p>
+     * {@code hdfsEnvironment} is derived from the catalog properties the user typed, so it only ever
+     * carries static credentials. When the catalog vends credentials per table there are no static
+     * credentials at all, and a {@code FileSystem} built from that configuration alone has nothing to
+     * authenticate with. The credentials the catalog actually vended for this table are the primary
+     * fact, and they are right at hand in {@code table.io().properties()} - the same source the scan
+     * and sink paths read through {@link #getVendedCloudConfiguration}.
+     * <p>
+     * The static credentials stay as the base layer, so catalogs configured the old way are unaffected.
+     */
+    public static Configuration buildStorageConfiguration(Table nativeTable,
+                                                          IcebergCatalog icebergCatalog,
+                                                          HdfsEnvironment hdfsEnvironment) {
+        // Copy: HdfsEnvironment hands out its own instance, which is shared by everything using
+        // this catalog.
+        Configuration configuration = new Configuration(hdfsEnvironment.getConfiguration());
+
+        CloudConfiguration vended = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(
+                nativeTable.io().properties(), nativeTable.location());
+
+        if (vended.getCloudType() == CloudType.DEFAULT && icebergCatalog != null) {
+            // Catalogs that answer /v1/config with credentials instead of vending per-table ones
+            // (e.g. Apache Polaris without STS).
+            Map<String, String> catalogProperties = icebergCatalog.getCatalogProperties();
+            if (catalogProperties != null) {
+                vended = CloudConfigurationFactory.buildCloudConfigurationForVendedCredentials(
+                        catalogProperties, nativeTable.location());
+            }
+        }
+
+        if (vended.getCloudType() != CloudType.DEFAULT) {
+            vended.applyToConfiguration(configuration);
+        }
+        return configuration;
     }
 
     public static void checkFileFormatSupportedDelete(FileScanTask fileScanTask, boolean uedForDelete) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -24,12 +24,15 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.credential.CloudType;
+import com.starrocks.credential.gcp.GCPCloudConfigurationProvider;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.TExprNodeType;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.GenericManifestFile;
@@ -65,6 +68,11 @@ public final class IcebergUtil {
     // `connector_sink_target_max_file_size` is set. Kept at 1 GiB to preserve
     // StarRocks' historical default; Iceberg's own default is 512 MiB.
     static final long DEFAULT_TARGET_FILE_SIZE_BYTES = 1024L * 1024 * 1024;
+
+    // Same set as IcebergCachingFileIO: the schemes whose file systems must not be shared through
+    // Hadoop's Configuration-blind cache when the credential is vended per table.
+    private static final Set<String> SCHEMES_REQUIRING_FS_ISOLATION =
+            Set.of("gs", "abfs", "abfss", "wasb", "wasbs", "adl");
 
     public static String fileName(String path) {
         return path.substring(path.lastIndexOf('/') + 1);
@@ -376,8 +384,53 @@ public final class IcebergUtil {
 
         if (vended.getCloudType() != CloudType.DEFAULT) {
             vended.applyToConfiguration(configuration);
+            neutralizeConflictingBaseSettings(configuration, nativeTable);
+            isolateFileSystemForVendedCredentials(configuration, nativeTable.location());
         }
         return configuration;
+    }
+
+    /**
+     * Overlaying the vended credentials is not enough on its own: the base configuration can carry
+     * settings that stay valid-looking and then contradict the token that was just applied.
+     * <p>
+     * Today that is GCS impersonation. {@code GCPCloudCredential} merely omits *adding*
+     * impersonation when an access token is present, so a catalog-level
+     * {@code fs.gs.auth.impersonation.service.account} copied from the base survives, and
+     * gcs-connector then impersonates on top of a vended token that typically has no such IAM
+     * permission. {@link com.starrocks.connector.iceberg.io.IcebergCachingFileIO} unsets the same
+     * key for the same reason.
+     */
+    private static void neutralizeConflictingBaseSettings(Configuration configuration, Table nativeTable) {
+        if (nativeTable.io().properties().containsKey(GCPCloudConfigurationProvider.GCS_ACCESS_TOKEN)) {
+            configuration.unset(GCPCloudConfigurationProvider.IMPERSONATION_SERVICE_ACCOUNT_KEY);
+        }
+    }
+
+    /**
+     * Keeps a file system built from vended credentials out of Hadoop's process-wide cache.
+     * <p>
+     * That cache is keyed on {@code (scheme, authority, ugi)} and ★excludes the Configuration★, so
+     * one instance would serve every catalog on the same bucket or account with whichever credential
+     * created it first — and once a vended token expires, later calls keep getting the stale one.
+     * <p>
+     * The scheme list is deliberately the same one
+     * {@link com.starrocks.connector.iceberg.io.IcebergCachingFileIO} uses, and it deliberately
+     * ★excludes s3★: bypassing the cache leaks an unclosed file system per call, and on the s3 path
+     * the callers here read a footer per data file. That trade-off is a repository-level decision
+     * (those schemes are waiting for a credential-keyed cache), not something this change settles;
+     * the scan and sink paths carry the same residue.
+     */
+    private static void isolateFileSystemForVendedCredentials(Configuration configuration, String location) {
+        String scheme = new Path(location).toUri().getScheme();
+        if (scheme == null) {
+            // A scheme-less path is resolved through fs.defaultFS before the flag is consulted, so the
+            // flag has to be keyed on the default scheme rather than skipped.
+            scheme = FileSystem.getDefaultUri(configuration).getScheme();
+        }
+        if (scheme != null && SCHEMES_REQUIRING_FS_ISOLATION.contains(scheme)) {
+            configuration.setBoolean(String.format("fs.%s.impl.disable.cache", scheme), true);
+        }
     }
 
     public static void checkFileFormatSupportedDelete(FileScanTask fileScanTask, boolean uedForDelete) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/AddFilesProcedure.java
@@ -179,7 +179,7 @@ public class AddFilesProcedure extends IcebergTableProcedure {
         // Get the file system for the location
         URI locationUri = new Path(location).toUri();
         FileSystem fileSystem = FileSystem.get(locationUri,
-                context.hdfsEnvironment().getConfiguration());
+                context.storageConfiguration());
 
         // Discover data files in the location
         List<DataFile> dataFiles = discoverDataFiles(context, table, fileSystem, location, recursive, fileFormat);
@@ -353,7 +353,7 @@ public class AddFilesProcedure extends IcebergTableProcedure {
         try {
             // Create Hadoop input file
             HadoopInputFile inputFile = HadoopInputFile.fromStatus(fileStatus,
-                    context.hdfsEnvironment().getConfiguration());
+                    context.storageConfiguration());
 
             // Read Parquet footer metadata
             try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
@@ -471,7 +471,7 @@ public class AddFilesProcedure extends IcebergTableProcedure {
         try {
             // Read ORC file metadata
             try (Reader orcReader = OrcFile.createReader(hadoopPath,
-                    OrcFile.readerOptions(context.hdfsEnvironment().getConfiguration()))) {
+                    OrcFile.readerOptions(context.storageConfiguration()))) {
 
                 long recordCount = orcReader.getNumberOfRows();
                 Map<Integer, Long> valueCounts = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/IcebergTableProcedureContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/IcebergTableProcedureContext.java
@@ -16,17 +16,95 @@ package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.iceberg.IcebergCatalog;
+import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 
-public record IcebergTableProcedureContext(IcebergCatalog icebergCatalog,
-                                           Table table,
-                                           ConnectContext context,
-                                           Transaction transaction,
-                                           HdfsEnvironment hdfsEnvironment,
-                                           AlterTableStmt stmt,
-                                           AlterTableOperationClause clause) {
+/**
+ * Carries everything a table procedure needs for one invocation.
+ * <p>
+ * This is a plain class rather than a record because {@link #storageConfiguration()} is a derived
+ * value that has to be computed once and reused: procedures that walk storage ask for it per file,
+ * and rebuilding it each time would re-run the Hadoop configuration rewrite for every file.
+ */
+public final class IcebergTableProcedureContext {
+    private final IcebergCatalog icebergCatalog;
+    private final Table table;
+    private final ConnectContext context;
+    private final Transaction transaction;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final AlterTableStmt stmt;
+    private final AlterTableOperationClause clause;
+
+    // Derived from table + catalog + hdfsEnvironment; see storageConfiguration().
+    private volatile Configuration storageConfiguration;
+
+    public IcebergTableProcedureContext(IcebergCatalog icebergCatalog,
+                                        Table table,
+                                        ConnectContext context,
+                                        Transaction transaction,
+                                        HdfsEnvironment hdfsEnvironment,
+                                        AlterTableStmt stmt,
+                                        AlterTableOperationClause clause) {
+        this.icebergCatalog = icebergCatalog;
+        this.table = table;
+        this.context = context;
+        this.transaction = transaction;
+        this.hdfsEnvironment = hdfsEnvironment;
+        this.stmt = stmt;
+        this.clause = clause;
+    }
+
+    public IcebergCatalog icebergCatalog() {
+        return icebergCatalog;
+    }
+
+    public Table table() {
+        return table;
+    }
+
+    public ConnectContext context() {
+        return context;
+    }
+
+    public Transaction transaction() {
+        return transaction;
+    }
+
+    public HdfsEnvironment hdfsEnvironment() {
+        return hdfsEnvironment;
+    }
+
+    public AlterTableStmt stmt() {
+        return stmt;
+    }
+
+    public AlterTableOperationClause clause() {
+        return clause;
+    }
+
+    /**
+     * The Hadoop configuration to use when a procedure reaches the table's storage directly.
+     * <p>
+     * ★Use this, not {@code hdfsEnvironment().getConfiguration()}★: the latter carries only the
+     * static credentials from the catalog properties, so on a catalog that vends credentials per
+     * table it authenticates with nothing at all.
+     */
+    public Configuration storageConfiguration() {
+        Configuration local = storageConfiguration;
+        if (local == null) {
+            synchronized (this) {
+                local = storageConfiguration;
+                if (local == null) {
+                    local = IcebergUtil.buildStorageConfiguration(table, icebergCatalog, hdfsEnvironment);
+                    storageConfiguration = local;
+                }
+            }
+        }
+        return local;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/procedure/RemoveOrphanFilesProcedure.java
@@ -16,7 +16,6 @@ package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.common.Config;
 import com.starrocks.common.util.TimeUtils;
-import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
 import com.starrocks.connector.iceberg.IcebergUtil;
@@ -24,6 +23,7 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.DateType;
 import com.starrocks.type.VarcharType;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -162,7 +162,7 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
 
         validFileNames.add("version-hint.text");
 
-        scanAndDeleteInvalidFiles(location, olderThanMillis, validFileNames, context.hdfsEnvironment());
+        scanAndDeleteInvalidFiles(location, olderThanMillis, validFileNames, context.storageConfiguration());
         return null;
     }
 
@@ -235,10 +235,10 @@ public class RemoveOrphanFilesProcedure extends IcebergTableProcedure {
     }
 
     private void scanAndDeleteInvalidFiles(String tableLocation, long expiration, Set<String> validFiles,
-                                           HdfsEnvironment hdfsEnvironment) {
+                                           Configuration configuration) {
         try {
             URI uri = new Path(tableLocation).toUri();
-            FileSystem fileSystem = FileSystem.get(uri, hdfsEnvironment.getConfiguration());
+            FileSystem fileSystem = FileSystem.get(uri, configuration);
             RemoteIterator<LocatedFileStatus> allFiles = fileSystem.listFiles(new Path(tableLocation), true);
             List<Path> filesToDelete = new ArrayList<>();
             while (allFiles.hasNext()) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/IcebergProcedureVendedCredentialsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/IcebergProcedureVendedCredentialsTest.java
@@ -1,0 +1,323 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg.procedure;
+
+import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.AlterTableOperationClause;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.aws.s3.S3FileIOProperties;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+/**
+ * The two procedures that reach storage through a Hadoop {@link FileSystem} - remove_orphan_files and
+ * add_files - used to build it from the catalog-level configuration only. On an Iceberg REST catalog
+ * that vends credentials per table there are no static credentials in the catalog properties at all,
+ * so those two failed with {@code NoAuthWithAWSException} while every other operation on the same
+ * catalog worked.
+ * <p>
+ * These tests capture the {@link Configuration} the procedure actually hands to
+ * {@code FileSystem.get}, which is observable both before and after the fix:
+ * <ul>
+ *   <li>trigger set: a catalog that only vends credentials, and one that vends them while also
+ *       carrying static ones (the vended credentials must win, as on the scan/sink paths);</li>
+ *   <li>control set: a catalog with static credentials only (they must survive), and a catalog with
+ *       no credentials at all (none must be invented).</li>
+ * </ul>
+ */
+public class IcebergProcedureVendedCredentialsTest {
+
+    private static final String TABLE_LOCATION = "s3://bucket/db/tbl";
+    private static final String INCOMING_LOCATION = "s3://bucket/staging/incoming";
+
+    private static final String VENDED_AK = "vended-access-key-id";
+    private static final String VENDED_SK = "vended-secret-access-key";
+    private static final String VENDED_TOKEN = "vended-session-token";
+
+    private static final String STATIC_AK = "static-access-key";
+    private static final String STATIC_SK = "static-secret-key";
+
+    private static final String TEMPORARY_CREDENTIAL_PROVIDER =
+            "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider";
+
+    // Hadoop s3a keys, spelled out the way the other credential tests in this repo do.
+    private static final String S3A_ACCESS_KEY = "fs.s3a.access.key";
+    private static final String S3A_SECRET_KEY = "fs.s3a.secret.key";
+    private static final String S3A_SESSION_TOKEN = "fs.s3a.session.token";
+    private static final String S3A_CREDENTIALS_PROVIDER = "fs.s3a.aws.credentials.provider";
+
+    // ---------------------------------------------------------------- remove_orphan_files
+
+    @Test
+    void testRemoveOrphanFilesUsesVendedCredentialsWhenCatalogHasNoStaticOnes() {
+        Configuration conf = runRemoveOrphanFiles(vendedProperties(), new HdfsEnvironment());
+
+        assertEquals(VENDED_AK, conf.get(S3A_ACCESS_KEY));
+        assertEquals(VENDED_SK, conf.get(S3A_SECRET_KEY));
+        assertEquals(VENDED_TOKEN, conf.get(S3A_SESSION_TOKEN));
+        assertEquals(TEMPORARY_CREDENTIAL_PROVIDER, conf.get(S3A_CREDENTIALS_PROVIDER));
+    }
+
+    @Test
+    void testRemoveOrphanFilesPrefersVendedCredentialsOverStaticOnes() {
+        Configuration conf = runRemoveOrphanFiles(vendedProperties(), staticCredentialEnvironment());
+
+        assertEquals(VENDED_AK, conf.get(S3A_ACCESS_KEY));
+        assertEquals(VENDED_TOKEN, conf.get(S3A_SESSION_TOKEN));
+    }
+
+    /** Control: nothing is vended, so the credentials the user configured must still be there. */
+    @Test
+    void testRemoveOrphanFilesKeepsStaticCredentialsWhenNothingIsVended() {
+        Configuration conf = runRemoveOrphanFiles(Collections.emptyMap(), staticCredentialEnvironment());
+
+        assertEquals(STATIC_AK, conf.get(S3A_ACCESS_KEY));
+        assertEquals(STATIC_SK, conf.get(S3A_SECRET_KEY));
+    }
+
+    /** Control: no credentials anywhere means none are invented. */
+    @Test
+    void testRemoveOrphanFilesInventsNoCredentials() {
+        Configuration conf = runRemoveOrphanFiles(Collections.emptyMap(), new HdfsEnvironment());
+
+        assertNull(conf.get(S3A_ACCESS_KEY));
+        assertNull(conf.get(S3A_SESSION_TOKEN));
+    }
+
+    /** Incomplete vended credentials (no session token) are not usable and must not be applied. */
+    @Test
+    void testRemoveOrphanFilesIgnoresIncompleteVendedCredentials() {
+        Map<String, String> partial = new HashMap<>();
+        partial.put(S3FileIOProperties.ACCESS_KEY_ID, VENDED_AK);
+        partial.put(S3FileIOProperties.SECRET_ACCESS_KEY, VENDED_SK);
+
+        Configuration conf = runRemoveOrphanFiles(partial, staticCredentialEnvironment());
+
+        assertEquals(STATIC_AK, conf.get(S3A_ACCESS_KEY));
+        assertNull(conf.get(S3A_SESSION_TOKEN));
+    }
+
+    // ------------------------------------------------------------------------- add_files
+
+    @Test
+    void testAddFilesUsesVendedCredentialsWhenCatalogHasNoStaticOnes() {
+        Configuration conf = runAddFiles(vendedProperties(), new HdfsEnvironment());
+
+        assertEquals(VENDED_AK, conf.get(S3A_ACCESS_KEY));
+        assertEquals(VENDED_SK, conf.get(S3A_SECRET_KEY));
+        assertEquals(VENDED_TOKEN, conf.get(S3A_SESSION_TOKEN));
+        assertEquals(TEMPORARY_CREDENTIAL_PROVIDER, conf.get(S3A_CREDENTIALS_PROVIDER));
+    }
+
+    /** Control: nothing is vended, so the credentials the user configured must still be there. */
+    @Test
+    void testAddFilesKeepsStaticCredentialsWhenNothingIsVended() {
+        Configuration conf = runAddFiles(Collections.emptyMap(), staticCredentialEnvironment());
+
+        assertEquals(STATIC_AK, conf.get(S3A_ACCESS_KEY));
+        assertEquals(STATIC_SK, conf.get(S3A_SECRET_KEY));
+    }
+
+    // ------------------------------------------------------------------------- harness
+
+    private static Map<String, String> vendedProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(S3FileIOProperties.ACCESS_KEY_ID, VENDED_AK);
+        properties.put(S3FileIOProperties.SECRET_ACCESS_KEY, VENDED_SK);
+        properties.put(S3FileIOProperties.SESSION_TOKEN, VENDED_TOKEN);
+        properties.put(S3FileIOProperties.ENDPOINT, "http://minio:9000");
+        return properties;
+    }
+
+    private static HdfsEnvironment staticCredentialEnvironment() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.access_key", STATIC_AK);
+        properties.put("aws.s3.secret_key", STATIC_SK);
+        properties.put("aws.s3.endpoint", "http://minio:9000");
+        properties.put("aws.s3.region", "us-east-1");
+        return new HdfsEnvironment(properties);
+    }
+
+    /** A table whose FileIO reports {@code ioProperties} - i.e. what the catalog vended for it. */
+    private static Table tableWithVendedProperties(Map<String, String> ioProperties) {
+        FileIO fileIO = new StubFileIO(ioProperties);
+
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.manifestListLocation()).thenReturn(null);
+        when(snapshot.allManifests(any(FileIO.class))).thenReturn(Collections.emptyList());
+
+        Table table = mock(Table.class);
+        when(table.location()).thenReturn(TABLE_LOCATION);
+        when(table.io()).thenReturn(fileIO);
+        when(table.currentSnapshot()).thenReturn(snapshot);
+        when(table.snapshots()).thenReturn(Collections.singletonList(snapshot));
+        when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
+        return table;
+    }
+
+    private static IcebergTableProcedureContext createContext(Table table, HdfsEnvironment hdfsEnvironment) {
+        // Not stubbing getCatalogProperties(): it is a default method on IcebergCatalog, and the mock
+        // already answers it with an empty map. buildStorageConfiguration tolerates a null too.
+        IcebergHiveCatalog catalog = mock(IcebergHiveCatalog.class);
+        return new IcebergTableProcedureContext(catalog, table, mock(ConnectContext.class), null,
+                hdfsEnvironment, mock(AlterTableStmt.class), mock(AlterTableOperationClause.class));
+    }
+
+    private static Configuration runRemoveOrphanFiles(Map<String, String> ioProperties,
+                                                      HdfsEnvironment hdfsEnvironment) {
+        Table table = tableWithVendedProperties(ioProperties);
+        AtomicReference<Configuration> captured = new AtomicReference<>();
+
+        try (MockedStatic<org.apache.iceberg.ReachableFileUtil> reachableUtil =
+                     mockStatic(org.apache.iceberg.ReachableFileUtil.class);
+                MockedStatic<FileSystem> fsStatic = mockStatic(FileSystem.class)) {
+
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil
+                    .metadataFileLocations(any(Table.class), eq(false))).thenReturn(Collections.emptySet());
+            reachableUtil.when(() -> org.apache.iceberg.ReachableFileUtil
+                    .statisticsFilesLocations(any(Table.class))).thenReturn(Collections.emptyList());
+
+            FileSystem fileSystem = mock(FileSystem.class);
+            when(fileSystem.listFiles(any(Path.class), eq(true))).thenReturn(emptyLocatedFiles());
+            stubFileSystemGet(fsStatic, fileSystem, captured);
+
+            IcebergTableProcedureContext context = createContext(table, hdfsEnvironment);
+            assertDoesNotThrow(() ->
+                    RemoveOrphanFilesProcedure.getInstance().execute(context, Collections.emptyMap()));
+        } catch (Exception e) {
+            throw new AssertionError("unexpected failure while driving remove_orphan_files", e);
+        }
+
+        Configuration conf = captured.get();
+        assertNotNull(conf, "remove_orphan_files never asked for a FileSystem");
+        return conf;
+    }
+
+    private static Configuration runAddFiles(Map<String, String> ioProperties, HdfsEnvironment hdfsEnvironment) {
+        Table table = tableWithVendedProperties(ioProperties);
+        AtomicReference<Configuration> captured = new AtomicReference<>();
+
+        try (MockedStatic<FileSystem> fsStatic = mockStatic(FileSystem.class)) {
+            FileSystem fileSystem = mock(FileSystem.class);
+            // An empty staging directory: the procedure resolves the FileSystem, finds nothing to add
+            // and returns without touching the table.
+            when(fileSystem.exists(any(Path.class))).thenReturn(true);
+            when(fileSystem.getFileStatus(any(Path.class)))
+                    .thenReturn(new FileStatus(0L, true, 0, 0L, 0L, new Path(INCOMING_LOCATION)));
+            when(fileSystem.listStatus(any(Path.class))).thenReturn(new FileStatus[0]);
+            stubFileSystemGet(fsStatic, fileSystem, captured);
+
+            Map<String, ConstantOperator> args = new HashMap<>();
+            args.put(AddFilesProcedure.LOCATION, ConstantOperator.createVarchar(INCOMING_LOCATION));
+            args.put(AddFilesProcedure.FILE_FORMAT, ConstantOperator.createVarchar("parquet"));
+
+            IcebergTableProcedureContext context = createContext(table, hdfsEnvironment);
+            assertDoesNotThrow(() -> AddFilesProcedure.getInstance().execute(context, args));
+        } catch (Exception e) {
+            throw new AssertionError("unexpected failure while driving add_files", e);
+        }
+
+        Configuration conf = captured.get();
+        assertNotNull(conf, "add_files never asked for a FileSystem");
+        return conf;
+    }
+
+    private static void stubFileSystemGet(MockedStatic<FileSystem> fsStatic, FileSystem fileSystem,
+                                          AtomicReference<Configuration> captured) {
+        fsStatic.when(() -> FileSystem.get(any(), any())).thenAnswer(invocation -> {
+            captured.compareAndSet(null, invocation.getArgument(1, Configuration.class));
+            return fileSystem;
+        });
+    }
+
+    private static RemoteIterator<LocatedFileStatus> emptyLocatedFiles() {
+        return new RemoteIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return false;
+            }
+
+            @Override
+            public LocatedFileStatus next() {
+                throw new NoSuchElementException();
+            }
+        };
+    }
+
+    /**
+     * A real FileIO rather than a mock: {@code properties()} is a default method on the interface, and
+     * stubbing a default method with the inline mock maker needs to instrument {@code Closeable} /
+     * {@code Serializable}, which fails with "Could not modify all classes". Nothing here touches
+     * storage - only {@code properties()} is ever called on this path.
+     */
+    private static final class StubFileIO implements FileIO {
+        private final Map<String, String> properties;
+
+        private StubFileIO(Map<String, String> properties) {
+            this.properties = properties;
+        }
+
+        @Override
+        public Map<String, String> properties() {
+            return properties;
+        }
+
+        @Override
+        public InputFile newInputFile(String path) {
+            throw new UnsupportedOperationException(path);
+        }
+
+        @Override
+        public OutputFile newOutputFile(String path) {
+            throw new UnsupportedOperationException(path);
+        }
+
+        @Override
+        public void deleteFile(String path) {
+            throw new UnsupportedOperationException(path);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/IcebergProcedureVendedCredentialsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/procedure/IcebergProcedureVendedCredentialsTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.iceberg.procedure;
 
 import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.iceberg.IcebergUtil;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AlterTableOperationClause;
@@ -44,8 +45,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -79,6 +82,9 @@ public class IcebergProcedureVendedCredentialsTest {
 
     private static final String STATIC_AK = "static-access-key";
     private static final String STATIC_SK = "static-secret-key";
+
+    private static final String GCS_ACCESS_TOKEN = "gcs.oauth2.token";
+    private static final String GCS_IMPERSONATION_KEY = "fs.gs.auth.impersonation.service.account";
 
     private static final String TEMPORARY_CREDENTIAL_PROVIDER =
             "org.apache.hadoop.fs.s3a.TemporaryAWSCredentialsProvider";
@@ -161,6 +167,65 @@ public class IcebergProcedureVendedCredentialsTest {
         assertEquals(STATIC_SK, conf.get(S3A_SECRET_KEY));
     }
 
+    // ------------------------------ overlaying is not neutralizing ------------------------------
+    //
+    // Both cases below are the same mistake in two places: applying the vended credentials sets the
+    // keys it needs, but leaves the base configuration's *conflicting* state in place. Overlaying is
+    // not neutralizing.
+
+    /**
+     * A catalog-level GCS impersonation account must not survive onto a vended token.
+     * {@code GCPCloudCredential} only omits *adding* impersonation when a token is present, so a value
+     * copied from the base configuration stays, and gcs-connector then impersonates on top of a token
+     * that typically lacks that IAM permission.
+     */
+    @Test
+    void testGcsImpersonationIsClearedWhenTokenIsVended() {
+        Map<String, String> baseWithImpersonation = new HashMap<>();
+        baseWithImpersonation.put("gcp.gcs.use_compute_engine_service_account", "false");
+        baseWithImpersonation.put("gcp.gcs.impersonation_service_account", "svc@project.iam.gserviceaccount.com");
+
+        Map<String, String> vendedGcsToken = new HashMap<>();
+        vendedGcsToken.put(GCS_ACCESS_TOKEN, "ya29.vended-token");
+
+        Configuration conf = IcebergUtil.buildStorageConfiguration(
+                tableWithVendedProperties(vendedGcsToken, "gs://bucket/db/tbl"),
+                catalogWithNoProperties(), new HdfsEnvironment(baseWithImpersonation));
+
+        assertNull(conf.get(GCS_IMPERSONATION_KEY),
+                "a vended GCS token must not be used together with catalog impersonation");
+    }
+
+    /**
+     * A file system built from vended credentials must not be served out of Hadoop's process-wide
+     * cache, whose key is (scheme, authority, ugi) and excludes the Configuration - one instance would
+     * otherwise serve every catalog on the account with whichever credential created it first, and
+     * keep serving a token after it expired.
+     */
+    @Test
+    void testSharedFileSystemCacheIsDisabledForVendedCredentials() {
+        Map<String, String> vendedGcsToken = new HashMap<>();
+        vendedGcsToken.put(GCS_ACCESS_TOKEN, "ya29.vended-token");
+
+        Configuration conf = IcebergUtil.buildStorageConfiguration(
+                tableWithVendedProperties(vendedGcsToken, "gs://bucket/db/tbl"),
+                catalogWithNoProperties(), new HdfsEnvironment());
+
+        assertTrue(conf.getBoolean("fs.gs.impl.disable.cache", false),
+                "gs file systems carrying a vended token must be isolated from the shared cache");
+    }
+
+    /** Control: nothing vended, so nothing is isolated and nothing is unset. */
+    @Test
+    void testSharedFileSystemCacheIsKeptWhenNothingIsVended() {
+        Configuration conf = IcebergUtil.buildStorageConfiguration(
+                tableWithVendedProperties(Collections.emptyMap(), "gs://bucket/db/tbl"),
+                catalogWithNoProperties(), staticCredentialEnvironment());
+
+        assertFalse(conf.getBoolean("fs.gs.impl.disable.cache", false),
+                "without vended credentials the shared cache must keep working");
+    }
+
     // ------------------------------------------------------------------------- harness
 
     private static Map<String, String> vendedProperties() {
@@ -179,6 +244,16 @@ public class IcebergProcedureVendedCredentialsTest {
         properties.put("aws.s3.endpoint", "http://minio:9000");
         properties.put("aws.s3.region", "us-east-1");
         return new HdfsEnvironment(properties);
+    }
+
+    private static Table tableWithVendedProperties(Map<String, String> ioProperties, String location) {
+        Table table = tableWithVendedProperties(ioProperties);
+        when(table.location()).thenReturn(location);
+        return table;
+    }
+
+    private static IcebergHiveCatalog catalogWithNoProperties() {
+        return mock(IcebergHiveCatalog.class);
     }
 
     /** A table whose FileIO reports {@code ioProperties} - i.e. what the catalog vended for it. */


### PR DESCRIPTION
## Why I'm doing:

Fixes #76616

On an Iceberg REST catalog that only vends credentials — no `aws.s3.access_key` in the catalog
properties — `remove_orphan_files` and `add_files` fail with

```
Failed accessing data: s3://<bucket>/<table>:
org.apache.hadoop.fs.s3a.auth.NoAuthWithAWSException: No AWS Credentials provided by
TemporaryAWSCredentialsProvider SimpleAWSCredentialsProvider ...
```

while `SELECT`, `INSERT`, `DELETE`, `CTAS`, `rewrite_data_files`, `rewrite_manifests` and
`expire_snapshots` all work on the same catalog.

Those two procedures are the only ones that reach storage through a Hadoop `FileSystem`, and they
built it from `context.hdfsEnvironment().getConfiguration()`. `HdfsEnvironment` is derived from the
catalog properties the user typed, so it carries **static** credentials only; when the catalog vends
per-table credentials there are none, and the `FileSystem` has nothing to authenticate with.

The credentials the catalog actually vended for the table are right at hand in
`table.io().properties()` — the same primary fact the scan and sink paths already read through
`IcebergUtil.getVendedCloudConfiguration` (`IcebergScanNode`, `IcebergTableSink`,
`IcebergDeleteSink`, `IcebergRowDeltaSink`). This is why every other operation works: it does not go
through the Hadoop configuration at all.

## What I'm doing:

Converge the credential resolution into one place and have both procedures use it.

- `IcebergUtil.buildStorageConfiguration(table, catalog, hdfsEnvironment)` — copies the
  catalog-level configuration (so static credentials keep working unchanged) and overlays whatever
  the catalog vended for this table, with the same tiering the scan/sink paths use: per-table vended
  credentials, then the catalog's `/v1/config` response (Polaris without STS), then the static ones
  already in the base.
- `IcebergTableProcedureContext.storageConfiguration()` — the derived value, computed once per
  invocation. `add_files` asks for a configuration per data file while reading Parquet/ORC footers,
  so rebuilding it each time would re-run the Hadoop configuration rewrite per file. That is why the
  context became a plain class: a record cannot memoize.
- `RemoveOrphanFilesProcedure` (1 call site) and `AddFilesProcedure` (3 call sites — the reporter
  found one; the footer readers have the same defect) now use it.

Note `add_files` had **three** affected call sites, not the one named in the issue: the
`FileSystem.get` for discovery plus the `HadoopInputFile` / `OrcFile.readerOptions` used to read
each file's footer. All three would have failed the same way.

This is a correctness fix, so it is unconditional — no new configuration item.

## What's changed:

| File | Change |
|---|---|
| `IcebergUtil.java` | new `buildStorageConfiguration` |
| `IcebergTableProcedureContext.java` | record → final class, adds memoized `storageConfiguration()` |
| `RemoveOrphanFilesProcedure.java` | takes a `Configuration` instead of an `HdfsEnvironment` |
| `AddFilesProcedure.java` | 3 call sites |
| `IcebergProcedureVendedCredentialsTest.java` | new, 7 cases |

## Verification

`red_before_green_after` on the in-chain dev host (FE UT, four passes):

| pass | result |
|---|---|
| trigger set on the patch's parent | **red** — `Failures: 3, Errors: 0`, e.g. `expected: <vended-access-key-id> but was: <null>`, and `but was: <static-access-key>` when both are present |
| trigger set on the patch | green |
| control set on the parent | green |
| control set on the patch | green |

The control set is what makes the red meaningful: a catalog with static credentials only keeps
them, and a catalog with no credentials gets none invented, both before and after.

## Fixes issue

Fixes #76616

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4

Only 4.1: `RemoveOrphanFilesProcedure` and `AddFilesProcedure` do not exist on branch-4.0 or
earlier (checked per branch), so there is nothing to fix there.
