### PR TITLE
[Feature] Support ALTER VIEW ... RENAME

### DIFF
--- a/docs/en/sql-reference/sql-statements/View/ALTER_VIEW.md
+++ b/docs/en/sql-reference/sql-statements/View/ALTER_VIEW.md
@@ -16,10 +16,19 @@ ALTER VIEW
 AS query_stmt
 ```
 
+```sql
+ALTER VIEW [db_name.]view_name RENAME new_view_name
+```
+
 Note:
 
 1. View is logical, where the data isn't stored in the physical medium. The view will be used as a subquery in the statement when queried. Therefore, modifying the definition of views is equivalent to modifying query_stmt.
 2. query_stmt is arbitrarily supported SQL.
+3. RENAME changes the name of the view only. The privileges granted on the view, its comment, and its SQL SECURITY characteristic are preserved.
+
+:::warning
+A view is referenced by name. After you rename a view, any other view, materialized view, or application SQL that still refers to the old name fails with a "table not found" error at query time; no warning is raised at rename time. Materialized views built on the renamed view are set to inactive, and they cannot be activated again until you either rename the view back or recreate the materialized views.
+:::
 
 ## Examples
 
@@ -35,4 +44,10 @@ c3 COMMENT "column 3"
 AS SELECT k1, k2, SUM(v1) 
 FROM example_table
 GROUP BY k1, k2
+```
+
+Rename `example_view` on `example_db` to `example_view_new_name`.
+
+```sql
+ALTER VIEW example_db.example_view RENAME example_view_new_name
 ```

--- a/docs/ja/sql-reference/sql-statements/View/ALTER_VIEW.md
+++ b/docs/ja/sql-reference/sql-statements/View/ALTER_VIEW.md
@@ -18,10 +18,19 @@ ALTER VIEW
 AS query_stmt
 ```
 
+```sql
+ALTER VIEW [db_name.]view_name RENAME new_view_name
+```
+
 注意:
 
 1. ビューは論理的なものであり、データは物理的な媒体に保存されません。クエリされたとき、ビューはステートメント内のサブクエリとして使用されます。したがって、ビューの定義を変更することは、query_stmt を変更することと同等です。
 2. query_stmt は任意の SQL をサポートします。
+3. RENAME はビューの名前のみを変更します。そのビューに付与された権限、コメント、および SQL SECURITY 特性は保持されます。
+
+:::warning
+ビューは名前で参照されます。ビューの名前を変更すると、古い名前を参照したままの他のビュー、マテリアライズドビュー、アプリケーションの SQL は、クエリ時に「テーブルが存在しない」エラーで失敗します。名前の変更時に警告は出力されません。名前を変更したビュー上に作成されたマテリアライズドビューは inactive になり、ビューの名前を元に戻すか、マテリアライズドビューを再作成するまで再度アクティブにできません。
+:::
 
 ## 例
 
@@ -37,4 +46,10 @@ c3 COMMENT "column 3"
 AS SELECT k1, k2, SUM(v1) 
 FROM example_table
 GROUP BY k1, k2
+```
+
+`example_db` の `example_view` の名前を `example_view_new_name` に変更します。
+
+```sql
+ALTER VIEW example_db.example_view RENAME example_view_new_name
 ```

--- a/docs/zh/sql-reference/sql-statements/View/ALTER_VIEW.md
+++ b/docs/zh/sql-reference/sql-statements/View/ALTER_VIEW.md
@@ -19,10 +19,19 @@ ALTER VIEW
 AS query_stmt
 ```
 
+```sql
+ALTER VIEW [db_name.]view_name RENAME new_view_name
+```
+
 说明：
 
 1. 逻辑视图中的数据不会存储在物理介质上，在查询时，逻辑视图将作为语句中的子查询，因此，修改逻辑视图的定义等价于修改 query_stmt。
 2. query_stmt 为任意支持的 SQL。
+3. RENAME 仅修改逻辑视图的名称。该视图上已授予的权限、注释以及 SQL SECURITY 特性均保持不变。
+
+:::warning
+逻辑视图是按名称被引用的。重命名之后，仍然使用旧名称的其他逻辑视图、物化视图或应用 SQL 会在查询时报“表不存在”的错误，重命名时不会有任何提示。基于该视图创建的物化视图会被置为 inactive，且在您将视图改回原名或重建这些物化视图之前无法重新激活。
+:::
 
 ## 示例
 
@@ -38,4 +47,10 @@ AS query_stmt
     AS SELECT k1, k2, SUM(v1) 
     FROM example_table
     GROUP BY k1, k2;
+    ```
+
+2. 将 example_db 上的逻辑视图 example_view 重命名为 example_view_new_name。
+
+    ```sql
+    ALTER VIEW example_db.example_view RENAME example_view_new_name;
     ```

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -32,6 +32,7 @@ import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.catalog.View;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
@@ -289,7 +290,28 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             return null;
         }
 
