### PR TITLE
[BugFix] Reject malformed binary column offsets at deserialization

### DIFF
--- a/be/src/column/serde/column_array_serde.cpp
+++ b/be/src/column/serde/column_array_serde.cpp
@@ -251,6 +251,43 @@ public:
     }
 };
 
+// A binary column is only well-formed when its offsets describe its byte payload: there is at least the
+// leading offset, the first one is zero, they never decrease, and the last one equals the payload size.
+// Consumers such as `append_selective` and `get_slice` index the byte buffer straight from the offsets,
+// so a buffer that violates any of this must be rejected here, at the boundary where it enters the process.
+static Status binary_column_corruption(const std::string& msg) {
+    if (config::enable_dcheck_on_serde_failure) {
+        DCHECK(false) << msg;
+    }
+    return Status::Corruption(msg);
+}
+
+template <typename T>
+static Status check_binary_offsets(const Buffer<T>& offsets, size_t bytes_size) {
+    if (UNLIKELY(offsets.empty())) {
+        return binary_column_corruption("binary column has no offsets");
+    }
+    if (UNLIKELY(offsets.front() != 0)) {
+        return binary_column_corruption(fmt::format("binary column first offset is {}, expected 0", offsets.front()));
+    }
+    if (UNLIKELY(offsets.back() != bytes_size)) {
+        return binary_column_corruption(fmt::format("binary column last offset {} does not match byte payload size {}",
+                                                    offsets.back(), bytes_size));
+    }
+    const T* data = offsets.data();
+    const size_t num_offsets = offsets.size();
+    bool non_decreasing = true;
+    for (size_t i = 1; i < num_offsets; ++i) {
+        non_decreasing &= (data[i - 1] <= data[i]);
+    }
+    if (UNLIKELY(!non_decreasing)) {
+        return binary_column_corruption(
+                fmt::format("binary column offsets are not non-decreasing, num_offsets: {}, byte payload size: {}",
+                            num_offsets, bytes_size));
+    }
+    return Status::OK();
+}
+
 class BinaryColumnSerde {
 public:
     template <typename T>
@@ -346,6 +383,15 @@ public:
         } else {
             ASSIGN_OR_RETURN(buff, read_little_endian_64(buff, end, &offset_bytes_size));
         }
+        // The bytes were already resized to the payload, so do not leave a rejected column half-built.
+        auto reject = [column](Status st) {
+            column->reset_column();
+            return st;
+        };
+        if (UNLIKELY(offset_bytes_size % sizeof(T) != 0)) {
+            return reject(binary_column_corruption(fmt::format(
+                    "binary column offset payload size {} is not a multiple of {}", offset_bytes_size, sizeof(T))));
+        }
         Buffer<T> offsets;
         raw::make_room(&offsets, offset_bytes_size / sizeof(T));
 
