### PR TITLE
[BugFix] Build a primary-key-range parent alias without gap synthesis, and stop scheduling tablet merge on that shape

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -68,6 +68,8 @@ bvar::Adder<int64_t> g_tablet_merge_dcg_rebuild_fallback_not_supported_total(
         "tablet_merge_dcg_rebuild_fallback_not_supported_total");
 
 bvar::Adder<int64_t> g_tablet_merge_gap_delvec_total("tablet_merge_gap_delvec_total");
+bvar::Adder<int64_t> g_tablet_merge_alias_partial_shared_contribution_total(
+        "tablet_merge_alias_partial_shared_contribution_total");
 bvar::Adder<int64_t> g_tablet_merge_non_pk_skip_dedup_total("tablet_merge_non_pk_skip_dedup_total");
 bvar::Adder<int64_t> g_tablet_merge_synthesized_only_delvec_total("tablet_merge_synthesized_only_delvec_total");
 
@@ -1892,6 +1894,91 @@ Status merge_idg_meta(const std::vector<TabletMergeContext>& merge_contexts,
     return Status::OK();
 }
 
+// A rowset holding at least one segment the split handed to every child. segment_metas_size() alone is
+// insufficient: a rowset can own only non-shared segments.
+bool carries_shared_segment(const RowsetMetadataPB& rowset) {
+    return std::any_of(rowset.segment_metas().begin(), rowset.segment_metas().end(),
+                       [](const SegmentMetadataPB& segment) { return segment.shared(); });
+}
+
+// A range-distributed primary-key tablet whose ORDER BY differs from the primary key. Such a tablet routes
+// rows by a range in PRIMARY-KEY space while its segments are laid out in sort-key order, so no rowid
+// interval of a segment corresponds to its range -- which is why Rowset::get_seek_range withholds the range
+// for this shape instead of publishing one no consumer can use.
+//
+// has_range() is tested first because it is a bit test and the schema construction is not: only a resharded
+// tablet can be in this shape at all, and this runs once per merge.
+bool routes_by_primary_key_range(const TabletMetadataPB& metadata) {
+    return metadata.has_range() && is_primary_key(metadata) && metadata.has_schema() &&
+           TabletSchema::create(metadata.schema())->has_separate_sort_key();
+}
+
+// The ids of the canonical rowsets that carry a shared segment and whose contributors leave part of the
+// merged range unclaimed -- exactly the rowsets compute_synthesized_gap_specs would then have to locate a
+// gap bitmap for by rowid.
+//
+// This is that function's range algebra and nothing more: no segment is opened and no bound is decoded
+// against a schema, so it is safe on a tablet whose range is in primary-key space while its segments are in
+// sort-key order. It is the same algebra update_canonical already ran over these bounds.
+StatusOr<std::vector<uint32_t>> rowsets_with_unclaimed_range(const TabletMetadataPB& new_metadata,
+                                                             const CanonicalContribMap& canonical_contribs) {
+    std::vector<uint32_t> rowset_ids;
+    for (const auto& [canonical_index, contrib] : canonical_contribs) {
+        if (canonical_index >= static_cast<size_t>(new_metadata.rowsets_size())) {
+            return Status::InternalError(
+                    fmt::format("rowsets_with_unclaimed_range: invalid canonical_index {}", canonical_index));
+        }
+        const auto& canonical = new_metadata.rowsets(static_cast<int>(canonical_index));
+        if (!carries_shared_segment(canonical)) continue;
+        ASSIGN_OR_RETURN(auto sorted_disjoint, tablet_reshard_helper::sort_and_merge_adjacent_ranges(contrib));
+        ASSIGN_OR_RETURN(auto unclaimed,
+                         tablet_reshard_helper::compute_disjoint_gaps_within(new_metadata.range(), sorted_disjoint));
+        if (!unclaimed.empty()) {
+            rowset_ids.emplace_back(canonical.id());
+        }
+    }
+    return rowset_ids;
+}
+
+// The query-side parent alias a primary-key-range split keeps alive serves every row of a shared segment it
+// carries, because that is exactly what the pre-split parent served: this shape never range-filters a
+// segment read, so the parent's view of a shared segment was the whole file minus its delete vector. Taking
+// the union of the children's delete vectors reproduces it, and the uid dedup keeps one copy, so no row is
+// served twice -- no gap masking needed, which is fortunate, because synthesizing one would mean turning a
+// primary-key interval into a rowid window and this shape cannot answer that.
+//
+// The one way that reasoning breaks is a source that no longer carries a shared rowset its sibling still
+// does -- a compaction that consumed its copy -- because the alias would then serve those rows twice: once
+// from the compaction output, once from the sibling's untouched copy, as duplicate primary keys. That cannot
+// happen today: PrimaryCompactionPolicy::pick_rowsets skips ordinary compaction for this shape while any
+// rowset carries a shared segment, and the UNSHARE that does consume them ends the alias phase. So this is a
+// tripwire for a future change that unblocks it, not a live case.
+//
+// Deliberately a warning and not an error: this runs on the publish critical path once per version, an alias
+// rebuild is deterministic, and so a failure here would be a permanent publish stall -- the exact failure
+// this shape has already been wedged by. Duplicate keys are visible and bounded; a wedged partition is not.
+void warn_on_partial_shared_contributions(const TabletMetadataPB& new_metadata,
+                                          const CanonicalContribMap& canonical_contribs, size_t num_sources) {
+    if (num_sources < 2) {
+        return;
+    }
+    for (const auto& [canonical_index, contrib] : canonical_contribs) {
+        if (canonical_index >= static_cast<size_t>(new_metadata.rowsets_size())) {
+            continue;
+        }
+        const auto& canonical = new_metadata.rowsets(static_cast<int>(canonical_index));
+        if (!carries_shared_segment(canonical) || contrib.size() == num_sources) {
+            continue;
+        }
+        g_tablet_merge_alias_partial_shared_contribution_total << 1;
+        LOG(WARNING) << "parent alias of a primary-key-range split carries a shared rowset that only " << contrib.size()
+                     << " of " << num_sources
+                     << " children still contribute; rows of the missing children's ranges may be served "
+                        "twice. tablet="
+                     << new_metadata.id() << " version=" << new_metadata.version() << " rowset=" << canonical.id();
+    }
+}
+
 // Phase 0: for every PK canonical rowset that owns at least one shared
 // segment, mask the rowids whose key falls outside ⋃ contributors but inside
 // the merged tablet range.
