### PR TITLE
[BugFix] Stop lambda array_map/array_sort from leaking synthetic common-expr slot ids

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -457,11 +457,27 @@ std::string ArrayMapExpr::debug_string() const {
 }
 
 int ArrayMapExpr::get_slot_ids(std::vector<SlotId>* slot_ids) const {
-    int num = Expr::get_slot_ids(slot_ids);
+    std::vector<SlotId> collected;
+    Expr::get_slot_ids(&collected);
+    // The columns the extracted common expressions depend on are genuine captures.
     for (const auto& [slot_id, expr] : _outer_common_exprs) {
-        slot_ids->push_back(slot_id);
+        expr->get_slot_ids(&collected);
+    }
+    int num = 0;
+    for (SlotId id : collected) {
+        // Drop the synthetic slot ids we assigned to the extracted common expressions themselves:
+        // each is produced and consumed inside this array_map's own evaluate_lambda_expr (in its
+        // private tmp_chunk) and never exists in an enclosing chunk. Such a slot can reach here
+        // through the child lambda's captured slots, because extraction rewrote the lambda body to
+        // reference it. Surfacing it to an enclosing lambda makes that lambda treat it as a
+        // captured column and look it up via Chunk::get_column_by_slot_id on the input chunk,
+        // crashing the BE (e.g. nested array_map over a constant array whose inner lambda captures
+        // the outer lambda argument).
+        if (_outer_common_exprs.find(id) != _outer_common_exprs.end()) {
+            continue;
+        }
+        slot_ids->push_back(id);
         num++;
-        num += (expr->get_slot_ids(slot_ids));
     }
     return num;
 }

--- a/be/src/exprs/array_sort_lambda_expr.cpp
+++ b/be/src/exprs/array_sort_lambda_expr.cpp
@@ -565,11 +565,25 @@ std::string ArraySortLambdaExpr::debug_string() const {
 }
 
 int ArraySortLambdaExpr::get_slot_ids(std::vector<SlotId>* slot_ids) const {
-    int num = Expr::get_slot_ids(slot_ids);
+    std::vector<SlotId> collected;
+    Expr::get_slot_ids(&collected);
+    // The columns the extracted common expressions depend on are genuine captures.
     for (const auto& [slot_id, expr] : _outer_common_exprs) {
-        slot_ids->push_back(slot_id);
+        expr->get_slot_ids(&collected);
+    }
+    int num = 0;
+    for (SlotId id : collected) {
+        // Drop the synthetic slot ids assigned to the extracted common expressions themselves:
+        // each is produced and consumed inside this expression's own evaluation (in its private
+        // tmp_chunk) and never exists in an enclosing chunk. It can reach here through the child
+        // lambda's captured slots after extraction rewrote the body to reference it; surfacing it
+        // to an enclosing lambda makes it look the slot up via Chunk::get_column_by_slot_id on the
+        // input chunk and crash the BE (nested lambda capturing the outer lambda argument).
+        if (_outer_common_exprs.find(id) != _outer_common_exprs.end()) {
+            continue;
+        }
+        slot_ids->push_back(id);
         num++;
-        num += (expr->get_slot_ids(slot_ids));
     }
     return num;
 }