-        AlterViewClause alterViewClause = (AlterViewClause) statement.getAlterClause();
+        AlterClause alterViewClause = statement.getAlterClause();
+        if (alterViewClause instanceof TableRenameClause) {
+            // RENAME re-keys the view in the database's nameToTable/idToTable maps -- DB-level state --
+            // so it takes the plain DB WRITE lock here, for the same reason ALTER TABLE / ALTER
+            // MATERIALIZED VIEW rename do (an intensive table lock only takes IX on the db, and IX is
+            // compatible with IS/IX, so a concurrent name lookup could observe a torn map). It also
+            // cannot go through visitTableRenameClause below: that handler is shared with ALTER TABLE
+            // and casts the table to OlapTable.
+            Locker locker = new Locker();
+            locker.lockDatabase(db.getId(), LockType.WRITE);
+            try {
+                if (!db.isExist()) {
+                    throw new AlterJobException("alter view failed. database:" + db.getFullName() + " not exist");
+                }
+                ErrorReport.wrapWithRuntimeException(() ->
+                        GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                .renameView(db, (View) table, (TableRenameClause) alterViewClause));
+            } finally {
+                locker.unLockDatabase(db.getId(), LockType.WRITE);
+            }
+            return null;
+        }
         visit(alterViewClause, context);
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -105,6 +105,10 @@ public class MaterializedViewExceptions {
         return "base-view changed: " + tableName;
     }
 
