### PR TITLE
[Tool] CI: move same-repo no-cascade steps off shared PAT to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -11,6 +11,10 @@ permissions:
   pull-requests: write
   issues: write
   actions: write
+  # get_next_release_tag.sh (version-label steps) reads /tags and /branches with
+  # GITHUB_TOKEN; with an explicit permissions block, unlisted scopes default to
+  # none, so grant contents:read or those queries are denied.
+  contents: read
 env:
   PR_NUMBER: ${{ github.event.number }}
 

--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -223,7 +223,9 @@ jobs:
           !contains(github.event.pull_request.labels.*.name, 'sync') &&
           contains(github.event.pull_request.title, '(backport #')
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          # Same-repo `gh label create`, no cascade; the sibling "add merge label"
+          # step already uses GITHUB_TOKEN. Off the shared PAT.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           LABEL="${GITHUB_BASE_REF##*-}-merged"
           gh label create "${LABEL}" -R ${GITHUB_REPOSITORY} -c 98C1D7 -f

--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -244,7 +244,10 @@ jobs:
         id: prepare_version_label
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          # Same-repo tag/branch reads only. Use the per-run GITHUB_TOKEN (its own
+          # rate-limit budget) instead of the shared PAT: a PAT rate limit here made
+          # get_next_release_tag.sh fall back to <branch>.0 and post a wrong version.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
           version=$(./scripts/get_next_release_tag.sh)
@@ -275,7 +278,10 @@ jobs:
         id: prepare_version_label
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          # Same-repo tag/branch reads only. Use the per-run GITHUB_TOKEN (its own
+          # rate-limit budget) instead of the shared PAT: a PAT rate limit here made
+          # get_next_release_tag.sh fall back to <branch>.0 and post a wrong version.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && git pull >/dev/null
           version=$(./scripts/get_next_release_tag.sh)

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -79,7 +79,8 @@ jobs:
       - name: update body
         if: always() && github.base_ref != 'main' && (github.event.action == 'opened' || github.event.action == 'reopened')
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          # Same-repo PR-body read/edit only, no cascade. Off the shared PAT.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr view ${PR_NUMBER} -R ${REPO} --json body -q .body > body.txt
           ori_body=$(cat body.txt)

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -79,8 +79,12 @@ jobs:
       - name: update body
         if: always() && github.base_ref != 'main' && (github.event.action == 'opened' || github.event.action == 'reopened')
         env:
-          # Same-repo PR-body read/edit only, no cascade. Off the shared PAT.
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # MUST stay a PAT: this step edits the PR body to check "[x] This is a
+          # backport pr", and the edit must emit an `edited` event that re-triggers
+          # this workflow so `check backport pr's title` runs on the updated body.
+          # GITHUB_TOKEN edits do not trigger workflows, which would silently skip
+          # the backport-title check.
+          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           gh pr view ${PR_NUMBER} -R ${REPO} --json body -q .body > body.txt
           ori_body=$(cat body.txt)


### PR DESCRIPTION
## Why I'm doing:

Several CI steps authenticate with the shared `secrets.PAT` (wanpengfei-git). When that account hits its GitHub API rate limit, same-repo steps fail or silently produce wrong output. Concretely, `ci-merged.yml`'s version-label step ran `get_next_release_tag.sh` as the PAT; on a rate limit the tag query returned empty, the script fell back to `<branch>.0`, and still exited 0 — posting a **wrong** `version:` label (real incident: backport PR #78664 into `branch-4.1` got `version:4.1.0` instead of `4.1.5`).

The per-run `secrets.GITHUB_TOKEN` (github-actions[bot]) has its **own, independent** rate-limit budget, so moving same-repo, no-cascade steps onto it removes this failure mode.

## What I'm doing:

`ci-merged.yml`
- Switch to `secrets.GITHUB_TOKEN`:
  - `update_backport_merged_msg` › `prepare version label` and `update_version_label_for_main_feature` › `prepare version label` — `get_next_release_tag.sh` reads same-repo tags/branches only.
  - `update_backport_merged_msg` › `prepare merge label` — same-repo `gh label create`; the sibling `add merge label` already uses `GITHUB_TOKEN`, and no workflow triggers on the `*-merged` label.
- **Grant `contents: read`** in the workflow `permissions` block: with an explicit permissions block, unlisted scopes default to `none`, and the `/tags` and `/branches` reads that `get_next_release_tag.sh` performs require `contents: read`, so `GITHUB_TOKEN` would otherwise be denied.

`pr-checker.yml`
- `title-check` › `update body` **stays on `secrets.PAT`** (only a clarifying comment is added). This step edits the PR body to tick `[x] This is a backport pr`, and that edit must emit an `edited` event that **re-triggers** the workflow so `check backport pr's title` runs against the updated body. `GITHUB_TOKEN` edits do not trigger workflows, so switching it would silently skip the backport-title check.

`GITHUB_TOKEN` is a safe drop-in only where the step is (a) same-repo, (b) has the required permission granted, and (c) does not need to cascade-trigger another workflow. The remaining `secrets.PAT` uses are intentionally left as-is (they add labels that trigger `label-action`, enable automerge, push to contributor forks, or request org-team reviewers).

Companion PR `StarRocks/ci-tool#5232` makes `get_next_release_tag.sh` fail loud instead of emitting the `<branch>.0` fallback.

Thanks to `@chatgpt-codex-connector` for catching the missing `contents` grant (P1) and the required cascade on the body edit (P2).

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5