### PR TITLE
[BugFix] Build Paimon decimal predicate literals with the column precision and scale

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -382,9 +382,5 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, P
         public String visitVariableReference(ColumnRefOperator operator, Void context) {
             return operator.getName();
         }
-
-        public String visitCastOperator(CastOperator operator, Void context) {
-            return operator.getChild(0).accept(this, context);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -268,11 +268,18 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, P
                 case DECIMALV2:
                 case DECIMAL32:
                 case DECIMAL64:
-                case DECIMAL128:
+                case DECIMAL128: {
+                    // paimon serializes the literal with the column's precision/scale
+                    if (!(dataType instanceof DecimalType)) {
+                        return null;
+                    }
+                    DecimalType columnType = (DecimalType) dataType;
                     BigDecimal bigDecimal = operator.getDecimal();
-                    PrimitiveType type = operator.getType().getPrimitiveType();
-                    return Decimal.fromBigDecimal(bigDecimal, PrimitiveType.getMaxPrecisionOfDecimal(type),
-                            PrimitiveType.getDefaultScaleOfDecimal(type));
+                    if (bigDecimal.stripTrailingZeros().scale() > columnType.getScale()) {
+                        return null;
+                    }
+                    return Decimal.fromBigDecimal(bigDecimal, columnType.getPrecision(), columnType.getScale());
+                }
                 case HLL:
                 case VARCHAR:
                 case CHAR:

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -35,7 +35,6 @@ import org.apache.paimon.data.Decimal;
 import org.apache.paimon.data.GenericArray;
 import org.apache.paimon.data.GenericRow;
 import org.apache.paimon.data.InternalRow;
-import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.predicate.And;
 import org.apache.paimon.predicate.CompoundPredicate;
 import org.apache.paimon.predicate.Equal;
@@ -312,105 +311,44 @@ public class PaimonPredicateConverterTest {
     }
 
     @Test
-    public void testPaimonCastPredicate() {
-        // double to int
-        ConstantOperator doubleValue = ConstantOperator.createDouble(11.11);
-        CastOperator cast0 = new CastOperator(IntegerType.INT, F0);
-        Predicate result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast0, doubleValue));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate0 = (LeafPredicate) result;
-        Assertions.assertEquals(11, leafPredicate0.literals().get(0));
-        // string to date
-        ConstantOperator string = ConstantOperator.createVarchar("2025-01-01");
-        CastOperator cast1 = new CastOperator(com.starrocks.type.DateType.DATE, F1);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast1, string));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate1 = (LeafPredicate) result;
-        Assertions.assertEquals(BinaryString.fromString("2025-01-01"), leafPredicate1.literals().get(0));
-        // float to double
-        ConstantOperator floatValue = ConstantOperator.createFloat(11.11);
-        CastOperator cast2 = new CastOperator(com.starrocks.type.FloatType.DOUBLE, F2);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast2, floatValue));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate2 = (LeafPredicate) result;
-        Assertions.assertEquals(11.11, leafPredicate2.literals().get(0));
-        // date to string
-        ConstantOperator date = ConstantOperator.createDate(
-                LocalDate.parse("2025-01-01").atTime(0, 0, 0, 0));
-        CastOperator cast3 = new CastOperator(StringType.STRING, F3);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast3, date));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate3 = (LeafPredicate) result;
-        Assertions.assertEquals(20089, leafPredicate3.literals().get(0));
-        // bool to string
-        ConstantOperator bool = ConstantOperator.createBoolean(true);
-        CastOperator cast4 = new CastOperator(IntegerType.INT, F1);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast4, bool));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate4 = (LeafPredicate) result;
-        Assertions.assertEquals(BinaryString.fromString("1"), leafPredicate4.literals().get(0));
-        // bool to int
-        ConstantOperator bool2 = ConstantOperator.createBoolean(false);
-        CastOperator cast5 = new CastOperator(IntegerType.INT, F0);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast5, bool2));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate5 = (LeafPredicate) result;
-        Assertions.assertEquals(0, leafPredicate5.literals().get(0));
-        // datetime to string
-        ConstantOperator ts = ConstantOperator.createDatetime(
-                LocalDate.parse("2025-01-01").atTime(0, 0, 0, 0));
-        CastOperator cast6 = new CastOperator(VarcharType.VARCHAR, F1);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast6, ts));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate6 = (LeafPredicate) result;
-        Assertions.assertEquals(BinaryString.fromString("2025-01-01 00:00:00"), leafPredicate6.literals().get(0));
-        // tinyInt to bool
-        ConstantOperator stringBool = ConstantOperator.createTinyInt((byte) 0);
-        CastOperator cast7 = new CastOperator(com.starrocks.type.BooleanType.BOOLEAN, F4);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast7, stringBool));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate7 = (LeafPredicate) result;
-        Assertions.assertEquals(false, leafPredicate7.literals().get(0));
-        // string to datetime
-        ConstantOperator stringTime = ConstantOperator.createVarchar("2025-01-01 00:00:00");
-        CastOperator cast8 = new CastOperator(com.starrocks.type.DateType.DATETIME, F5);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast8, stringTime));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate8 = (LeafPredicate) result;
-        Assertions.assertEquals(1735689600000L, ((Timestamp) (leafPredicate8.literals().get(0))).getMillisecond());
-        // smallInt to string
-        ConstantOperator si = ConstantOperator.createSmallInt((short) 200);
-        CastOperator cast9 = new CastOperator(VarcharType.VARCHAR, F1);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast9, si));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate9 = (LeafPredicate) result;
-        Assertions.assertEquals(BinaryString.fromString("200"), leafPredicate9.literals().get(0));
-        // int to long
-        ConstantOperator i = ConstantOperator.createInt(200);
-        CastOperator cast10 = new CastOperator(IntegerType.BIGINT, F6);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast10, i));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate10 = (LeafPredicate) result;
-        Assertions.assertEquals(200L, leafPredicate10.literals().get(0));
-        // int to smallint
-        ConstantOperator is = ConstantOperator.createInt(200);
-        CastOperator cast11 = new CastOperator(IntegerType.BIGINT, F8);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast11, is));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate11 = (LeafPredicate) result;
-        Assertions.assertEquals((short) 200, leafPredicate11.literals().get(0));
-        // int to tinyint
-        ConstantOperator it = ConstantOperator.createInt(10);
-        CastOperator cast12 = new CastOperator(IntegerType.BIGINT, F9);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast12, it));
-        Assertions.assertTrue(result instanceof LeafPredicate);
-        LeafPredicate leafPredicate12 = (LeafPredicate) result;
-        Assertions.assertEquals((byte) 10, leafPredicate12.literals().get(0));
-        // can not cast to decimal
-        ConstantOperator d = ConstantOperator.createDouble(14.11);
-        CastOperator cast99 = new CastOperator(com.starrocks.type.DecimalType.DEFAULT_DECIMAL128, F7);
-        result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast99, d));
-        Assertions.assertNull(result);
+    public void testCastOnColumnIsNotPushedDown() {
+        // a cast on the column can change the comparison (rounding, narrowing, string formats), so the
+        // predicate stays with StarRocks, same as the BE converter which only accepts bare slots
+        Object[][] cases = {
+                {IntegerType.INT, F0, ConstantOperator.createDouble(11.11)},
+                {com.starrocks.type.DateType.DATE, F1, ConstantOperator.createVarchar("2025-01-01")},
+                {com.starrocks.type.FloatType.DOUBLE, F2, ConstantOperator.createFloat(11.11)},
+                {StringType.STRING, F3, ConstantOperator.createDate(LocalDate.parse("2025-01-01").atTime(0, 0))},
+                {IntegerType.INT, F1, ConstantOperator.createBoolean(true)},
+                {IntegerType.INT, F0, ConstantOperator.createBoolean(false)},
+                {VarcharType.VARCHAR, F1, ConstantOperator.createDatetime(LocalDate.parse("2025-01-01").atTime(0, 0))},
+                {com.starrocks.type.BooleanType.BOOLEAN, F4, ConstantOperator.createTinyInt((byte) 0)},
+                {com.starrocks.type.DateType.DATETIME, F5, ConstantOperator.createVarchar("2025-01-01 00:00:00")},
+                {IntegerType.BIGINT, F6, ConstantOperator.createInt(200)},
+                {IntegerType.BIGINT, F8, ConstantOperator.createInt(200)},
+                {IntegerType.BIGINT, F9, ConstantOperator.createInt(10)},
+                {com.starrocks.type.DecimalType.DEFAULT_DECIMAL128, F7, ConstantOperator.createDouble(14.11)},
+        };
+        for (Object[] c : cases) {
+            CastOperator cast = new CastOperator((com.starrocks.type.Type) c[0], (ColumnRefOperator) c[1]);
+            Predicate result = CONVERTER.convert(new BinaryPredicateOperator(BinaryType.EQ, cast, (ConstantOperator) c[2]));
+            Assertions.assertNull(result, "cast to " + c[0] + " on " + ((ColumnRefOperator) c[1]).getName());
+        }
+        Assertions.assertNull(CONVERTER.convert(new IsNullPredicateOperator(false, new CastOperator(IntegerType.BIGINT, F0))));
+        Assertions.assertNull(CONVERTER.convert(new InPredicateOperator(false, new CastOperator(IntegerType.BIGINT, F0),
+                ConstantOperator.createInt(1), ConstantOperator.createInt(2))));
+
+        // CAST(d AS DECIMAL(15,1)) = 1.2 on DECIMAL(15,2): stored 1.16 matches the SQL predicate after
+        // rounding but not a pushed-down d = 1.20, so it must not be pushed; the bare column still is
+        RowType rowType = new RowType(List.of(new DataField(0, "d", new DecimalType(15, 2))));
+        PaimonPredicateConverter converter = new PaimonPredicateConverter(rowType);
+        ColumnRefOperator d = new ColumnRefOperator(0,
+                new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 2), "d", true, false);
+        ConstantOperator lit = ConstantOperator.createDecimal(new BigDecimal("1.2"),
+                new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 1));
+        CastOperator rounding = new CastOperator(new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 1), d);
+        Assertions.assertNull(converter.convert(new BinaryPredicateOperator(BinaryType.EQ, rounding, lit)));
+        assertDecimalLeaf(converter.convert(new BinaryPredicateOperator(BinaryType.EQ, d, lit)), Equal.class, "1.20", 15, 2);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -27,9 +27,14 @@ import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.StringType;
 import com.starrocks.type.VarcharType;
 import org.apache.paimon.data.BinaryString;
+import org.apache.paimon.data.Decimal;
+import org.apache.paimon.data.GenericArray;
+import org.apache.paimon.data.GenericRow;
+import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.predicate.And;
 import org.apache.paimon.predicate.CompoundPredicate;
@@ -57,6 +62,7 @@ import org.apache.paimon.types.SmallIntType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
 import org.apache.paimon.types.VarCharType;
+import org.apache.paimon.utils.InstantiationUtil;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -454,5 +460,78 @@ public class PaimonPredicateConverterTest {
         ScalarOperator op52 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, op22.clone());
         Predicate convert2 = CONVERTER.convert(op52);
         Assertions.assertTrue(convert2 == null);
+    }
+
+    private static Predicate convertDecimalPredicate(PrimitiveType srType, int precision, int scale,
+                                                     BinaryType op, ConstantOperator literal) {
+        RowType rowType = new RowType(List.of(new DataField(0, "d", new DecimalType(precision, scale))));
+        ColumnRefOperator col = new ColumnRefOperator(0,
+                new com.starrocks.type.DecimalType(srType, precision, scale), "d", true, false);
+        return new PaimonPredicateConverter(rowType).convert(new BinaryPredicateOperator(op, col, literal));
+    }
+
+    private static void assertDecimalLeaf(Predicate result, Class<?> function, String expected, int precision,
+                                          int scale) {
+        Assertions.assertNotNull(result, "decimal predicate must be pushed down");
+        Assertions.assertTrue(result instanceof LeafPredicate);
+        LeafPredicate leaf = (LeafPredicate) result;
+        Assertions.assertTrue(function.isInstance(leaf.function()));
+        Decimal literal = (Decimal) leaf.literals().get(0);
+        Assertions.assertEquals(precision, literal.precision());
+        Assertions.assertEquals(scale, literal.scale());
+        Assertions.assertEquals(new BigDecimal(expected), literal.toBigDecimal());
+    }
+
+    @Test
+    public void testDecimalColumnPredicateUsesColumnPrecisionAndScale() {
+        Predicate d64 = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.LT,
+                ConstantOperator.createDecimal(new BigDecimal("5.00"),
+                        new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 2)));
+        assertDecimalLeaf(d64, LessThan.class, "5.00", 15, 2);
+
+        Predicate d32 = convertDecimalPredicate(PrimitiveType.DECIMAL32, 9, 2, BinaryType.EQ,
+                ConstantOperator.createDecimal(new BigDecimal("123.45"),
+                        new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL32, 9, 2)));
+        assertDecimalLeaf(d32, Equal.class, "123.45", 9, 2);
+
+        Predicate d128 = convertDecimalPredicate(PrimitiveType.DECIMAL128, 38, 9, BinaryType.GE,
+                ConstantOperator.createDecimal(new BigDecimal("12345678901234567890.123456789"),
+                        com.starrocks.type.DecimalType.DEFAULT_DECIMAL128));
+        assertDecimalLeaf(d128, GreaterOrEqual.class, "12345678901234567890.123456789", 38, 9);
+    }
+
+    @Test
+    public void testDecimalColumnWithIntegerLiteral() {
+        Predicate result = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.LT,
+                ConstantOperator.createInt(5));
+        assertDecimalLeaf(result, LessThan.class, "5.00", 15, 2);
+    }
+
+    @Test
+    public void testDecimalLiteralSurvivesPredicateSerialization() throws Exception {
+        // the JNI reader gets the predicate through this serialization; a wrong scale used to become 5e14 here
+        Predicate pushed = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.GT,
+                ConstantOperator.createDecimal(new BigDecimal("0.05"),
+                        new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 2)));
+        assertDecimalLeaf(pushed, GreaterThan.class, "0.05", 15, 2);
+        Predicate roundTrip = InstantiationUtil.deserializeObject(InstantiationUtil.serializeObject(pushed),
+                getClass().getClassLoader());
+        assertDecimalLeaf(roundTrip, GreaterThan.class, "0.05", 15, 2);
+        InternalRow minValues = GenericRow.of(Decimal.fromBigDecimal(new BigDecimal("0.00"), 15, 2));
+        InternalRow maxValues = GenericRow.of(Decimal.fromBigDecimal(new BigDecimal("0.10"), 15, 2));
+        Assertions.assertTrue(roundTrip.test(100, minValues, maxValues, new GenericArray(new Long[] {0L})));
+
+        Predicate trailingZeros = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.LT,
+                ConstantOperator.createDecimal(new BigDecimal("5.000"),
+                        new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 3)));
+        assertDecimalLeaf(trailingZeros, LessThan.class, "5.00", 15, 2);
+    }
+
+    @Test
+    public void testDecimalLiteralWiderScaleThanColumnIsNotPushedDown() {
+        Predicate result = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.LT,
+                ConstantOperator.createDecimal(new BigDecimal("5.005"),
+                        new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 3)));
+        Assertions.assertNull(result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -528,6 +528,20 @@ public class PaimonPredicateConverterTest {
     }
 
     @Test
+    public void testDecimalLiteralExceedingColumnPrecisionIsNotPushedDown() {
+        // 21 digits do not fit DECIMAL(15,2); Decimal.fromBigDecimal returns null instead of truncating
+        Predicate result = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.GT,
+                ConstantOperator.createDecimal(new BigDecimal("100000000000000000000"),
+                        com.starrocks.type.DecimalType.DEFAULT_DECIMAL128));
+        Assertions.assertNull(result);
+        // 13 integer digits is the most DECIMAL(15,2) holds
+        Predicate fits = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.GT,
+                ConstantOperator.createDecimal(new BigDecimal("9999999999999.99"),
+                        new com.starrocks.type.DecimalType(PrimitiveType.DECIMAL64, 15, 2)));
+        assertDecimalLeaf(fits, GreaterThan.class, "9999999999999.99", 15, 2);
+    }
+
+    @Test
     public void testDecimalLiteralWiderScaleThanColumnIsNotPushedDown() {
         Predicate result = convertDecimalPredicate(PrimitiveType.DECIMAL64, 15, 2, BinaryType.LT,
                 ConstantOperator.createDecimal(new BigDecimal("5.005"),


### PR DESCRIPTION
## Why I'm doing:

Predicates on DECIMAL columns of Paimon tables are converted into Paimon `Decimal` literals with the wrong (precision, scale). `PaimonPredicateConverter.visitConstant` builds the literal from the StarRocks type *family* of the constant (`PrimitiveType.getMaxPrecisionOfDecimal` / `getDefaultScaleOfDecimal`, e.g. 18/18 for DECIMAL64, 38/38 for DECIMAL128) instead of the column's Paimon `DecimalType`. Two consequences:

- Literals with a non-zero integer part (`l_quantity < 5`) do not fit a scale that equals the precision, `Decimal.fromBigDecimal` returns null and the predicate is silently dropped from Paimon file pruning.
- Literals with `|value| < 1` (`l_discount > 0.05`) *do* fit and are pushed with scale 18. Paimon serializes a leaf literal with the **column's** type, so the JNI reader decodes the unscaled value at scale 2 and evaluates `l_discount > 500000000000000.00`. Every file is pruned and the query returns **wrong results**.

Reproduced on TPC-H SF100 `lineitem` (Paimon, `l_discount DECIMAL(15,2)`):

| query | correct (StarRocks native reader / Iceberg copy) | Paimon JNI reader | Paimon PK table, default `paimon_reader_mode=AUTO` |
|---|---|---|---|
| `WHERE l_discount > 0.05` | 272,738,597 | **0** | **0** |
| `WHERE l_discount = 0.05` | 54,555,445 | **0** | |
| `WHERE l_discount < 0.05` | 272,743,860 | 272,743,860 (under-prunes, happens to be right) | |

Primary-key tables route merge splits to the JNI reader under the default mode, so no special setting is required to hit this. The code has been this way since #25246.

## What I'm doing:

Build the decimal literal with the column's `DecimalType` precision and scale, which is what Paimon uses to serialize and compare it. A literal with more fractional digits than the column (e.g. `5.005` against `DECIMAL(15,2)`) is not pushed down, because rounding it would change the predicate; a literal that does not fit the column precision keeps returning null (no pushdown), which is always safe because StarRocks still evaluates the conjunct on the rows.

Second part, raised by review: `ExtractColumnName` used to strip a `CAST` wrapped around the column and push the predicate on the bare column. That is only valid for lossless casts; `CAST(d AS DECIMAL(15,1)) = 1.2` on a `DECIMAL(15,2)` column would be pushed as `d = 1.20` and prune rows such as `1.16` that match after rounding, and the same applies to the existing string/date/int casts. With the decimal literal now built correctly this path became reachable for decimal columns, so the converter now only accepts predicates on bare columns, the same rule the BE converter for the paimon-cpp reader already applies. Predicates with a cast on the column are still evaluated by StarRocks, they are just no longer used for Paimon file pruning.

Tests (`PaimonPredicateConverterTest`):

- decimal literals against DECIMAL(9,2) / (15,2) / (38,9) columns carry the column's precision and scale;
- an integer literal against a decimal column is cast and pushed as `5.00`;
- `l_discount > 0.05` survives the Java serialization round trip used for the JNI reader and still matches a file with range `[0.00, 0.10]`; trailing zeros (`5.000`) are accepted;
- a literal with a wider scale than the column is not pushed down;
- a literal that does not fit the column precision is not pushed down;
- any `CAST` on the column (binary, IN, IS NULL) is not pushed down, including the `CAST(d AS DECIMAL(15,1)) = 1.2` case, while the same predicate on the bare column is.

The first two and the round-trip test fail on current main; the cast cases replace the former `testPaimonCastPredicate` expectations.

Observability: the existing `Tracers` EXTERNAL records of the converted filters (`Paimon.plan.<table>.filter.N`) and scan metrics are unchanged; after the fix decimal filters appear there, which is the intended signal. No new signal needed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjEqn3Q4QojKPfJrHJcPJP