+    public static String inactiveReasonForBaseViewRenamed(String tableName) {
+        return "base-view renamed: " + tableName;
+    }
+
     public static String inactiveReasonForBaseInfoMissed() {
         return "base-info missed";
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
@@ -64,7 +64,7 @@ public class ConnectorViewDefinition {
     }
 
     public static ConnectorViewDefinition fromAlterViewStmt(AlterViewStmt stmt) {
-        AlterViewClause alterViewClause = stmt.getAlterClause();
+        AlterViewClause alterViewClause = (AlterViewClause) stmt.getAlterClause();
         return new ConnectorViewDefinition(
                 stmt.getCatalog(),
                 stmt.getDbName(),

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -389,6 +389,11 @@ public class EditLog {
                     globalStateMgr.getAlterJobMgr().replayAlterView(info);
                     break;
                 }
+                case OperationType.OP_RENAME_VIEW: {
+                    TableInfo info = (TableInfo) journal.data();
+                    globalStateMgr.getLocalMetastore().replayRenameView(info);
+                    break;
+                }
                 case OperationType.OP_SET_VIEW_SECURITY_LOG: {
                     AlterViewInfo info = (AlterViewInfo) journal.data();
                     globalStateMgr.getAlterJobMgr().updateViewSecurity(info);
@@ -1862,6 +1867,10 @@ public class EditLog {
 
     public void logModifyViewDef(AlterViewInfo alterViewInfo, WALApplier walApplier) {
         logJsonObject(OperationType.OP_MODIFY_VIEW_DEF, alterViewInfo, walApplier);
+    }
+
+    public void logViewRename(TableInfo tableInfo, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_RENAME_VIEW, tableInfo, walApplier);
     }
 
     public void logRollupRename(TableInfo tableInfo, WALApplier walApplier) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -112,6 +112,7 @@ public class EditLogDeserializer {
             .put(OperationType.OP_RENAME_COLUMN_V2, ColumnRenameInfo.class)
             .put(OperationType.OP_MODIFY_VIEW_DEF, AlterViewInfo.class)
             .put(OperationType.OP_SET_VIEW_SECURITY_LOG, AlterViewInfo.class)
+            .put(OperationType.OP_RENAME_VIEW, TableInfo.class)
             .put(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES, ModifyTablePropertyOperationLog.class)
             .put(OperationType.OP_RENAME_MATERIALIZED_VIEW, RenameMaterializedViewLog.class)
             .put(OperationType.OP_ALTER_MATERIALIZED_VIEW_STATUS, AlterMaterializedViewStatusLog.class)

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -701,6 +701,14 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_ERASE_MATERIALIZED_INDEX = 13558;
 
+    // ALTER VIEW ... RENAME. Deliberately not folded into OP_RENAME_TABLE_V2: sharing that op would
+    // force replayRenameTable to accept any Table instead of an OlapTable, and an FE that predates
+    // this op would then hit a ClassCastException that is silently swallowed (the op is ignorable),
+    // leaving that node's view name diverged from the leader's. A distinct op makes such an FE stop
+    // on an unknown operation type instead.
+    @IgnorableOnReplayFailed
+    public static final short OP_RENAME_VIEW = 13559;
+
     /*
      * NOTICE: OperationType cannot use a value exceeding 20000, please follow the above sequence number
      */

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3888,6 +3888,73 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         });
     }
 
+    /**
+     * Entry of the view rename operation. The caller must hold the database WRITE lock: renaming
+     * re-keys the view in the database's nameToTable map, and an intensive table lock only takes IX
+     * on the database, which a concurrent IS/IX holder could observe mid-update. Mirrors the table
+     * and materialized-view rename paths.
+     */
+    public void renameView(Database db, View view, TableRenameClause tableRenameClause) throws DdlException {
+        String oldViewName = view.getName();
+        String newViewName = tableRenameClause.getNewTableName();
+        if (oldViewName.equals(newViewName)) {
+            throw new DdlException("Same view name");
+        }
+
+        // The view was resolved before the caller took the database lock. Re-check that it is still
+        // registered: a DROP VIEW that won the race would otherwise be undone here, because the rename
+        // re-registers the object, while replaying the log elsewhere finds no such id and skips.
+        if (getTable(db.getId(), view.getId()) == null) {
+            throw new DdlException("View[" + oldViewName + "] does not exist");
+        }
+
+        // check if name is already used
+        if (getTable(db.getFullName(), newViewName) != null) {
+            throw new DdlException("Table name[" + newViewName + "] is already used");
+        }
+
+        TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), view.getId(), newViewName);
+        GlobalStateMgr.getCurrentState().getEditLog().logViewRename(tableInfo, wal -> {
+            view.setName(newViewName);
+            db.dropTable(oldViewName);
+            db.registerTableUnlocked(view);
+        });
+        // Materialized views built on this view store the view's name in their definition SQL, so they
+        // can no longer be refreshed or used for rewrite. Same treatment as a renamed base table and as
+        // a redefined base view.
+        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(view,
+                MaterializedViewExceptions.inactiveReasonForBaseViewRenamed(oldViewName));
+        LOG.info("rename view[{}] to {}, viewId: {}", oldViewName, newViewName, view.getId());
+    }
+
+    public void replayRenameView(TableInfo tableInfo) {
+        long dbId = tableInfo.getDbId();
+        long tableId = tableInfo.getTableId();
+        String newViewName = tableInfo.getNewTableName();
+
+        Database db = getDb(dbId);
+        if (db == null) {
+            LOG.warn("db {} does not exist when replaying rename view, tableId: {}", dbId, tableId);
+            return;
+        }
+        Locker locker = new Locker();
+        locker.lockDatabase(db.getId(), LockType.WRITE);
+        try {
+            View view = (View) getTable(db.getId(), tableId);
+            if (view == null) {
+                LOG.warn("view {} does not exist when replaying rename view in db {}", tableId, dbId);
+                return;
+            }
+            String viewName = view.getName();
+            db.dropTable(viewName);
+            view.setName(newViewName);
+            db.registerTableUnlocked(view);
+            LOG.info("replay rename view[{}] to {}, viewId: {}", viewName, newViewName, view.getId());
+        } finally {
+            locker.unLockDatabase(db.getId(), LockType.WRITE);
+        }
+    }
+
     public void replayRenameTable(TableInfo tableInfo) {
         long dbId = tableInfo.getDbId();
         long tableId = tableInfo.getTableId();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ViewAnalyzer.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.TableRenameClause;
 import org.apache.commons.collections4.MapUtils;
 
 import java.util.HashSet;
@@ -131,28 +132,40 @@ public class ViewAnalyzer {
             }
 
             AlterClause alterClause = stmt.getAlterClause();
-            AlterViewClause alterViewClause = (AlterViewClause) alterClause;
-
-            Analyzer.analyze(alterViewClause.getQueryStatement(), context);
-            AnalyzerUtils.prohibitTimeTravelQuery(alterViewClause.getQueryStatement(), "alter view");
-            boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(((AlterViewClause) alterClause).getQueryStatement());
-            if (hasTemporaryTable) {
-                throw new SemanticException("View can't base on temporary table");
+            if (alterClause instanceof TableRenameClause) {
+                // Renaming re-keys the view in the database's name index, which only the internal catalog
+                // owns. External catalogs route ALTER VIEW to their connector, where a rename clause would
+                // otherwise fall through to a message about ALTER VIEW AS.
+                if (!CatalogMgr.isInternalCatalog(catalog)) {
+                    throw new SemanticException("Rename view is not supported for catalog: " + catalog);
+                }
             }
-
-            List<Column> viewColumns = analyzeViewColumns(alterViewClause.getQueryStatement().getQueryRelation(),
-                    alterViewClause.getColWithComments());
-            alterViewClause.setColumns(viewColumns);
-            String viewSql = AstToSQLBuilder.toSQL(alterViewClause.getQueryStatement());
-            alterViewClause.setInlineViewDef(viewSql);
-            Preconditions.checkArgument(stmt.getOrigStmt() != null, "View's original statement is null");
-            String originalViewDef = stmt.getOrigStmt().originStmt;
-            Preconditions.checkArgument(originalViewDef != null, "View's original view definition is null");
-            Preconditions.checkArgument(alterViewClause.getQueryStartIndex() >= 0 &&
-                            alterViewClause.getQueryStopIndex() >= alterViewClause.getQueryStartIndex(),
-                    "View's query start or stop index is invalid");
-            alterViewClause.setOriginalViewDefineSql(
-                    originalViewDef.substring(alterViewClause.getQueryStartIndex(), alterViewClause.getQueryStopIndex()));
+            if (alterClause instanceof AlterViewClause) {
+                AlterViewClause alterViewClause = (AlterViewClause) alterClause;
+                Analyzer.analyze(alterViewClause.getQueryStatement(), context);
+                AnalyzerUtils.prohibitTimeTravelQuery(alterViewClause.getQueryStatement(), "alter view");
+                boolean hasTemporaryTable = AnalyzerUtils.hasTemporaryTables(alterViewClause.getQueryStatement());
+                if (hasTemporaryTable) {
+                    throw new SemanticException("View can't base on temporary table");
+                }
+                List<Column> viewColumns = analyzeViewColumns(alterViewClause.getQueryStatement().getQueryRelation(),
+                        alterViewClause.getColWithComments());
+                alterViewClause.setColumns(viewColumns);
+                String viewSql = AstToSQLBuilder.toSQL(alterViewClause.getQueryStatement());
+                alterViewClause.setInlineViewDef(viewSql);
+                Preconditions.checkArgument(stmt.getOrigStmt() != null, "View's original statement is null");
+                String originalViewDef = stmt.getOrigStmt().originStmt;
+                Preconditions.checkArgument(originalViewDef != null, "View's original view definition is null");
+                Preconditions.checkArgument(alterViewClause.getQueryStartIndex() >= 0 &&
+                                alterViewClause.getQueryStopIndex() >= alterViewClause.getQueryStartIndex(),
+                        "View's query start or stop index is invalid");
+                alterViewClause.setOriginalViewDefineSql(
+                        originalViewDef.substring(alterViewClause.getQueryStartIndex(),
+                                alterViewClause.getQueryStopIndex()));
+            } else {
+                AlterTableClauseAnalyzer alterTableClauseAnalyzer = new AlterTableClauseAnalyzer(table);
+                alterTableClauseAnalyzer.analyze(context, alterClause);
+            }
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewStmt.java
@@ -25,7 +25,7 @@ public class AlterViewStmt extends DdlStmt {
     private final boolean security;
     private final AlterDialectType alterDialect;
     private final Map<String, String> properties;
-    private final AlterViewClause alterClause;
+    private final AlterClause alterClause;
 
     public enum AlterDialectType {
         NONE,
@@ -34,7 +34,7 @@ public class AlterViewStmt extends DdlStmt {
     }
 
     public AlterViewStmt(TableRef tableRef, boolean security, AlterDialectType alterDialect, Map<String, String> properties,
-                         AlterViewClause alterClause, NodePosition pos) {
+                         AlterClause alterClause, NodePosition pos) {
         super(pos);
         this.tableRef = tableRef;
         this.security = security;
@@ -93,17 +93,20 @@ public class AlterViewStmt extends DdlStmt {
         return properties;
     }
 
-    public AlterViewClause getAlterClause() {
+    public AlterClause getAlterClause() {
         return alterClause;
     }
 
     public String getOriginalViewDefineSql() {
-        return alterClause == null ? null : alterClause.getOriginalViewDefineSql();
+        if (alterClause instanceof AlterViewClause) {
+            return ((AlterViewClause) alterClause).getOriginalViewDefineSql();
+        }
+        return null;
     }
 
     public void setOriginalViewDefineSql(String originalViewDefineSql) {
-        if (alterClause != null) {
-            alterClause.setOriginalViewDefineSql(originalViewDefineSql);
+        if (alterClause instanceof AlterViewClause) {
+            ((AlterViewClause) alterClause).setOriginalViewDefineSql(originalViewDefineSql);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1981,6 +1981,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             properties.putAll(getCaseSensitiveProperties(context.properties()));
             return new AlterViewStmt(targetTableRef, isSecurity, AlterViewStmt.AlterDialectType.NONE, properties,
                     null, createPos(context));
+        } else if (context.tableRenameClause() != null) {
+            return new AlterViewStmt(targetTableRef, isSecurity, AlterViewStmt.AlterDialectType.NONE, properties,
+                    (AlterClause) visit(context.tableRenameClause()), createPos(context));
         } else {
             AlterViewStmt.AlterDialectType alterDialectType = context.ADD() != null ? AlterViewStmt.AlterDialectType.ADD :
                     context.MODIFY() != null ? AlterViewStmt.AlterDialectType.MODIFY : AlterViewStmt.AlterDialectType.NONE;

--- a/fe/fe-core/src/test/java/com/starrocks/persist/AlterViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/AlterViewTest.java
@@ -27,6 +27,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
@@ -137,5 +138,98 @@ public class AlterViewTest {
         editLog.loadJournal(GlobalStateMgr.getCurrentState(), journalEntity);
 
         Assertions.assertTrue(((View) table).isSecurity());
+    }
+
+    private static MockedLocalMetaStore setUpViewForRename(ConnectContext context) throws Exception {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        context.setThreadLocalInfo();
+        context.setGlobalStateMgr(globalStateMgr);
+
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        globalStateMgr.setLocalMetastore(localMetastore);
+
+        MockedMetadataMgr mockedMetadataMgr = new MockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
+        globalStateMgr.setMetadataMgr(mockedMetadataMgr);
+
+        localMetastore.createDb("db1");
+
+        String createTable = "create table db1.tbl1 (c1 bigint, c2 bigint, c3 bigint)";
+        CreateTableStmt createTableStmt =
+                (CreateTableStmt) SqlParser.parseSingleStatement(createTable, context.getSessionVariable().getSqlMode());
+        Analyzer.analyze(createTableStmt, context);
+        localMetastore.createTable(createTableStmt);
+
+        String createView = "create view db1.view1 as select * from db1.tbl1";
+        CreateViewStmt createViewStmt =
+                (CreateViewStmt) SqlParser.parseSingleStatement(createView, SqlModeHelper.MODE_DEFAULT);
+        Analyzer.analyze(createViewStmt, context);
+        localMetastore.createView(createViewStmt);
+
+        return localMetastore;
+    }
+
+    private static void alterView(String sql, ConnectContext context) {
+        AlterViewStmt stmt = (AlterViewStmt) SqlParser.parseSingleStatement(sql, SqlModeHelper.MODE_DEFAULT);
+        Analyzer.analyze(stmt, context);
+        new AlterJobExecutor().process(stmt, context);
+    }
+
+    @Test
+    public void testRenameView() throws Exception {
+        ConnectContext context = new ConnectContext();
+        MockedLocalMetaStore localMetastore = setUpViewForRename(context);
+
+        Table view = localMetastore.getTable("db1", "view1");
+        Assertions.assertTrue(view.isView());
+
+        alterView("alter view db1.view1 rename view2", context);
+
+        Assertions.assertEquals("view2", view.getName());
+        Assertions.assertNull(localMetastore.getTable("db1", "view1"));
+        Assertions.assertSame(view, localMetastore.getTable("db1", "view2"));
+
+        TableInfo info = (TableInfo) UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_RENAME_VIEW);
+        Assertions.assertEquals(localMetastore.getDb("db1").getId(), info.getDbId());
+        Assertions.assertEquals(view.getId(), info.getTableId());
+        Assertions.assertEquals("view2", info.getNewTableName());
+    }
+
+    @Test
+    public void testRenameViewToUsedName() throws Exception {
+        ConnectContext context = new ConnectContext();
+        MockedLocalMetaStore localMetastore = setUpViewForRename(context);
+
+        Table view = localMetastore.getTable("db1", "view1");
+
+        Assertions.assertThrows(Exception.class, () -> alterView("alter view db1.view1 rename tbl1", context));
+        // the failed rename leaves both the view and the occupied name untouched
+        Assertions.assertEquals("view1", view.getName());
+        Assertions.assertSame(view, localMetastore.getTable("db1", "view1"));
+        Assertions.assertNotNull(localMetastore.getTable("db1", "tbl1"));
+    }
+
+    @Test
+    public void testRenameViewToSameName() throws Exception {
+        ConnectContext context = new ConnectContext();
+        setUpViewForRename(context);
+
+        Assertions.assertThrows(SemanticException.class, () -> alterView("alter view db1.view1 rename view1", context));
+    }
+
+    @Test
+    public void testReplayRenameView() throws Exception {
+        ConnectContext context = new ConnectContext();
+        MockedLocalMetaStore localMetastore = setUpViewForRename(context);
+
+        Table view = localMetastore.getTable("db1", "view1");
+        Database database = localMetastore.getDb("db1");
+
+        TableInfo tableInfo = TableInfo.createForTableRename(database.getId(), view.getId(), "view2");
+        EditLog editLog = new EditLog(null);
+        editLog.loadJournal(GlobalStateMgr.getCurrentState(), new JournalEntity(OperationType.OP_RENAME_VIEW, tableInfo));
+
+        Assertions.assertEquals("view2", view.getName());
+        Assertions.assertNull(localMetastore.getTable("db1", "view1"));
+        Assertions.assertSame(view, localMetastore.getTable("db1", "view2"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/OperationTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/OperationTypeTest.java
@@ -115,6 +115,7 @@ public class OperationTypeTest {
         Assertions.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_CREATE_REPOSITORY_V2));
         Assertions.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_DROP_TABLE_V2));
         Assertions.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_RENAME_TABLE_V2));
+        Assertions.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_RENAME_VIEW));
         Assertions.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_RENAME_PARTITION_V2));
         Assertions.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_RENAME_COLUMN_V2));
         Assertions.assertTrue(OperationType.IGNORABLE_OPERATIONS.contains(OperationType.OP_DROP_ROLLUP_V2));

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -685,6 +685,7 @@ alterViewStatement
     | ALTER VIEW qualifiedName SET SECURITY (NONE | INVOKER)
     | ALTER VIEW qualifiedName SET properties
     | ALTER VIEW qualifiedName (ADD | MODIFY) DIALECT (STARROCKS)?  queryStatement
