### PR TITLE
[BugFix] Keep files() schema inference off the planner meta lock for CTAS

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -48,6 +48,7 @@ import com.starrocks.sql.analyzer.InsertAnalyzer;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.analyzer.QueryAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
@@ -270,6 +271,24 @@ public class StatementPlanner {
                     new QueryAnalyzer(session).analyzeExternalTablesOnly(statement,
                             session.getSessionVariable().isEnableInsertSelectExternalAutoRefresh());
                 }
+            }
+
+            // CTAS is not an INSERT at plan time: its target table does not exist until execution, so it
+            // cannot use the deferred-lock path above. Its SELECT still needs the same treatment as an
+            // INSERT-SELECT though -- files() schema inference does an object-store LIST plus a BE
+            // get_file_schema RPC, and running that inside the PlannerMetaLock critical section stalls
+            // every db-level DDL behind the database intention lock. Pre-resolve it here; resolveTableRef
+            // reuses the already-built TableFunctionTable once the lock is held.
+            // Unwrap SUBMIT TASK as well: it carries either an INSERT (handled above) or a CTAS.
+            CreateTableAsSelectStmt ctasStmt = null;
+            if (statement instanceof CreateTableAsSelectStmt ctas) {
+                ctasStmt = ctas;
+            } else if (statement instanceof SubmitTaskStmt submitTaskStmt) {
+                ctasStmt = submitTaskStmt.getCreateTableAsSelectStmt();
+            }
+            if (ctasStmt != null && locker != null && !locker.isEmpty()
+                    && !AnalyzerUtils.collectFileTableFunctionRelation(ctasStmt.getQueryStatement()).isEmpty()) {
+                new QueryAnalyzer(session).analyzeFilesOnly(ctasStmt.getQueryStatement());
             }
 
             if (deferredLock) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
@@ -61,6 +61,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -347,6 +348,90 @@ class StatementPlannerTest extends PlanTestBase {
         } finally {
             FeConstants.runningUnitTest = originalRunningUnitTest;
         }
+    }
+
+    @Test
+    public void testCtasFilesResolvedBeforeLock() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "create table ctas_files_target as "
+                    + "with src as (select col_int, col_string "
+                    + "from files(\"path\"=\"fake://ctas\", \"format\"=\"csv\")) "
+                    + "select src.col_int as c1 from src join t0 on src.col_int = t0.v1";
+            assertFilesResolvedBeforeLock(sql);
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testSubmitTaskCtasFilesResolvedBeforeLock() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            // SUBMIT TASK carries the CTAS in its own field, so the statement is a SubmitTaskStmt and
+            // the CTAS has to be unwrapped before the pre-pass can see its files().
+            String sql = "submit task as create table submit_ctas_files_target as "
+                    + "with src as (select col_int, col_string "
+                    + "from files(\"path\"=\"fake://submit\", \"format\"=\"csv\")) "
+                    + "select src.col_int as c1 from src join t0 on src.col_int = t0.v1";
+            assertFilesResolvedBeforeLock(sql);
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    @Test
+    public void testInsertFilesMixedWithNormalTableResolvedBeforeLock() throws Exception {
+        boolean originalRunningUnitTest = FeConstants.runningUnitTest;
+        try {
+            FeConstants.runningUnitTest = false;
+            String sql = "insert into t0 select t.v1, t.v2, t.v3 "
+                    + "from files(\"path\"=\"fake://insert\", \"format\"=\"csv\") as f "
+                    + "join t0 as t on true";
+            assertFilesResolvedBeforeLock(sql);
+        } finally {
+            FeConstants.runningUnitTest = originalRunningUnitTest;
+        }
+    }
+
+    /**
+     * Asserts that every files() relation of the statement is already resolved by the time the
+     * PlannerMetaLock is taken, i.e. the object-store LIST and the BE get_file_schema RPC stay off
+     * the lock critical path.
+     */
+    private void assertFilesResolvedBeforeLock(String sql) throws Exception {
+        // parseStmtWithNewParser() analyzes as well, which would resolve files() up front and make the
+        // assertion below vacuous. Parse only, so analyzeStatement() sees a pristine AST.
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParserNotIncludeAnalyzer(sql, connectContext);
+        List<FileTableFunctionRelation> fileRelations = AnalyzerUtils.collectFileTableFunctionRelation(stmt);
+        assertFalse(fileRelations.isEmpty(), "no files() relation found in: " + sql);
+        fileRelations.forEach(relation -> assertNull(relation.getTable(),
+                "files() must be unresolved right after parsing: " + sql));
+
+        AtomicInteger lockCalls = new AtomicInteger();
+        AtomicBoolean resolvedAtLockTime = new AtomicBoolean(false);
+        PlannerMetaLocker locker = new PlannerMetaLocker(connectContext, stmt) {
+            @Override
+            public void lock() {
+                lockCalls.incrementAndGet();
+                resolvedAtLockTime.set(fileRelations.stream()
+                        .allMatch(relation -> relation.getTable() instanceof TableFunctionTable));
+                super.lock();
+            }
+        };
+        // Without an internal table to lock there is no critical section to stay out of.
+        assertFalse(locker.isEmpty(), "statement must lock at least one internal table: " + sql);
+
+        // close() drains the whole heldStack; unlock() would pop only one frame and leak a real
+        // read lock into the rest of the surefire fork if the statement ever locked twice.
+        try (PlannerMetaLocker ignored = locker) {
+            StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+        }
+
+        assertTrue(lockCalls.get() >= 1, "meta lock should be taken at least once");
+        assertTrue(resolvedAtLockTime.get(), "files() must be resolved before the meta lock is taken: " + sql);
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

CREATE TABLE ... AS SELECT ... FROM FILES(...) joined with an internal table resolved files() inside the PlannerMetaLock critical section: the object-store LIST plus the BE get_file_schema RPC ran while the database intention-shared lock was held, so every db-level DDL queued behind it. Observed holding the lock for 6.5s; the RPC's own ceiling is the 600s onceTalkTimeout on get_file_schema.

INSERT-SELECT already pre-resolves files() before taking the lock (#64274), but that pre-pass sits behind `insertStmt != null` and CTAS never reaches it: CreateTableAsSelectStmt is neither an InsertStmt nor a SubmitTaskStmt carrying one, so analyzeStatement leaves insertStmt null and falls straight through to takeLock + Analyzer.analyze.

## What I'm doing:

CTAS cannot simply reuse the INSERT path. Its target table does not exist until execution -- Analyzer.visitCreateTableAsSelectStatement says so explicitly and InsertAnalyzer.getTargetTable would throw -- so the deferred-lock branch is not available to it. Instead, unwrap the statement and run the same lock-free files() pre-pass on its query; resolveTableRef then reuses the already-built TableFunctionTable once the lock is held. SUBMIT TASK is unwrapped too: it carries either an INSERT (handled by the existing pre-pass) or a CTAS in its own field, so the statement itself is a SubmitTaskStmt in that case.

Scoped to CTAS on purpose. A plain SELECT mixing files() with an internal table has the same problem and is left to a follow-up, as are the pre-existing gaps: files() inside a view body, the listing for list_files_only=true (done later in convertFileTableFunctionRelation), and the SPM rewrite path, which pre-analyzes the query under its own lock when enable_spm_rewrite is on.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
