### PR TITLE
[BugFix] Name exec_mem_limit in the routine load memory limit error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load.routineload;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -128,6 +129,8 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.starrocks.common.ErrorCode.ERR_LOAD_DATA_PARSE_ERROR;
@@ -152,6 +155,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
     public static final boolean DEFAULT_PAUSE_ON_FATAL_PARSE_ERROR = false;
 
     protected static final String STAR_STRING = "*";
+
+    // The BE sentence for a fragment memory limit, anchored on the tracker phrase and on the variable
+    // it names so the span to replace stays pinned while the wording between them may move.
+    private static final Pattern BE_SINGLE_QUERY_MEM_LIMIT_ADVICE =
+            Pattern.compile("Mem usage has exceed the limit of single query.*?query_mem_limit\\.");
 
     /*
                      +-----------------+
@@ -1409,6 +1417,27 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
         }
     }
 
+    /**
+     * A routine load task is capped by this job's exec_mem_limit, which the job captured from the
+     * session that created it and which ALTER ROUTINE LOAD cannot change. The BE knows only the byte
+     * value, so the advice is composed here, where the job is at hand. A reason that does not match
+     * BE_SINGLE_QUERY_MEM_LIMIT_ADVICE is left untouched.
+     */
+    @VisibleForTesting
+    String annotateMemLimitExceeded(String txnStatusChangeReasonStr) {
+        if (txnStatusChangeReasonStr == null) {
+            return null;
+        }
+        Matcher matcher = BE_SINGLE_QUERY_MEM_LIMIT_ADVICE.matcher(txnStatusChangeReasonStr);
+        if (!matcher.find()) {
+            return txnStatusChangeReasonStr;
+        }
+        return matcher.replaceFirst(Matcher.quoteReplacement(
+                "This task is capped by this job's " + SessionVariable.EXEC_MEM_LIMIT + "=" + getExecMemLimit()
+                        + ", captured when the job was created. Raise it with SET "
+                        + SessionVariable.EXEC_MEM_LIMIT + " and re-create the job."));
+    }
+
     // check task exists or not before call method
     private void executeTaskOnTxnStatusChanged(RoutineLoadTaskInfo routineLoadTaskInfo, TransactionState txnState,
                                                TransactionStatus txnStatus, String txnStatusChangeReasonStr)