@@ -1921,17 +2008,8 @@ StatusOr<std::vector<CanonicalGapSpec>> compute_synthesized_gap_specs(TabletMana
                     fmt::format("compute_synthesized_gap_specs: invalid canonical_index {}", canonical_index));
         }
         const auto& canonical = new_metadata.rowsets(static_cast<int>(canonical_index));
-        // segment_metas_size() alone is insufficient because a rowset can own only
-        // non-shared segments. Only synthesize gap bits when at least one segment is
-        // actually shared.
-        bool has_shared = false;
-        for (const auto& segment_meta : canonical.segment_metas()) {
-            if (segment_meta.shared()) {
-                has_shared = true;
-                break;
-            }
-        }
-        if (!has_shared) continue;
+        // Only synthesize gap bits when at least one segment is actually shared.
+        if (!carries_shared_segment(canonical)) continue;
 
         ASSIGN_OR_RETURN(auto sorted_disjoint, tablet_reshard_helper::sort_and_merge_adjacent_ranges(contrib));
         ASSIGN_OR_RETURN(auto non_contributed,
@@ -3395,6 +3473,15 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     if (old_tablet_metadatas.empty()) {
         return Status::InvalidArgument("No old tablet metadata to merge");
     }
+    // A range-distributed primary-key tablet whose ORDER BY differs from the primary key needs different
+    // handling below: it has no rowid window for a key range, so gap-delvec synthesis cannot run on it.
+    //
+    // Answered over every source, not just the first: the shape is a schema property that all of them
+    // share, but has_range() is per tablet, and a table still migrating to range distribution can hand a
+    // rangeless source in alongside ranged ones.
+    const bool primary_key_range_layout = std::any_of(
+            old_tablet_metadatas.begin(), old_tablet_metadatas.end(),
+            [](const auto& metadata) { return metadata != nullptr && routes_by_primary_key_range(*metadata); });
 
     std::vector<TabletMergeContext> merge_contexts;
     merge_contexts.reserve(old_tablet_metadatas.size());
@@ -3473,7 +3560,37 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // (merge_delvecs), so the two paths cannot diverge. For non-PK tables the
     // specs stay empty, which keeps DCG coverage strict.
     std::vector<CanonicalGapSpec> gap_specs;
-    if (is_primary_key(*new_tablet_metadata)) {
+    if (primary_key_range_layout && skip_sstable_merge) {
+        // The read-only parent alias. It carries every row of a shared segment on purpose -- that is what
+        // the pre-split parent served -- so there is nothing to mask, which is fortunate because a
+        // primary-key interval has no rowid window here. See the helper for the invariant this leans on and
+        // the one thing that would break it.
+        warn_on_partial_shared_contributions(*new_tablet_metadata, canonical_contribs, merge_contexts.size());
+    } else if (primary_key_range_layout) {
+        // A real MERGE does have to attribute each row of a shared segment to a source, and gap synthesis
+        // is how it does that. Refuse exactly the merges that need a bitmap this shape cannot locate --
+        // never more than that: a merge whose contributors cover the merged range needs no bitmap and
+        // produces precisely what it did before, and MergeTabletJob cannot abort once it is past shard
+        // creation, so refusing one of those would create the permanent publish stall this change removes.
+        //
+        // FE stops scheduling merges on this shape at all (TabletReshardUtils.tabletMergeUnsupported); this
+        // is the backstop for an FE that has not caught up or a job replayed from the edit log, and the
+        // guard to lift once the bitmap is built by a row-level primary-key filter -- the tool the UNSHARE
+        // compaction already has.
+        ASSIGN_OR_RETURN(auto unclaimed, rowsets_with_unclaimed_range(*new_tablet_metadata, canonical_contribs));
+        if (!unclaimed.empty()) {
+            std::string rowset_ids;
+            for (uint32_t rowset_id : unclaimed) {
+                if (!rowset_ids.empty()) rowset_ids += ",";
+                rowset_ids += std::to_string(rowset_id);
+            }
+            return Status::NotSupported(fmt::format(
+                    "tablet merge is not supported on a range-distributed primary-key tablet whose ORDER BY "
+                    "differs from the primary key when a shared rowset is not fully contributed, new_tablet={} "
+                    "rowsets={}",
+                    merging_tablet.new_tablet_id(), rowset_ids));
+        }
+    } else if (is_primary_key(*new_tablet_metadata)) {
         ASSIGN_OR_RETURN(gap_specs,
                          compute_synthesized_gap_specs(tablet_manager, *new_tablet_metadata, canonical_contribs));
         if (!gap_specs.empty()) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -767,6 +767,103 @@ protected:
         return metadata;
     }
 
+    // A range-distributed primary-key tablet whose ORDER BY is (c1, c0): the shape whose tablet range lives
+    // in PRIMARY-KEY space (one value) while its segments are laid out in sort-key order (two columns), so
+    // no rowid interval of a segment corresponds to the range. Column unique ids and types match
+    // write_two_column_segment's, so a segment written by that helper opens with this schema.
+    void set_separate_sort_key_primary_key_schema(TabletMetadataPB* metadata, int64_t schema_id) {
+        auto* schema = metadata->mutable_schema();
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_id(schema_id);
+        schema->set_num_short_key_columns(1);
+        auto* c0 = schema->add_column();
+        c0->set_unique_id(1001);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        auto* c1 = schema->add_column();
+        c1->set_unique_id(1002);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_aggregation("REPLACE");
+        // ORDER BY (c1, c0): a sort key that is not the primary key.
+        schema->add_sort_key_idxes(1);
+        schema->add_sort_key_idxes(0);
+    }
+
+    // Two children of a primary-key-range split, in the layout the production stall was found in: both
+    // inherit the SAME rowset (same uid) over the same shared segment, their tablet ranges partition the
+    // parent's, and each rowset carries its own effective range -- child A's narrower than its tablet range,
+    // because update_rowset_range intersects at every reshard while a merge unions the tablet range. The
+    // union of the two rowset ranges therefore covers only [rowset_lower_key, +inf) of the merged parent's
+    // (-inf, +inf), which is what makes a gap the alias build used to try to convert into a rowid window.
+    std::pair<MutableTabletMetadataPtr, MutableTabletMetadataPtr> make_primary_key_range_split_children(
+            int64_t child_a, int64_t child_b, const std::string& segment_name, int split_key,
+            std::optional<int> rowset_lower_key) {
+        auto make_child = [&](int64_t tablet_id, bool is_left) {
+            auto metadata = std::make_shared<TabletMetadataPB>();
+            metadata->set_id(tablet_id);
+            metadata->set_version(1);
+            metadata->set_next_rowset_id(2);
+            set_separate_sort_key_primary_key_schema(metadata.get(), /*schema_id=*/9001);
+
+            auto* range = metadata->mutable_range();
+            if (is_left) {
+                *range->mutable_upper_bound() = generate_sort_key(split_key);
+                range->set_upper_bound_included(false);
+            } else {
+                *range->mutable_lower_bound() = generate_sort_key(split_key);
+                range->set_lower_bound_included(true);
+            }
+
+            auto* rowset = metadata->add_rowsets();
+            rowset->set_id(1);
+            rowset->set_version(1);
+            rowset->set_num_rows(10);
+            rowset->set_data_size(100);
+            auto* segment = rowset->add_segment_metas();
+            segment->set_filename(segment_name);
+            segment->set_size(100);
+            segment->set_shared(true);
+            auto* rowset_range = rowset->mutable_range();
+            if (is_left) {
+                // No lower bound means this rowset claims everything below the split point, so the two
+                // contributions cover the merged range and no gap arises.
+                if (rowset_lower_key.has_value()) {
+                    *rowset_range->mutable_lower_bound() = generate_sort_key(*rowset_lower_key);
+                    rowset_range->set_lower_bound_included(true);
+                }
+                *rowset_range->mutable_upper_bound() = generate_sort_key(split_key);
+                rowset_range->set_upper_bound_included(false);
+            } else {
+                *rowset_range->mutable_lower_bound() = generate_sort_key(split_key);
+                rowset_range->set_lower_bound_included(true);
+            }
+            // Same uid on both children: one physical rowset handed to each by the split.
+            stamp_physical_identity_uid(rowset, segment_name);
+            return metadata;
+        };
+        return {make_child(child_a, /*is_left=*/true), make_child(child_b, /*is_left=*/false)};
+    }
+
+    StatusOr<MutableTabletMetadataPtr> merge_tablet_directly(const std::vector<TabletMetadataPtr>& sources,
+                                                             int64_t target_tablet_id, int64_t new_version,
+                                                             bool skip_sstable_merge) {
+        MergingTabletInfoPB merging;
+        for (const auto& source : sources) {
+            merging.add_old_tablet_ids(source->id());
+        }
+        merging.set_new_tablet_id(target_tablet_id);
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(next_id());
+        txn_info.set_commit_time(1);
+        txn_info.set_gtid(1);
+        return lake::merge_tablet(_tablet_manager.get(), sources, merging, new_version, txn_info, skip_sstable_merge);
+    }
+
     StatusOr<TabletMetadataPtr> merge_delvec_sources(const std::vector<TabletMetadataPtr>& sources,
                                                      int64_t merged_tablet, int64_t new_version = 2,
                                                      int64_t txn_id = 10) {
@@ -17304,6 +17401,106 @@ TEST_F(LakeTabletReshardTest, publish_resharding_tablet_shared_first_skips_per_t
     // The old tablet's own version-1 key was never probed; the shared object was read exactly once.
     EXPECT_EQ(0, count_ending_with(lake::tablet_metadata_filename(old_tablet_id, 1)));
     EXPECT_EQ(1, count_ending_with(lake::tablet_initial_metadata_filename()));
+}
+
+// A real MERGE of a range-distributed primary-key tablet whose ORDER BY differs from the primary key has no
+// way to decide which source still owns a given row of a segment they share, so it must be refused at the
+// door instead of failing at publish -- where it fails identically on every retry and takes every later
+// transaction on the partition with it.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_refuses_a_primary_key_range_layout) {
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) {
+        prepare_tablet_dirs(tablet_id);
+    }
+
+    auto [meta_a, meta_b] = make_primary_key_range_split_children(child_a, child_b, "refused_shared.dat",
+                                                                  /*split_key=*/100, /*rowset_lower_key=*/90);
+
+    auto merged = merge_tablet_directly({meta_a, meta_b}, merged_tablet, /*new_version=*/2,
+                                        /*skip_sstable_merge=*/false);
+    ASSERT_FALSE(merged.ok());
+    EXPECT_TRUE(merged.status().is_not_supported()) << merged.status();
+    EXPECT_NE(std::string::npos, merged.status().to_string().find("tablet merge is not supported")) << merged.status();
+}
+
+// ... and refuses no more than that. A merge whose contributors do cover the merged range needs no gap
+// bitmap at all, so it produces exactly what it produced before -- and MergeTabletJob cannot abort once it
+// is past shard creation, so refusing one of those would be the permanent publish stall over again.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_allows_a_fully_contributed_primary_key_range_layout) {
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, merged_tablet}) {
+        prepare_tablet_dirs(tablet_id);
+    }
+
+    auto [meta_a, meta_b] = make_primary_key_range_split_children(child_a, child_b, "covered_shared.dat",
+                                                                  /*split_key=*/100,
+                                                                  /*rowset_lower_key=*/std::nullopt);
+
+    ASSIGN_OR_ABORT(auto merged, merge_tablet_directly({meta_a, meta_b}, merged_tablet, /*new_version=*/2,
+                                                       /*skip_sstable_merge=*/false));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(1, merged->rowsets(0).segment_metas_size());
+    // Nothing was masked: no gap bitmap was needed, so no delete vector was manufactured for it.
+    EXPECT_TRUE(merged->delvec_meta().delvecs().empty());
+}
+
+// The read-only parent alias a primary-key-range split keeps alive is not such a merge: it reproduces the
+// pre-split parent, which served every row of a shared segment exactly once. So it must build -- carrying
+// the shared rowset once and the union of the children's delete vectors -- rather than try to locate a gap
+// it has no rowid window for, which is what wedged publish on this shape.
+TEST_F(LakeTabletReshardTest, test_parent_alias_of_a_primary_key_range_split_unions_shared_delvecs) {
+    constexpr int64_t kNewVersion = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t alias_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, alias_tablet}) {
+        prepare_tablet_dirs(tablet_id);
+    }
+
+    const std::string segment_name = "alias_shared.dat";
+    auto [meta_a, meta_b] = make_primary_key_range_split_children(child_a, child_b, segment_name,
+                                                                  /*split_key=*/100, /*rowset_lower_key=*/90);
+    // A real segment under the ALIAS tablet id, which is where gap synthesis would look for it: without the
+    // file this test would pass for the wrong reason (a missing segment) instead of proving the
+    // primary-key-interval-to-rowid conversion is gone.
+    write_two_column_segment(
+            alias_tablet, segment_name, /*num_rows=*/10, [](int key) { return key * 2; },
+            /*key_start=*/90);
+
+    // Each child deleted rows of the shared segment that fall in its own range; neither knows the other's.
+    DelVector delvec_a;
+    const uint32_t deleted_by_a[] = {3, 9};
+    delvec_a.init(/*version=*/10, deleted_by_a, std::size(deleted_by_a));
+    add_delvec(meta_a.get(), child_a, /*version=*/10, /*segment_id=*/1, "alias_a.delvec", delvec_a.save());
+    DelVector delvec_b;
+    const uint32_t deleted_by_b[] = {5};
+    delvec_b.init(/*version=*/10, deleted_by_b, std::size(deleted_by_b));
+    add_delvec(meta_b.get(), child_b, /*version=*/10, /*segment_id=*/1, "alias_b.delvec", delvec_b.save());
+
+    ASSIGN_OR_ABORT(auto alias, merge_tablet_directly({meta_a, meta_b}, alias_tablet, kNewVersion,
+                                                      /*skip_sstable_merge=*/true));
+
+    // One copy of the shared rowset: the uid dedup is what keeps the alias from serving it twice.
+    ASSERT_EQ(1, alias->rowsets_size());
+    ASSERT_EQ(1, alias->rowsets(0).segment_metas_size());
+    EXPECT_EQ(segment_name, alias->rowsets(0).segment_metas(0).filename());
+    // Read-only alias: no primary index is rebuilt for it.
+    EXPECT_TRUE(alias->sstable_meta().sstables().empty());
+
+    const uint32_t target_rssid = alias->rowsets(0).id();
+    DelVector loaded;
+    LakeIOOptions io_options;
+    ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *alias, target_rssid, false, io_options, &loaded));
+    ASSERT_NE(nullptr, loaded.roaring());
+    // The union, and nothing more: no gap bits masking rows the pre-split parent was serving.
+    EXPECT_EQ(3, loaded.cardinality());
+    EXPECT_TRUE(loaded.roaring()->contains(3));
+    EXPECT_TRUE(loaded.roaring()->contains(5));
+    EXPECT_TRUE(loaded.roaring()->contains(9));
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJobMgr.java
@@ -213,6 +213,13 @@ public class TabletReshardJobMgr extends LeaderDaemon implements GsonPostProcess
             throw new StarRocksException("Tablet merge is disabled. " +
                     "Set tablet_reshard_enable_tablet_merge=true to enable it.");
         }
