### PR TITLE
[BugFix] Rebuild the SQL blacklist snapshot once when loading the image

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
@@ -67,10 +67,19 @@ public class SqlBlackList {
 
     public void load(SRMetaBlockReader reader) throws IOException, SRMetaBlockException, SRMetaBlockEOFException {
         try (LockCloseable ignored = new LockCloseable(updateLock)) {
-            int cnt = reader.readInt();
-            for (int i = 0; i < cnt; i++) {
-                SqlBlackListPersistInfo sqlBlackListPersistInfo = reader.readJson(SqlBlackListPersistInfo.class);
-                put(sqlBlackListPersistInfo.id, Pattern.compile(sqlBlackListPersistInfo.pattern));
+            try {
+                int cnt = reader.readInt();
+                for (int i = 0; i < cnt; i++) {
+                    SqlBlackListPersistInfo sqlBlackListPersistInfo = reader.readJson(SqlBlackListPersistInfo.class);
+                    Pattern pattern = Pattern.compile(sqlBlackListPersistInfo.pattern);
+                    BlackListSql blackListSql = sqlBlackListMap.get(pattern.toString());
+                    if (blackListSql == null) {
+                        ids.set(Math.max(ids.get(), sqlBlackListPersistInfo.id + 1));
+                        sqlBlackListMap.put(pattern.toString(), new BlackListSql(pattern, sqlBlackListPersistInfo.id));
+                    }
+                }
+            } finally {
+                refreshSnapshot();
             }
             LOG.info("loaded {} SQL blacklist patterns", sqlBlackListMap.size());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistLockFreeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistLockFreeTest.java
@@ -16,6 +16,10 @@ package com.starrocks.meta;
 
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.persist.SqlBlackListPersistInfo;
+import com.starrocks.persist.metablock.SRMetaBlockEOFException;
+import com.starrocks.persist.metablock.SRMetaBlockID;
+import com.starrocks.persist.metablock.SRMetaBlockWriter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
@@ -116,6 +120,49 @@ public class SqlBlacklistLockFreeTest {
         long third = recovered.put(Pattern.compile("rule_added_after_load"));
         Assertions.assertTrue(third > second, "expected an id above the loaded ones, got " + third);
         Assertions.assertEquals(3, recovered.getBlackLists().size());
+    }
+
+    @Test
+    public void testLoadRestoresOutOfOrderIdsSorted() throws Exception {
+        SqlBlackList original = new SqlBlackList();
+        original.put(7L, Pattern.compile("rule_replayed_c"));
+        original.put(2L, Pattern.compile("rule_replayed_a"));
+        original.put(5L, Pattern.compile("rule_replayed_b"));
+
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        original.save(image.getImageWriter());
+
+        SqlBlackList recovered = new SqlBlackList();
+        recovered.load(image.getMetaBlockReader());
+
+        List<BlackListSql> rules = recovered.getBlackLists();
+        Assertions.assertEquals(3, rules.size());
+        Assertions.assertEquals(2L, rules.get(0).id);
+        Assertions.assertEquals(5L, rules.get(1).id);
+        Assertions.assertEquals(7L, rules.get(2).id);
+
+        long next = recovered.put(Pattern.compile("rule_added_after_unordered_load"));
+        Assertions.assertEquals(8L, next);
+        Assertions.assertEquals(4, recovered.getBlackLists().size());
+    }
+
+    @Test
+    public void testLoadPublishesRulesRestoredBeforeToleratedEof() throws Exception {
+        UtFrameUtils.PseudoImage image = new UtFrameUtils.PseudoImage();
+        SRMetaBlockWriter writer = image.getImageWriter().getBlockWriter(SRMetaBlockID.BLACKLIST_MGR, 3);
+        writer.writeInt(3);
+        writer.writeJson(new SqlBlackListPersistInfo(2L, "rule_before_eof_a"));
+        writer.writeJson(new SqlBlackListPersistInfo(5L, "rule_before_eof_b"));
+        writer.close();
+
+        SqlBlackList recovered = new SqlBlackList();
+        Assertions.assertThrows(SRMetaBlockEOFException.class, () -> recovered.load(image.getMetaBlockReader()));
+
+        List<BlackListSql> rules = recovered.getBlackLists();
+        Assertions.assertEquals(2, rules.size());
+        Assertions.assertEquals(2L, rules.get(0).id);
+        Assertions.assertEquals(5L, rules.get(1).id);
+        Assertions.assertThrows(AnalysisException.class, () -> recovered.verifying("select rule_before_eof_b from t"));
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #78476

## Why I'm doing:

`SqlBlackList.load()` calls `put(id, pattern)` once per persisted rule, and `put()` rebuilds and sorts the whole immutable snapshot on every call. Loading N rules therefore rebuilds the snapshot N times, `O(N² log N)` in total with `O(N²)` cumulative snapshot allocation. `load()` runs at FE startup and on every checkpoint.

## What I'm doing:

`load()` now fills `sqlBlackListMap` directly under `updateLock` and calls `refreshSnapshot()` once after the loop. Deduplication and id advancement match `put(id, pattern)`. `put()`, `delete()` and the query path are unchanged.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