+    | ALTER VIEW qualifiedName tableRenameClause
     ;
 
 dropViewStatement

--- a/test/sql/test_view/R/test_rename_view
+++ b/test/sql/test_view/R/test_rename_view
@@ -1,0 +1,51 @@
+-- name: test_rename_view
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t1(c1 bigint, c2 bigint);
+-- result:
+-- !result
+insert into t1 values (1, 2);
+-- result:
+-- !result
+create view v1 comment 'view comment' as select * from t1;
+-- result:
+-- !result
+alter view v1 rename v2;
+-- result:
+-- !result
+select TABLE_NAME from information_schema.views where TABLE_SCHEMA = 'db_${uuid0}';
+-- result:
+v2
+-- !result
+select TABLE_NAME, TABLE_COMMENT from information_schema.tables where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'v2';
+-- result:
+v2	view comment
+-- !result
+select * from v2;
+-- result:
+1	2
+-- !result
+select * from v1;
+-- result:
+[REGEX].*Unknown table.*v1.*
+-- !result
+alter view v2 rename t1;
+-- result:
+[REGEX].*Table name\[t1\] is already used.*
+-- !result
+select TABLE_NAME from information_schema.views where TABLE_SCHEMA = 'db_${uuid0}';
+-- result:
+v2
+-- !result
+alter view v2 rename v2;
+-- result:
+[REGEX].*Same table name v2.*
+-- !result
+alter table v2 rename v3;
+-- result:
+[REGEX].*Do not support alter non-native table/materialized-view.*
+-- !result