@@ -354,6 +400,9 @@ public:
             ASSIGN_OR_RETURN(buff, decode_integers<is_i32>(buff, end, offsets.data(), offset_bytes_size));
         } else {
             ASSIGN_OR_RETURN(buff, read_raw(buff, end, offsets.data(), offset_bytes_size));
+        }
+        if (auto st = check_binary_offsets<T>(offsets, bytes_size); !st.ok()) {
+            return reject(std::move(st));
         }
         if constexpr (std::is_same_v<T, uint32_t>) {
             column->get_offset().set_small_buffer(std::move(offsets));

--- a/be/test/runtime/serde_core_test.cpp
+++ b/be/test/runtime/serde_core_test.cpp
@@ -15,6 +15,9 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 #include "base/coding.h"
 #include "base/failpoint/fail_point.h"
@@ -785,6 +788,146 @@ PARALLEL_TEST(ColumnArraySerdeTest, binary_column_serialize_rejects_unrepresenta
     ASSERT_FALSE(st.ok());
     ASSERT_TRUE(st.status().is_capacity_limit_exceeded()) << st.status();
     ASSERT_NE(std::string::npos, std::string(st.status().message()).find("byte payload size")) << st.status();
+}
+
+// The serializer writes the offsets verbatim, so a malformed offset array can be pushed through it and
+// presented to the deserializer. The bytes are backed by a ContainerResource: the column is deliberately
+// inconsistent, and a resource-backed column skips the bytes/offsets consistency DCHECK on destruction.
+template <typename ColumnType>
+static typename ColumnType::MutablePtr make_malformed_binary_column(const std::shared_ptr<std::string>& bytes,
+                                                                    const std::vector<uint64_t>& offsets) {
+    const bool old_zero_copy = config::enable_zero_copy_from_page_cache;
+    config::enable_zero_copy_from_page_cache = true;
+    DeferOp restore_zero_copy([old_zero_copy] { config::enable_zero_copy_from_page_cache = old_zero_copy; });
+
+    ContainerResource resource(bytes, bytes->data(), bytes->size());
+    typename ColumnType::Offsets column_offsets;
+    if constexpr (std::is_same_v<ColumnType, BinaryColumn>) {
+        Buffer<uint32_t> buf;
+        for (auto offset : offsets) {
+            buf.push_back(static_cast<uint32_t>(offset));
+        }
+        column_offsets.set_small_buffer(std::move(buf));
+    } else {
+        Buffer<uint64_t> buf(offsets.begin(), offsets.end());
+        column_offsets.set_large_buffer(std::move(buf));
+    }
+    return ColumnType::create(std::move(resource), std::move(column_offsets));
+}
+
+template <typename ColumnType>
+static void assert_deserialize_rejects_offsets(const std::string& bytes, const std::vector<uint64_t>& offsets,
+                                               const std::string& expected_message) {
+    auto owner = std::make_shared<std::string>(bytes);
+    auto malformed = make_malformed_binary_column<ColumnType>(owner, offsets);
+    for (auto level = -1; level < 8; ++level) {
+        std::vector<uint8_t> buffer(ColumnArraySerde::max_serialized_size(*malformed, level));
+        const auto* end = buffer.data() + buffer.size();
+        ASSERT_OK(ColumnArraySerde::serialize(*malformed, buffer.data(), false, level));
+
+        auto column = ColumnType::create();
+        auto st = ColumnArraySerde::deserialize(buffer.data(), end, column.get(), false, level);
+        ASSERT_FALSE(st.ok()) << "encode level " << level << " accepted offsets " << ::testing::PrintToString(offsets);
+        ASSERT_TRUE(st.status().is_corruption()) << "encode level " << level << ": " << st.status();
+        ASSERT_NE(std::string::npos, std::string(st.status().message()).find(expected_message))
+                << "encode level " << level << ": " << st.status();
+        // A rejected buffer must not leave a half-built column behind.
+        ASSERT_EQ(0u, column->size());
+        ASSERT_EQ(0u, column->get_immutable_bytes().size());
+    }
+}
+
+// A well-formed column with enough rows to reach the integer-encoded offset path must still round-trip.
+template <typename ColumnType>
+static void assert_well_formed_offsets_round_trip() {
+    auto c1 = ColumnType::create();
+    for (int i = 0; i < 300; ++i) {
+        std::string value = (i % 3 == 0) ? "" : std::string(1 + i % 7, 'a' + i % 26);
+        c1->append(Slice(value));
+    }
+    for (auto level = -1; level < 8; ++level) {
+        std::vector<uint8_t> buffer(ColumnArraySerde::max_serialized_size(*c1, level));
+        const auto* end = buffer.data() + buffer.size();
+        ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data(), false, level));
+        auto c2 = ColumnType::create();
+        ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), end, c2.get(), false, level));
+        ASSERT_EQ(c1->size(), c2->size());
+        for (size_t i = 0; i < c1->size(); i++) {
+            ASSERT_EQ(c1->get_slice(i), c2->get_slice(i));
+        }
+    }
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, binary_column_deserialize_rejects_malformed_offsets) {
+    // Consumers index the byte buffer straight from the offsets, so every one of these would let a later
+    // append_selective or get_slice read outside the payload if the deserializer accepted it.
+    assert_deserialize_rejects_offsets<BinaryColumn>("bbbbbcccc", {0, 6, 3, 9}, "not non-decreasing");
+    assert_deserialize_rejects_offsets<BinaryColumn>("bbbbbcccc", {0, 3, 6, 12}, "does not match byte payload size");
+    assert_deserialize_rejects_offsets<BinaryColumn>("bbbbbcccc", {0, 3, 6, 8}, "does not match byte payload size");
+    assert_deserialize_rejects_offsets<BinaryColumn>("bbbbbcccc", {1, 3, 6, 9}, "first offset is 1");
+    // The last offset is right, but an inner one points past the payload and wraps the row length.
+    assert_deserialize_rejects_offsets<BinaryColumn>("bbbbbcccc", {0, 3, 4294967295ull, 9}, "not non-decreasing");
+
+    assert_deserialize_rejects_offsets<LargeBinaryColumn>("bbbbbcccc", {0, 6, 3, 9}, "not non-decreasing");
+    assert_deserialize_rejects_offsets<LargeBinaryColumn>("bbbbbcccc", {0, 3, 6, 12},
+                                                          "does not match byte payload size");
+    assert_deserialize_rejects_offsets<LargeBinaryColumn>("bbbbbcccc", {1, 3, 6, 9}, "first offset is 1");
+
+    // Enough offsets to take the integer-encoded path: 101 offsets are above ENCODE_SIZE_LIMIT bytes.
+    {
+        std::string bytes(200, 'x');
+        std::vector<uint64_t> offsets;
+        for (int i = 0; i <= 100; ++i) {
+            offsets.push_back(i * 2);
+        }
+        std::swap(offsets[40], offsets[41]);
+        assert_deserialize_rejects_offsets<BinaryColumn>(bytes, offsets, "not non-decreasing");
+        assert_deserialize_rejects_offsets<LargeBinaryColumn>(bytes, offsets, "not non-decreasing");
+    }
+
+    assert_well_formed_offsets_round_trip<BinaryColumn>();
+    assert_well_formed_offsets_round_trip<LargeBinaryColumn>();
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, binary_column_deserialize_rejects_empty_or_misaligned_offsets) {
+    std::vector<Slice> strings{{"bbb"}, {"bbc"}, {"ccc"}};
+    auto c1 = BinaryColumn::create();
+    c1->append_strings(strings.data(), strings.size());
+
+    std::vector<uint8_t> buffer(ColumnArraySerde::max_serialized_size(*c1));
+    const auto* end = buffer.data() + buffer.size();
+    ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data()));
+
+    // Layout: u32 bytes_size, bytes, u32 offset_bytes_size, offsets.
+    const size_t offset_bytes_size_pos = sizeof(uint32_t) + c1->get_immutable_bytes().size();
+
+    auto expect_rejected = [&](uint32_t offset_bytes_size, const std::string& expected_message) {
+        auto corrupted = buffer;
+        encode_fixed32_le(corrupted.data() + offset_bytes_size_pos, offset_bytes_size);
+        const auto* corrupted_end = corrupted.data() + corrupted.size();
+        auto c2 = BinaryColumn::create();
+        auto st = ColumnArraySerde::deserialize(corrupted.data(), corrupted_end, c2.get());
+        ASSERT_FALSE(st.ok()) << "offset_bytes_size " << offset_bytes_size;
+        ASSERT_TRUE(st.status().is_corruption()) << st.status();
+        ASSERT_NE(std::string::npos, std::string(st.status().message()).find(expected_message)) << st.status();
+        ASSERT_EQ(0u, c2->size());
+        ASSERT_EQ(0u, c2->get_immutable_bytes().size());
+    };
+
+    // No offsets at all: not even the leading zero.
+    expect_rejected(0, "has no offsets");
+    // Not a whole number of u32 offsets.
+    expect_rejected(15, "not a multiple of");
+
+    // The untouched buffer still round-trips.
+    auto c3 = BinaryColumn::create();
+    ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), end, c3.get()));
+    ASSERT_EQ(c1->size(), c3->size());
+    for (size_t i = 0; i < c1->size(); i++) {
+        ASSERT_EQ(c1->get_slice(i), c3->get_slice(i));
+    }
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
## Why I'm doing:

