### PR TITLE
[BugFix] Resolve large binary serde backport conflicts

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -14,12 +14,9 @@
 
 #pragma once
 
-<<<<<<< HEAD
-=======
 #include <fmt/format.h>
 
 #include <exception>
->>>>>>> ab166f6 ([Enhancement] Check Large BinaryColumn Serde (#75504))
 #include <memory>
 
 #include "column/bytes.h"

--- a/be/src/serde/column_array_serde.cpp
+++ b/be/src/serde/column_array_serde.cpp
@@ -281,12 +281,7 @@ public:
             buff = write_raw(bytes.data(), bytes_size, buff);
         }
 
-<<<<<<< HEAD:be/src/serde/column_array_serde.cpp
-        //TODO: if T is uint32_t, `offsets_size` may be overflow
         T offsets_size = offsets.size() * sizeof(typename BinaryColumnBase<T>::Offset);
-=======
-        T offsets_size = offsets.size() * sizeof(T);
->>>>>>> ab166f6 ([Enhancement] Check Large BinaryColumn Serde (#75504)):be/src/column/serde/column_array_serde.cpp
         if constexpr (std::is_same_v<T, uint32_t>) {
             buff = write_little_endian_32(offsets_size, buff);
         } else {

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -27,11 +27,7 @@
 #include "storage/lake/pk_tablet_sst_writer.h"
 #include "storage/lake/pk_tablet_unsort_sst_writer.h"
 #include "storage/lake/tablet_manager.h"
-<<<<<<< HEAD
 #include "storage/primary_key_encoder.h"
-=======
-#include "storage/primitive/primary_key_encoder.h"
->>>>>>> ab166f6 ([Enhancement] Check Large BinaryColumn Serde (#75504))
 #include "storage/rows_mapper.h"
 #include "storage/rowset/segment_writer.h"
 #include "util/crc32c.h"

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -58,15 +58,9 @@
 #include "storage/index/inverted/inverted_index_option.h"
 #include "storage/merge_iterator.h"
 #include "storage/metadata_util.h"
-<<<<<<< HEAD
 #include "storage/olap_define.h"
+#include "storage/primary_key_encoder.h"
 #include "storage/row_source_mask.h"
-=======
-#include "storage/primitive/empty_iterator.h"
-#include "storage/primitive/primary_key_encoder.h"
-#include "storage/primitive/storage_define.h"
-#include "storage/primitive/type_utils.h"
->>>>>>> ab166f6 ([Enhancement] Check Large BinaryColumn Serde (#75504))
 #include "storage/rows_mapper.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"

--- a/be/test/serde/column_array_serde_test.cpp
+++ b/be/test/serde/column_array_serde_test.cpp
@@ -16,17 +16,6 @@
 
 #include <gtest/gtest.h>
 
-<<<<<<< HEAD:be/test/serde/column_array_serde_test.cpp
-=======
-#include <memory>
-
-#include "base/coding.h"
-#include "base/failpoint/fail_point.h"
-#include "base/hash/hash_std.hpp"
-#include "base/testutil/assert.h"
-#include "base/testutil/parallel_test.h"
-#include "base/utility/defer_op.h"
->>>>>>> ab166f6 ([Enhancement] Check Large BinaryColumn Serde (#75504)):be/test/runtime/serde_core_test.cpp
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column_helper.h"
@@ -35,12 +24,13 @@
 #include "column/json_column.h"
 #include "column/nullable_column.h"
 #include "column/variant_column.h"
-#include "common/config_local_io_fwd.h"
+#include "common/config.h"
 #include "common/statusor.h"
 #include "gutil/strings/substitute.h"
 #include "testutil/assert.h"
 #include "testutil/parallel_test.h"
 #include "types/hll.h"
+#include "util/defer_op.h"
 #include "util/failpoint/fail_point.h"
 #include "util/hash_util.hpp"
 #include "util/json.h"
@@ -53,8 +43,8 @@ static BinaryColumn::MutablePtr make_unrepresentable_binary_column() {
     config::enable_zero_copy_from_page_cache = true;
     DeferOp restore_zero_copy([old_zero_copy] { config::enable_zero_copy_from_page_cache = old_zero_copy; });
 
-    auto owner = std::make_shared<std::string>("x");
-    ContainerResource resource(owner, owner->data(), Column::MAX_CAPACITY_LIMIT);
+    // The size check must reject this view without reading its payload.
+    ContainerResource resource(nullptr, "x", Column::MAX_CAPACITY_LIMIT);
     BinaryColumn::Offsets offsets;
     offsets.emplace_back(0);
     offsets.emplace_back(Column::MAX_CAPACITY_LIMIT);

--- a/be/test/storage/primary_key_encoder_test.cpp
+++ b/be/test/storage/primary_key_encoder_test.cpp
@@ -19,21 +19,17 @@
 #include <limits>
 #include <memory>
 
-#include "base/utility/defer_op.h"
 #include "column/binary_column.h"
 #include "column/chunk.h"
-<<<<<<< HEAD
 #include "column/datum.h"
-=======
-#include "column/chunk_factory.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
->>>>>>> ab166f6 ([Enhancement] Check Large BinaryColumn Serde (#75504))
 #include "column/schema.h"
-#include "common/config_local_io_fwd.h"
+#include "common/config.h"
 #include "gutil/stringprintf.h"
 #include "storage/chunk_helper.h"
 #include "types/date_value.h"
+#include "util/defer_op.h"
 
 using namespace std;
 
@@ -59,8 +55,8 @@ static BinaryColumn::MutablePtr make_unrepresentable_binary_column() {
     config::enable_zero_copy_from_page_cache = true;
     DeferOp restore_zero_copy([old_zero_copy] { config::enable_zero_copy_from_page_cache = old_zero_copy; });
 
-    auto owner = std::make_shared<std::string>("x");
-    ContainerResource resource(owner, owner->data(), Column::MAX_CAPACITY_LIMIT);
+    // The size check must reject this view without reading its payload.
+    ContainerResource resource(nullptr, "x", Column::MAX_CAPACITY_LIMIT);
     BinaryColumn::Offsets offsets;
     offsets.emplace_back(0);
     offsets.emplace_back(Column::MAX_CAPACITY_LIMIT);
@@ -267,17 +263,6 @@ TEST(PrimaryKeyEncoderTest, testDeleteFileBinaryColumnSizeCheck) {
     auto binary = BinaryColumn::create();
     binary->append_strings(strings.data(), strings.size());
     ASSERT_TRUE(PrimaryKeyEncoder::check_delete_file_binary_column_size(*binary).ok());
-
-    auto sticky_large = BinaryColumn::create();
-    sticky_large->append_strings(strings.data(), strings.size());
-    AdaptiveOffsets::Large large_offsets;
-    large_offsets.resize(sticky_large->get_offset().size());
-    for (size_t i = 0; i < sticky_large->get_offset().size(); ++i) {
-        large_offsets[i] = sticky_large->get_offset()[i];
-    }
-    sticky_large->get_offset().set_large_buffer(std::move(large_offsets));
-    ASSERT_TRUE(sticky_large->get_offset().is_large());
-    ASSERT_TRUE(PrimaryKeyEncoder::check_delete_file_binary_column_size(*sticky_large).ok());
 
     auto nullable_data = BinaryColumn::create();
     nullable_data->append_strings(strings.data(), strings.size());


### PR DESCRIPTION
Resolve the conflict markers left by the #75504 backport and retain the branch-4.1 include paths and offset representation.

Adapt the oversized-payload test views to the PageHandle-based ContainerResource API and omit the AdaptiveOffsets-only case unavailable on this branch.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
