### PR TITLE
[BugFix] Report elapsed time in the scan SampleTime counter

### DIFF
--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -1028,8 +1028,7 @@ void OlapChunkSource::_update_counter() {
                                         : static_cast<double>(_params.sample_options.probability_percent);
         _runtime_profile->add_info_string("SampleMethod", to_string(_params.sample_options.sample_method));
         _runtime_profile->add_info_string("SamplePercent", std::to_string(sample_percent) + "%");
-        COUNTER_UPDATE(ADD_CHILD_TIMER(_runtime_profile, "SampleTime", parent_name),
-                       _reader->stats().sample_population_size);
+        COUNTER_UPDATE(ADD_CHILD_TIMER(_runtime_profile, "SampleTime", parent_name), _reader->stats().sample_time_ns);
         COUNTER_UPDATE(ADD_CHILD_TIMER(_runtime_profile, "SampleBuildHistogramTime", parent_name),
                        _reader->stats().sample_build_histogram_time_ns);
         COUNTER_UPDATE(ADD_CHILD_COUNTER(_runtime_profile, "SampleSize", TUnit::UNIT, parent_name),

--- a/be/test/exec/pipeline/olap_scan_operator_test.cpp
+++ b/be/test/exec/pipeline/olap_scan_operator_test.cpp
@@ -14,7 +14,9 @@
 
 #include "exec/pipeline/scan/olap_scan_operator.h"
 
+#include "common/util/table_metrics.h"
 #include "compute_env/global_dict/fragment_dict_state.h"
+#include "compute_env/query/fragment_runtime_state.h"
 #include "exec/exec_env.h"
 #include "exec/olap_scan_node.h"
 #include "exec/pipeline/query_context.h"
@@ -25,6 +27,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/runtime_state.h"
 #include "storage/query/olap_fixed_morsel_queue.h"
+#include "storage/tablet_schema_helper.h"
 
 namespace starrocks::pipeline {
 
@@ -52,6 +55,14 @@ void expect_vector_index_counters(RuntimeProfile* profile) {
     expect_vector_index_counter(profile, "VectorANNSearch", "VectorIndexSearch");
     expect_vector_index_counter(profile, "VectorResultProcess", "VectorIndexSearch");
     expect_vector_index_counter(profile, "VectorIndexFilterRows", "VectorIndexSearch");
+}
+
+void expect_sample_counter(RuntimeProfile* profile, const char* name, TUnit::type unit, int64_t value) {
+    auto it = profile->_counter_map.find(name);
+    ASSERT_NE(it, profile->_counter_map.end()) << name;
+    EXPECT_EQ(it->second.second, "SegmentRead") << name;
+    EXPECT_EQ(it->second.first->type(), unit) << name;
+    EXPECT_EQ(it->second.first->value(), value) << name;
 }
 
 } // namespace
@@ -176,6 +187,56 @@ TEST_F(OlapScanOperatorTest, pipeline_chunk_source_registers_vector_index_counte
     olap_chunk_source->_init_counter(&_runtime_state);
 
     expect_vector_index_counters(olap_chunk_source->_runtime_profile);
+    scan_node.close(&_runtime_state);
+}
+
+// Each sample counter must report its own statistic. SampleTime used to be fed sample_population_size,
+// so a block/page count was rendered as a duration in the profile.
+TEST_F(OlapScanOperatorTest, sample_counters_report_their_own_statistic) {
+    OlapScanNode scan_node(&_object_pool, _tnode, *_tbl);
+    auto scan_ctx_factory =
+            std::make_shared<OlapScanContextFactory>(&scan_node, 1, false, false, std::move(_chunk_buffer_limiter));
+    OlapScanOperatorFactory scan_operator_factory(1, &scan_node, scan_ctx_factory);
+    auto scan_operator = std::make_shared<OlapScanOperator>(&scan_operator_factory, 1, 0, 1, &scan_node,
+                                                            scan_ctx_factory->get_or_create(0));
+    TScanRange scan_range;
+    auto chunk_source = scan_operator->create_chunk_source(std::make_unique<ScanMorsel>(1, scan_range), 0);
+    auto* olap_chunk_source = down_cast<OlapChunkSource*>(chunk_source.get());
+
+    ASSERT_TRUE(olap_chunk_source->ChunkSource::prepare(&_runtime_state).ok());
+    olap_chunk_source->_runtime_state = &_runtime_state;
+    olap_chunk_source->_init_counter(&_runtime_state);
+
+    FragmentRuntimeState fragment_runtime_state;
+    _runtime_state.set_fragment_runtime_state(&fragment_runtime_state);
+
+    // _update_counter() only reads the reader statistics and the table metrics, so a reader over an empty
+    // schema is enough to check how the sample statistics are mapped onto the profile counters.
+    olap_chunk_source->_table_metrics = std::make_shared<TableMetrics>(1, false);
+    olap_chunk_source->_reader = std::make_shared<TabletReader>(nullptr, Version(0, 1), Schema(),
+                                                                TabletSchemaHelper::create_tablet_schema());
+
+    olap_chunk_source->_params.sample_options.__set_enable_sampling(true);
+    olap_chunk_source->_params.sample_options.__set_sample_method(SampleMethod::BY_BLOCK);
+    olap_chunk_source->_params.sample_options.__set_probability_percent(10);
+
+    // Distinct values so that a counter fed from the wrong statistic is unambiguous.
+    auto* stats = olap_chunk_source->_reader->mutable_stats();
+    stats->sample_time_ns = 111;
+    stats->sample_build_histogram_time_ns = 222;
+    stats->sample_size = 333;
+    stats->sample_population_size = 444;
+    stats->sample_build_histogram_count = 555;
+
+    olap_chunk_source->_update_counter();
+
+    auto* profile = olap_chunk_source->_runtime_profile;
+    expect_sample_counter(profile, "SampleTime", TUnit::TIME_NS, 111);
+    expect_sample_counter(profile, "SampleBuildHistogramTime", TUnit::TIME_NS, 222);
+    expect_sample_counter(profile, "SampleSize", TUnit::UNIT, 333);
+    expect_sample_counter(profile, "SamplePopulationSize", TUnit::UNIT, 444);
+    expect_sample_counter(profile, "SampleBuildHistogramCount", TUnit::UNIT, 555);
+
     scan_node.close(&_runtime_state);
 }
 


### PR DESCRIPTION
The SampleTime child timer under SegmentRead is registered as TUnit::TIME_NS but was fed OlapReaderStatistics::sample_population_size, a count of sampled blocks or pages. The profile therefore rendered a row count as a duration, and SampleTime always tracked SamplePopulationSize exactly.

Feed it sample_time_ns instead, the SCOPED_RAW_TIMER that already wraps SegmentIterator::_apply_data_sampling and was otherwise never read. The three neighbouring sample counters were already correct and are unchanged.

Add a unit test that drives OlapChunkSource::_update_counter() with distinct values for every sample statistic, so a counter fed from the wrong field is unambiguous.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5