--- a/be/test/exprs/array_sort_lambda_expr_test.cpp
+++ b/be/test/exprs/array_sort_lambda_expr_test.cpp
@@ -224,9 +224,9 @@ TEST_F(ArraySortLambdaExprTest, invalid_comparator_error_is_not_cached) {
 //   array_sort(arr_of_arrays, (x, y) -> array_length(array_map(z -> array_length(x) + z, x)) < array_length(y))
 // Must not crash.
 TEST_F(ArraySortLambdaExprTest, nested_array_map_in_comparator_captures_arg) {
-    const SlotId kZ = 100002; // inner array_map argument
-    TypeDescriptor int_arr = array_type(TYPE_INT);         // array<int>  (comparator element type: x, y)
-    TypeDescriptor int_arr_arr = array_type(int_arr);      // array<array<int>> (sorted array)
+    const SlotId kZ = 100002;                         // inner array_map argument
+    TypeDescriptor int_arr = array_type(TYPE_INT);    // array<int>  (comparator element type: x, y)
+    TypeDescriptor int_arr_arr = array_type(int_arr); // array<array<int>> (sorted array)
 
     // Sorted array column: 2 rows, each an array<array<int>> = [[4,4],[1],[3,3,3]].
     auto array = ColumnHelper::create_column(int_arr_arr, false);

--- a/be/test/exprs/array_sort_lambda_expr_test.cpp
+++ b/be/test/exprs/array_sort_lambda_expr_test.cpp
@@ -25,10 +25,13 @@
 #include "column/column_helper.h"
 #include "column/fixed_length_column.h"
 #include "common/object_pool.h"
+#include "exprs/arithmetic_expr.h"
+#include "exprs/array_map_expr.h"
 #include "exprs/binary_predicate.h"
 #include "exprs/column_ref.h"
 #include "exprs/expr_context.h"
 #include "exprs/expr_executor.h"
+#include "exprs/function_call_expr.h"
 #include "exprs/lambda_function.h"
 #include "exprs/mock_vectorized_expr.h"
 #include "runtime/runtime_state.h"
@@ -210,6 +213,130 @@ TEST_F(ArraySortLambdaExprTest, invalid_comparator_error_is_not_cached) {
         ASSERT_TRUE(result.status().is_invalid_argument()) << result.status();
         ASSERT_NE(std::string::npos, result.status().message().find("irreflexivity")) << result.status();
     }
+    ExprExecutor::close(ctxs, &_runtime_state);
+}
+
+// Same defect as ArrayMapExpr::get_slot_ids, in ArraySortLambdaExpr: a comparator lambda whose
+// body contains a nested array_map that captures the comparator argument. The nested array_map
+// extracts array_length(x) as a common expression under a synthetic slot id, which used to leak
+// through the comparator lambda's captured slots and be looked up via Chunk::get_column_by_slot_id
+// on the input chunk, crashing the BE. Reachable from SQL as
+//   array_sort(arr_of_arrays, (x, y) -> array_length(array_map(z -> array_length(x) + z, x)) < array_length(y))
+// Must not crash.
+TEST_F(ArraySortLambdaExprTest, nested_array_map_in_comparator_captures_arg) {
+    const SlotId kZ = 100002; // inner array_map argument
+    TypeDescriptor int_arr = array_type(TYPE_INT);         // array<int>  (comparator element type: x, y)
+    TypeDescriptor int_arr_arr = array_type(int_arr);      // array<array<int>> (sorted array)
+
+    // Sorted array column: 2 rows, each an array<array<int>> = [[4,4],[1],[3,3,3]].
+    auto array = ColumnHelper::create_column(int_arr_arr, false);
+    for (size_t i = 0; i < 2; ++i) {
+        array->append_datum(DatumArray{Datum(DatumArray{Datum((int32_t)4), Datum((int32_t)4)}),
+                                       Datum(DatumArray{Datum((int32_t)1)}),
+                                       Datum(DatumArray{Datum((int32_t)3), Datum((int32_t)3), Datum((int32_t)3)})});
+    }
+    TExprNode arr_node;
+    arr_node.__set_node_type(TExprNodeType::INT_LITERAL);
+    arr_node.__set_num_children(0);
+    arr_node.__set_type(int_arr_arr.to_thrift());
+    auto* array_expr = _pool.add(new FakeConstExpr(arr_node));
+    array_expr->_column = std::move(array);
+
+    auto slot_ref = [&](SlotId id, const TypeDescriptor& type) {
+        TExprNode n;
+        n.node_type = TExprNodeType::SLOT_REF;
+        n.type = type.to_thrift();
+        n.num_children = 0;
+        n.__isset.slot_ref = true;
+        n.slot_ref.slot_id = id;
+        n.slot_ref.tuple_id = 0;
+        n.__set_is_nullable(true);
+        return _pool.add(new ColumnRef(n));
+    };
+    auto array_length = [&](Expr* child) {
+        TExprNode n;
+        n.node_type = TExprNodeType::FUNCTION_CALL;
+        n.type = gen_type_desc(TPrimitiveType::INT);
+        n.num_children = 1;
+        n.__isset.fn = true;
+        n.fn.name.function_name = "array_length";
+        n.fn.fid = 150000;
+        n.fn.__isset.fid = true;
+        n.fn.binary_type = TFunctionBinaryType::BUILTIN;
+        auto* e = _pool.add(new VectorizedFunctionCallExpr(n));
+        e->add_child(child);
+        return e;
+    };
+
+    // nested array_map(z -> array_length(x) + z, x) capturing the comparator arg x (kArgX).
+    TExprNode add_node;
+    add_node.opcode = TExprOpcode::ADD;
+    add_node.child_type = TPrimitiveType::INT;
+    add_node.node_type = TExprNodeType::BINARY_PRED;
+    add_node.num_children = 2;
+    add_node.__isset.opcode = true;
+    add_node.__isset.child_type = true;
+    add_node.type = gen_type_desc(TPrimitiveType::INT);
+    auto* add_expr = _pool.add(VectorizedArithmeticExprFactory::from_thrift(add_node));
+    add_expr->add_child(array_length(slot_ref(kArgX, int_arr)));
+    add_expr->add_child(slot_ref(kZ, TypeDescriptor(TYPE_INT)));
+
+    TExprNode tlambda_inner;
+    tlambda_inner.opcode = TExprOpcode::ADD;
+    tlambda_inner.child_type = TPrimitiveType::INT;
+    tlambda_inner.node_type = TExprNodeType::LAMBDA_FUNCTION_EXPR;
+    tlambda_inner.num_children = 2;
+    tlambda_inner.__isset.opcode = true;
+    tlambda_inner.__isset.child_type = true;
+    tlambda_inner.type = gen_type_desc(TPrimitiveType::INT);
+    auto* inner_lambda = _pool.add(new LambdaFunction(tlambda_inner));
+    inner_lambda->add_child(add_expr);
+    inner_lambda->add_child(slot_ref(kZ, TypeDescriptor(TYPE_INT)));
+
+    auto* inner_map = _pool.add(new ArrayMapExpr(int_arr));
+    inner_map->clear_children();
+    inner_map->add_child(inner_lambda);
+    inner_map->add_child(slot_ref(kArgX, int_arr));
+
+    // comparator body: array_length(inner_map) < array_length(y)
+    TExprNode lt_node;
+    lt_node.node_type = TExprNodeType::BINARY_PRED;
+    lt_node.opcode = TExprOpcode::LT;
+    lt_node.child_type = TPrimitiveType::INT;
+    lt_node.num_children = 2;
+    lt_node.__isset.opcode = true;
+    lt_node.__isset.child_type = true;
+    lt_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+    auto* lt = _pool.add(VectorizedBinaryPredicateFactory::from_thrift(lt_node));
+    lt->add_child(array_length(inner_map));
+    lt->add_child(array_length(slot_ref(kArgY, int_arr)));
+
+    TExprNode lambda_node;
+    lambda_node.node_type = TExprNodeType::LAMBDA_FUNCTION_EXPR;
+    lambda_node.num_children = 3; // body + 2 args
+    lambda_node.type = gen_type_desc(TPrimitiveType::BOOLEAN);
+    auto* comparator = _pool.add(new LambdaFunction(lambda_node));
+    comparator->add_child(lt);
+    comparator->add_child(slot_ref(kArgX, int_arr));
+    comparator->add_child(slot_ref(kArgY, int_arr));
+
+    auto* expr = _pool.add(new ArraySortLambdaExpr(int_arr_arr));
+    expr->add_child(array_expr);
+    expr->add_child(comparator);
+
+    ExprContext ctx(expr);
+    std::vector<ExprContext*> ctxs = {&ctx};
+    ASSERT_OK(ExprExecutor::prepare(ctxs, &_runtime_state));
+    ASSERT_OK(ExprExecutor::open(ctxs, &_runtime_state));
+
+    auto chunk = std::make_shared<Chunk>();
+    auto rows = Int32Column::create();
+    rows->append(0);
+    rows->append(1);
+    chunk->append_column(std::move(rows), 1);
+    ColumnPtr result = expr->evaluate(&ctx, chunk.get()); // must not crash
+    ASSERT_EQ(2, result->size());
+
     ExprExecutor::close(ctxs, &_runtime_state);
 }
 

--- a/be/test/exprs/lambda_array_expr_test.cpp
+++ b/be/test/exprs/lambda_array_expr_test.cpp
@@ -667,8 +667,8 @@ TEST_F(VectorizedLambdaFunctionExprTest, nested_array_map_captures_outer_arg_con
     const SlotId kOuterArg = 100000; // a : array<int>
     const SlotId kInnerArg = 100001; // b : int
 
-    TypeDescriptor type_arr_int = array_type(TYPE_INT);            // array<int>
-    TypeDescriptor type_arr_arr_int = array_type(type_arr_int);    // array<array<int>>
+    TypeDescriptor type_arr_int = array_type(TYPE_INT);         // array<int>
+    TypeDescriptor type_arr_arr_int = array_type(type_arr_int); // array<array<int>>
 
     // Outer input: const ARRAY<ARRAY<INT>>[[1, 2]] (one row).
     auto arr2 = ColumnHelper::create_column(type_arr_arr_int, true);

--- a/be/test/exprs/lambda_array_expr_test.cpp
+++ b/be/test/exprs/lambda_array_expr_test.cpp
@@ -657,4 +657,120 @@ TEST_F(VectorizedLambdaFunctionExprTest, test_lambda_common_expr_slot_conflict) 
     ExprExecutor::close(expr_ctxs, &_runtime_state);
 }
 
+// Reproduces fuzz finding a0903_mut_111: a nested array_map over a CONSTANT nested array literal,
+// where the inner lambda captures the outer lambda argument. Historically this crashed the BE with
+// a SIGSEGV in ArrayMapExpr::evaluate_lambda_expr's get_column_by_slot_id, because the outer
+// lambda's captured_slot_ids leaked the inner lambda's argument slot, which is never present in
+// the input chunk.
+//   array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<INT>>[[1, 2]])
+TEST_F(VectorizedLambdaFunctionExprTest, nested_array_map_captures_outer_arg_const_input) {
+    const SlotId kOuterArg = 100000; // a : array<int>
+    const SlotId kInnerArg = 100001; // b : int
+
+    TypeDescriptor type_arr_int = array_type(TYPE_INT);            // array<int>
+    TypeDescriptor type_arr_arr_int = array_type(type_arr_int);    // array<array<int>>
+
+    // Outer input: const ARRAY<ARRAY<INT>>[[1, 2]] (one row).
+    auto arr2 = ColumnHelper::create_column(type_arr_arr_int, true);
+    arr2->append_datum(DatumArray{Datum(DatumArray{Datum((int32_t)1), Datum((int32_t)2)})});
+    auto const_input = ConstColumn::create(std::move(arr2), 1);
+    auto* outer_input = new_fake_const_expr(std::move(const_input), type_arr_arr_int);
+
+    // Slot ref helpers (same slot id may be referenced from multiple sites).
+    auto make_slot_ref = [&](SlotId slot_id, const TypeDescriptor& type) {
+        TExprNode n;
+        n.node_type = TExprNodeType::SLOT_REF;
+        n.type = type.to_thrift();
+        n.num_children = 0;
+        n.__isset.slot_ref = true;
+        n.slot_ref.slot_id = slot_id;
+        n.slot_ref.tuple_id = 0;
+        n.__set_is_nullable(true);
+        return _objpool.add(new ColumnRef(n));
+    };
+
+    // inner lambda body: array_length(a) + b
+    TExprNode len_node;
+    len_node.node_type = TExprNodeType::FUNCTION_CALL;
+    len_node.type = gen_type_desc(TPrimitiveType::INT);
+    len_node.num_children = 1;
+    len_node.__isset.fn = true;
+    len_node.fn.name.function_name = "array_length";
+    len_node.fn.fid = 150000;
+    len_node.fn.__isset.fid = true;
+    len_node.fn.binary_type = TFunctionBinaryType::BUILTIN;
+    auto* array_length_expr = _objpool.add(new VectorizedFunctionCallExpr(len_node));
+    array_length_expr->add_child(make_slot_ref(kOuterArg, type_arr_int));
+
+    TExprNode add_node;
+    add_node.opcode = TExprOpcode::ADD;
+    add_node.child_type = TPrimitiveType::INT;
+    add_node.node_type = TExprNodeType::BINARY_PRED;
+    add_node.num_children = 2;
+    add_node.__isset.opcode = true;
+    add_node.__isset.child_type = true;
+    add_node.type = gen_type_desc(TPrimitiveType::INT);
+    auto* add_expr = _objpool.add(VectorizedArithmeticExprFactory::from_thrift(add_node));
+    add_expr->add_child(array_length_expr);
+    add_expr->add_child(make_slot_ref(kInnerArg, TypeDescriptor(TYPE_INT)));
+
+    // inner lambda: b -> array_length(a) + b
+    TExprNode tlambda_inner;
+    tlambda_inner.opcode = TExprOpcode::ADD;
+    tlambda_inner.child_type = TPrimitiveType::INT;
+    tlambda_inner.node_type = TExprNodeType::LAMBDA_FUNCTION_EXPR;
+    tlambda_inner.num_children = 2;
+    tlambda_inner.__isset.opcode = true;
+    tlambda_inner.__isset.child_type = true;
+    tlambda_inner.type = gen_type_desc(TPrimitiveType::INT);
+    auto* inner_lambda = _objpool.add(new LambdaFunction(tlambda_inner));
+    inner_lambda->add_child(add_expr);
+    inner_lambda->add_child(make_slot_ref(kInnerArg, TypeDescriptor(TYPE_INT)));
+
+    // inner array_map: array_map(b -> array_length(a) + b, a)
+    auto* inner_map = _objpool.add(new ArrayMapExpr(type_arr_int));
+    inner_map->clear_children();
+    inner_map->add_child(inner_lambda);
+    inner_map->add_child(make_slot_ref(kOuterArg, type_arr_int));
+
+    // outer lambda: a -> inner_map
+    TExprNode tlambda_outer;
+    tlambda_outer.opcode = TExprOpcode::ADD;
+    tlambda_outer.child_type = TPrimitiveType::INT;
+    tlambda_outer.node_type = TExprNodeType::LAMBDA_FUNCTION_EXPR;
+    tlambda_outer.num_children = 2;
+    tlambda_outer.__isset.opcode = true;
+    tlambda_outer.__isset.child_type = true;
+    tlambda_outer.type = type_arr_int.to_thrift();
+    auto* outer_lambda = _objpool.add(new LambdaFunction(tlambda_outer));
+    outer_lambda->add_child(inner_map);
+    outer_lambda->add_child(make_slot_ref(kOuterArg, type_arr_int));
+
+    // outer array_map: array_map(a -> ..., [[1,2]])
+    ArrayMapExpr outer_map(type_arr_arr_int);
+    outer_map.clear_children();
+    outer_map.add_child(outer_lambda);
+    outer_map.add_child(outer_input);
+
+    ExprContext exprContext(&outer_map);
+    std::vector<ExprContext*> expr_ctxs = {&exprContext};
+    ASSERT_OK(ExprExecutor::prepare(expr_ctxs, &_runtime_state));
+    ASSERT_OK(ExprExecutor::open(expr_ctxs, &_runtime_state));
+
+    auto chunk = std::make_shared<Chunk>();
+    chunk->append_column(build_int_column({0}), 999); // dummy single row
+
+    // Must not crash. Expected result: [[array_length([1,2]) + 1, array_length([1,2]) + 2]] = [[3, 4]].
+    ColumnPtr result = outer_map.evaluate(&exprContext, chunk.get());
+    ASSERT_EQ(1, result->size());
+    auto outer_arr = result->get(0).get_array();
+    ASSERT_EQ(1, outer_arr.size());
+    auto inner_arr = outer_arr[0].get_array();
+    ASSERT_EQ(2, inner_arr.size());
+    ASSERT_EQ(3, inner_arr[0].get_int32());
+    ASSERT_EQ(4, inner_arr[1].get_int32());
+
+    ExprExecutor::close(expr_ctxs, &_runtime_state);
+}
+
 } // namespace starrocks

