### PR TITLE
[Tool] ci-merged: guard add version label against empty LABEL

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -262,7 +262,11 @@ jobs:
           gh label create "${version_label}" -R ${GITHUB_REPOSITORY} -c 1d76db -f
 
       - name: add version label
-        if: always()
+        # Skip when the version could not be computed (get_next_release_tag.sh exits
+        # non-zero instead of emitting a <branch>.0 fallback): prepare_version_label
+        # then fails with an empty LABEL, and posting labels[]= would 422. Skip cleanly
+        # and let the failed prepare step signal a re-run.
+        if: always() && steps.prepare_version_label.outputs.LABEL != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_LABEL: ${{ steps.prepare_version_label.outputs.LABEL }}
@@ -296,7 +300,11 @@ jobs:
           gh label create "${version_label}" -R ${GITHUB_REPOSITORY} -c 1d76db -f
 
       - name: add version label
-        if: always()
+        # Skip when the version could not be computed (get_next_release_tag.sh exits
+        # non-zero instead of emitting a <branch>.0 fallback): prepare_version_label
+        # then fails with an empty LABEL, and posting labels[]= would 422. Skip cleanly
+        # and let the failed prepare step signal a re-run.
+        if: always() && steps.prepare_version_label.outputs.LABEL != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION_LABEL: ${{ steps.prepare_version_label.outputs.LABEL }}


### PR DESCRIPTION
## Why I'm doing:

Follow-up to the version-label token change (StarRocks#78715 / CelerData#62099) and the fail-loud hardening in `StarRocks/ci-tool#5232`. `get_next_release_tag.sh` now **exits non-zero** instead of emitting a wrong `<branch>.0` fallback. Under the default `bash -eo pipefail`, `version=$(./scripts/get_next_release_tag.sh)` then aborts the `prepare version label` step, so its `LABEL` output is empty. But `add version label` is `if: always()`, so it still runs and posts `labels[]=` (empty) — a `422` and extra noise.

## What I'm doing:

Guard both `add version label` steps to run only when a label was computed:

```yaml
if: always() && steps.prepare_version_label.outputs.LABEL != 
```

Now if the version cannot be computed, the failed `prepare` step is the single clear signal (re-run), and `add version label` is skipped cleanly instead of 422-ing on an empty label. No other change.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] This is a backport pr