@@ -1450,7 +1479,9 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
             if (txnStatus == TransactionStatus.ABORTED) {
                 RoutineLoadTaskInfo newRoutineLoadTaskInfo = unprotectRenewTask(
                         System.currentTimeMillis() + taskSchedIntervalS * 1000, routineLoadTaskInfo);
-                newRoutineLoadTaskInfo.setMsg("previous task aborted because of " + txnStatusChangeReasonStr, true);
+                newRoutineLoadTaskInfo.setMsg(
+                        "previous task aborted because of " + annotateMemLimitExceeded(txnStatusChangeReasonStr),
+                        true);
                 GlobalStateMgr.getCurrentState().getRoutineLoadMgr()
                         .releaseBeTaskSlot(routineLoadTaskInfo.getWarehouseId(),
                                 routineLoadTaskInfo.getJobId(), routineLoadTaskInfo.getBeId());
@@ -1870,6 +1901,12 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback
 
     public Map<String, String> getSessionVariables() {
         return sessionVariables;
+    }
+
+    // The per-task memory limit this job hands the BE as TQueryOptions.mem_limit.
+    public long getExecMemLimit() {
+        String execMemLimit = sessionVariables.get(SessionVariable.EXEC_MEM_LIMIT);
+        return execMemLimit == null ? SessionVariable.DEFAULT_EXEC_MEM_LIMIT : Long.parseLong(execMemLimit);
     }
 
     private String jobPropertiesToJsonString() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadInfo.java
@@ -477,11 +477,7 @@ public class StreamLoadInfo {
         }
         partialUpdate = routineLoadJob.isPartialUpdate();
         partialUpdateMode = TPartialUpdateMode.ROW_MODE;
-        if (routineLoadJob.getSessionVariables().containsKey(SessionVariable.EXEC_MEM_LIMIT)) {
-            execMemLimit = Long.parseLong(routineLoadJob.getSessionVariables().get(SessionVariable.EXEC_MEM_LIMIT));
-        } else {
-            execMemLimit = SessionVariable.DEFAULT_EXEC_MEM_LIMIT;
-        }
+        execMemLimit = routineLoadJob.getExecMemLimit();
         if (routineLoadJob.getSessionVariables().containsKey(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE)) {
             compressionType = CompressionUtils.findTCompressionByName(
                     routineLoadJob.getSessionVariables().get(SessionVariable.LOAD_TRANSMISSION_COMPRESSION_TYPE));

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -54,6 +54,7 @@ import com.starrocks.persist.EditLog;
 import com.starrocks.persist.OriginStatementInfo;
 import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterRoutineLoadStmt;
@@ -1440,5 +1441,67 @@ public class RoutineLoadJobTest {
         Deencapsulation.setField(routineLoadJob, "jobProperties", jobProperties);
 
         Assertions.assertEquals(CreateRoutineLoadStmt.ENVELOPE_DEBEZIUM, routineLoadJob.getEnvelope());
+    }
+
+    @Test
+    public void testAnnotateMemLimitExceededLeavesOtherReasonsAlone() {
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+
+        Assertions.assertNull(routineLoadJob.annotateMemLimitExceeded(null));
+        Assertions.assertEquals("too many filtered rows",
+                routineLoadJob.annotateMemLimitExceeded("too many filtered rows"));
+        // exec_mem_limit does not raise a BE-wide or a query pool limit.
+        Assertions.assertEquals("Mem usage has exceed the limit of BE",
+                routineLoadJob.annotateMemLimitExceeded("Mem usage has exceed the limit of BE"));
+        Assertions.assertEquals("Mem usage has exceed the limit of query pool",
+                routineLoadJob.annotateMemLimitExceeded("Mem usage has exceed the limit of query pool"));
+        // The big query limit of a resource group is not raised by exec_mem_limit either, and it is
+        // the one other variant that mentions a query.
+        String bigQuery = "Mem usage has exceed the big query limit of the resource group [rg1]. "
+                + "You can change the limit by modifying [big_query_mem_limit] of this group";
+        Assertions.assertEquals(bigQuery, routineLoadJob.annotateMemLimitExceeded(bigQuery));
+        // A BE that no longer names query_mem_limit is passed through rather than half rewritten.
+        String drifted = "Mem usage has exceed the limit of single query, raise something else.";
+        Assertions.assertEquals(drifted, routineLoadJob.annotateMemLimitExceeded(drifted));
+    }
+
+    @Test
+    public void testAnnotateMemLimitExceededToleratesAdviceWordingDrift() {
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+
+        // Only the tracker phrase and the variable it names are anchored, so the wording between
+        // them may move without leaving half of the old sentence behind.
+        String reworded = "Used: 3, Limit: 2. Mem usage has exceed the limit of single query, "
+                + "please raise the session variable query_mem_limit. Backend: 127.0.0.1";
+
+        String annotated = routineLoadJob.annotateMemLimitExceeded(reworded);
+        Assertions.assertFalse(annotated.contains("query_mem_limit"), annotated);
+        Assertions.assertTrue(annotated.startsWith("Used: 3, Limit: 2. "), annotated);
+        Assertions.assertTrue(annotated.endsWith(" Backend: 127.0.0.1"), annotated);
+        Assertions.assertTrue(annotated.contains("re-create the job."), annotated);
+    }
+
+    @Test
+    public void testAnnotateMemLimitExceededReplacesTheQueryMemLimitAdvice() {
+        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+
+        String head = "Memory of Fragment abc exceed limit. QUERY Backend: 127.0.0.1, Used: 2160761544, "
+                + "Limit: 2147483648. ";
+        String beMsg = head + "Mem usage has exceed the limit of single query, You can change the limit by "
+                + "set session variable query_mem_limit.";
+
+        String annotated = routineLoadJob.annotateMemLimitExceeded(beMsg);
+        Assertions.assertTrue(annotated.startsWith(head), annotated);
+        Assertions.assertFalse(annotated.contains("query_mem_limit"), annotated);
+        Assertions.assertTrue(
+                annotated.contains(SessionVariable.EXEC_MEM_LIMIT + "=" + SessionVariable.DEFAULT_EXEC_MEM_LIMIT),
+                annotated);
+        Assertions.assertTrue(annotated.endsWith("and re-create the job."), annotated);
+
+        routineLoadJob.getSessionVariables().put(SessionVariable.EXEC_MEM_LIMIT, "4294967296");
+        Assertions.assertTrue(
+                routineLoadJob.annotateMemLimitExceeded(beMsg)
+                        .contains(SessionVariable.EXEC_MEM_LIMIT + "=4294967296"),
+                annotated);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

A routine load task that exceeds its memory budget reports a variable that has no effect on it:

```
[task id: 031043d8-...] [txn id: -1] previous task aborted because of Memory of Fragment
3dd76879-... exceed limit. QUERY Backend: 21.250.149.248, fragment: 3dd76879-... Used: 2160761544,
Limit: 2147483648. Mem usage has exceed the limit of single query, You can change the limit by set
session variable query_mem_limit.
```

`Limit: 2147483648` is `SessionVariable.DEFAULT_EXEC_MEM_LIMIT`; the session's `query_mem_limit` was
20GB, so `query_mem_limit` is not what capped this task. Setting it changes nothing.

Where the limit actually comes from:

1. `RoutineLoadJob` persists the creating session's `exec_mem_limit` into the job.
2. `StreamLoadInfo.fromRoutineLoadJob` reads it back as `execMemLimit`.
3. `StreamLoadPlanner.plan()` derives **only** `TQueryOptions.mem_limit` from it and never sets
   `query_mem_limit`.
4. `RuntimeState::init_mem_trackers` caps its tracker with `_query_options.mem_limit`.

`MemTracker::err_msg` composes that advice from the tracker type alone, so it cannot tell which
option the FE filled — in the pipeline engine a `QUERY` tracker really is capped by
`query_mem_limit`, and the same type is reused for the non-pipeline engine's `mem_limit` tracker.

## What I'm doing:

Rewrite the advice on the FE, where the job is at hand and strictly more is known than the BE can
know: the byte value is *this job's* `exec_mem_limit`, it was captured from the session that created
the job, and `ALTER ROUTINE LOAD` cannot change it (`exec_mem_limit` is not in
`AlterRoutineLoadStmt.CONFIGURABLE_PROPERTIES_SET`). So the message can say what actually helps —
re-create the job:

```
[task id: 031043d8-...] [txn id: -1] previous task aborted because of Memory of Fragment
3dd76879-... exceed limit. QUERY Backend: 21.250.149.248, fragment: 3dd76879-... Used: 2160761544,
Limit: 2147483648. This task is capped by this job's exec_mem_limit=2147483648, captured when the
job was created. Raise it with SET exec_mem_limit and re-create the job.
```

Scoping, so this cannot mislead in the other direction:

- The reason is matched on a pattern **anchored at both ends** — on the tracker phrase
  (`of single query`) and on the variable the BE names (`query_mem_limit.`) — so the wording between
  them may move while the span to replace stays pinned. Anchoring only the head would replace up to
  the first `.` and could leave half of a reworded sentence behind. A reason missing either anchor is
  left untouched, degrading to today's message rather than emitting a half-rewritten one.
- The matched span is replaced, not appended to, so the `query_mem_limit` advice does not survive
  alongside the correct one.
- `Mem usage has exceed the limit of BE`, `... of query pool` and `... of the resource group [x]`
  are BE-wide limits that `exec_mem_limit` does not raise, so they are left alone. Covered by tests.
- Only the `single query` sentence is rewritten. When it is the one the BE emitted, the tracker that
  tripped is the `QUERY` one and the `Limit:` it printed is `mem_limit` — had an ancestor (query
  pool, process, resource group) been the binding one, `err_msg` would have emitted that ancestor's
  sentence instead.

`StreamLoadInfo.fromRoutineLoadJob` was deriving `exec_mem_limit` from the job's session variables
inline; that is folded into `RoutineLoadJob.getExecMemLimit()` and used by both, so the value the
message names is the one handed to the BE rather than a second copy of the same derivation that can
drift.

The BE message is left as it is: `query_mem_limit` is the right advice for a pipeline query, and
changing the shared `MemTrackerType::QUERY` text would have needed the BE to learn which FE option
produced its limit.

Test: `RoutineLoadJobTest`, `StreamLoadInfoTest` and `StreamLoadPlannerTest` pass (50 tests),
including two new cases for the rewrite and for the reasons that must pass through untouched.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