--- a/test/sql/test_array_fn/R/test_nested_lambda_window
+++ b/test/sql/test_array_fn/R/test_nested_lambda_window
@@ -1,0 +1,14 @@
+-- name: test_nested_lambda_window
+select count(array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])) over ();
+-- result:
+1
+-- !result
+select count(array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])) over () order by array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) desc limit 7, 100;
+-- result:
+-- !result
+select x, count(array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])) over () from (select 3 as x union all select 1 union all select 2) t order by x desc;
+-- result:
+3	3
+2	3
+1	3
+-- !result

--- a/test/sql/test_array_fn/T/test_nested_lambda_window
+++ b/test/sql/test_array_fn/T/test_nested_lambda_window
@@ -1,0 +1,12 @@
+-- name: test_nested_lambda_window
+-- A nested array_map whose inner lambda captures the outer lambda argument, over a CONSTANT nested
+-- array, used as a window-function argument. The analytic node keeps array_length() inline (unlike
+-- an ORDER BY copy, which the optimizer extracts), so the BE runs extract_outer_common_exprs and
+-- assigns array_length(a) a synthetic common-expr slot id. That synthetic slot used to leak out of
+-- the nested array_map through the enclosing lambda's captured slots and get looked up via
+-- Chunk::get_column_by_slot_id on the input chunk, crashing the BE.
+select count(array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])) over ();
+-- the exact fuzzer shape: the offset skips past the single row, so the result is empty
+select count(array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])) over () order by array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]]) desc limit 7, 100;
+-- the window still works across several rows
+select x, count(array_map(a -> array_map(b -> array_length(a) + b, a), ARRAY<ARRAY<TINYINT>>[ARRAY<TINYINT>[1,2]])) over () from (select 3 as x union all select 1 union all select 2) t order by x desc;


### PR DESCRIPTION
## Why I'm doing:

```
[1788459352.564][thread: 140314160289472] je_mallctl execute dontdump success
*** Aborted at 1788459352 (unix time) try "date -d @1788459352" if you are using GNU date ***
PC: @     0x7fa033f15b2c pthread_kill
*** SIGABRT (@0x334cea) received by PID 3362026 (TID 0x7f9d6fae56c0) LWP(3365728) from PID 3362026; stack trace: ***
    @         0x33b75047 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fa033f18ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x33b74846 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fa033ebc330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7fa033f15b2c pthread_kill
    @     0x7fa033ebc27e gsignal
    @     0x7fa033e9f8ff abort
    @         0x1b440fcd starrocks::failure_function()
    @         0x33b6895d google::LogMessage::Fail()
    @         0x33b69a44 google::LogMessageFatal::~LogMessageFatal()
    @         0x1cf37132 starrocks::Chunk::get_column_by_slot_id(int)
    @         0x2af64dc6 starrocks::StatusOr<starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> > starrocks::ArrayMapExpr::evaluate_lambda_expr<true, false>(starrocks::ExprContext*, starrocks::Chunk*, std::vector<starr
ocks::Cow<starrocks::Column>::ImmutPtr<starrocks::C@
    @         0x2af5b055 starrocks::ArrayMapExpr::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @         0x2a778b3b starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @         0x2a778255 starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @         0x1cd4c8c0 starrocks::Analytor::_add_chunk(std::shared_ptr<starrocks::Chunk> const&)
    @         0x1cd42dec starrocks::Analytor::process(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x1d8e9a89 starrocks::pipeline::AnalyticSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x22d64ae5 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1d104ad6 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1d102bbc starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1d10b906 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1d10b072 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int
)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x1d10ab36 std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1b285bee std::function<void ()>::operator()() const
    @         0x2eddd72a starrocks::FunctionRunnable::run()
    @         0x2edd7530 starrocks::ThreadPool::dispatch_thread()
    @         0x2edf8ab2 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2edf7450 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starro
cks::ThreadPool*&)
    @         0x2edf5ec4 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2edf4520 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2edf27a6 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
```

A nested array_map whose inner lambda captures the outer lambda argument, over a constant nested array, crashed the BE. When the inner array_map is prepared, extract_outer_common_exprs pulls array_length(a) out as a common sub-expression and gives it a synthetic slot id (max_used_slot_id + 1). ArrayMapExpr::get_slot_ids then exposed that synthetic slot id to enclosing scopes -- both directly and through the child lambda's captured slots, which after extraction reference it. The enclosing lambda treated it as a captured column and looked it up via Chunk::get_column_by_slot_id on the input chunk, where it never exists, aborting the BE. It shows up from a window function such as
count(array_map(a -> array_map(b -> array_length(a) + b, a), [[1,2]])) OVER (), whose analytic node keeps array_length() inline instead of extracting it in the FE.

Filter the synthetic common-expr slot ids out of get_slot_ids and report only the columns the common expressions depend on, which are the genuine captures. Apply the same fix to ArraySortLambdaExpr::get_slot_ids, which has the identical defect.

Add BE unit tests reproducing both nested-lambda shapes, and a SQLTest for the window-function query.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
