### PR TITLE
[BugFix] Reject column ALTER on an incrementally maintained materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -36,6 +36,9 @@ public class MaterializedViewExceptions {
     public static final String INACTIVE_REASON_FOR_INCREMENTAL_BREAKING =
             "incremental refresh broken by non-append-only base change: ";
 
+    public static final String INACTIVE_REASON_FOR_MV_SCHEMA_MISMATCH =
+            "incremental refresh broken: materialized view schema no longer matches its definition: ";
+
     /**
      * Create the inactive reason when base table not exists
      */
@@ -74,19 +77,69 @@ public class MaterializedViewExceptions {
         return INACTIVE_REASON_FOR_INCREMENTAL_BREAKING + mvName;
     }
 
+    /**
+     * Which reason to inactivate with, for a failure {@link #isIncrementalBreakingFailure} accepted.
+     * A base-table column change and a column ALTER on the MV itself raise the same two schema
+     * markers, so that branch states the condition without attributing a cause it cannot tell apart.
+     */
+    public static String inactiveReasonForBreakingFailure(Throwable e, String mvName) {
+        for (Throwable t = e; t != null && t != t.getCause(); t = t.getCause()) {
+            String msg = t.getMessage();
+            if (msg != null && (msg.contains(MV_SCHEMA_COLUMN_CHANGED_MARKER)
+                    || msg.contains(MV_SCHEMA_COLUMN_NOT_COMPATIBLE_MARKER))) {
+                return INACTIVE_REASON_FOR_MV_SCHEMA_MISMATCH + mvName;
+            }
+        }
+        return inactiveReasonForIncrementalBreaking(mvName);
+    }
+
     // Canonical marker for a permanently-breaking (non-append-only) base change. MVIVMRefreshProcessor builds
     // its message from this constant and isIncrementalBreakingFailure matches it, so wording and detection can't drift.
     public static final String FE_NON_APPEND_ONLY_MARKER = "do not support non-append-only base changes";
 
+    // Both classifiers of a stored schema that no longer matches the maintenance query --
+    // isIncrementalBreakingFailure and MVRefreshSchemaChecker#isLikelyDriftException -- match these,
+    // so wording and detection can't drift apart.
+    public static final String MV_SCHEMA_COLUMN_CHANGED_MARKER = "base table schema changed for columns: ";
+    public static final String MV_SCHEMA_COLUMN_NOT_COMPATIBLE_MARKER = "column schema not compatible: ";
+
     /**
      * Whether an MV refresh failure is a non-append-only breakage that permanently disables incremental
+<<<<<<< HEAD
      * refresh (vs. a transient error), so a single caller can inactivate the MV. Walks the cause chain
      * since the marker may be wrapped by the refresh pipeline.
+=======
+     * refresh (as opposed to a transient error). Covers the FE-detected non-append-only change, a
+     * BE-detected non-trackable CHANGES failure, and a stored schema that no longer matches the
+     * maintenance query, so a single caller handles OLAP and external tables the same way. Walks the
+     * cause chain because the marker may be wrapped by the refresh pipeline.
+>>>>>>> d7d6842cb10 ([BugFix] Reject column ALTER on an incrementally maintained materialized view (#61708))
      */
     public static boolean isIncrementalBreakingFailure(Throwable e) {
         for (Throwable t = e; t != null && t != t.getCause(); t = t.getCause()) {
             String msg = t.getMessage();
+<<<<<<< HEAD
             if (msg != null && msg.contains(FE_NON_APPEND_ONLY_MARKER)) {
+=======
+            if (msg != null && (msg.contains(FE_NON_APPEND_ONLY_MARKER)
+                    || msg.contains(MV_SCHEMA_COLUMN_CHANGED_MARKER)
+                    || msg.contains(MV_SCHEMA_COLUMN_NOT_COMPATIBLE_MARKER)
+                    || CdcErrorUtils.isChangeNotTrackable(msg))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether the backend rejected the CHANGES scan as non-trackable. Narrower than
+     * {@link #isIncrementalBreakingFailure}: it deliberately excludes the frontend-detected marker, because
+     * that one is already caught while the plan is built and never reaches execution.
+     */
+    public static boolean isChangeNotTrackableFailure(Throwable e) {
+        for (Throwable t = e; t != null && t != t.getCause(); t = t.getCause()) {
+            if (CdcErrorUtils.isChangeNotTrackable(t.getMessage())) {
+>>>>>>> d7d6842cb10 ([BugFix] Reject column ALTER on an incrementally maintained materialized view (#61708))
                 return true;
             }
         }
@@ -114,11 +167,20 @@ public class MaterializedViewExceptions {
     }
 
     public static String inactiveReasonForColumnNotCompatible(String existingType, String newType) {
-        return String.format("column schema not compatible: (%s) and (%s)", existingType, newType);
+        return String.format("%s(%s) and (%s)", MV_SCHEMA_COLUMN_NOT_COMPATIBLE_MARKER, existingType, newType);
     }
 
     public static String inactiveReasonForColumnChanged(Set<String> columns) {
-        return "base table schema changed for columns: " + StringUtils.join(columns, ",");
+        return MV_SCHEMA_COLUMN_CHANGED_MARKER + StringUtils.join(columns, ",");
+    }
+
+    public static String unsupportedReasonForIvmColumnChange(String operation, String columnName, String mvName) {
+        return String.format("Cannot %s column '%s' on incrementally maintained materialized view '%s': its "
+                        + "stored schema carries hidden columns whose layout is fixed at creation, so a column "
+                        + "change breaks every later incremental refresh. Rebuild instead: CREATE a new "
+                        + "materialized view with the columns you want, REFRESH it, 'ALTER MATERIALIZED VIEW %s "
+                        + "SWAP WITH <new_mv>', then DROP the swapped-out one.",
+                operation, columnName, mvName, mvName);
     }
 
     public static String inactiveReasonForSchemaCheckFailed(String mvName, String detail) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -454,7 +454,7 @@ public class TaskRun implements Comparable<TaskRun> {
                 // refresh here -- that would eat the actionable error; the consecutive-failure path suspends the task.
                 if (mv != null && mv.isActive()) {
                     AlterMVJobExecutor.inactiveMvAndLog(mv,
-                            MaterializedViewExceptions.inactiveReasonForIncrementalBreaking(mv.getName()));
+                            MaterializedViewExceptions.inactiveReasonForBreakingFailure(e, mv.getName()));
                     throw e;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshSchemaChecker.java
@@ -122,8 +122,8 @@ public final class MVRefreshSchemaChecker {
         // "No matching function with signature" covers FunctionAnalyzer rejections after a
         // base column type changes (e.g. bitand(int,int) → bitand(bigint,int) no longer resolves).
         return msg.contains("cannot be resolved")
-                || msg.contains("column schema not compatible")
-                || msg.contains("base table schema changed for columns")
+                || msg.contains(MaterializedViewExceptions.MV_SCHEMA_COLUMN_NOT_COMPATIBLE_MARKER)
+                || msg.contains(MaterializedViewExceptions.MV_SCHEMA_COLUMN_CHANGED_MARKER)
                 || msg.contains("No matching function with signature")
                 // IVM re-derive incompatibility (row-id strategy flip / no longer IVM-rewritable) is a
                 // drop-and-recreate condition -- inactivate with the reason, don't retry forever.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterMVClauseAnalyzerVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterMVClauseAnalyzerVisitor.java
@@ -17,6 +17,11 @@ import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
+<<<<<<< HEAD:fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterMVClauseAnalyzerVisitor.java
+=======
+import com.starrocks.common.MaterializedViewExceptions;
+import com.starrocks.epack.sql.analyzer.AlterTableClauseAnalyzerEPack;
+>>>>>>> d7d6842cb10 ([BugFix] Reject column ALTER on an incrementally maintained materialized view (#61708)):fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterMVClauseAnalyzer.java
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AddMVColumnClause;
 import com.starrocks.sql.ast.DropMVColumnClause;
@@ -45,9 +50,23 @@ public class AlterMVClauseAnalyzerVisitor extends AlterTableClauseAnalyzer {
         return null;
     }
 
+    /**
+     * Both conditions are needed to recognise a real IVM MV: the mode alone misfires on a
+     * non-IVM-eligible AUTO MV, and __ROW_ID__ alone on a PCT MV that merely outputs a column
+     * with that name.
+     */
+    private void rejectColumnChangeOnIvmMv(String operation, String columnName) {
+        MaterializedView mv = (MaterializedView) table;
+        if (mv.getCurrentRefreshMode().isIncrementalOrAuto() && mv.getRowIdStrategy() != null) {
+            throw new SemanticException(MaterializedViewExceptions.unsupportedReasonForIvmColumnChange(
+                    operation, columnName, mv.getName()));
+        }
+    }
+
     public Void visitAddMVColumnClause(AddMVColumnClause clause, ConnectContext context) {
-        // Validate the column name
         String columnName = clause.getColumnName();
+        rejectColumnChangeOnIvmMv("add", columnName);
+
         if (columnName == null || columnName.isEmpty()) {
             throw new SemanticException("Column name cannot be empty");
         }
@@ -86,13 +105,15 @@ public class AlterMVClauseAnalyzerVisitor extends AlterTableClauseAnalyzer {
 
     public Void visitDropMVColumnClause(DropMVColumnClause clause, ConnectContext context) {
         String columnName = clause.getColumnName();
+        rejectColumnChangeOnIvmMv("drop", columnName);
+
         if (columnName == null || columnName.isEmpty()) {
             throw new SemanticException("Column name cannot be empty");
         }
 
         MaterializedView mv = (MaterializedView) table;
         if (mv.getColumn(columnName) == null) {
-            throw new SemanticException("Column '{}' does not exist in materialized view", columnName);
+            throw new SemanticException("Column '%s' does not exist in materialized view", columnName);
         }
 
         ParseNode astParseNode = mv.getDefineQueryParseNode();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewIvmColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterMaterializedViewIvmColumnTest.java
@@ -1,0 +1,157 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AlterMaterializedViewStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An IVM MV's stored schema is position-aligned with its rewritten maintenance query, hidden
+ * __ROW_ID__ / __AGG_STATE_* columns included. A column ALTER only maintains the visible half --
+ * it never creates the companion __AGG_STATE_* column the rewrite derives for a new aggregate --
+ * so IvmSchemaCompat.compare fails on every later refresh while is_active stays true. Reject the
+ * DDL instead and point at the shadow-MV + SWAP rebuild.
+ */
+public class AlterMaterializedViewIvmColumnTest extends StarRocksTestBase {
+    private static final String DB = "db_ivm_alter_col";
+
+    private static ConnectContext ctx;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        ctx = UtFrameUtils.createDefaultCtx();
+        UtFrameUtils.setDefaultConfigForAsyncMVTest(ctx);
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase(DB).useDatabase(DB);
+
+        starRocksAssert.withTable("CREATE TABLE base_tbl (\n"
+                + "  dt DATE NOT NULL, k INT NOT NULL, v BIGINT, w BIGINT\n"
+                + ") DUPLICATE KEY(dt, k)\n"
+                + "DISTRIBUTED BY HASH(k) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1')");
+    }
+
+    private static void createMv(String name, String refreshMode) throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW " + name + "\n"
+                + "DISTRIBUTED BY HASH(k) BUCKETS 1\n"
+                + "REFRESH DEFERRED MANUAL\n"
+                + "PROPERTIES ('refresh_mode' = '" + refreshMode + "')\n"
+                + "AS SELECT k, SUM(v) AS total FROM base_tbl GROUP BY k");
+    }
+
+    private static MaterializedView getMv(String name) {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB);
+        return (MaterializedView) db.getTable(name);
+    }
+
+    private static void runAlter(String sql) throws Exception {
+        AlterMaterializedViewStmt stmt =
+                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        DDLStmtExecutor.execute(stmt, ctx);
+    }
+
+    private static final String IVM_GATE_MARKER = "incrementally maintained materialized view";
+
+    private static void assertRejectedByIvmGate(String sql, MaterializedView mv) {
+        int columnsBefore = mv.getColumns().size();
+        Exception e = Assertions.assertThrows(Exception.class, () -> runAlter(sql));
+        Assertions.assertTrue(e.getMessage() != null && e.getMessage().contains(IVM_GATE_MARKER),
+                "must be rejected by the IVM gate, got: " + e.getMessage());
+        Assertions.assertTrue(e.getMessage().contains("SWAP"),
+                "rejection must point at the SWAP rebuild, got: " + e.getMessage());
+        Assertions.assertEquals(columnsBefore, mv.getColumns().size(),
+                "a rejected ALTER must leave the schema untouched");
+    }
+
+    @Test
+    public void testAddColumnRejectedOnIvmMv() throws Exception {
+        createMv("mv_ivm_add", "INCREMENTAL");
+        try {
+            MaterializedView mv = getMv("mv_ivm_add");
+            Assertions.assertNotNull(mv.getRowIdStrategy(),
+                    "guard: this shape must materialize as a real IVM MV, else the test is vacuous");
+            assertRejectedByIvmGate(
+                    "alter materialized view mv_ivm_add add column w_total as sum(w)", mv);
+        } finally {
+            starRocksAssert.dropMaterializedView("mv_ivm_add");
+        }
+    }
+
+    @Test
+    public void testDropColumnRejectedOnIvmMv() throws Exception {
+        createMv("mv_ivm_drop", "INCREMENTAL");
+        try {
+            MaterializedView mv = getMv("mv_ivm_drop");
+            Assertions.assertNotNull(mv.getRowIdStrategy(),
+                    "guard: this shape must materialize as a real IVM MV, else the test is vacuous");
+            assertRejectedByIvmGate(
+                    "alter materialized view mv_ivm_drop drop column total", mv);
+        } finally {
+            starRocksAssert.dropMaterializedView("mv_ivm_drop");
+        }
+    }
+
+    /** force mode relaxes the fast schema evolution rules, so the gate has to sit ahead of them. */
+    @Test
+    public void testAddColumnRejectedUnderForceMode() throws Exception {
+        createMv("mv_ivm_force", "INCREMENTAL");
+        String originalMode = Config.mv_fast_schema_change_mode;
+        try {
+            Config.mv_fast_schema_change_mode = "force";
+            assertRejectedByIvmGate(
+                    "alter materialized view mv_ivm_force add column w_total as sum(w)",
+                    getMv("mv_ivm_force"));
+        } finally {
+            Config.mv_fast_schema_change_mode = originalMode;
+            starRocksAssert.dropMaterializedView("mv_ivm_force");
+        }
+    }
+
+    /**
+     * The reject is keyed on being an IVM MV, not on the ALTER shape. A PCT MV may still be refused
+     * by the pre-existing FSE rules, so this only pins that the new IVM gate does not fire on it.
+     */
+    @Test
+    public void testPctMvNotRejectedByIvmGate() throws Exception {
+        createMv("mv_pct_add", "PCT");
+        try {
+            MaterializedView mv = getMv("mv_pct_add");
+            Assertions.assertNull(mv.getRowIdStrategy(),
+                    "guard: a PCT MV has no __ROW_ID__, else this case proves nothing");
+            try {
+                runAlter("alter materialized view mv_pct_add add column w_total as sum(w)");
+            } catch (Exception e) {
+                Assertions.assertFalse(e.getMessage() != null && e.getMessage().contains(IVM_GATE_MARKER),
+                        "the IVM gate must not fire on a PCT MV, got: " + e.getMessage());
+            }
+        } finally {
+            starRocksAssert.dropMaterializedView("mv_pct_add");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/MaterializedViewExceptionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/MaterializedViewExceptionsTest.java
@@ -16,6 +16,8 @@ package com.starrocks.common;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -41,4 +43,64 @@ public class MaterializedViewExceptionsTest {
         assertFalse(MaterializedViewExceptions.isIncrementalBreakingFailure(new RuntimeException()));
         assertFalse(MaterializedViewExceptions.isIncrementalBreakingFailure(null));
     }
+<<<<<<< HEAD
+=======
+
+    @Test
+    public void testIsChangeNotTrackableFailure() {
+        assertTrue(MaterializedViewExceptions.isChangeNotTrackableFailure(new RuntimeException(
+                "CDC-ERROR-1 (CHANGE_NOT_TRACKABLE): CDC for DUP_KEYS does not support delete")));
+        assertTrue(MaterializedViewExceptions.isChangeNotTrackableFailure(new RuntimeException(
+                "CDC-ERROR-1 (CHANGE_NOT_TRACKABLE): CDC for AGG_KEYS does not support delete")));
+        assertTrue(MaterializedViewExceptions.isChangeNotTrackableFailure(
+                new RuntimeException("refresh failed",
+                        new IllegalStateException(
+                                "query failed: CDC-ERROR-1 (CHANGE_NOT_TRACKABLE): history missing"))));
+
+        // The deliberate difference from isIncrementalBreakingFailure.
+        assertFalse(MaterializedViewExceptions.isChangeNotTrackableFailure(new RuntimeException(
+                "INCREMENTAL materialized views " + MaterializedViewExceptions.FE_NON_APPEND_ONLY_MARKER)));
+
+        assertFalse(MaterializedViewExceptions.isChangeNotTrackableFailure(
+                new RuntimeException("CDC-ERROR-2 (CHANGE_NOT_TRACKABLE): unknown code")));
+        assertFalse(MaterializedViewExceptions.isChangeNotTrackableFailure(
+                new RuntimeException("get database write lock timeout")));
+        assertFalse(MaterializedViewExceptions.isChangeNotTrackableFailure(new RuntimeException()));
+        assertFalse(MaterializedViewExceptions.isChangeNotTrackableFailure(null));
+    }
+
+    /**
+     * A column ALTER on an IVM MV knocks its stored schema out of position-alignment with the
+     * rewritten maintenance query; IvmSchemaCompat reports that through these two reasons. The
+     * mismatch is deterministic -- it never heals -- so it must classify as breaking and inactivate
+     * the MV, rather than leaving is_active true with only a FAILED run. Both the pure-IVM path and
+     * the hybrid fallback-to-PCT path surface the same message.
+     */
+    @Test
+    public void testSchemaMismatchIsBreaking() {
+        assertTrue(MaterializedViewExceptions.isIncrementalBreakingFailure(new RuntimeException(
+                "Getting analyzing error. Detail message: "
+                        + MaterializedViewExceptions.inactiveReasonForColumnChanged(
+                                Collections.singleton("column count 6 vs 7")))));
+        assertTrue(MaterializedViewExceptions.isIncrementalBreakingFailure(new RuntimeException(
+                MaterializedViewExceptions.inactiveReasonForColumnNotCompatible(
+                        "`imp` bigint", "`imp` largeint"))));
+        assertTrue(MaterializedViewExceptions.isIncrementalBreakingFailure(
+                new RuntimeException("Refresh mv s1_mv failed after 1 times",
+                        new IllegalStateException(MaterializedViewExceptions.inactiveReasonForColumnChanged(
+                                Collections.singleton("column count 6 vs 7"))))));
+    }
+
+    @Test
+    public void testBreakingFailureReasonFollowsTheMatchedCause() {
+        assertTrue(MaterializedViewExceptions.inactiveReasonForBreakingFailure(
+                        new RuntimeException(MaterializedViewExceptions.inactiveReasonForColumnChanged(
+                                Collections.singleton("column count 6 vs 7"))), "mv1")
+                .startsWith(MaterializedViewExceptions.INACTIVE_REASON_FOR_MV_SCHEMA_MISMATCH));
+        // a non-append-only breakage keeps its own reason rather than being relabelled a schema mismatch
+        assertTrue(MaterializedViewExceptions.inactiveReasonForBreakingFailure(
+                        new RuntimeException("x " + MaterializedViewExceptions.FE_NON_APPEND_ONLY_MARKER + " y"), "mv1")
+                .startsWith(MaterializedViewExceptions.INACTIVE_REASON_FOR_INCREMENTAL_BREAKING));
+    }
+>>>>>>> d7d6842cb10 ([BugFix] Reject column ALTER on an incrementally maintained materialized view (#61708))
 }

--- a/test/sql/test_cloud_native_mv_incremental/R/lifecycle/mv_column_alter_rejected
+++ b/test/sql/test_cloud_native_mv_incremental/R/lifecycle/mv_column_alter_rejected
@@ -1,0 +1,92 @@
+-- name: test_ivm_mv_add_column_rejected @cloud
+CREATE TABLE mvcol_add (k INT, v BIGINT, w BIGINT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2 PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO mvcol_add VALUES (1,10,100),(2,20,200);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_mvcol_add
+DISTRIBUTED BY HASH(k) BUCKETS 2
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "INCREMENTAL")
+AS SELECT k, SUM(v) AS sv FROM mvcol_add GROUP BY k;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_mvcol_add WITH SYNC MODE;
+ALTER MATERIALIZED VIEW mv_mvcol_add ADD COLUMN sw AS SUM(w);
+-- result:
+[REGEX].*Cannot add column 'sw' on incrementally maintained materialized view.*SWAP WITH.*
+-- !result
+INSERT INTO mvcol_add VALUES (3,30,300);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_mvcol_add WITH SYNC MODE;
+SELECT IS_ACTIVE, LAST_REFRESH_STATE FROM information_schema.materialized_views
+WHERE TABLE_SCHEMA = database() AND TABLE_NAME = 'mv_mvcol_add';
+-- result:
+true	SUCCESS
+-- !result
+SELECT k, sv FROM mv_mvcol_add ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+-- !result
+-- name: test_ivm_mv_drop_column_rejected @cloud
+CREATE TABLE mvcol_drop (k INT, v BIGINT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2 PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO mvcol_drop VALUES (1,10),(2,20);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_mvcol_drop
+DISTRIBUTED BY HASH(k) BUCKETS 2
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "INCREMENTAL")
+AS SELECT k, SUM(v) AS sv FROM mvcol_drop GROUP BY k;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_mvcol_drop WITH SYNC MODE;
+ALTER MATERIALIZED VIEW mv_mvcol_drop DROP COLUMN sv;
+-- result:
+[REGEX].*Cannot drop column 'sv' on incrementally maintained materialized view.*SWAP WITH.*
+-- !result
+INSERT INTO mvcol_drop VALUES (3,30);
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_mvcol_drop WITH SYNC MODE;
+SELECT IS_ACTIVE, LAST_REFRESH_STATE FROM information_schema.materialized_views
+WHERE TABLE_SCHEMA = database() AND TABLE_NAME = 'mv_mvcol_drop';
+-- result:
+true	SUCCESS
+-- !result
+SELECT k, sv FROM mv_mvcol_drop ORDER BY k;
+-- result:
+1	10
+2	20
+3	30
+-- !result
+-- name: test_pct_mv_not_caught_by_ivm_gate @cloud
+CREATE TABLE mvcol_pct (k INT, v BIGINT, w BIGINT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2 PROPERTIES ('replication_num' = '1');
+-- result:
+-- !result
+INSERT INTO mvcol_pct VALUES (1,10,100),(2,20,200);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv_mvcol_pct
+DISTRIBUTED BY HASH(k) BUCKETS 2
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "PCT")
+AS SELECT k, SUM(v) AS sv FROM mvcol_pct GROUP BY k;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv_mvcol_pct WITH SYNC MODE;
+[UC]ALTER MATERIALIZED VIEW mv_mvcol_pct ADD COLUMN sw AS SUM(w);
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+WHERE TABLE_SCHEMA = database() AND TABLE_NAME = 'mv_mvcol_pct';
+-- result:
+true
+-- !result

--- a/test/sql/test_cloud_native_mv_incremental/T/lifecycle/mv_column_alter_rejected
+++ b/test/sql/test_cloud_native_mv_incremental/T/lifecycle/mv_column_alter_rejected
@@ -1,0 +1,56 @@
+-- The MV side of lifecycle/schema_evolution: a column ALTER on the MV itself used to be accepted
+-- silently and then fail every later refresh with `column count N vs N+1`, because it appends the
+-- visible column but never the __AGG_STATE_* column the IVM rewrite derives for the new aggregate.
+-- mv_fast_schema_change_mode = force is covered in AlterMaterializedViewIvmColumnTest, not here: it
+-- is a cluster-wide FE config and cases run concurrently, so setting it here leaks into other cases.
+-- name: test_ivm_mv_add_column_rejected @cloud
+CREATE TABLE mvcol_add (k INT, v BIGINT, w BIGINT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2 PROPERTIES ('replication_num' = '1');
+INSERT INTO mvcol_add VALUES (1,10,100),(2,20,200);
+CREATE MATERIALIZED VIEW mv_mvcol_add
+DISTRIBUTED BY HASH(k) BUCKETS 2
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "INCREMENTAL")
+AS SELECT k, SUM(v) AS sv FROM mvcol_add GROUP BY k;
+REFRESH MATERIALIZED VIEW mv_mvcol_add WITH SYNC MODE;
+ALTER MATERIALIZED VIEW mv_mvcol_add ADD COLUMN sw AS SUM(w);
+INSERT INTO mvcol_add VALUES (3,30,300);
+REFRESH MATERIALIZED VIEW mv_mvcol_add WITH SYNC MODE;
+SELECT IS_ACTIVE, LAST_REFRESH_STATE FROM information_schema.materialized_views
+WHERE TABLE_SCHEMA = database() AND TABLE_NAME = 'mv_mvcol_add';
+SELECT k, sv FROM mv_mvcol_add ORDER BY k;
+
+-- name: test_ivm_mv_drop_column_rejected @cloud
+CREATE TABLE mvcol_drop (k INT, v BIGINT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2 PROPERTIES ('replication_num' = '1');
+INSERT INTO mvcol_drop VALUES (1,10),(2,20);
+CREATE MATERIALIZED VIEW mv_mvcol_drop
+DISTRIBUTED BY HASH(k) BUCKETS 2
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "INCREMENTAL")
+AS SELECT k, SUM(v) AS sv FROM mvcol_drop GROUP BY k;
+REFRESH MATERIALIZED VIEW mv_mvcol_drop WITH SYNC MODE;
+ALTER MATERIALIZED VIEW mv_mvcol_drop DROP COLUMN sv;
+INSERT INTO mvcol_drop VALUES (3,30);
+REFRESH MATERIALIZED VIEW mv_mvcol_drop WITH SYNC MODE;
+SELECT IS_ACTIVE, LAST_REFRESH_STATE FROM information_schema.materialized_views
+WHERE TABLE_SCHEMA = database() AND TABLE_NAME = 'mv_mvcol_drop';
+SELECT k, sv FROM mv_mvcol_drop ORDER BY k;
+
+-- A PCT MV must not be caught by the IVM gate. The ALTER is [UC] because the pre-existing fast
+-- schema evolution rule compares the base column's creation time against partition visible times,
+-- which flips between runs here -- observed both refused and accepted. The deterministic assertion
+-- that the gate does not fire lives in AlterMaterializedViewIvmColumnTest.
+-- name: test_pct_mv_not_caught_by_ivm_gate @cloud
+CREATE TABLE mvcol_pct (k INT, v BIGINT, w BIGINT) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 2 PROPERTIES ('replication_num' = '1');
+INSERT INTO mvcol_pct VALUES (1,10,100),(2,20,200);
+CREATE MATERIALIZED VIEW mv_mvcol_pct
+DISTRIBUTED BY HASH(k) BUCKETS 2
+REFRESH DEFERRED MANUAL
+PROPERTIES ("refresh_mode" = "PCT")
+AS SELECT k, SUM(v) AS sv FROM mvcol_pct GROUP BY k;
+REFRESH MATERIALIZED VIEW mv_mvcol_pct WITH SYNC MODE;
+[UC]ALTER MATERIALIZED VIEW mv_mvcol_pct ADD COLUMN sw AS SUM(w);
+SELECT IS_ACTIVE FROM information_schema.materialized_views
+WHERE TABLE_SCHEMA = database() AND TABLE_NAME = 'mv_mvcol_pct';


### PR DESCRIPTION
## Conflict Info:  
UU fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java<br />UU fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterMVClauseAnalyzerVisitor.java<br />UU fe/fe-core/src/test/java/com/starrocks/common/MaterializedViewExceptionsTest.java
## Why I'm doing:

`ALTER MATERIALIZED VIEW... ADD/DROP COLUMN` is accepted on an MV with `refresh_mode = incremental` and then breaks it permanently: every later refresh fails, while `is_active` stays `true`. Monitoring that alerts on `is_active` sees nothing — only `last_refresh_state` exposes it — and the new column reads `NULL` forever.

Reproduced on a shared-data cluster:

```sql
CREATE TABLE base_f (
 event_day datetime NOT NULL, advertiser_id bigint NOT NULL,
 imp bigint SUM NOT NULL DEFAULT "0"
) AGGREGATE KEY(event_day, advertiser_id)
PARTITION BY date_trunc('day', event_day)
DISTRIBUTED BY HASH(event_day, advertiser_id) BUCKETS 2;

CREATE MATERIALIZED VIEW mv_ivm
PARTITION BY (date_trunc('day', event_day))
DISTRIBUTED BY HASH(event_day, advertiser_id) BUCKETS 2
REFRESH DEFERRED MANUAL
PROPERTIES ('refresh_mode' = 'incremental')
AS SELECT event_day, advertiser_id, SUM(imp) AS imp FROM base_f GROUP BY 1, 2;

REFRESH MATERIALIZED VIEW mv_ivm WITH SYNC MODE; -- SUCCESS

ALTER TABLE base_f ADD COLUMN m_late bigint SUM NOT NULL DEFAULT "0";
ALTER MATERIALIZED VIEW mv_ivm ADD COLUMN m_late AS SUM(m_late); -- accepted, no error

INSERT INTO base_f SELECT '2028-01-01', i%7, 1, 9 FROM TABLE(generate_series(0, 4999)) t(i);
REFRESH MATERIALIZED VIEW mv_ivm WITH SYNC MODE; -- FAILED, and every run after
```

```
SemanticException: Getting analyzing error. Detail message:
base table schema changed for columns: column count 6 vs 7
 at com.starrocks.sql.analyzer.mv.IvmSchemaCompat.compare(IvmSchemaCompat.java:41)
 at com.starrocks.sql.analyzer.mv.IvmRefreshDefinition.derive(IvmRefreshDefinition.java:79)
 at com.starrocks.scheduler.mv.ivm.MVIVMRefreshProcessor.prepareRefreshPlan(...)
```

Observed state afterwards: `IS_ACTIVE = true`, `LAST_REFRESH_STATE = FAILED`, `INACTIVE_REASON` empty, MV `SUM(imp) = 10000` against a base table at `15000`, `SUM(m_late) = NULL` against `45000`.

An IVM MV's stored schema is position-aligned with its **rewritten** maintenance query, hidden `__ROW_ID__` / `__AGG_STATE_*` columns included, and that alignment is fixed at creation in `MaterializedViewAnalyzer`. The column ALTER maintains only the visible half: adding `SUM(m_late)` appends one visible column, while the rewrite derives two fields for it — the visible one plus a companion `__AGG_STATE_sum(m_late)`, because `sum` is not in `METRIC_STATE_UNION_FUNCTIONS` and so is not a collapsible metric-state union. Hence `column count 6 vs 7` on every refresh. `DROP COLUMN` is the mirror case, orphaning the `__AGG_STATE_*` column the rewrite no longer emits.

A PCT MV with the same definition is unaffected, so this is IVM-specific. `ALTER MATERIALIZED VIEW... ADD/DROP COLUMN` is not covered by any doc page under `docs/*/sql-reference/sql-statements/materialized_view/`.

## What I'm doing:

Rejecting the DDL on an IVM MV in `AlterMVClauseAnalyzer`, and classifying the schema mismatch as a breaking refresh failure so MVs already broken in the field become visible.

**Why reject rather than make fast schema evolution IVM-aware.** The new aggregate's state cannot be backfilled for existing rows — `state_union(NULL, delta)` yields the delta alone, i.e. a metric that is correct going forward and silently missing all history. Keeping the capability therefore requires a full recompute, which the shadow-MV + `SWAP` path already does atomically and without downtime. The error message names that path.

The reject is unconditional. Two things were checked rather than assumed:

- An "empty MV" exemption is **not** safe. A never-refreshed MV has no history to backfill, but its first refresh after the ALTER still fails — the schema is structurally short a hidden column, so even a from-scratch rebuild cannot match. Verified on the cluster.
- `mv_fast_schema_change_mode = force` is covered, because the gate sits ahead of that branch. Force mode was the more dangerous path before: it let through the case needing historical backfill, and the compensating "clear affected partition entries" step operates on `baseTableVisibleVersionMap`, which is PCT's version map and a no-op for IVM.

The gate reuses the predicate already vetted in `MVRefreshSchemaChecker`, `getCurrentRefreshMode().isIncrementalOrAuto() && getRowIdStrategy()!= null`. Both halves are needed: the mode alone misfires on a non-IVM-eligible AUTO MV, `__ROW_ID__` alone on a PCT MV that merely outputs a column with that name.

**Why the classifier change is also needed.** Rejection only protects MVs that are still healthy; it cannot reach the ones already broken. Those surface through `TaskRun`, whose `isIncrementalBreakingFailure` did not match this message, so the run was marked `FAILED` and the MV left active. One place covers both refresh paths: on a hybrid MV the IVM attempt's exception is swallowed and PCT is tried, but PCT's terminal rebuild re-derives the same query and fails identically — confirmed on the cluster, where the same error arrives under `MVPCTRefreshProcessor` instead of `MVIVMRefreshProcessor`. So this is a hard failure on both paths, never a silent wrong result.

The inactive reason states the condition without naming a cause: a base-table column change raises the same two markers and cannot be told apart from the message alone. It keeps the existing `incremental refresh broken` prefix, so the six existing assertions and goldens that match on that prefix are unchanged. Both classifiers of those markers — `isIncrementalBreakingFailure` and `MVRefreshSchemaChecker#isLikelyDriftException` — now share them, since their disagreement is what let this failure stay invisible.

Also fixes a literal `{}` placeholder leaking to users from the `DROP COLUMN` column-existence check (`SemanticException` formats with `%s`, not `{}`).

Not changed, and unreachable once the gate lands: `visitAddMVColumnClause` appends `newQueryOutputIndices.size()` as the new column's index, but `getQueryOutputIndices` filters out `NO_QUERY_OUTPUT` entries, so for an `AUTO_INCREMENT` row-id MV that list is shorter than `baseSchema` and the appended index points at the last pre-existing column. That row-id strategy is IVM-only, so the gate covers it.

### Verification

FE UT:

```bash
cd fe && mvn -pl fe-core -am test -Dtest=AlterMaterializedViewIvmColumnTest,MaterializedViewExceptionsTest,MVRefreshSchemaCheckerTest,AlterMaterializedViewTest
```

| Test class | Result |
|---|---|
| `AlterMaterializedViewIvmColumnTest` (new) | 4/4 |
| `alter.AlterMaterializedViewTest` | 15/15 |
| `analysis.AlterMaterializedViewTest` (covers ADD/DROP MV column) | 26/26 |
| `MVRefreshSchemaCheckerTest` | 16/16 |
| `MaterializedViewExceptionsTest` | 2 added cases pass |

The new test asserted the failure first: before the gate, both ADD and DROP raised `Expected java.lang.Exception to be thrown, but nothing was thrown` on a real SHARED_DATA IVM MV.

End-to-end on a shared-data cluster (1 FE + 1 CN), FE reporting `main-cb6ca2b` — the same FE change as this branch; the later edits on top are test-only:

| Statement | Result |
|---|---|
| `ALTER MV... ADD COLUMN sw AS SUM(w)` | refused, message names the SWAP rebuild |
| `ALTER MV... DROP COLUMN sv` | refused |
| same ADD under `mv_fast_schema_change_mode = force` | refused (now asserted in the unit test, see below) |
| `INSERT` + `REFRESH` after the refused DDL | `IS_ACTIVE = true`, `LAST_REFRESH_STATE = SUCCESS`, new row picked up, bidirectional diff `0` |

So a refused ALTER leaves the MV healthy and still incrementally refreshable.

SQL test: `test_cloud_native_mv_incremental/lifecycle/mv_column_alter_rejected` — the MV-side counterpart of the existing `lifecycle/schema_evolution` (which covers base-table ALTER). Recorded and then validated twice against that cluster, both passing. Replacing the gate's wording in the golden with a phrase that never occurs makes two cases fail, so the `[REGEX]` assertions have teeth rather than matching anything.

Force mode is asserted in the unit test rather than the SQL test, after a Codex review finding: `mv_fast_schema_change_mode` is a cluster-wide FE config and SQL-tester runs cases concurrently by default, so setting it in a SQL case lets other cases observe relaxed ALTER behaviour — `lifecycle/schema_evolution` in the same suite exercises MV fast schema evolution — and a failed assertion in between would leave the relaxed mode set for the rest of the run. Marking the case `@sequential` would fix the concurrency half but drop the coverage: `choose_cases.py` skips sequential cases unless `-a` names them. The unit test saves and restores the config within one JVM, the way `AlterMVJobExecutorFastSchemaChangeModeTest` already does; that test asserts the config's value and still passes, which is what shows the restore holds.

Two defects in the tests themselves surfaced only on the cluster and are fixed here:

- The unit test keyed "rejected by the IVM gate" on the word `SWAP`, but the pre-existing fast schema evolution refusal also says "use \`SWAP MV\` to replace the current" — the check could not tell the two rules apart, and passed only because the PCT case happened not to throw in the mini-cluster, leaving the assertion unevaluated. It now keys on the wording unique to the gate.
- The PCT case's ALTER is `[UC]`. That fast schema evolution rule compares the base column's creation time against partition visible times, and with the table created moments before the refresh the outcome flips between runs — the same statement was refused during recording and accepted during validation. Only the gate's own behaviour is deterministic, so that assertion lives in the unit test.

Note for anyone re-running this on: `StarRocks` `main` currently builds only with `--linux-distro ubuntu`. The centos7 image fails in BE with `'validate_positive_int64' is not a member of 'staros::starlet::common'`, which is unrelated to this PR — that call landed on 2026-08-18 in while StarRocks main kept building green through 2026-08-31, and PR hit the identical error.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A statement that used to be accepted now returns an error, and an MV whose refresh hits this mismatch now becomes inactive instead of staying active with a failing run. Both are on IVM MVs only; PCT MVs are unaffected.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

`ALTER MATERIALIZED VIEW... ADD/DROP COLUMN` has no doc page, so there is no documented behavior to correct.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5