### PR TITLE
[UT] Make JsonDocumentStreamParserTest.with_dynamic_batch_size_6 actually use a small batch

### DIFF
--- a/be/test/formats/json/json_parser_test.cpp
+++ b/be/test/formats/json/json_parser_test.cpp
@@ -393,7 +393,15 @@ TEST_F(JsonDocumentStreamParserTest, test_truncated_bytes) {
 }
 
 TEST_F(JsonDocumentStreamParserTest, with_dynamic_batch_size_6) {
-    config::json_parse_many_batch_size = 1;
+    // JsonDocumentStreamParser copies config::json_parse_many_batch_size in its constructor, so
+    // the parser built by SetUp() (default batch size) has to be rebuilt after the config changes.
+    // The constructor also falls back to DEFAULT_BATCH_SIZE unless the value exceeds
+    // simdjson::dom::MINIMAL_BATCH_SIZE (32), so the previous `1` never took effect: this test only
+    // exercised the dynamic batch growth by accident, through the 40 leaked by earlier tests before
+    // the fixtures restored the config. 40 is what the sibling tests use and is shorter than the
+    // second document below, which is what forces the batch to grow.
+    config::json_parse_many_batch_size = 40;
+    _parser = std::make_unique<JsonDocumentStreamParser>(&_simdjson_parser);
     // ndjson with ' ', '/t', '\n'
     std::string input = R"(   {"key1": 1}
     {"keyxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx2": 2}


### PR DESCRIPTION
## Why I'm doing:

`JsonDocumentStreamParser` copies `config::json_parse_many_batch_size` in its constructor, and only honours values above `simdjson::dom::MINIMAL_BATCH_SIZE` (32) — anything smaller falls back to `DEFAULT_BATCH_SIZE`:

```cpp
JsonDocumentStreamParser::JsonDocumentStreamParser(simdjson::ondemand::parser* parser) : JsonParser(parser) {
    _batch_size = (config::json_parse_many_batch_size > simdjson::dom::MINIMAL_BATCH_SIZE)
                          ? config::json_parse_many_batch_size
                          : simdjson::dom::DEFAULT_BATCH_SIZE;
}
```

`JsonDocumentStreamParserTest.with_dynamic_batch_size_6` sets the config to `1` **after** `SetUp()` has already constructed `_parser`, so the value never reaches the parser — and `1` would have been replaced by the default anyway.

Before #75921 the test still went through the dynamic batch growth path (`_check_and_new_doc_stream_iterator`), but only by accident: the preceding `JsonParserTest.test_json_document_stream_parser_with_dynamic_batch_size_*` cases left the config at `40` and `SetUp()` built the parser with that leaked value. Now that both fixtures save/restore the config, the parser is built with the 1 MB default, the ~200-byte input is parsed in a single batch, and the growth logic the test is named for is no longer covered.

We noticed this while running `json_parser_test.cpp` in a single process on a downstream 4.1.4 build: the leaked `40` also made `test_truncated_bytes` see a 44-byte input split into 40-byte batches (`truncated_bytes()` = 4294967295). #75921 already fixed that leak on `main`; this PR fixes the test that silently lost its coverage as a result.

## What I'm doing:

- Set `config::json_parse_many_batch_size` to `40` — what the sibling tests use, and shorter than the second document, so the batch has to grow.
- Rebuild `_parser` after setting it, since the constructor is where the value is read.
- Comment the two constraints (construction-time copy, `MINIMAL_BATCH_SIZE` floor) at the test so the pattern is not repeated.

`test_big_json` sets `1` as well, which is equally ineffective, but its input (`big.json`, 1.7 MB) exceeds the 1 MB default batch, so it still exercises multi-batch parsing; left unchanged.

Fixes #issue (none filed; test-only)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature (test-only change)
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)