A 4.1.1 shared-nothing BE crashed with this stack (#78718, same signature as #68968):

```text
PC: starrocks::BinaryColumnBase<unsigned int>::append_selective
    starrocks::MemTable::insert
    starrocks::DeltaWriter::write
    starrocks::AsyncDeltaWriter::_execute
```

About 1.4 s before the signal, the same thread logged a `large memory alloc` of `4308971234` bytes from `bytes.resize()` inside that same `append_selective`, with zero query and fragment ids. The destination is a MemTable that `DeltaWriter::write` flushes as soon as one insert pushes it past `write_buffer_size` (100 MB by default), so the 4.3 GB was not accumulated across inserts: it is the sum of `src_offsets[idx + 1] - src_offsets[idx]` over the rows selected from **one** incoming load chunk, and the faulting instruction is the read of that chunk's bytes. The source column's offsets did not describe its byte buffer. A `BinaryColumn` with `uint32` offsets cannot legitimately hold 4.2 GB, and a single decreasing offset pair wraps to a row length of almost exactly that.

How the malformed column came to be is not established (no core), so this PR does not claim to fix the root cause of that incident. What it fixes is the one place on the load path where a binary column's offsets enter the process without being checked:

`LoadChannel::_deserialize_chunk` → `ProtobufChunkDeserializer::deserialize` → `ColumnArraySerde::deserialize` → `BinaryColumnSerde::deserialize` reads the byte payload and the offset array and installs the offsets as they are. It does not check that the offset payload is a whole number of offsets, that the array is non-empty, that it starts at 0, that it never decreases, or that its last element equals the byte payload size. `ProtobufChunkDeserializer` only checks the row count. Every consumer downstream (`append_selective`, `append`, `get_slice`, ...) indexes the byte buffer straight from those offsets, and the capacity guards from #77163 measure the byte size, not whether the offsets describe it. The same deserializer serves the exchange receiver, spill, the partial-update `.upt` and del files, the dictionary cache and primary key recovery, so the check covers those too. It is identical on branch-4.1, branch-4.0 and branch-3.5 (under `be/src/serde/`).

## What I'm doing:

Reject a malformed offset array in `BinaryColumnSerde::deserialize` with `Status::Corruption`, for both `BinaryColumn` and `LargeBinaryColumn` and on both the raw and the integer-encoded offset paths:

- the offset payload size must be a multiple of the offset width (checked before the buffer is read);
- there must be at least the leading offset;
- the first offset must be 0;
- the last offset must equal the byte payload size;
- the offsets must be non-decreasing (one branch-free linear pass, the only O(rows) part).

A rejected column is reset instead of being left with its bytes already resized to the payload, so the caller never sees a half-built column. The check honours `enable_dcheck_on_serde_failure` like the existing size checks in this file.

Cost: one pass over `rows + 1` offsets per deserialized string column, next to the copy of the byte payload itself. The O(1) checks alone are not enough: an inner decreasing pair with a correct last offset is exactly the case that wraps a row length to ~4 GiB.

Tests (`runtime_test`, `ColumnArraySerdeTest`):

- `binary_column_deserialize_rejects_malformed_offsets`: builds columns whose offsets decrease, overshoot or undershoot the payload, start at 1, or contain an inner offset past the payload that wraps the row length; serializes them (the serializer writes offsets verbatim) at every encode level from -1 to 7, and asserts that deserialization returns `Corruption` naming the violated property and leaves the target column empty. Covers `BinaryColumn` and `LargeBinaryColumn`, and a 101-offset case that takes the streamvbyte path. Also checks a well-formed 300-row column still round-trips at every level. On the unpatched code every one of these deserializes successfully.
- `binary_column_deserialize_rejects_empty_or_misaligned_offsets`: patches a valid serialized buffer to claim zero offset bytes, then 15 offset bytes, and asserts `Corruption`; the untouched buffer still round-trips.

Verification (x86_64, official dev image, `BUILD_TYPE=ASAN`):

```text
BUILD_TYPE=ASAN ./run-be-ut.sh --build-target runtime_test --module runtime_test --without-java-ext -j6 --gtest_filter='ColumnArraySerdeTest.*'
python3 build-support/check_be_module_boundaries.py --mode full   # OK
python3 build-support/render_be_agents.py --check                  # OK
clang-format-10 (the CI binary) on both files; git diff --check clean
```

Results are in the first comment. The incident was on aarch64; the change is plain C++ with no architecture-specific code, but it has only been exercised on x86_64.

Observability: deserialization failures on this path already surface through the `Status` returned to `LoadChannel::_deserialize_chunk` (reported to the sink as the load error, with the load id logged there) and to the exchange receiver, and the load profile's `DeserializeChunkCount`/`DeserializeChunkTime` cover the deserialization itself. The new rejection reuses that same `Status` path and the message style of the existing size checks, so no new signal is needed; the message names the violated property and the sizes involved.

Issue: #78718 (this PR is the hardening described there; the root cause of the malformed source column is still open, so the issue is not closed by this PR). Related: #68968.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

A serialized string column whose offset array does not describe its byte payload is now rejected with `Corruption` at deserialization (load and exchange receivers, spill, `.upt`/del files, dictionary cache, PK recovery) instead of being accepted and consumed. Well-formed data, which is everything a correct writer produces, is unaffected; the wire and file formats are unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
