### PR TITLE
[BugFix] Never schedule a fragment onto zero nodes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
@@ -274,6 +274,18 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
         }
     }
 
+    /**
+     * How many nodes this fragment should run on, given the cardinalities of its children.
+     * <p>
+     * ★Never returns less than one★: a fragment that runs on zero nodes gets zero instances, and
+     * deployment asserts on that ({@code Preconditions.checkState(!fragment.getInstances().isEmpty())}),
+     * so the query dies with a bare {@code IllegalStateException} instead of running. Zero is
+     * reachable whenever the right child's cardinality is not positive - notably when it is the
+     * {@code -1} that {@link com.starrocks.planner.PlanNode} carries for "unknown", which is what
+     * scans over {@code information_schema} report, since they never estimate a row count. A
+     * negative cardinality divided down lands in (-1, 0), and {@code Math.ceil} of that is
+     * {@code -0.0}, which narrows to {@code 0}.
+     */
     public static long getOptimalNodeNums(long outputOfMostLeftChild, long maxOutputOfRightChild, int dop, int candidateSize) {
         long baseNodeNums = (long) Math.ceil((double) maxOutputOfRightChild / TINY_SCALE_ROWS_LIMIT / dop);
         double base = Math.max(Math.E, baseNodeNums);
@@ -281,7 +293,7 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
         long amplifyFactor = Math.round(Math.max(1,
                 Math.log(outputOfMostLeftChild / TINY_SCALE_ROWS_LIMIT / dop) / Math.log(base)));
 
-        return Math.min(amplifyFactor * baseNodeNums, candidateSize);
+        return Math.max(1, Math.min(amplifyFactor * baseNodeNums, candidateSize));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/AdaptiveChooseNodesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/AdaptiveChooseNodesTest.java
@@ -133,6 +133,43 @@ public class AdaptiveChooseNodesTest extends DistributedEnvPlanTestBase {
                         maxOutputOfRightChild, dop, candidateSize));
     }
 
+    /**
+     * A fragment always runs on at least one node. Zero nodes means zero instances, and deployment
+     * asserts on that, so the query dies with a bare IllegalStateException instead of running.
+     * <p>
+     * Zero is what the formula produced whenever the right child's cardinality was not positive -
+     * including the -1 that PlanNode carries for "unknown", which is what information_schema scans
+     * report because they never estimate a row count. That is why joining two information_schema
+     * tables could fail outright under an instance-decreasing mode.
+     */
+    @ParameterizedTest
+    @MethodSource("getNonPositiveRightCardinalityCases")
+    public void testNeverChoosesZeroNodes(long outputOfMostLeftChild, long maxOutputOfRightChild, int dop,
+                                          int candidateSize) {
+        long nodeNums = RemoteFragmentAssignmentStrategy.getOptimalNodeNums(outputOfMostLeftChild,
+                maxOutputOfRightChild, dop, candidateSize);
+        Assertions.assertTrue(nodeNums >= 1,
+                "a fragment must run on at least one node, got " + nodeNums + " for right cardinality "
+                        + maxOutputOfRightChild);
+    }
+
+    private static Stream<Arguments> getNonPositiveRightCardinalityCases() {
+        List<Arguments> cases = Lists.newArrayList();
+
+        // Unknown cardinality: what an information_schema scan reports. -1 / 50000 / dop lands in
+        // (-1, 0), and Math.ceil of that is -0.0, which narrows to 0.
+        cases.add(Arguments.of(1000L, -1L, 1, 16));
+        cases.add(Arguments.of(1000000L, -1L, 16, 128));
+
+        // Both children unknown - the shape of the reported information_schema join.
+        cases.add(Arguments.of(-1L, -1L, 8, 32));
+
+        // An empty right child: a genuine zero, not an unknown.
+        cases.add(Arguments.of(1000000L, 0L, 16, 16));
+
+        return cases.stream();
+    }
+
     private static Stream<Arguments> getCases() {
         List<Arguments> cases = Lists.newArrayList();
 


### PR DESCRIPTION
## Why I'm doing:

Fixes #73024

Joining two `information_schema` tables could fail outright with a bare

```
java.lang.IllegalStateException: null
  at com.google.common.base.Preconditions.checkState(Preconditions.java:496)
  at com.starrocks.qe.scheduler.Deployer.createFragmentInstanceExecStates(Deployer.java:181)
```

That assertion is `!fragment.getInstances().isEmpty()`, and the instance list was empty because
the adaptive node count came out as **zero**:

```
getOptimalNodeNums() -> 0
  -> adaptiveChooseNodes(): childHosts.stream().limit(0)  -> empty worker set
    -> fragment with no instances
      -> checkState fires
```

Zero is reachable whenever the right child's cardinality is not positive:

```java
long baseNodeNums = (long) Math.ceil((double) maxOutputOfRightChild / TINY_SCALE_ROWS_LIMIT / dop);
```

`PlanNode` carries `-1` for "unknown", and a scan over `information_schema` keeps that default
because it never estimates a row count. `-1 / 50000 / dop` lands in `(-1, 0)`, `Math.ceil` of that
is `-0.0`, and narrowing gives `0`. The amplify factor is then multiplied by zero. An empty right
child (a genuine `0`) reaches the same place.

This accounts for all three conditions the report gives:

| Reported condition | Where it lands in the code |
|---|---|
| `choose_execute_instances_mode` = AUTO or ADAPTIVE_DECREASE | selects the `enableDecreaseInstance()` branch |
| candidate nodes ≥ `adaptive_choose_instances_threshold` | the branch's second condition |
| left child's output very small (< 50000 × DOP) | leaves `amplifyFactor` clamped at 1, so the node count is just `baseNodeNums` |

## What I'm doing:

Clamp the node count at one, where the number is produced. Zero nodes is meaningless for every
caller — a fragment that runs nowhere produces nothing — so the invariant belongs in
`getOptimalNodeNums` rather than in each branch that consumes it.

```java
return Math.max(1, Math.min(amplifyFactor * baseNodeNums, candidateSize));
```

This is a correctness fix, so it is unconditional — no new configuration item.

## Verification

`red_before_green_after` on an in-chain dev host (FE UT, four passes):

| pass | result |
|---|---|
| trigger set on the patch's parent | **red** — `Failures: 4, Errors: 0`, `a fragment must run on at least one node, got 0 for right cardinality -1` |
| trigger set on the patch | green |
| control set on the parent | green |
| control set on the patch | green |

The control set is `testNumberEstimateFormula`, the six pre-existing formula cases. They all use
cardinalities of 10000 or more, and any positive value ceils to at least one node, so they never
covered the non-positive case — which is exactly why they make a good control: the clamp must not
move any of them.

The new trigger cases cover unknown cardinality on the right child, unknown on both children (the
shape of the reported `information_schema` join), and a genuinely empty right child.

## Fixes issue

Fixes #73024

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4

All four carry the defect — checked per branch that
`Math.min(amplifyFactor * baseNodeNums, candidateSize)` is still unclamped on each. The report
names 3.3.18 and 3.5.15; 3.3 is not in the backport list.