+        // The funnel for both the MERGE TABLET statement and the auto-merge scheduler. The statement is
+        // also rejected in analysis, which is where a user sees it; this catches the paths that never go
+        // through an analyzer, and the auto scheduler skips the shape before it plans anything.
+        if (TabletReshardUtils.tabletMergeUnsupported(table)) {
+            throw new StarRocksException("Tablet merge is not supported on a range-distributed primary key "
+                    + "table whose ORDER BY differs from the primary key: " + table.getName());
+        }
         TabletReshardJob job = new MergeTabletJobFactory(db, table, mergeTabletClause).createTabletReshardJob();
         addTabletReshardJob(job);
     }
@@ -377,7 +384,11 @@ public class TabletReshardJobMgr extends LeaderDaemon implements GsonPostProcess
             // fires and the latch never arms. Evaluating the latch first would therefore pay that walk
             // on every stat pass, forever, for a job that cannot run. Before this feature the same
             // path threw immediately with no walk at all.
-            if (Config.tablet_reshard_enable_tablet_merge
+            //
+            // tabletMergeUnsupported joins it for the same reason, and additionally so that a table of
+            // that shape does not log a warning from the catch below on every stat pass: unlike the empty
+            // plan, its rejection is permanent and there is nothing to latch or re-arm.
+            if (Config.tablet_reshard_enable_tablet_merge && !TabletReshardUtils.tabletMergeUnsupported(table)
                     && TabletReshardUtils.needMerge(minAdjacentTabletPairSize)) {
                 long mergeSignature = ColocateChecker.tableConvergenceSignature(db, table,
                         mergePlanSignature(minAdjacentTabletPairSize));

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardUtils.java
@@ -224,6 +224,37 @@ public class TabletReshardUtils {
         }
     }
 
+    /**
+     * Whether a tablet merge of this table is unsupported for now.
+     *
+     * <p>True for the same shape as {@link #splitRewritesEveryShard}: a range-distributed primary-key
+     * table whose ORDER BY key differs from the primary key. A merge has to decide, for every row of a
+     * segment its sources share, which source still owns it, and the BE answers that by turning a
+     * primary-key interval into a rowid window. On this shape there is no such window -- the tablet range
+     * is in primary-key space while the segments are laid out in sort-key order -- so the merge fails at
+     * publish, permanently, and takes every later transaction on the partition with it.
+     *
+     * <p>Not gated on file bundling, unlike {@code splitRewritesEveryShard}: that gate is about the cost
+     * of the UNSHARE rewrite the split knobs bound, while this is about a merge that cannot be made
+     * correct. CREATE TABLE requires file_bundling=true for this shape anyway, so the two agree in
+     * practice; where they could disagree, refusing the merge is the safe answer.
+     *
+     * <p>The read-only parent alias a split keeps alive is not affected: it reproduces the pre-split
+     * parent rather than deciding ownership per row. See {@code merge_tablet} on the BE.
+     */
+    public static boolean tabletMergeUnsupported(OlapTable table) {
+        if (table == null) {
+            return false;
+        }
+        try {
+            return MetaUtils.hasSeparateSortKey(table, table.getBaseIndexMetaId());
+        } catch (IllegalArgumentException e) {
+            // Base index meta went away underneath us; leave the decision to the BE backstop rather than
+            // throwing from a scheduling decision.
+            return false;
+        }
+    }
+
     /** Per-tablet split fan-out cap for this table. */
     public static int effectiveMaxSplitCount(OlapTable table) {
         int cap = Config.tablet_reshard_max_split_count;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.alter.MaterializedViewHandler;
+import com.starrocks.alter.reshard.TabletReshardUtils;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnBuilder;
@@ -1474,6 +1475,13 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
     public Void visitMergeTabletClause(MergeTabletClause clause, ConnectContext context) {
         if (!table.isCloudNativeTableOrMaterializedView()) {
             throw new SemanticException("Merge tablet only support cloud native tables");
+        }
+
+        // A merge of this shape cannot attribute the rows of a segment its sources share, and fails at
+        // publish for good rather than at submission. Say so here, where the user is looking.
+        if (TabletReshardUtils.tabletMergeUnsupported((OlapTable) table)) {
+            throw new SemanticException("Merge tablet is not supported on a range-distributed primary key table "
+                    + "whose ORDER BY differs from the primary key");
         }
 
         if (clause.getPartitionNames() != null && clause.getTabletGroupList() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MergeTabletClauseAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MergeTabletClauseAnalyzerTest.java
@@ -39,6 +39,8 @@ import java.util.Map;
 public class MergeTabletClauseAnalyzerTest {
     private static Database db;
     private static OlapTable table;
+    private static OlapTable separateSortKeyTable;
+    private static OlapTable sortKeyIsPrimaryKeyTable;
 
     @BeforeAll
     public static void beforeClass() throws Exception {
@@ -57,6 +59,24 @@ public class MergeTabletClauseAnalyzerTest {
         table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                 .getTable(db.getFullName(), "test_table");
         Assertions.assertNotNull(table);
+
+        starRocksAssert.withTable("create table test_pk_separate_sort_key "
+                + "(k1 int not null, k2 int not null, v1 int)\n"
+                + "primary key(k1, k2)\n"
+                + "order by(v1)\n"
+                + "properties('replication_num' = '1', 'file_bundling' = 'true');");
+        separateSortKeyTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_pk_separate_sort_key");
+        Assertions.assertNotNull(separateSortKeyTable);
+
+        starRocksAssert.withTable("create table test_pk_sort_key_is_key "
+                + "(k1 int not null, k2 int not null, v1 int)\n"
+                + "primary key(k1, k2)\n"
+                + "order by(k1, k2)\n"
+                + "properties('replication_num' = '1', 'file_bundling' = 'true');");
+        sortKeyIsPrimaryKeyTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), "test_pk_sort_key_is_key");
+        Assertions.assertNotNull(sortKeyIsPrimaryKeyTable);
     }
 
     @Test
@@ -146,6 +166,29 @@ public class MergeTabletClauseAnalyzerTest {
         SemanticException exception = Assertions.assertThrows(SemanticException.class,
                 () -> analyzer.analyze(null, clause));
         Assertions.assertTrue(exception.getMessage().contains("Unknown properties"));
+    }
+
+    // A merge of this shape cannot attribute the rows of a segment its sources share and would fail at
+    // publish for good, so it is refused where the user can see why.
+    @Test
+    public void testRejectSeparateSortKeyPrimaryKeyTable() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(separateSortKeyTable);
+        MergeTabletClause clause = new MergeTabletClause(null,
+                new TabletGroupList(List.of(List.of(1L, 2L))), null);
+        SemanticException exception = Assertions.assertThrows(SemanticException.class,
+                () -> analyzer.analyze(null, clause));
+        Assertions.assertTrue(exception.getMessage().contains("Merge tablet is not supported"),
+                exception.getMessage());
+    }
+
+    // The refusal is about the ORDER BY, not about primary-key tables: one whose sort key IS its primary key
+    // routes and merges by the same columns, so it keeps working.
+    @Test
+    public void testAcceptPrimaryKeyTableWhoseSortKeyIsTheKey() {
+        AlterTableClauseAnalyzer analyzer = new AlterTableClauseAnalyzer(sortKeyIsPrimaryKeyTable);
+        MergeTabletClause clause = new MergeTabletClause(null,
+                new TabletGroupList(List.of(List.of(1L, 2L))), null);
+        analyzer.analyze(null, clause);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

On a range-distributed **PRIMARY KEY** table whose `ORDER BY` differs from the primary key, every publish taken while a split waits for UNSHARE rebuilds the query-side parent alias — `build_parent_tablet_metadata` → `merge_tablet` (`lake_service.cpp`). That build ran `compute_synthesized_gap_specs`, which turns "the part of the merged range no source contributed" into a **rowid window**. This shape has no such window: the range is in primary-key space, the segments are laid out in sort-key order. `create_seek_range_from` rejected the arity-1 bound against the arity-2 sort key, and the publish failed:

```
Fail to publish version for tablets:[], error msg: Unexpected number of values in
TabletRangePB bound value, expected at least: 2, actual: 1
```

An alias rebuild is deterministic, so it failed identically on every retry and the partition's version never moved again. Measured on a soak cluster that is still in this state:

| | |
|---|---|
| `t_pksort_0` visible / next version | 3496 / 4070 — **573 committed transactions never published** |
| stuck since | the exact minute the partition's `LastUpdateTime` froze |
| db running transactions | **1001**, against a limit of 1000 — every later load rejected |
| FE retry rate | ~50/s, no backoff (983 identical stacks in a 20 s log window) |
| shared segments after 3 days | 250 of 250 — UNSHARE is itself a transaction that has to publish |

Two of three 12-hour soak runs wedged this way within their first half hour (StarRocksTest#12145). The soak framework saw it as "stream loads returned success and the rows never appeared"; the rows are not lost, their transactions are COMMITTED with `PublishTime` NULL.

## What I'm doing:

**The alias needs no gap masking at all**, so it no longer computes any.

It exists to reproduce the pre-split parent, and this shape never range-filters a segment read — `Rowset::get_seek_range` returns no range for it, deliberately, with the comment *"Parent-tablet reads therefore read a deduplicated shared segment in full; UNSHARE applies the PK range row-by-row."* So the parent's view of a shared segment was the whole file minus its delete vector, and carrying the shared rowset once (uid dedup) with the **union of the children's delete vectors** is that view exactly.

Masking a gap would have been wrong even where it was computable: the gaps here are an artifact of `update_rowset_range` **intersecting** a rowset's range at every reshard while a merge **unions** the tablet range, so a per-rowset coverage walk always finds one. On the wedged cluster, 208 of 250 rowsets on one child carry `[153951,154211)` under a tablet range of `(-∞,154211)`; the "gap" `(-∞,153951)` is territory the pre-split parent was serving. Same trap as #78237's compaction stall — a range a merge stamps for bookkeeping, read as an ownership claim.

**A real MERGE is no longer scheduled on this shape**, because it genuinely does have to attribute each row of a shared segment to a source and gap synthesis is how it does that. FE refuses it: `MERGE TABLET` is rejected in analysis, the auto-merge scheduler skips the shape before it plans anything, and `TabletReshardJobMgr` rejects it in the funnel both paths go through.

The BE keeps a backstop for an FE that has not caught up or a job replayed from the edit log — but a **precise** one. `merge_tablet` returns `NotSupported` only when a shared rowset's contributors leave part of the merged range unclaimed, which is exactly the case whose bitmap this shape cannot locate. A merge whose contributors cover the range needs no bitmap and produces precisely what it produced before, and `MergeTabletJob` cannot abort once it is past shard creation (`MergeTabletJob.java:142-161`), so refusing one of those would create the very stall this PR removes. The check is the range algebra `compute_synthesized_gap_specs` runs *before* it opens a segment, so it needs no arity conversion of its own. `skip_sstable_merge` separates the read-only alias from a real merge (see `tablet_merger.h`).

It is the guard to lift once the bitmap is built by a row-level primary-key filter — the tool the UNSHARE compaction already has. **Splits are unaffected.**

### The one invariant this leans on

The alias's reasoning breaks only if a source no longer carries a shared rowset its sibling still does (a compaction that consumed its copy): the alias would then serve those rows twice, from the compaction output and from the sibling's untouched copy. `PrimaryCompactionPolicy::pick_rowsets` makes that unreachable for this shape while any segment is shared, and the UNSHARE that does consume them ends the alias phase. It is now a tripwire: a `LOG(WARNING)` plus `tablet_merge_alias_partial_shared_contribution_total`, **not** an error — a failure on this path would be another permanent publish stall, which is the thing being removed here. Duplicate keys are visible and bounded; a wedged partition is not.

## Tests

- `test_parent_alias_of_a_primary_key_range_split_unions_shared_delvecs` — builds the alias over the layout that used to fail (with a real segment under the alias tablet, so the old code reached the rejected conversion rather than tripping over a missing file), and asserts one copy of the shared rowset and the union of both children's delete vectors, nothing more.
- `test_tablet_merging_refuses_a_primary_key_range_layout` — a real merge of the same sources, whose contributors leave a gap, is `NotSupported`.
- `test_tablet_merging_allows_a_fully_contributed_primary_key_range_layout` — one whose contributors cover the merged range still merges, and masks nothing.
- `MergeTabletClauseAnalyzerTest` — `MERGE TABLET` is rejected on this shape and still accepted on a primary-key table whose sort key IS its primary key.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.

If yes, please specify the type of change:
- [x] Policy changes: `MERGE TABLET` (manual and automatic) is refused on a range-distributed primary-key table whose `ORDER BY` differs from the primary key. Such a merge previously succeeded when its sources happened to cover the merged range completely and wedged the partition permanently when they did not; FE now declines it up front, and the BE refuses only the second case.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
- [ ] 3.5
- [ ] 4.0
- [ ] 4.1

Reachable only through range-distributed primary-key tables whose `ORDER BY` differs from the primary key, which no release branch carries: the ORDER BY reshard configuration exists on main only. No backport applies.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016izTM83572H3JrgYn8B7VH
