### PR TITLE
[BugFix] Guarantee a completed merge-commit load reports full merge window progress

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/batchwrite/MergeCommitTask.java
@@ -955,7 +955,12 @@ public class MergeCommitTask extends AbstractStreamLoadTask implements Runnable 
             } else {
                 mergeWindowElapsedMs = System.currentTimeMillis() - execStartTime;
             }
-            double progress = (double) Math.min(mergeCommitIntervalMs, mergeWindowElapsedMs) / mergeCommitIntervalMs;
+            // A completed load did run the merge window out. The elapsed time above cannot show that reliably:
+            // the backends start the window while the load fragments are still being deployed, before
+            // execWaitStartTimeMs is taken, and time it on a clock of their own. It can also come out negative,
+            // since both of its ends are read from a wall clock that NTP can step backwards.
+            double progress = taskState == TaskState.FINISHED ? 1.0
+                    : (double) Math.max(0, Math.min(mergeCommitIntervalMs, mergeWindowElapsedMs)) / mergeCommitIntervalMs;
             info.setProgress(String.format("Merge Window %.2f%%", progress * 100));
             return info;
         });

--- a/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/batchwrite/MergeCommitTaskTest.java
@@ -51,6 +51,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -879,8 +881,16 @@ public class MergeCommitTaskTest extends BatchWriteTestBase {
         assertEquals("NORMAL", info.getPriority());
         assertNotNull(info.getCreate_time());
         assertNotNull(info.getRuntime_details());
-        assertNotNull(info.getProgress());
-        assertTrue(info.getProgress().startsWith("Merge Window"));
+        // Merge window progress is a rough estimate, so only its guarantees are asserted: a load that completed
+        // reports the window as fully advanced, and every other load reports a percentage within 0 to 100 - the
+        // pattern below carries the lower bound, since it does not admit a leading minus sign.
+        if (taskState == MergeCommitTask.TaskState.FINISHED) {
+            assertEquals("Merge Window 100.00%", info.getProgress());
+        } else {
+            Matcher progressMatcher = Pattern.compile("^Merge Window (\\d+\\.\\d{2})%$").matcher(info.getProgress());
+            assertTrue(progressMatcher.matches(), info.getProgress());
+            assertTrue(Double.parseDouble(progressMatcher.group(1)) <= 100.0, info.getProgress());
+        }
         String expectedState = convertTaskStateToLoadState(taskState);
         assertEquals(expectedState, info.getState());
         assertNotNull(info.getWarehouse());

--- a/test/sql/test_stream_load/R/test_merge_commit_observability
+++ b/test/sql/test_stream_load/R/test_merge_commit_observability
@@ -96,9 +96,9 @@ select count(*) from t2;
 -- result:
 0
 -- !result
-select STATE, TYPE, (DB_NAME = 'db_${uuid1}'), TABLE_NAME, starts_with(LABEL, 'merge_commit'), WAREHOUSE, SCAN_ROWS, SCAN_BYTES, FILTERED_ROWS, SINK_ROWS, UNSELECTED_ROWS, PROGRESS from information_schema.loads where DB_NAME='db_${uuid1}' and TABLE_NAME='t2';
+select STATE, TYPE, (DB_NAME = 'db_${uuid1}'), TABLE_NAME, starts_with(LABEL, 'merge_commit'), WAREHOUSE, SCAN_ROWS, SCAN_BYTES, FILTERED_ROWS, SINK_ROWS, UNSELECTED_ROWS from information_schema.loads where DB_NAME='db_${uuid1}' and TABLE_NAME='t2';
 -- result:
-CANCELLED	MERGE_COMMIT	1	t2	1	default_warehouse	1	65	1	0	0	Merge Window 100.00%
+CANCELLED	MERGE_COMMIT	1	t2	1	default_warehouse	1	65	1	0	0
 -- !result
 SELECT j.`key`, j.`value` FROM information_schema.loads, LATERAL json_each(PROPERTIES) AS j WHERE DB_NAME='db_${uuid1}' and TABLE_NAME='t2' ORDER BY j.`key`;
 -- result:

--- a/test/sql/test_stream_load/T/test_merge_commit_observability
+++ b/test/sql/test_stream_load/T/test_merge_commit_observability
@@ -68,7 +68,7 @@ sync;
 select count(*) from t2;
 
 -- Verify information_schema.loads for failed merge commit stream load
-select STATE, TYPE, (DB_NAME = 'db_${uuid1}'), TABLE_NAME, starts_with(LABEL, 'merge_commit'), WAREHOUSE, SCAN_ROWS, SCAN_BYTES, FILTERED_ROWS, SINK_ROWS, UNSELECTED_ROWS, PROGRESS from information_schema.loads where DB_NAME='db_${uuid1}' and TABLE_NAME='t2';
+select STATE, TYPE, (DB_NAME = 'db_${uuid1}'), TABLE_NAME, starts_with(LABEL, 'merge_commit'), WAREHOUSE, SCAN_ROWS, SCAN_BYTES, FILTERED_ROWS, SINK_ROWS, UNSELECTED_ROWS from information_schema.loads where DB_NAME='db_${uuid1}' and TABLE_NAME='t2';
 SELECT j.`key`, j.`value` FROM information_schema.loads, LATERAL json_each(PROPERTIES) AS j WHERE DB_NAME='db_${uuid1}' and TABLE_NAME='t2' ORDER BY j.`key`;
 SELECT j.`key` FROM information_schema.loads, LATERAL json_each(RUNTIME_DETAILS) AS j WHERE DB_NAME='db_${uuid1}' and TABLE_NAME='t2' ORDER BY j.`key`;
 select like(ERROR_MSG, 'There is a data quality issue. Please check the tracking URL or SQL for details. Tracking URL: %. Tracking SQL: %') as MATCHES_PATTERN from information_schema.loads where DB_NAME='db_${uuid1}' and TABLE_NAME='t2';


### PR DESCRIPTION
## Why I'm doing:

`information_schema.loads` reports merge-commit progress as `Merge Window <pct>%`, derived on the frontend from
`endTimeMs - execWaitStartTimeMs` and clamped to the merge-commit interval. That is a measurement the frontend
cannot make:

- The window is timed on the backends. `TimeBoundedStreamLoadPipe` starts its clock when the pipe is constructed
 during fragment preparation, while `coordinator.exec()` is still in flight — before `execWaitStartTimeMs` is
 taken. The origin is late, so the elapsed time reads short.
- `endTimeMs` is taken when the task reaches a final state, after the window closed and the transaction was
 committed or aborted. The end is late as well, which happens to cancel out the first error — usually.
- The two are read from different clocks anyway: the backend times the window with `MonotonicNanos()`, the
 frontend measures with `System.currentTimeMillis()`, which NTP can slew and step.

So the reported value only reached 100% when the finish tail happened to outrun the deploy tail. A load that ends
in a data-quality abort has almost no finish tail — one `abortTransaction` — so the two are the same order of
magnitude and the outcome is a race:

```
CANCELLED MERGE_COMMIT... Merge Window 99.93%
```

That is 2998 ms measured for a window the backend pipe held open for a full 3000 ms; `_finish_pipe_if_needed()`
finishes the pipe only once `current_ts - _start_time_ns - _active_window_ns >= 0` and has no early-close path.
A completed load whose progress never reaches 100% is wrong on its own, and it makes
`test_merge_commit_observability` flaky.

## What I'm doing:

Stop presenting the value as if it were exact, and guarantee only what the frontend can actually deliver:

- a load that completed reports exactly `Merge Window 100.00%`;
- every other load reports the existing elapsed-time estimate, now held within 0% and 100%.

The lower bound is a second, unrelated defect the same expression carries: both ends of the elapsed time are read
from a wall clock that NTP can step backwards, and `Math.min` only bounded it from above, so a backward step
could render the column as `Merge Window -133.33%`. A unit test cannot reach that branch without faking the
clock, so it is not covered by one; the asserted format simply does not admit a leading minus sign.

`MergeCommitTaskTest.testObservability` asserts those two guarantees separately: the exact string for FINISHED,
and format plus the `<= 100%` bound for the other states. The FINISHED assertion fails without the change.

`test_merge_commit_observability` keeps asserting the exact progress of the successful load, and no longer asserts
the progress of the failed one, which is the value this PR deliberately does not pin down.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5