--- a/test/sql/test_view/T/test_rename_view
+++ b/test/sql/test_view/T/test_rename_view
@@ -1,0 +1,33 @@
+-- name: test_rename_view
+-- description: ALTER VIEW ... RENAME re-keys the view in the database, keeps the view usable
+--              under the new name, and rejects a name that is already taken.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t1(c1 bigint, c2 bigint);
+insert into t1 values (1, 2);
+
+create view v1 comment 'view comment' as select * from t1;
+
+alter view v1 rename v2;
+
+-- the view is registered under the new name only, and keeps its comment
+select TABLE_NAME from information_schema.views where TABLE_SCHEMA = 'db_${uuid0}';
+select TABLE_NAME, TABLE_COMMENT from information_schema.tables where TABLE_SCHEMA = 'db_${uuid0}' and TABLE_NAME = 'v2';
+
+-- the renamed view still resolves its base table
+select * from v2;
+
+-- the old name is gone
+select * from v1;
+
+-- a name that is already taken is rejected, and the view keeps its current name
+alter view v2 rename t1;
+select TABLE_NAME from information_schema.views where TABLE_SCHEMA = 'db_${uuid0}';
+
+-- renaming to the current name is rejected
+alter view v2 rename v2;
+
+-- ALTER TABLE is still not a way to rename a view
+alter table v2 rename v3;


