### PR TITLE
[BugFix] Fix substr returning bytes of neighboring rows on invalid UTF-8

### DIFF
--- a/be/src/base/string/utf8.h
+++ b/be/src/base/string/utf8.h
@@ -97,10 +97,12 @@ static inline Slice truncate_utf8(const Slice& str, const size_t max_size) {
 template <bool use_skipped_chars>
 static inline const char* skip_leading_utf8(const char* p, const char* end, size_t n,
                                             [[maybe_unused]] size_t* skipped_chars) {
-    int char_size = 0;
+    size_t char_size = 0;
     size_t i = 0;
     for (; i < n && p < end; ++i, p += char_size) {
-        char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<uint8_t>(*p)];
+        // A truncated/invalid UTF-8 lead byte at the tail can claim more bytes than remain;
+        // clamp to the rest of the string so the returned pointer stays within the input.
+        char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<uint8_t>(*p)], static_cast<size_t>(end - p));
     }
     if constexpr (use_skipped_chars) {
         *skipped_chars = i;

--- a/be/src/base/string/utf8_encoding.h
+++ b/be/src/base/string/utf8_encoding.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -70,8 +71,10 @@ public:
 };
 
 static inline size_t encode_utf8_chars(const Slice& str, std::vector<EncodedUtf8Char>* encoded_values) {
-    for (int i = 0, char_size = 0; i < str.size; i += char_size) {
-        char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])];
+    for (size_t i = 0, char_size = 0; i < str.size; i += char_size) {
+        // A truncated/invalid UTF-8 lead byte at the tail can claim more bytes than remain;
+        // clamp to the rest of the string to avoid an out-of-bounds read of adjacent memory.
+        char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])], str.size - i);
         encoded_values->emplace_back(str.data + i, char_size);
     }
     return encoded_values->size();

--- a/be/src/exprs/locate.cpp
+++ b/be/src/exprs/locate.cpp
@@ -207,8 +207,7 @@ ColumnPtr haystack_vector_and_needle_vector(const ColumnPtr& haystack_ptr, const
             auto searcher =
                     LocateCaseSensitiveUTF8::createSearcherInSmallHaystack(needle_slice.data, needle_slice.size);
 
-            const char* beg =
-                    skip_leading_utf8(haystack_slice.data, haystack_slice.data + haystack_size - 1, start - 1);
+            const char* beg = skip_leading_utf8(haystack_slice.data, haystack_slice.data + haystack_size, start - 1);
             /// searcher returns a pointer to the found substring or to the end of `haystack`.
             const char* res_pointer = searcher.search(beg, haystack_size - (beg - haystack_slice.data));
             if (!res_pointer) {

--- a/be/test/base/string/utf8_encoding_test.cpp
+++ b/be/test/base/string/utf8_encoding_test.cpp
@@ -46,6 +46,17 @@ TEST(Utf8EncodingTest, encodesAsciiAndMultibyteCharacters) {
     EXPECT_EQ(std::string_view(input + 4, 4), encoded_value_as_string_view(values[2]));
 }
 
+TEST(Utf8EncodingTest, clampsTruncatedTailLeadByteToInput) {
+    const char input[] = {'a', static_cast<char>(0xF0)};
+    std::vector<EncodedUtf8Char> values;
+
+    EXPECT_EQ(2, encode_utf8_chars(Slice(input, sizeof(input)), &values));
+    ASSERT_EQ(2, values.size());
+
+    EXPECT_EQ(std::string_view(input, 1), encoded_value_as_string_view(values[0]));
+    EXPECT_EQ(std::string_view(input + 1, 1), encoded_value_as_string_view(values[1]));
+}
+
 TEST(Utf8EncodingTest, defaultValueConvertsToEmptySlice) {
     EncodedUtf8Char value;
     Slice slice = value;

--- a/be/test/exprs/string_fn_locate_test.cpp
+++ b/be/test/exprs/string_fn_locate_test.cpp
@@ -145,6 +145,51 @@ TEST_F(StringFunctionLocateTest, locatePosTest) {
     }
 }
 
+TEST_F(StringFunctionLocateTest, locateStartBeyondLastUtf8CharTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto sub = BinaryColumn::create();
+    auto str = BinaryColumn::create();
+    auto pos = Int32Column::create();
+
+    // a start position past the last character leaves nothing to scan, so the result is 0;
+    // the walk has to step over the whole last character to reach that end
+    str->append("你a");
+    sub->append("a");
+    pos->append(3);
+
+    str->append("你好b");
+    sub->append("b");
+    pos->append(4);
+
+    // a start position on the last character still finds it
+    str->append("你好");
+    sub->append("好");
+    pos->append(2);
+
+    // the 0xF0 lead byte claims four bytes while only two are left, so the walk ends at the end
+    // of the value and the search is left with nothing to scan
+    str->append(
+            Slice("a\xF0"
+                  "b",
+                  3));
+    sub->append("b");
+    pos->append(3);
+
+    columns.emplace_back(std::move(sub));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
+
+    ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
+    ASSERT_EQ(4, result->size());
+
+    auto v = ColumnHelper::cast_to<TYPE_INT>(result);
+    ASSERT_EQ(0, v->get_data()[0]);
+    ASSERT_EQ(0, v->get_data()[1]);
+    ASSERT_EQ(2, v->get_data()[2]);
+    ASSERT_EQ(0, v->get_data()[3]);
+}
+
 TEST_F(StringFunctionLocateTest, locateHayStackEqualNeedleTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -160,6 +160,30 @@ PARALLEL_TEST(VecStringFunctionsTest, substrConstASCIITest) {
     }
 }
 
+PARALLEL_TEST(VecStringFunctionsTest, substrTruncatedUtf8TailTest) {
+    // a lead byte at the tail that claims more bytes than remain must not extend the result past the input
+    auto str = BinaryColumn::create();
+    str->append(Slice("A\xF0", 2));
+    str->append(Slice("\xE4\xBD", 2));
+    str->append("壹贰");
+
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    auto state = std::make_unique<SubstrState>();
+    ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, state.get());
+    state->is_const = true;
+    state->pos = 1;
+    state->len = 2;
+    starrocks::Columns columns;
+    columns.emplace_back(str);
+
+    ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
+    auto* binary = down_cast<const BinaryColumn*>(result.get());
+    ASSERT_EQ(3, binary->size());
+    ASSERT_EQ(Slice("A\xF0", 2), binary->get_slice(0));
+    ASSERT_EQ(Slice("\xE4\xBD", 2), binary->get_slice(1));
+    ASSERT_EQ("壹贰", binary->get_slice(2).to_string());
+}
+
 PARALLEL_TEST(VecStringFunctionsTest, substrConstZhTest) {
     auto str = BinaryColumn::create();
     str->append("壹贰叁肆伍陆柒捌玖");


### PR DESCRIPTION
## Why I'm doing:

`substr`, `left`, `lpad`, `rpad` and `translate` return bytes that were never part of the input when a value ends in a truncated UTF-8 lead byte, and `locate` searches past the end of such a value.

```sql
create table t(id int, s varchar(50), n varchar(10)) duplicate key(id) distributed by hash(id) buckets 1
properties("replication_num" = "1");
insert into t select 1, unhex('6162F0'), 'b' from table(generate_series(1, 1));
insert into t select 2, unhex('61F062'), 'b' from table(generate_series(1, 1));
select id, hex(s), hex(substr(s, 1, 3)), locate(n, s, 3) from t order by id;
-- 1  6162F0  6162F061F062     0
-- 2  61F062  61F0624576     499
select locate('a', '你a', 3), locate('b', '你好b', 4);
-- 2  3   (MySQL: 0  0)
```

Row 1 ends with the bytes of row 2, and row 2 gets a position far past a three-byte value; the exact bytes and position change from run to run with what sits next to the value in memory.

`skip_leading_utf8` (`be/src/base/string/utf8.h`) and `encode_utf8_chars` (`be/src/base/string/utf8_encoding.h`) step by `UTF8_BYTE_LENGTH_TABLE[lead byte]` without checking how many bytes remain, so the walk ends up to three bytes past the value; the callers copy up to the returned pointer, or the encoded character carries those bytes. #75068 fixed the same lookup in `split`, `split_part` and `str_to_map` and left the two shared helpers as they were.

`locate` with a column needle (`be/src/exprs/locate.cpp`) hands the same walk an end one byte short of the haystack. Past a truncated tail the returned pointer lands beyond the row and `haystack_size - (beg - haystack_slice.data)` underflows, so the search runs off the row. With well-formed UTF-8 the short end stops the walk before the last character, so a start past the last character still finds a match.

## What I'm doing:

Clamp `char_size` to the bytes that remain in both helpers, the way #75068 did in `split.cpp`, and pass `locate` the real end of the haystack. The overshoot can only happen on the step that ends the loop, so the character count is unchanged; only the returned pointer and the last encoded character shrink to the input.

`Utf8EncodingTest.clampsTruncatedTailLeadByteToInput`, `VecStringFunctionsTest.substrTruncatedUtf8TailTest` and `StringFunctionLocateTest.locateStartBeyondLastUtf8CharTest` fail on main: the first and the last abort under ASAN (stack-buffer-overflow in `encode_utf8_chars`, SEGV in `locate`), and the substr case returns five bytes for a two-byte value.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
