### PR TITLE
[BugFix] Fix the misspelled ZoneMapIndexFilter key in the profile dictionary

### DIFF
--- a/docs/en/table_design/indexes/Bitmap_index.md
+++ b/docs/en/table_design/indexes/Bitmap_index.md
@@ -291,7 +291,7 @@ IOTaskExecTime: 2s77ms // Total time for scanning data, longer than without bitm
     DictDecode: 329.696ms // Time for decoding dictionary for low cardinality optimization is similar since the output row count is the same.
     BitmapIndexFilter: 419.308ms // Time for filtering data with the bitmap index.
     BitmapIndexFilterRows: 123.433M (123432975) // Number of rows filtered by the bitmap index.
-    ZoneMapIndexFiter: 171.580ms // Time for filtering data with ZoneMap Index.
+    ZoneMapIndexFilter: 171.580ms // Time for filtering data with ZoneMap Index.
 ```
 
 ##### Determine whether to use bitmap index based on StarRocks default configuration

--- a/docs/ja/table_design/indexes/Bitmap_index.md
+++ b/docs/ja/table_design/indexes/Bitmap_index.md
@@ -290,7 +290,7 @@ IOTaskExecTime: 2s77ms // データスキャンの合計時間。ビットマッ
     DictDecode: 329.696ms // 出力行数が同じであるため、低基数最適化のための辞書デコード時間は同様です。
     BitmapIndexFilter: 419.308ms // ビットマップインデックスによるデータフィルタリングの時間。
     BitmapIndexFilterRows: 123.433M (123432975) // ビットマップインデックスによってフィルタリングされた行数。
-    ZoneMapIndexFiter: 171.580ms // ZoneMapインデックスによるデータフィルタリングの時間。
+    ZoneMapIndexFilter: 171.580ms // ZoneMapインデックスによるデータフィルタリングの時間。
 ```
 
 ##### StarRocksのデフォルト設定に基づいてビットマップインデックスを使用するかどうかを決定

--- a/docs/zh/table_design/indexes/Bitmap_index.md
+++ b/docs/zh/table_design/indexes/Bitmap_index.md
@@ -291,7 +291,7 @@ IOTaskExecTime: 2s77ms // Scan 数据总时间，相对于没创建 Bitmap 索�
     DictDecode: 329.696ms // 因为输出的行数是一样的，所以低基数优化字典解码的时间所花时间差不多
     BitmapIndexFilter: 419.308ms // Bitmap 索引过滤数据的时间。
     BitmapIndexFilterRows: 123.433M (123432975) // Bitmap 索引过滤掉的数据行数。
-    ZoneMapIndexFiter: 171.580ms // ZoneMap 索引过滤数据花了 0.17 秒。
+    ZoneMapIndexFilter: 171.580ms // ZoneMap 索引过滤数据花了 0.17 秒。
 ```
 
 ##### 由 StarRocks 默认配置决定是否使用 Bitmap 索引

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileKeyDictionary.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileKeyDictionary.java
@@ -173,7 +173,7 @@ public final class ProfileKeyDictionary {
     public static final String PRED_FILTER = "PredFilter";
     public static final String PRED_FILTER_ROWS = "PredFilterRows";
     public static final String ZONE_MAP_INDEX_FILTER_ROWS = "ZoneMapIndexFilterRows";
-    public static final String ZONE_MAP_INDEX_FITER = "ZoneMapIndexFiter";
+    public static final String ZONE_MAP_INDEX_FILTER = "ZoneMapIndexFilter";
     public static final String SHORT_KEY_FILTER_ROWS = "ShortKeyFilterRows";
     public static final String SHORT_KEY_RANGE_NUMBER = "ShortKeyRangeNumber";
     public static final String BITMAP_INDEX_FILTER_ROWS = "BitmapIndexFilterRows";
@@ -378,7 +378,7 @@ public final class ProfileKeyDictionary {
             PRED_FILTER,
             PRED_FILTER_ROWS,
             ZONE_MAP_INDEX_FILTER_ROWS,
-            ZONE_MAP_INDEX_FITER,
+            ZONE_MAP_INDEX_FILTER,
             SHORT_KEY_FILTER_ROWS,
             SHORT_KEY_RANGE_NUMBER,
             BITMAP_INDEX_FILTER_ROWS,


### PR DESCRIPTION
The static profile-key dictionary carried "ZoneMapIndexFiter" instead of the name the BE emits, and the bitmap index docs printed the same misspelling in a sample scan profile.

The BE was corrected to "ZoneMapIndexFilter", the dictionary entry has never matched anything: the live name misses the dictionary and is written out uncompressed on every profile, while the stale entry occupies a static ID for nothing. The docs have likewise not matched the product since that PR, which did not update them.

The misspelling is corrected in place rather than kept alongside the new name.

STATIC_NAMES keeps its length, so no static IDs shift. The docs change is the counter name only, in all three languages; the timing value and the surrounding profile are untouched.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5