### PR DESCRIPTION
## Why I'm doing:

Renaming a view has no entry point today. `ALTER TABLE ... RENAME` rejects non-native tables in the
executor (and `LocalMetastore.renameTable` casts to `OlapTable` anyway), and the `ALTER VIEW` grammar
has no `RENAME` form. The only workaround is `DROP VIEW` plus `CREATE VIEW`, which silently loses:

- the grants on the view (RBAC stores them per object id, so a recreated view starts with none),
- the view comment,
- the `SQL SECURITY` characteristic,
- the row/column access policies attached to the old object.

## What I'm doing:

Add `ALTER VIEW [db.]view RENAME new_name`, mirroring `ALTER MATERIALIZED VIEW ... RENAME`.

- **Grammar / AST**: new `alterViewStatement` alternative carrying `tableRenameClause`;
  `AlterViewStmt` now holds an `AlterClause` instead of an `AlterViewClause` so it can carry either.
- **Analyzer**: `ViewAnalyzer` routes non-`AlterViewClause` clauses to `AlterTableClauseAnalyzer`,
  which already validates the new name. External catalogs are rejected here, so a rename never
  reaches a connector's `alterView` and surfaces an unrelated message about `ALTER VIEW AS`.
- **Executor**: the rename takes the plain database `WRITE` lock, because it re-keys the view in the
  database's `nameToTable` / `idToTable` maps. An intensive table lock only takes `IX` on the
  database, and `IX` is compatible with `IS`/`IX`, so a concurrent name lookup could observe a torn
  map. It cannot reuse `AlterJobExecutor.visitTableRenameClause`, which is shared with `ALTER TABLE`
  and casts the table to `OlapTable`.
- **Materialized views** built on the view store its name in their definition SQL and are set to
  inactive, matching what a renamed base table and a redefined base view already do.
- **Edit log**: journaled under a new `OP_RENAME_VIEW` rather than folded into `OP_RENAME_TABLE_V2`.
  Sharing that op would require `replayRenameTable` to accept any `Table` instead of an `OlapTable`,
  and an FE that predates this change would then hit a `ClassCastException` there. That op is
  `@IgnorableOnReplayFailed` and `metadata_journal_ignore_replay_failure` defaults to true, so the
  exception would be swallowed and that node's view name would silently diverge from the leader's.
  An unknown op code instead stops such an FE, which is the safer failure for metadata. The payload
  reuses `TableInfo`, as the other rename ops do.
- **Race**: `renameView` re-checks that the view is still registered once the database lock is held.
  The view is resolved before the lock is taken, and a `DROP VIEW` that won the race would otherwise
  be undone by the re-registration here, while replay elsewhere finds no such id and skips.

Tests: `AlterViewTest` covers the edit-log round trip and the analyzer paths; `test/sql/test_view/T/test_rename_view`
covers the statement end to end. Docs updated in `en` / `zh` / `ja`.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr