### PR TITLE
[Doc] Fix a link whose anchor contains spaces in External_table.md

### DIFF
--- a/docs/en/data_source/External_table.md
+++ b/docs/en/data_source/External_table.md
@@ -206,7 +206,7 @@ The required parameters in `properties` are as follows:
 
 * `table`: the target table name in the database.
 
-For supported data types and data type mapping between StarRocks and target databases, see [Data type mapping](External_table.md#Data type mapping).
+For supported data types and data type mapping between StarRocks and target databases, see [Data type mapping](#data-type-mapping).
 
 > Note:
 >

--- a/docs/ja/data_source/External_table.md
+++ b/docs/ja/data_source/External_table.md
@@ -206,7 +206,7 @@ properties (
 
 * `table`: データベース内のターゲットテーブル名。
 
-StarRocksとターゲットデータベース間のサポートされているデータ型とデータ型のマッピングについては、[Data type mapping](External_table.md#Data type mapping) を参照してください。
+StarRocksとターゲットデータベース間のサポートされているデータ型とデータ型のマッピングについては、[Data type mapping](#data-type-mapping) を参照してください。
 
 > 注：
 >


### PR DESCRIPTION
## Why I'm doing:

`[Data type mapping](External_table.md#Data type mapping)` in `data_source/External_table.md` is not a link. A CommonMark link destination cannot contain an unescaped space, so the whole construct stays a text node and renders as literal brackets and parentheses on the page. Readers have been seeing the raw markup rather than a link.

## What I'm doing:

Replacing it with `](#data-type-mapping)`. The target exists — `### Data type mapping` in the same file — and since it is a same-page reference the filename is unnecessary as well.

`en` and `ja` only; `zh` already uses a valid anchor.

This is the only occurrence of the pattern in `docs/en` in either this repo or `StarRocks/starrocks`, so it is a one-line typo rather than a class of problem.

**How it was found:** while adding `:::product` support to `StarRocks/doc-translator`, a Chinese translation rendered the "anchor" as `#数据类型映射`. That is correct behaviour for something the parser sees as prose, and it led back here.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5