### PR TITLE
[BugFix] Keep year 0000 when batch-building date range partitions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PartitionTimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PartitionTimeUtils.java
@@ -1,0 +1,191 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.TimestampArithmeticExpr.TimeUnit;
+import com.starrocks.type.Type;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.Locale;
+
+/**
+ * Aligns and renders the time values a date range partition is built from: its bounds and its name.
+ *
+ * <p>Every formatter here is a {@code *_FORMATTER_UNIX} one, built on the proleptic
+ * {@code ChronoField.YEAR}.
+ */
+public class PartitionTimeUtils {
+
+    /** Time units batch DDL accepts. */
+    public static final ImmutableSet<TimeUnit> BATCH_PARTITION_TIME_UNITS = ImmutableSet.of(
+            TimeUnit.HOUR,
+            TimeUnit.DAY,
+            TimeUnit.WEEK,
+            TimeUnit.MONTH,
+            TimeUnit.YEAR
+    );
+
+    /** Time units automatic partitioning accepts. */
+    public static final ImmutableSet<TimeUnit> AUTO_PARTITION_TIME_UNITS = ImmutableSet.of(
+            TimeUnit.MINUTE,
+            TimeUnit.HOUR,
+            TimeUnit.DAY,
+            TimeUnit.MONTH,
+            TimeUnit.YEAR
+    );
+
+    private PartitionTimeUtils() {
+    }
+
+    /** Formatter for a bound of a date or datetime partition column. */
+    public static DateTimeFormatter getPartitionBoundFormatter(Type partitionColumnType) {
+        if (partitionColumnType.isDatetime()) {
+            return DateUtils.DATE_TIME_FORMATTER_UNIX;
+        }
+        return DateUtils.DATE_FORMATTER_UNIX;
+    }
+
+    /** Renders {@code time} as a partition bound. */
+    public static String formatPartitionBound(LocalDateTime time, Type partitionColumnType) {
+        return time.format(getPartitionBoundFormatter(partitionColumnType));
+    }
+
+    /**
+     * Formatter for the name suffix of {@code timeUnit}, e.g. {@code YEAR -> "0000"}.
+     * {@link TimeUnit#WEEK} has no single formatter; use {@link #formatPartitionNameSuffix}.
+     */
+    public static DateTimeFormatter getPartitionNameFormatter(TimeUnit timeUnit) {
+        switch (timeUnit) {
+            case MINUTE:
+                return DateUtils.MINUTE_FORMATTER_UNIX;
+            case HOUR:
+                return DateUtils.HOUR_FORMATTER_UNIX;
+            case DAY:
+                return DateUtils.DATEKEY_FORMATTER_UNIX;
+            case MONTH:
+                return DateUtils.MONTH_FORMATTER_UNIX;
+            case YEAR:
+                return DateUtils.YEAR_FORMATTER_UNIX;
+            default:
+                throw new SemanticException("Partition name is not defined for time unit: " + timeUnit);
+        }
+    }
+
+    /** Renders the name suffix of the partition starting at {@code time}, which must already be aligned. */
+    public static String formatPartitionNameSuffix(LocalDateTime time, TimeUnit timeUnit) {
+        if (timeUnit == TimeUnit.WEEK) {
+            return formatWeekNameSuffix(time);
+        }
+        return time.format(getPartitionNameFormatter(timeUnit));
+    }
+
+    /**
+     * Aligns {@code time} down to the start of its time unit, keeping the time of day for
+     * {@code WEEK}, {@code MONTH} and {@code YEAR}, since batch DDL allows an unaligned START.
+     * {@code dayOfWeek} / {@code dayOfMonth} follow the {@code dynamic_partition.start_day_of_week}
+     * / {@code .start_day_of_month} properties.
+     */
+    public static LocalDateTime alignToUnitStart(LocalDateTime time, TimeUnit timeUnit, int dayOfWeek, int dayOfMonth) {
+        switch (timeUnit) {
+            case HOUR:
+                return time.withMinute(0).withSecond(0).withNano(0);
+            case DAY:
+                return time.withHour(0).withMinute(0).withSecond(0).withNano(0);
+            case WEEK:
+                return time.with(TemporalAdjusters.previousOrSame(DayOfWeek.of(dayOfWeek)));
+            case MONTH:
+                return time.withDayOfMonth(dayOfMonth);
+            case YEAR:
+                return time.withDayOfYear(1);
+            default:
+                throw new SemanticException("Batch build partition does not support time interval type: " + timeUnit);
+        }
+    }
+
+    /**
+     * Truncates {@code time} down to the exact start of its time unit, clearing every smaller
+     * field, as an automatically created partition always begins there.
+     */
+    public static LocalDateTime truncateToUnitStart(LocalDateTime time, TimeUnit timeUnit) {
+        switch (timeUnit) {
+            case MINUTE:
+                return time.withSecond(0).withNano(0);
+            case HOUR:
+                return time.withMinute(0).withSecond(0).withNano(0);
+            case DAY:
+                return time.withHour(0).withMinute(0).withSecond(0).withNano(0);
+            case MONTH:
+                return time.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+            case YEAR:
+                return time.withDayOfYear(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
+            default:
+                throw new SemanticException("Unsupported automatic partition granularity: " + timeUnit);
+        }
+    }
+
+    /** Moves {@code time} forward by {@code interval} units, to the start of the next partition. */
+    public static LocalDateTime plus(LocalDateTime time, TimeUnit timeUnit, long interval) {
+        switch (timeUnit) {
+            case MINUTE:
+                return time.plusMinutes(interval);
+            case HOUR:
+                return time.plusHours(interval);
+            case DAY:
+                return time.plusDays(interval);
+            case WEEK:
+                return time.plusWeeks(interval);
+            case MONTH:
+                return time.plusMonths(interval);
+            case YEAR:
+                return time.plusYears(interval);
+            default:
+                throw new SemanticException("Partition interval is not defined for time unit: " + timeUnit);
+        }
+    }
+
+    /**
+     * Week partitions are named after the week of year of the JVM locale, the same rules
+     * {@link java.util.Calendar} applies, so batch and dynamic partitioning name the same week
+     * identically. The week is read off the proleptic date: passing year 0000 through
+     * {@code GregorianCalendar} would resolve it as 1 BCE on the Julian calendar, whose weeks are
+     * two days off, and the resulting week number is one short under the locales whose week starts
+     * on Sunday.
+     */
+    private static String formatWeekNameSuffix(LocalDateTime time) {
+        if (time.getYear() < 0) {
+            // The week holding START begins before 0000-01-01, so it has no name in range: aligning
+            // 0000-01-01 back to a Monday, say, lands on -0001-12-27.
+            throw new SemanticException("Batch build partition can not create a week partition whose " +
+                    "week begins before 0000-01-01, which is outside the DATE range. " +
+                    "Move START forward to the first day of a week.");
+        }
+        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
+        int weekOfYear = time.get(weekFields.weekOfWeekBasedYear());
+        if (weekOfYear <= 1 && time.getMonthValue() == 12) {
+            // eg: JDK think 2019-12-30 as the first week of year 2020, we need to handle this.
+            // to make it as the 53rd week of year 2019.
+            weekOfYear += 52;
+        }
+        // The year is formatted rather than printed as an int so that it is padded to four digits
+        // like every other unit.
+        return String.format("%s_%02d", time.format(DateUtils.YEAR_FORMATTER_UNIX), weekOfYear);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -54,6 +54,7 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.PartitionTimeUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.LakeMaterializedView;
 import com.starrocks.lake.LakeTable;
@@ -115,6 +116,7 @@ import com.starrocks.sql.ast.expression.MaxLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.Subquery;
+import com.starrocks.sql.ast.expression.TimestampArithmeticExpr.TimeUnit;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PCellSortedSet;
@@ -1632,36 +1634,28 @@ public class AnalyzerUtils {
      * used by both partition clause creation and dedup key generation.
      */
     public static String truncateToPartitionBoundary(String dateValue, String granularity) throws AnalysisException {
+        TimeUnit timeUnit = toAutoPartitionTimeUnit(granularity,
+                "unsupported automatic partition granularity: " + granularity);
         try {
             if ("NULL".equalsIgnoreCase(dateValue)) {
                 dateValue = "0000-01-01";
             }
             DateTimeFormatter fmt = DateUtils.probeFormat(dateValue);
             LocalDateTime dt = DateUtils.parseStringWithDefaultHSM(dateValue, fmt);
-            switch (granularity.toLowerCase()) {
-                case "minute":
-                    dt = dt.withSecond(0).withNano(0);
-                    return dt.format(DateUtils.MINUTE_FORMATTER_UNIX);
-                case "hour":
-                    dt = dt.withMinute(0).withSecond(0).withNano(0);
-                    return dt.format(DateUtils.HOUR_FORMATTER_UNIX);
-                case "day":
-                    dt = dt.withHour(0).withMinute(0).withSecond(0).withNano(0);
-                    return dt.format(DateUtils.DATEKEY_FORMATTER_UNIX);
-                case "month":
-                    dt = dt.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-                    return dt.format(DateUtils.MONTH_FORMATTER_UNIX);
-                case "year":
-                    dt = dt.withDayOfYear(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-                    return dt.format(DateUtils.YEAR_FORMATTER_UNIX);
-                default:
-                    throw new AnalysisException("unsupported automatic partition granularity: " + granularity);
-            }
-        } catch (AnalysisException e) {
-            throw e;
+            dt = PartitionTimeUtils.truncateToUnitStart(dt, timeUnit);
+            return dt.format(PartitionTimeUtils.getPartitionNameFormatter(timeUnit));
         } catch (Exception e) {
             throw new AnalysisException("failed to parse partition value: " + dateValue);
         }
+    }
+
+    /** Resolves an automatic partition granularity into its time unit. */
+    private static TimeUnit toAutoPartitionTimeUnit(String granularity, String errorMessage) throws AnalysisException {
+        TimeUnit timeUnit = TimeUnit.fromName(granularity);
+        if (timeUnit == null || !PartitionTimeUtils.AUTO_PARTITION_TIME_UNITS.contains(timeUnit)) {
+            throw new AnalysisException(errorMessage);
+        }
+        return timeUnit;
     }
 
     public static PartitionMeasure checkAndGetPartitionMeasure(Expr expr)
@@ -1884,30 +1878,10 @@ public class AnalyzerUtils {
 
                 beginDateTimeFormat = DateUtils.probeFormat(partitionItem);
                 beginTime = DateUtils.parseStringWithDefaultHSM(partitionItem, beginDateTimeFormat);
-                switch (granularity.toLowerCase()) {
-                    case "minute":
-                        beginTime = beginTime.withSecond(0).withNano(0);
-                        endTime = beginTime.plusMinutes(interval);
-                        break;
-                    case "hour":
-                        beginTime = beginTime.withMinute(0).withSecond(0).withNano(0);
-                        endTime = beginTime.plusHours(interval);
-                        break;
-                    case "day":
-                        beginTime = beginTime.withHour(0).withMinute(0).withSecond(0).withNano(0);
-                        endTime = beginTime.plusDays(interval);
-                        break;
-                    case "month":
-                        beginTime = beginTime.withDayOfMonth(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-                        endTime = beginTime.plusMonths(interval);
-                        break;
-                    case "year":
-                        beginTime = beginTime.withDayOfYear(1).withHour(0).withMinute(0).withSecond(0).withNano(0);
-                        endTime = beginTime.plusYears(interval);
-                        break;
-                    default:
-                        throw new AnalysisException("unsupported automatic partition granularity:" + granularity);
-                }
+                TimeUnit timeUnit = toAutoPartitionTimeUnit(granularity,
+                        "unsupported automatic partition granularity:" + granularity);
+                beginTime = PartitionTimeUtils.truncateToUnitStart(beginTime, timeUnit);
+                endTime = PartitionTimeUtils.plus(beginTime, timeUnit, interval);
                 PartitionKeyDesc partitionKeyDesc =
                         createPartitionKeyDesc(firstPartitionColumnType, beginTime, endTime);
 
@@ -1939,18 +1913,16 @@ public class AnalyzerUtils {
     private static PartitionKeyDesc createPartitionKeyDesc(Type partitionType, LocalDateTime beginTime,
                                                            LocalDateTime endTime) throws AnalysisException {
         boolean isMaxValue;
-        DateTimeFormatter outputDateFormat;
         if (partitionType.isDate()) {
-            outputDateFormat = DateUtils.DATE_FORMATTER_UNIX;
             isMaxValue =
                     endTime.isAfter(TimeUtils.MAX_DATE.atTime(0, 0, 0));
         } else if (partitionType.isDatetime()) {
-            outputDateFormat = DateUtils.DATE_TIME_FORMATTER_UNIX;
             isMaxValue = endTime.isAfter(
                     TimeUtils.MAX_DATETIME);
         } else {
             throw new AnalysisException(String.format("failed to analyse partition value:%s", partitionType));
         }
+        DateTimeFormatter outputDateFormat = PartitionTimeUtils.getPartitionBoundFormatter(partitionType);
         String lowerBound = beginTime.format(outputDateFormat);
 
         PartitionValue upperPartitionValue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionDescAnalyzer.java
@@ -32,6 +32,7 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.common.util.PartitionTimeUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.DataCacheInfo;
@@ -67,10 +68,8 @@ import com.starrocks.type.Type;
 import org.apache.logging.log4j.util.Strings;
 import org.threeten.extra.PeriodDuration;
 
-import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -122,7 +121,7 @@ public class PartitionDescAnalyzer {
             TimestampArithmeticExpr.TimeUnit timeUnitType = TimestampArithmeticExpr.TimeUnit.fromName(timeUnit);
             if (timeUnitType == null) {
                 throw new SemanticException("Batch build partition does not support time interval type.");
-            } else if (!MultiRangePartitionDesc.SUPPORTED_TIME_UNIT_TYPE.contains(timeUnitType)) {
+            } else if (!PartitionTimeUtils.BATCH_PARTITION_TIME_UNITS.contains(timeUnitType)) {
                 throw new SemanticException("Batch build partition does not support time interval type: " + timeUnit);
             }
         }
@@ -287,55 +286,26 @@ public class PartitionDescAnalyzer {
 
         TimestampArithmeticExpr.TimeUnit timeUnitType = TimestampArithmeticExpr.TimeUnit.fromName(partitionGranularity);
         Preconditions.checkNotNull(timeUnitType);
+        if (!PartitionTimeUtils.BATCH_PARTITION_TIME_UNITS.contains(timeUnitType)) {
+            throw new SemanticException("Batch build partition does not support time interval type: " +
+                    partitionGranularity);
+        }
 
-        LocalDateTime standardBeginTime;
-        LocalDateTime standardEndTime;
+        LocalDateTime standardBeginTime =
+                PartitionTimeUtils.alignToUnitStart(partitionBeginDateTime, timeUnitType, dayOfWeek, dayOfMonth);
+        LocalDateTime standardEndTime =
+                PartitionTimeUtils.alignToUnitStart(partitionEndDateTime, timeUnitType, dayOfWeek, dayOfMonth);
+        if (standardBeginTime.equals(standardEndTime)) {
+            standardEndTime = PartitionTimeUtils.plus(standardEndTime, timeUnitType, partitionStep);
+        }
         String extraMsg = "";
-        switch (timeUnitType) {
-            case HOUR:
-                standardBeginTime = partitionBeginDateTime.withMinute(0).withSecond(0).withNano(0);
-                standardEndTime = partitionEndDateTime.withMinute(0).withSecond(0).withNano(0);
-                if (standardBeginTime.equals(standardEndTime)) {
-                    standardEndTime = standardEndTime.plusHours(partitionStep);
-                }
-                break;
-            case DAY:
-                standardBeginTime = partitionBeginDateTime.withHour(0).withMinute(0).withSecond(0).withNano(0);
-                standardEndTime = partitionEndDateTime.withHour(0).withMinute(0).withSecond(0).withNano(0);
-                if (standardBeginTime.equals(standardEndTime)) {
-                    standardEndTime = standardEndTime.plusDays(partitionStep);
-                }
-                break;
-            case WEEK:
-                standardBeginTime = partitionBeginDateTime.with(TemporalAdjusters.previousOrSame(DayOfWeek.of(dayOfWeek)));
-                standardEndTime = partitionEndDateTime.with(TemporalAdjusters.previousOrSame(DayOfWeek.of(dayOfWeek)));
-                if (standardBeginTime.equals(standardEndTime)) {
-                    standardEndTime = standardEndTime.plusWeeks(partitionStep);
-                }
-                extraMsg = "with start day of week " + dayOfWeek;
-                break;
-            case MONTH:
-                standardBeginTime = partitionBeginDateTime.withDayOfMonth(dayOfMonth);
-                standardEndTime = partitionEndDateTime.withDayOfMonth(dayOfMonth);
-                if (standardBeginTime.equals(standardEndTime)) {
-                    standardEndTime = standardEndTime.plusMonths(partitionStep);
-                }
-                extraMsg = "with start day of month " + dayOfMonth;
-                break;
-            case YEAR:
-                standardBeginTime = partitionBeginDateTime.withDayOfYear(1);
-                standardEndTime = partitionEndDateTime.withDayOfYear(1);
-                if (standardBeginTime.equals(standardEndTime)) {
-                    standardEndTime = standardEndTime.plusYears(partitionStep);
-                }
-                break;
-            default:
-                throw new SemanticException("Batch build partition does not support time interval type: " +
-                        partitionGranularity);
+        if (timeUnitType == TimestampArithmeticExpr.TimeUnit.WEEK) {
+            extraMsg = "with start day of week " + dayOfWeek;
+        } else if (timeUnitType == TimestampArithmeticExpr.TimeUnit.MONTH) {
+            extraMsg = "with start day of month " + dayOfMonth;
         }
         if (!(standardBeginTime.equals(partitionBeginDateTime) && standardEndTime.equals(partitionEndDateTime))) {
-            DateTimeFormatter outputDateFormat = partitionColumnType.isDate()
-                    ? DateUtils.DATE_FORMATTER_UNIX : DateUtils.DATE_TIME_FORMATTER_UNIX;
+            DateTimeFormatter outputDateFormat = PartitionTimeUtils.getPartitionBoundFormatter(partitionColumnType);
 
             String msg = "Batch build partition range [" +
                     partitionBeginDateTime.format(outputDateFormat) + "," +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/MultiRangePartitionDesc.java
@@ -16,7 +16,6 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.common.AnalysisException;
@@ -24,23 +23,17 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DynamicPartitionUtil;
-import com.starrocks.common.util.TimeUtils;
+import com.starrocks.common.util.PartitionTimeUtils;
 import com.starrocks.sql.analyzer.PartitionDescAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.TimestampArithmeticExpr;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.Type;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.TemporalAdjusters;
-import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
 public class MultiRangePartitionDesc extends PartitionDesc {
 
@@ -50,14 +43,6 @@ public class MultiRangePartitionDesc extends PartitionDesc {
     private final String partitionEnd;
     private Long step;
     private final String timeUnit;
-    private static final SimpleDateFormat DATEKEY_SDF = new SimpleDateFormat("yyyyMMdd");
-    public static final ImmutableSet<TimestampArithmeticExpr.TimeUnit> SUPPORTED_TIME_UNIT_TYPE = ImmutableSet.of(
-            TimestampArithmeticExpr.TimeUnit.HOUR,
-            TimestampArithmeticExpr.TimeUnit.DAY,
-            TimestampArithmeticExpr.TimeUnit.WEEK,
-            TimestampArithmeticExpr.TimeUnit.MONTH,
-            TimestampArithmeticExpr.TimeUnit.YEAR
-    );
 
     public MultiRangePartitionDesc(String partitionBegin, String partitionEnd, Long step,
                                    String timeUnit, NodePosition pos) {
@@ -144,7 +129,6 @@ public class MultiRangePartitionDesc extends PartitionDesc {
         // it will follow this configuration to set day of week
         int dayOfWeek = 1;
         int dayOfMonth = 1;
-        TimeZone timeZone = TimeUtils.getSystemTimeZone();
         String partitionPrefix = defaultPrefix;
         if (context.isTempPartition()) {
             partitionPrefix = defaultTempPartitionPrefix;
@@ -179,13 +163,14 @@ public class MultiRangePartitionDesc extends PartitionDesc {
             }
         }
 
-        DateTimeFormatter outputDateFormat = DateUtils.DATE_FORMATTER;
-        if (context.getFirstPartitionColumnType().isDatetime()) {
-            outputDateFormat = DateUtils.DATE_TIME_FORMATTER;
-        }
+        DateTimeFormatter outputDateFormat =
+                PartitionTimeUtils.getPartitionBoundFormatter(context.getFirstPartitionColumnType());
 
         TimestampArithmeticExpr.TimeUnit timeUnitType = TimestampArithmeticExpr.TimeUnit.fromName(timeUnit);
         Preconditions.checkNotNull(timeUnitType);
+        if (!PartitionTimeUtils.BATCH_PARTITION_TIME_UNITS.contains(timeUnitType)) {
+            throw new AnalysisException("Batch build partition does not support time interval type: " + timeUnit);
+        }
 
         if (context.isAutoPartitionTable()) {
             PartitionDescAnalyzer.checkManualAddPartitionDateAligned(
@@ -195,54 +180,16 @@ public class MultiRangePartitionDesc extends PartitionDesc {
                     context.getFirstPartitionColumnType());
         }
 
-        String partitionName;
         while (beginTime.isBefore(endTime)) {
+            // The first lower bound is START as the user wrote it; only the name and the
+            // following bounds are aligned.
             PartitionValue lowerPartitionValue = new PartitionValue(beginTime.format(outputDateFormat));
 
-            switch (timeUnitType) {
-                case HOUR:
-                    partitionName = partitionPrefix + beginTime.format(DateUtils.HOUR_FORMATTER);
-                    beginTime = beginTime.withMinute(0).withSecond(0).withNano(0);
-                    beginTime = beginTime.plusHours(timeInterval);
-                    break;
-                case DAY:
-                    partitionName = partitionPrefix + beginTime.format(DateUtils.DATEKEY_FORMATTER);
-                    beginTime = beginTime.withHour(0).withMinute(0).withSecond(0).withNano(0);
-                    beginTime = beginTime.plusDays(timeInterval);
-                    break;
-                case WEEK:
-                    // Compatible with dynamic partitioning
-                    // First calculate the first day of the week, then calculate the week of the year
-                    beginTime = beginTime.with(TemporalAdjusters.previousOrSame(DayOfWeek.of(dayOfWeek)));
-                    Calendar calendar = Calendar.getInstance(timeZone);
-                    try {
-                        calendar.setTime(DATEKEY_SDF.parse(beginTime.format(DateUtils.DATEKEY_FORMATTER)));
-                    } catch (ParseException e) {
-                        throw new RuntimeException(e);
-                    }
-                    int weekOfYear = calendar.get(Calendar.WEEK_OF_YEAR);
-                    if (weekOfYear <= 1 && calendar.get(Calendar.MONTH) >= 11) {
-                        // eg: JDK think 2019-12-30 as the first week of year 2020, we need to handle this.
-                        // to make it as the 53rd week of year 2019.
-                        weekOfYear += 52;
-                    }
-                    partitionName = partitionPrefix + String.format("%s_%02d", calendar.get(Calendar.YEAR), weekOfYear);
-                    beginTime = beginTime.plusWeeks(timeInterval);
-                    break;
-                case MONTH:
-                    partitionName = partitionPrefix + beginTime.format(DateUtils.MONTH_FORMATTER);
-                    beginTime = beginTime.withDayOfMonth(dayOfMonth);
-                    beginTime = beginTime.plusMonths(timeInterval);
-                    break;
-                case YEAR:
-                    partitionName = partitionPrefix + beginTime.format(DateUtils.YEAR_FORMATTER);
-                    beginTime = beginTime.withDayOfYear(1);
-                    beginTime = beginTime.plusYears(timeInterval);
-                    break;
-                default:
-                    throw new AnalysisException("Batch build partition does not support time interval type: " +
-                            timeUnit);
-            }
+            beginTime = PartitionTimeUtils.alignToUnitStart(beginTime, timeUnitType, dayOfWeek, dayOfMonth);
+            String partitionName = partitionPrefix
+                    + PartitionTimeUtils.formatPartitionNameSuffix(beginTime, timeUnitType);
+            beginTime = PartitionTimeUtils.plus(beginTime, timeUnitType, timeInterval);
+
             if (timeUnitType != TimestampArithmeticExpr.TimeUnit.DAY && beginTime.isAfter(endTime)) {
                 beginTime = endTime;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/PartitionTimeUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/PartitionTimeUtilsTest.java
@@ -1,0 +1,160 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.expression.TimestampArithmeticExpr.TimeUnit;
+import com.starrocks.type.DateType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+
+public class PartitionTimeUtilsTest {
+
+    @Test
+    public void testFormatPartitionBoundKeepsYearZero() {
+        LocalDateTime yearZero = LocalDateTime.of(0, 1, 1, 0, 0, 0);
+        Assertions.assertEquals("0000-01-01", PartitionTimeUtils.formatPartitionBound(yearZero, DateType.DATE));
+        Assertions.assertEquals("0000-01-01 00:00:00",
+                PartitionTimeUtils.formatPartitionBound(yearZero, DateType.DATETIME));
+    }
+
+    @Test
+    public void testFormatPartitionBound() {
+        LocalDateTime time = LocalDateTime.of(2024, 3, 5, 10, 30, 15);
+        Assertions.assertEquals("2024-03-05", PartitionTimeUtils.formatPartitionBound(time, DateType.DATE));
+        Assertions.assertEquals("2024-03-05 10:30:15", PartitionTimeUtils.formatPartitionBound(time, DateType.DATETIME));
+    }
+
+    @Test
+    public void testFormatPartitionNameSuffixKeepsYearZero() {
+        LocalDateTime yearZero = LocalDateTime.of(0, 1, 1, 0, 0, 0);
+        Assertions.assertEquals("0000", PartitionTimeUtils.formatPartitionNameSuffix(yearZero, TimeUnit.YEAR));
+        Assertions.assertEquals("000001", PartitionTimeUtils.formatPartitionNameSuffix(yearZero, TimeUnit.MONTH));
+        Assertions.assertEquals("00000101", PartitionTimeUtils.formatPartitionNameSuffix(yearZero, TimeUnit.DAY));
+        Assertions.assertEquals("0000010100", PartitionTimeUtils.formatPartitionNameSuffix(yearZero, TimeUnit.HOUR));
+        Assertions.assertEquals("000001010000",
+                PartitionTimeUtils.formatPartitionNameSuffix(yearZero, TimeUnit.MINUTE));
+    }
+
+    @Test
+    public void testFormatPartitionNameSuffix() {
+        LocalDateTime time = LocalDateTime.of(2024, 3, 5, 10, 30, 15);
+        Assertions.assertEquals("2024", PartitionTimeUtils.formatPartitionNameSuffix(time, TimeUnit.YEAR));
+        Assertions.assertEquals("202403", PartitionTimeUtils.formatPartitionNameSuffix(time, TimeUnit.MONTH));
+        Assertions.assertEquals("20240305", PartitionTimeUtils.formatPartitionNameSuffix(time, TimeUnit.DAY));
+        Assertions.assertEquals("2024030510", PartitionTimeUtils.formatPartitionNameSuffix(time, TimeUnit.HOUR));
+        Assertions.assertEquals("202403051030", PartitionTimeUtils.formatPartitionNameSuffix(time, TimeUnit.MINUTE));
+    }
+
+    @Test
+    public void testFormatWeekPartitionNameSuffix() {
+        // Calendar puts 2019-12-30 in the first week of 2020; we keep naming it week 53 of 2019.
+        LocalDateTime lastWeekOf2019 = LocalDateTime.of(2019, 12, 30, 0, 0, 0);
+        Assertions.assertEquals("2019_53",
+                PartitionTimeUtils.formatPartitionNameSuffix(lastWeekOf2019, TimeUnit.WEEK));
+    }
+
+    @Test
+    public void testFormatWeekPartitionNameSuffixOnYearZero() {
+        // The expected week number is the locale's own week rules read off the proleptic date.
+        // Resolving year 0000 through GregorianCalendar instead lands on 1 BCE in the Julian
+        // calendar, two days off, which shifts the week under every locale whose week starts on
+        // Sunday. The year must also be padded to four digits like every other unit.
+        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
+        for (LocalDate monday : List.of(LocalDate.of(0, 1, 3), LocalDate.of(0, 1, 10),
+                LocalDate.of(0, 3, 6), LocalDate.of(0, 6, 5))) {
+            Assertions.assertEquals(DayOfWeek.MONDAY, monday.getDayOfWeek(), monday.toString());
+            String suffix = PartitionTimeUtils.formatPartitionNameSuffix(monday.atStartOfDay(), TimeUnit.WEEK);
+            Assertions.assertTrue(suffix.startsWith("0000_"), suffix);
+            Assertions.assertEquals(String.format("0000_%02d", monday.get(weekFields.weekOfWeekBasedYear())), suffix);
+        }
+        // Years below 1000 are padded too, matching what the YEAR unit produces for the same year.
+        Assertions.assertEquals("0001",
+                PartitionTimeUtils.formatPartitionNameSuffix(LocalDateTime.of(1, 1, 1, 0, 0, 0), TimeUnit.YEAR));
+        Assertions.assertTrue(
+                PartitionTimeUtils.formatPartitionNameSuffix(LocalDateTime.of(1, 1, 1, 0, 0, 0), TimeUnit.WEEK)
+                        .startsWith("0001_"));
+    }
+
+    @Test
+    public void testFormatWeekPartitionNameSuffixRejectsWeekBeforeMinDate() {
+        // Aligning 0000-01-01 (a Saturday) back to Monday lands on -0001-12-27, which no DATE can
+        // hold; naming it would yield the invalid partition name p-1_52.
+        LocalDateTime beforeMinDate = LocalDateTime.of(0, 1, 1, 0, 0, 0)
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        Assertions.assertEquals(-1, beforeMinDate.getYear());
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> PartitionTimeUtils.formatPartitionNameSuffix(beforeMinDate, TimeUnit.WEEK));
+        Assertions.assertTrue(e.getMessage().contains("week begins before 0000-01-01"), e.getMessage());
+    }
+
+    @Test
+    public void testAlignToUnitStart() {
+        LocalDateTime time = LocalDateTime.of(2024, 3, 5, 10, 30, 15);
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 5, 10, 0, 0),
+                PartitionTimeUtils.alignToUnitStart(time, TimeUnit.HOUR, 1, 1));
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 5, 0, 0, 0),
+                PartitionTimeUtils.alignToUnitStart(time, TimeUnit.DAY, 1, 1));
+        // 2024-03-05 is a Tuesday; WEEK / MONTH / YEAR keep the time of day.
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 4, 10, 30, 15),
+                PartitionTimeUtils.alignToUnitStart(time, TimeUnit.WEEK, 1, 1));
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 1, 10, 30, 15),
+                PartitionTimeUtils.alignToUnitStart(time, TimeUnit.MONTH, 1, 1));
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 15, 10, 30, 15),
+                PartitionTimeUtils.alignToUnitStart(time, TimeUnit.MONTH, 1, 15));
+        Assertions.assertEquals(LocalDateTime.of(2024, 1, 1, 10, 30, 15),
+                PartitionTimeUtils.alignToUnitStart(time, TimeUnit.YEAR, 1, 1));
+        Assertions.assertThrows(SemanticException.class,
+                () -> PartitionTimeUtils.alignToUnitStart(time, TimeUnit.MINUTE, 1, 1));
+    }
+
+    @Test
+    public void testTruncateToUnitStart() {
+        LocalDateTime time = LocalDateTime.of(2024, 3, 5, 10, 30, 15);
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 5, 10, 30, 0),
+                PartitionTimeUtils.truncateToUnitStart(time, TimeUnit.MINUTE));
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 5, 10, 0, 0),
+                PartitionTimeUtils.truncateToUnitStart(time, TimeUnit.HOUR));
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 5, 0, 0, 0),
+                PartitionTimeUtils.truncateToUnitStart(time, TimeUnit.DAY));
+        // Unlike alignToUnitStart, this also clears the time of day.
+        Assertions.assertEquals(LocalDateTime.of(2024, 3, 1, 0, 0, 0),
+                PartitionTimeUtils.truncateToUnitStart(time, TimeUnit.MONTH));
+        Assertions.assertEquals(LocalDateTime.of(2024, 1, 1, 0, 0, 0),
+                PartitionTimeUtils.truncateToUnitStart(time, TimeUnit.YEAR));
+        Assertions.assertThrows(SemanticException.class,
+                () -> PartitionTimeUtils.truncateToUnitStart(time, TimeUnit.WEEK));
+    }
+
+    @Test
+    public void testPlus() {
+        LocalDateTime time = LocalDateTime.of(0, 1, 1, 0, 0, 0);
+        Assertions.assertEquals(LocalDateTime.of(0, 1, 1, 0, 1, 0), PartitionTimeUtils.plus(time, TimeUnit.MINUTE, 1));
+        Assertions.assertEquals(LocalDateTime.of(0, 1, 1, 1, 0, 0), PartitionTimeUtils.plus(time, TimeUnit.HOUR, 1));
+        Assertions.assertEquals(LocalDateTime.of(0, 1, 2, 0, 0, 0), PartitionTimeUtils.plus(time, TimeUnit.DAY, 1));
+        Assertions.assertEquals(LocalDateTime.of(0, 1, 8, 0, 0, 0), PartitionTimeUtils.plus(time, TimeUnit.WEEK, 1));
+        Assertions.assertEquals(LocalDateTime.of(0, 2, 1, 0, 0, 0), PartitionTimeUtils.plus(time, TimeUnit.MONTH, 1));
+        Assertions.assertEquals(LocalDateTime.of(1, 1, 1, 0, 0, 0), PartitionTimeUtils.plus(time, TimeUnit.YEAR, 1));
+        Assertions.assertThrows(SemanticException.class, () -> PartitionTimeUtils.plus(time, TimeUnit.SECOND, 1));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/MultiRangePartitionDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/MultiRangePartitionDescTest.java
@@ -1,0 +1,137 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.DateType;
+import com.starrocks.type.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.List;
+import java.util.Locale;
+
+public class MultiRangePartitionDescTest {
+
+    private static List<SingleRangePartitionDesc> convert(String begin, String end, long step, String timeUnit,
+                                                          Type columnType) throws AnalysisException {
+        MultiRangePartitionDesc desc =
+                new MultiRangePartitionDesc(begin, end, step, timeUnit, NodePosition.ZERO);
+        PartitionConvertContext context = new PartitionConvertContext();
+        context.setFirstPartitionColumnType(columnType);
+        return desc.convertToSingle(context);
+    }
+
+    private static void assertPartition(SingleRangePartitionDesc desc, String name, String lower, String upper) {
+        Assertions.assertEquals(name, desc.getPartitionName());
+        Assertions.assertEquals(lower, desc.getPartitionKeyDesc().getLowerValues().get(0).getStringValue());
+        Assertions.assertEquals(upper, desc.getPartitionKeyDesc().getUpperValues().get(0).getStringValue());
+    }
+
+    /** Year 0000 used to be formatted as 0001, collapsing the range and failing the DDL. */
+    @Test
+    public void testBuildYearPartitionOnYearZero() throws AnalysisException {
+        List<SingleRangePartitionDesc> descs = convert("0000-01-01", "0002-01-01", 1, "year", DateType.DATE);
+        Assertions.assertEquals(2, descs.size());
+        assertPartition(descs.get(0), "p0000", "0000-01-01", "0001-01-01");
+        assertPartition(descs.get(1), "p0001", "0001-01-01", "0002-01-01");
+    }
+
+    @Test
+    public void testBuildDayPartitionOnYearZero() throws AnalysisException {
+        List<SingleRangePartitionDesc> descs = convert("0000-01-01", "0000-01-03", 1, "day", DateType.DATE);
+        Assertions.assertEquals(2, descs.size());
+        assertPartition(descs.get(0), "p00000101", "0000-01-01", "0000-01-02");
+        assertPartition(descs.get(1), "p00000102", "0000-01-02", "0000-01-03");
+    }
+
+    @Test
+    public void testBuildMonthPartitionOnYearZeroDatetime() throws AnalysisException {
+        List<SingleRangePartitionDesc> descs =
+                convert("0000-01-01 00:00:00", "0000-03-01 00:00:00", 1, "month", DateType.DATETIME);
+        Assertions.assertEquals(2, descs.size());
+        assertPartition(descs.get(0), "p000001", "0000-01-01 00:00:00", "0000-02-01 00:00:00");
+        assertPartition(descs.get(1), "p000002", "0000-02-01 00:00:00", "0000-03-01 00:00:00");
+    }
+
+    @Test
+    public void testBuildYearPartition() throws AnalysisException {
+        List<SingleRangePartitionDesc> descs = convert("2023-01-01", "2025-01-01", 1, "year", DateType.DATE);
+        Assertions.assertEquals(2, descs.size());
+        assertPartition(descs.get(0), "p2023", "2023-01-01", "2024-01-01");
+        assertPartition(descs.get(1), "p2024", "2024-01-01", "2025-01-01");
+    }
+
+    @Test
+    public void testBuildDayPartition() throws AnalysisException {
+        List<SingleRangePartitionDesc> descs = convert("2024-02-28", "2024-03-02", 1, "day", DateType.DATE);
+        Assertions.assertEquals(3, descs.size());
+        assertPartition(descs.get(0), "p20240228", "2024-02-28", "2024-02-29");
+        assertPartition(descs.get(1), "p20240229", "2024-02-29", "2024-03-01");
+        assertPartition(descs.get(2), "p20240301", "2024-03-01", "2024-03-02");
+    }
+
+    @Test
+    public void testBuildHourPartition() throws AnalysisException {
+        List<SingleRangePartitionDesc> descs =
+                convert("2024-03-05 00:00:00", "2024-03-05 02:00:00", 1, "hour", DateType.DATETIME);
+        Assertions.assertEquals(2, descs.size());
+        assertPartition(descs.get(0), "p2024030500", "2024-03-05 00:00:00", "2024-03-05 01:00:00");
+        assertPartition(descs.get(1), "p2024030501", "2024-03-05 01:00:00", "2024-03-05 02:00:00");
+    }
+
+    @Test
+    public void testBuildWeekPartition() throws AnalysisException {
+        // 2024-01-01 is a Monday.
+        List<SingleRangePartitionDesc> descs = convert("2024-01-01", "2024-01-15", 1, "week", DateType.DATE);
+        Assertions.assertEquals(2, descs.size());
+        assertPartition(descs.get(0), "p2024_01", "2024-01-01", "2024-01-08");
+        assertPartition(descs.get(1), "p2024_02", "2024-01-08", "2024-01-15");
+    }
+
+    @Test
+    public void testBuildWeekPartitionOnYearZero() throws AnalysisException {
+        // 0000-01-03 is a Monday. The week number follows the locale's week rules read off the
+        // proleptic date, so derive it the same way rather than hard-coding one locale's answer.
+        WeekFields weekFields = WeekFields.of(Locale.getDefault(Locale.Category.FORMAT));
+        String firstWeek = String.format("p0000_%02d", LocalDate.of(0, 1, 3).get(weekFields.weekOfWeekBasedYear()));
+        String secondWeek = String.format("p0000_%02d", LocalDate.of(0, 1, 10).get(weekFields.weekOfWeekBasedYear()));
+
+        List<SingleRangePartitionDesc> descs = convert("0000-01-03", "0000-01-17", 1, "week", DateType.DATE);
+        Assertions.assertEquals(2, descs.size());
+        assertPartition(descs.get(0), firstWeek, "0000-01-03", "0000-01-10");
+        assertPartition(descs.get(1), secondWeek, "0000-01-10", "0000-01-17");
+    }
+
+    @Test
+    public void testBuildWeekPartitionRejectsStartBeforeFirstWeek() {
+        // 0000-01-01 is a Saturday, so its week begins at -0001-12-27, which no DATE can hold.
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> convert("0000-01-01", "0000-02-01", 1, "week", DateType.DATE));
+        Assertions.assertTrue(e.getMessage().contains("week begins before 0000-01-01"), e.getMessage());
+    }
+
+    @Test
+    public void testUnsupportedTimeUnit() {
+        AnalysisException e = Assertions.assertThrows(AnalysisException.class,
+                () -> convert("2024-03-05 00:00:00", "2024-03-05 00:10:00", 1, "minute", DateType.DATETIME));
+        Assertions.assertTrue(e.getMessage().contains("Batch build partition does not support time interval type"),
+                e.getMessage());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Batch DDL cannot create a date range partition that starts at year 0000, even though `0000-01-01` is a legal StarRocks `DATE` value:

```sql
ALTER TABLE t ADD PARTITIONS START ("0000-01-01") END ("0001-01-01") EVERY (INTERVAL 1 YEAR);
-- ERROR: the range of the partition is invalid
```

`MultiRangePartitionDesc.buildDateTypePartition()` parses START/END correctly, but formats the resulting bounds and the partition name with the legacy `DateUtils` patterns, which spell the year as Java's `yyyy` (year-of-era). That symbol cannot represent year 0000 and renders it as `0001`:

```
[0000-01-01, 0001-01-01)  --yyyy-MM-dd-->  [0001-01-01, 0001-01-01)
```

`RangePartitionInfo.checkNewRange()` then sees `lower >= upper` and rejects the DDL. The name is affected the same way, so the partition would be called `p0001` rather than `p0000`.

Creating the same partition automatically through an `INSERT` succeeds, because automatic partitioning formats with the `*_FORMATTER_UNIX` variants, which are built on the proleptic `ChronoField.YEAR`. That divergence is what this PR removes.

Found via the cross-cluster migration tool: it generates this batch DDL when replicating a source partition that covers year 0000, and the DDL fails on the target FE.

## What I'm doing:

Extract the date/time handling that the batch and automatic partition paths had each copied into a new `PartitionTimeUtils` — time-unit alignment, interval advance, bound formatting and partition-name formatting — and make both paths use the UNIX formatters, so year 0000 round-trips on either.

The alignment switch existed in three private copies, which now share one implementation:

- `MultiRangePartitionDesc.buildDateTypePartition()` (batch DDL, the buggy one)
- `AnalyzerUtils.getAddPartitionClauseForRangePartition()` / `truncateToPartitionBoundary()` (automatic partitioning)
- `PartitionDescAnalyzer.checkManualAddPartitionDateAligned()` (batch DDL alignment validation)

Alignment intentionally keeps two shapes, because the two paths differ:

- `alignToUnitStart` preserves the time of day for `WEEK`, `MONTH` and `YEAR`, since batch DDL allows an unaligned START.
- `truncateToUnitStart` clears every smaller field, since an automatically created partition always begins at the exact start of its unit.

Also drops the static `SimpleDateFormat` round trip in the `WEEK` branch. It was not thread safe, it disagreed with the `Calendar` time zone, and its era-based year hit the same 0000 problem; the week number still comes from `Calendar.WEEK_OF_YEAR` so batch and dynamic partitioning keep naming the same week identically.

### Week partition names

Three further `WEEK` fixes, raised in review:

- **The week number is now read off the proleptic date** with `WeekFields`, taken from the same JVM locale `Calendar` used, rather than by passing the year through `GregorianCalendar`. Year 0000 was resolving as 1 BCE on the Julian calendar, whose weeks are two days off, which left the week one short under every locale whose week starts on Sunday: `0000-01-03` was named week `01` where the locale's own rules on the proleptic date give week `02`. All 52 proleptic Mondays of year 0000 were affected under `en_US` and `zh_CN` (Sunday, 1 minimum day); locales on ISO rules (`en_GB`, `de_DE` — Monday, 4) happened to be unaffected, which is why the first revision of this PR missed it.
- The year is now formatted through `YEAR_FORMATTER_UNIX` rather than printed as an `int`, so it is padded to four digits like every other unit. **Years below 1000 change**: `p50_01` becomes `p0050_01`. That matches what the `YEAR` unit already produced for the same year (`p0050`), and years >= 1000 are unaffected.
- Aligning a week back past `0000-01-01` has no name in range. The week holding `0000-01-01` starts at `-0001-12-27`, and its name `p-1_52` fails `FeNameFormat.checkPartitionName` because `COMMON_NAME_REGEX` does not allow a hyphen. That case now reports what to do instead of emitting an invalid name.

Batch and dynamic partitioning still name the same week identically: over **every day from 1900 to 2100** (73414 days) the `WeekFields` result matches `Calendar.WEEK_OF_YEAR` exactly, under `en_US`, `zh_CN`, `en_GB`, `de_DE`, `fr_FR`, `ja_JP` and `ar_SA`. The two week-rule sources agree too — `WeekFields.of(locale)` returns the same `firstDayOfWeek` / `minimalDaysInFirstWeek` as `Calendar.getInstance()` for all 1017 available locales.

Behavior is unchanged for every input other than year-0000 week numbers and the sub-1000 week names above. Verified with a differential harness that runs the old and new implementations side by side:

- batch path: 19200 combinations (`hour`/`day`/`week`/`month`/`year` x step 1/2/3 x `start_day_of_week` 1/2/5/7 x `start_day_of_month` 1/5/15/28 x dates spanning 2019-2023 including year boundaries x DATE/DATETIME) — **0 differences**
- automatic partitioning and alignment validation: 5480 combinations — identical except that when both the granularity and the date value are invalid, the granularity error is now reported first instead of the parse error

### Observability

Reviewed the signals on this path: it is DDL analysis, so no metric or query profile is involved. The existing `LOG.warn("failed to analyse partition value", e)` in `AnalyzerUtils` is preserved, and every user-visible error message and exception type is unchanged apart from the ordering noted above. No observability change was needed.

### Testing

`mvn -B test -pl fe-core` with checkstyle enabled, 240 tests, 0 failures:

`PartitionTimeUtilsTest` (new), `MultiRangePartitionDescTest` (new), `CreateTableWithPartitionTest`, `alter.AlterTest`, `lake.AlterTest`, `RangePartitionInfoTest`, `DropPartitionWithExprListTest`, `DynamicPartitionSchedulerTest`, `InsertPreSplitHookTableTest`, `QueryDumpAutoPartitionReplayTest`, `DateUtilsTest`.

The year-0000 cases in `MultiRangePartitionDescTest` fail against the pre-fix code (`expected: <p0000> but was: <p0001>`) and pass after it, while the normal-year cases pass on both. For reference, `START ("0000-01-03") END ("0000-01-17") EVERY (INTERVAL 1 WEEK)` produced `p1_02[0001-01-03,0001-01-10) p1_03[0001-01-10,0001-01-17)` before this change and produces `p0000_02[0000-01-03,0000-01-10) p0000_03[0000-01-10,0000-01-17)` after it under Sunday-start locales.

The year-0000 week tests derive the expected week from the JVM locale's own rules applied to the proleptic date, so they do not hard-code one locale's answer. That oracle fails on the previous revision of this PR for all four dates it checks (`0000-01-03` expected `0000_02`, got `0000_01`) and passes now.

Not covered: an end-to-end cross-cluster migration run, which needs two live clusters.

### Known related issue, not fixed here

`SyncPartitionUtils` (materialized-view partition sync) still builds partition names with the same legacy formatters, so an MV over a base table with a year-0000 partition can collide with the real year-0001 partition. That is a separate path with its own metadata-compatibility question — existing MVs have these names persisted — so it is left for a follow-up.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5


