### PR TITLE
[UT] Quiesce the reshard leader daemon in TabletReshardJobMgrTest

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/reshard/TabletReshardJobMgrTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.LeaderDaemon;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
 import com.starrocks.proto.ParentTabletPublishInfoPB;
@@ -256,6 +257,22 @@ public class TabletReshardJobMgrTest {
     @BeforeAll
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+
+        // In shared-data mode the singleton TabletReshardJobMgr is started as a leader daemon and
+        // ticks every tablet_reshard_job_scheduler_interval_ms (10ms), running the very code these
+        // cases drive by hand: it drains reshardCandidates, creates jobs into tabletReshardJobs and
+        // calls createTabletReshardJob -- which several cases replace with a counting MockUp that a
+        // class-level MockUp also applies to the singleton. So the daemon thread would race the test
+        // thread and land its effects between a `before` read and the assertion, exactly like the
+        // ColocateChecker race stubbed out in SplitTabletJobColocateTest (#73662). Quiesce it once
+        // here so every tick in this class is an explicit runAfterCatalogReadyForTest() call.
+        TabletReshardJobMgr sharedMgr = GlobalStateMgr.getCurrentState().getTabletReshardJobMgr();
+        Assertions.assertTrue(sharedMgr.isRunning(),
+                "the reshard daemon must be up before it is stopped; otherwise a later start() would "
+                        + "clear the stop request and resurrect the racing tick");
+        sharedMgr.setStop();
+        LeaderDaemon.awaitQuiesced(List.<LeaderDaemon>of(sharedMgr), 30_000L);
+
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         Config.enable_range_distribution = true;


### PR DESCRIPTION
## Why I'm doing:

`TabletReshardJobMgrTest` is flaky. Observed failure:

```
TabletReshardJobMgrTest.testTickSkippedWhenAdmissionClosed
no new reshard job should be created when admission is closed ==> expected: <0> but was: <1>
    at TabletReshardJobMgrTest.java:543
```

The gate under test is fine: `runAfterLeaseValid()` returns right after `isLeaderAdmissionOpen()` fails, so the tick the test drives cannot create a job. The extra job comes from **another thread**.

In shared-data mode the singleton `TabletReshardJobMgr` is started as a leader daemon (`GlobalStateMgr#startLeaderOnlyDaemonThreads`) and ticks every `tablet_reshard_job_scheduler_interval_ms` — **10ms** by default. Seven cases in this class drive `runAfterCatalogReadyForTest()` on that *same singleton* and assert on state the daemon also writes: `reshardCandidates`, `tabletReshardJobs`, and the mocked `createTabletReshardJob`. So the daemon lands its effects between a `before` read and the assertion that follows it. In the failure above it drained the pre-seeded candidate into a real job while the test thread was flipping leader-work admission closed — hence `before == 0` and `after == 1`.

Same race, same remedy as #73662 (`[UT] Stub ColocateChecker daemon in SplitTabletJobColocateTest`), which hit the identical 10ms tick through `ColocateChecker`.

## What I'm doing:

Stop and await the singleton reshard daemon once in `@BeforeAll`, so every tick in this class is an explicit `runAfterCatalogReadyForTest()` call.

Notes on the choices:

- **Why not just switch those cases to a local `new TabletReshardJobMgr()`** (the dominant idiom in this file)? Three of them install a class-level `new MockUp<TabletReshardJobMgr>()` of `createTabletReshardJob`, which JMockit applies to *every* instance — the daemon would keep bumping their counters (`mergeAttempts`, `signatureWalks`) from its own thread. Quiescing the daemon covers all seven cases at once.
- **`awaitQuiesced` rather than a bare `setStop()`**: `setStop()` only requests a stop; a tick already in flight could still be inside `triggerTabletReshard`. `LeaderDaemon.awaitQuiesced` waits for `isRunning() == false`.
- **The `assertTrue(sharedMgr.isRunning())` before stopping** is deliberate: `LeaderDaemon.start()` clears `isStopRequested`, so a stop issued before the daemon starts would be undone. `MockedFrontend.start()` waits for `isReady()`, which is set after `startLeaderOnlyDaemonThreads()`, so the daemon is up here — the assertion pins that ordering, and a future change to it fails loudly instead of restoring the flakiness.
- **No leak into other test classes**: `fe-core` runs with `reuseForks=false`, one JVM per test class.

Test-only change; no production code touched.

Known residual, deliberately out of scope: `TabletStatMgr` (interval `tablet_stat_update_interval_second`) also feeds candidates into the singleton, a minutes-vs-milliseconds window against `testAddReshardCandidateDropsNonActionableSignal`. Happy to add a `@BeforeEach` candidate reset if reviewers prefer it closed too.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
