### PR TITLE
[Enhancement] Allow EXECUTE AS on a group member that has no StarRocks account

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/user_query_loading.md
+++ b/docs/en/administration/configuration/FE_parameters/user_query_loading.md
@@ -54,6 +54,15 @@ This topic introduces the following types of FE configurations:
 
 ## User, role, and privilege
 
+### `execute_as_external_user_allowed_groups`
+
+- Default: (empty)
+- Type: String[]
+- Unit: -
+- Is mutable: Yes
+- Description: The groups whose members can be the target of an [EXECUTE AS](../../../sql-reference/sql-statements/account-management/EXECUTE_AS.md) statement without having been created with CREATE USER first. If there are multiple, separate them with commas. Such a target becomes an ephemeral user identity that owns no privileges of its own, so its authorization comes entirely from the roles mapped to the groups the [group providers](../../user_privs/group_provider.md) report for it. Impersonating an unregistered user still requires the IMPERSONATE privilege on it, which in practice means `GRANT IMPERSONATE ON ALL USERS`, because a per-user grant cannot name a user that does not exist. Such a target must also be written as `user` or `'user'@'%'`. Empty (the default) disables the feature: EXECUTE AS then fails with `cannot find user` for anyone who was not created.
+- Introduced in: v4.2.0
+
 ### `enable_task_info_mask_credential`
 
 - Default: true

--- a/docs/en/sql-reference/sql-statements/account-management/EXECUTE_AS.md
+++ b/docs/en/sql-reference/sql-statements/account-management/EXECUTE_AS.md
@@ -17,12 +17,40 @@ EXECUTE AS user WITH NO REVERT
 
 ## Parameters
 
-`user`: The user must already exist.
+`user`: The user must already exist, unless it is a member of a group listed in `execute_as_external_user_allowed_groups`. See [Impersonating a user that was not created](#impersonating-a-user-that-was-not-created).
 
 ## Usage notes
 
 - The current login user (who calls the EXECUTE AS statement) must be granted the privilege to impersonate another user. For more information, see [GRANT](./GRANT.md).
 - The EXECUTE AS statement must contain the WITH NO REVERT clause, which means the execution context of the current session cannot be switched back to the original login user before the current session ends.
+
+## Impersonating a user that was not created
+
+From v4.2.0, a target that was never created with [CREATE USER](./CREATE_USER.md) can still be impersonated if it belongs to one of the groups listed in the FE configuration item `execute_as_external_user_allowed_groups`. This is useful when a service such as a notebook or a scheduler runs each query as the person who submitted it: those people no longer need an account in StarRocks before they can be impersonated.
+
+The group membership is read from the [group providers](../../../administration/user_privs/group_provider.md) that apply to the session. A target admitted this way becomes an *ephemeral* user identity: it owns no privileges of its own, so its authorization comes entirely from the roles mapped to its groups, and per-user settings such as `max_user_connections` do not apply to it.
+
+The configuration item is empty by default, which disables the feature. EXECUTE AS then fails with `cannot find user` for any target that was not created, and setting the item back to an empty value turns the feature off again at runtime.
+
+```SQL
+-- 1. Let the service account impersonate users that do not exist yet. Only the ALL USERS form can
+--    cover such a target: a per-user grant cannot name a user that has not been created.
+GRANT IMPERSONATE ON ALL USERS TO USER 'notebook_service'@'%';
+
+-- 2. Allow members of the group to be impersonated.
+ADMIN SET FRONTEND CONFIG ("execute_as_external_user_allowed_groups" = "analysts");
+
+-- 3. With native access control, map the group to the roles it should have. This step is not
+--    needed with Apache Ranger, which evaluates the session's groups directly.
+GRANT analyst_role TO EXTERNAL GROUP 'analysts';
+```
+
+Two restrictions apply to a target that has no account:
+
+- It must be written as `user` or `'user'@'%'`. An explicit host or the `'user'@['domain']` form is refused, because the host of the identity is also what Apache Ranger uses as the request's client IP.
+- A grant that names the user does not cover it, even if one exists because a user of the same name was created and later dropped. Impersonating a name that has no account always requires `IMPERSONATE ON ALL USERS`.
+
+Whether the target is a member of an allowed group is decided only after the caller's IMPERSONATE privilege has been verified, and a refusal is worded exactly like an unknown user. A caller without that privilege therefore cannot use EXECUTE AS to find out who exists or who belongs to which group; the reason for a refusal is written to the FE log instead.
 
 ## Examples
 

--- a/fe/fe-core/src/main/java/com/starrocks/authorization/UserPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authorization/UserPEntryObject.java
@@ -38,7 +38,11 @@ public class UserPEntryObject implements PEntryObject {
             return new UserPEntryObject(null);
         }
 
-        if (!GlobalStateMgr.getCurrentState().getAuthenticationMgr().doesUserExist(user)) {
+        // An ephemeral identity is by definition absent from AuthenticationMgr, so the existence check
+        // would reject the very users it is meant to describe. It only reaches here from the IMPERSONATE
+        // check of `EXECUTE AS` on an external target: GRANT builds its objects from a non-ephemeral
+        // UserIdentity and has already run checkUserExist(), so this does not weaken the grant path.
+        if (!user.isEphemeral() && !GlobalStateMgr.getCurrentState().getAuthenticationMgr().doesUserExist(user)) {
             throw new PrivObjNotFoundException("cannot find user " + user);
         }
         return new UserPEntryObject(user);
@@ -59,6 +63,17 @@ public class UserPEntryObject implements PEntryObject {
         UserPEntryObject other = (UserPEntryObject) obj;
         if (other.userIdentity == null) {
             return true; // this object is all
+        }
+        if (userIdentity == null) {
+            return false; // this(ALL), other(userx) -> false, as documented above
+        }
+        // UserIdentity.equals() ignores the ephemeral flag, so without this an ephemeral identity - a name
+        // with no account at all - would match a grant naming that same name. Such a grant can only be a
+        // leftover from a dropped namesake, and impersonating a name with no account must require
+        // `ON ALL USERS`. Compared in both directions because PrivilegeCollectionV2.searchObject() also
+        // calls objectMatch() with the arguments swapped.
+        if (userIdentity.isEphemeral() != other.userIdentity.isEphemeral()) {
+            return false;
         }
         return userIdentity.equals(other.userIdentity);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -4800,6 +4800,21 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static int group_provider_refresh_thread_num = 4;
 
+    /**
+     * Groups whose members may be the target of `EXECUTE AS` without having been registered with
+     * `CREATE USER` first. Such a target becomes an ephemeral user identity: it owns no privileges of
+     * its own, so its authorization comes entirely from the roles mapped to the groups the group
+     * providers report for it. If there are multiple, separate them with commas.
+     * <p>Impersonating an unregistered user still requires the IMPERSONATE privilege on it, which in
+     * practice means `GRANT IMPERSONATE ON ALL USERS` - a per-user grant cannot name a user that does
+     * not exist, and one left over from a dropped namesake does not cover it either.
+     * <p>Empty (the default) disables the feature: `EXECUTE AS` then fails with `cannot find user` for
+     * anyone who was not created. That also makes it the kill switch, available at runtime via
+     * ADMIN SET FRONTEND CONFIG.
+     */
+    @ConfField(mutable = true)
+    public static String[] execute_as_external_user_allowed_groups = {};
+
     @ConfField(mutable = true)
     public static boolean transaction_state_print_partition_info = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteAsExecutor.java
@@ -17,15 +17,20 @@ package com.starrocks.qe;
 import com.google.common.base.Preconditions;
 import com.starrocks.authentication.AuthenticationHandler;
 import com.starrocks.authentication.UserProperty;
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.ExecuteAsStmt;
 import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.UserRef;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -45,22 +50,17 @@ public class ExecuteAsExecutor {
     public static void execute(ExecuteAsStmt stmt, ConnectContext ctx) throws DdlException {
         // only support WITH NO REVERT for now
         Preconditions.checkArgument(!stmt.isAllowRevert());
-        LOG.info("{} EXEC AS {} from now on", ctx.getCurrentUserIdentity(), stmt.getToUser());
-
         UserRef user = stmt.getToUser();
-        // Create UserIdentity with ephemeral flag for external users
-        UserIdentity userIdentity;
-        if (user.isExternal()) {
-            userIdentity = UserIdentity.createEphemeralUserIdent(user.getUser(), user.getHost());
-        } else {
-            userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
-        }
-        ctx.setCurrentUserIdentity(userIdentity);
+        UserIdentity registeredIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
 
-        // Refresh groups and roles for all users based on security integration
-        refreshGroupsAndRoles(ctx, userIdentity);
+        if (ctx.getGlobalStateMgr().getAuthenticationMgr().doesUserExist(registeredIdentity)) {
+            // A registered user keeps the existing behaviour verbatim, including the fact that a failed group
+            // refresh is swallowed: those users own privileges of their own, and making a flaky group
+            // provider start failing existing EXECUTE AS would be a regression.
+            LOG.info("{} EXEC AS {} from now on", ctx.getCurrentUserIdentity(), user);
+            ctx.setCurrentUserIdentity(registeredIdentity);
+            refreshGroupsAndRoles(ctx, registeredIdentity);
 
-        if (!userIdentity.isEphemeral()) {
             UserProperty userProperty = ctx.getGlobalStateMgr().getAuthenticationMgr()
                     .getUserProperty(user.getUser());
             ctx.updateByUserProperty(userProperty);
@@ -71,7 +71,137 @@ public class ExecuteAsExecutor {
                 SetExecutor executor = new SetExecutor(ctx, setStmt);
                 executor.execute();
             }
+            return;
         }
+
+        // The target has no account. Everything is resolved into locals and applied in one go below, so a
+        // refusal or a failure anywhere leaves the session exactly as it was - rather than running as the
+        // target while still carrying the impersonator's groups and roles.
+        UserIdentity userIdentity = UserIdentity.createEphemeralUserIdent(user.getUser(), user.getHost());
+        Set<String> groups = admitExternalUserOrFail(user, ctx);
+        requireImpersonateOnEphemeralOrFail(userIdentity, user, ctx);
+        // Mutable on purpose: AuthorizationMgr.loadPrivilegeCollection's ephemeral branch aliases the
+        // context's role id set (validRoleIds = roleIdsSpecified) and then addAll()s group roles into it.
+        Set<Long> roleIds = new HashSet<>();
+        for (String group : groups) {
+            roleIds.addAll(ctx.getGlobalStateMgr().getAuthorizationMgr().getRoleIdListByGroup(group));
+        }
+
+        // Worth naming "external" in the log: it is the one case where EXEC AS grants privileges nobody
+        // granted to a user nobody created, so an auditor needs to be able to find these lines.
+        //
+        // The groups are named here, unlike in the refusal above, because here they ARE the privileges:
+        // every one of them is fed to getRoleIdListByGroup() just below and to Ranger through
+        // ctx.setGroups(), so none of them is an idle piece of directory trivia - and a group that maps to
+        // nothing today maps to something the day a policy is added. AuditEvent carries only User and
+        // AuthorizedUser (no group field), so this line is the only record of what that session's
+        // privileges rested on. Reducing it to a count would leave that question unanswerable.
+        LOG.info("{} EXEC AS {} (external) from now on, groups {}", ctx.getCurrentUserIdentity(), user, groups);
+        ctx.setCurrentUserIdentity(userIdentity);
+        ctx.setGroups(groups);
+        ctx.setCurrentRoleIds(roleIds);
+    }
+
+    /**
+     * Re-asks the IMPERSONATE question against the identity this branch is actually going to run as.
+     *
+     * <p>AuthorizerStmtVisitor.visitExecuteAsStatement chose which identity to check by asking
+     * AuthenticationMgr whether the target is registered, and the branch above asked the same question
+     * again. A `DROP USER` can land between those two questions, and then the check that passed was made
+     * against a NAMED identity while the session is about to become an EPHEMERAL one - so a grant naming
+     * the user would end up authorizing an accountless namesake. UserPEntryObject.match() refuses exactly
+     * that for a grant which outlives its user; this is the same rule for a user dropped mid-statement.
+     *
+     * <p>Only the external branch needs it. The registered branch is unchanged, and the opposite
+     * race is harmless on its own terms: a check that passed against an ephemeral identity means the caller
+     * holds IMPERSONATE ON ALL USERS, which covers a named identity too.
+     *
+     * <p>When nothing changed - every real call - this is the identical call the authorizer just made, same
+     * context and same identity, so it re-reads the merged privilege collection the first one populated.
+     * Under Ranger it is inert either way: RangerStarRocksAccessController builds its resource from
+     * impersonateUser.getUser(), and that string is the same for both identities.
+     *
+     * <p>Runs after admission rather than before it, so that a refusal stays attributable to the thing that
+     * refused: every other rejection on this path is an admission decision, and this one is not.
+     */
+    private static void requireImpersonateOnEphemeralOrFail(UserIdentity ephemeral, UserRef user, ConnectContext ctx)
+            throws DdlException {
+        try {
+            Authorizer.checkUserAction(ctx, ephemeral, PrivilegeType.IMPERSONATE);
+        } catch (AccessDeniedException e) {
+            // `cannot find user` is not a euphemism here - the account really did just disappear.
+            LOG.warn("EXECUTE AS denied for {}: {} lost its account between the IMPERSONATE check and the " +
+                            "switch, and impersonating a name with no account needs IMPERSONATE ON ALL USERS",
+                    ctx.getCurrentUserIdentity(), user);
+            throw cannotFindUser(user);
+        }
+    }
+
+    /**
+     * Decides whether a target that has no StarRocks account may be impersonated, and returns the groups
+     * its session will be authorized with.
+     *
+     * <p>This runs here rather than in the analyzer, and that placement is the point. The caller has
+     * already been shown to hold IMPERSONATE by the time the executor is reached, so answering "is this
+     * person in an allowed group?" no longer tells an unprivileged caller anything: to them every target
+     * looks the same. And the groups are resolved immediately before they are applied, so the set that
+     * admitted the target is the very set the session runs with.
+     *
+     * @return the target's groups, never null
+     * @throws DdlException with the analyzer's own wording, so a refusal here is indistinguishable from
+     *                      analyzer's `cannot find user` when the feature is off
+     */
+    private static Set<String> admitExternalUserOrFail(UserRef user, ConnectContext ctx) throws DdlException {
+        String[] allowedGroups = Config.execute_as_external_user_allowed_groups;
+        if (allowedGroups == null || allowedGroups.length == 0) {
+            // Feature off. Unreachable in practice - the analyzer already rejected - but the executor must
+            // not depend on that to stay closed.
+            throw cannotFindUser(user);
+        }
+
+        if (user.isDomain() || !"%".equals(user.getHost())) {
+            // 'u'@['domain'] only means something for a registered user. An explicit host is refused for a
+            // different reason: RangerStarRocksAccessRequest uses the identity's host as the request's
+            // client IP, so allowing one here would let the text of a SQL statement choose the value that
+            // Ranger policies match on and audit records show.
+            LOG.warn("EXECUTE AS denied for {}: {} has no account, and an unregistered target may only be " +
+                    "named as 'user' or 'user'@'%'", ctx.getCurrentUserIdentity(), user);
+            throw cannotFindUser(user);
+        }
+
+        List<String> groupProviderList = getGroupProviderListWithoutFallback(ctx);
+        if (groupProviderList == null) {
+            // Could not consult the directory this session is supposed to trust. Falling back to the
+            // default provider would admit the target on the word of a directory nobody pointed at.
+            LOG.warn("EXECUTE AS denied for {}: security integration '{}' names group providers that could " +
+                            "not be resolved, and admission must not fall back to Config.group_provider - " +
+                            "it is a different directory",
+                    ctx.getCurrentUserIdentity(), ctx.getSecurityIntegration());
+            throw cannotFindUser(user);
+        }
+
+        UserIdentity ephemeral = UserIdentity.createEphemeralUserIdent(user.getUser(), user.getHost());
+        Set<String> groups = AuthenticationHandler.getGroups(ephemeral, user.getUser(), groupProviderList);
+        if (Arrays.stream(allowedGroups).noneMatch(groups::contains)) {
+            // The FE log is the sole diagnostic channel here - the client is told nothing beyond the usual
+            // wording - but it gets the group COUNT, not the membership. The count carries what a diagnosis
+            // needs: zero says the directory answered with nothing (a provider or DN problem), non-zero says
+            // the target is known but in none of the allowed groups (a policy problem). The names themselves
+            // would only be a record of someone's directory profile, kept for the log's whole retention, on
+            // an occasion where nothing was authorized on their basis. Contrast the success path, which does
+            // log the groups: there they become the session's privileges, so the line is the only record of
+            // why that session could do what it did.
+            LOG.warn("EXECUTE AS denied for {}: {} is not a registered user, and none of its {} group(s) " +
+                            "intersect execute_as_external_user_allowed_groups {}",
+                    ctx.getCurrentUserIdentity(), user, groups.size(), Arrays.toString(allowedGroups));
+            throw cannotFindUser(user);
+        }
+        return groups;
+    }
+
+    private static DdlException cannotFindUser(UserRef user) {
+        return new DdlException("cannot find user " +
+                new UserIdentity(user.getUser(), user.getHost(), user.isDomain()) + "!");
     }
 
     /**
@@ -101,8 +231,32 @@ public class ExecuteAsExecutor {
 
     /**
      * Get group provider list based on security integration
+     * <p>Falls back to the default provider when the session's security integration cannot be resolved,
+     * which is the pre-existing behaviour and is only reached from the registered-user refresh above. Admission of
+     * an unregistered user must not fall back - see {@link #getGroupProviderListWithoutFallback}.
      */
     private static List<String> getGroupProviderList(ConnectContext ctx) {
+        List<String> groupProviderList = getGroupProviderListWithoutFallback(ctx);
+        // Fallback to default group provider
+        return groupProviderList != null ? groupProviderList : List.of(Config.group_provider);
+    }
+
+    /**
+     * The group providers the session's security integration names.
+     *
+     * <p>An unset or native integration is not a failure: {@code Config.group_provider} IS its
+     * configuration. Returning null is reserved for a session that names some other integration which then
+     * could not be resolved - deleted, erroring, or naming no provider.
+     *
+     * <p>The caller decides what that means. The registered-user refresh accepts the default provider,
+     * because it always did and because those users own privileges of their own either way. The
+     * admission gate for an unregistered user must not: the default provider is a different directory
+     * from the one the session was told to trust, and letting it vouch would admit a user on the strength
+     * of a directory nobody pointed at.
+     *
+     * @return null when the named security integration could not be resolved
+     */
+    private static List<String> getGroupProviderListWithoutFallback(ConnectContext ctx) {
         String securityIntegration = ctx.getSecurityIntegration();
 
         // If no security integration is set, use default group provider
@@ -118,12 +272,12 @@ public class ExecuteAsExecutor {
             if (si != null && si.getGroupProviderName() != null && !si.getGroupProviderName().isEmpty()) {
                 return si.getGroupProviderName();
             }
+            LOG.warn("Security integration {} names no group provider", securityIntegration);
         } catch (Exception e) {
             LOG.warn("Failed to get group provider from security integration {}: {}",
                     securityIntegration, e.getMessage());
         }
 
-        // Fallback to default group provider
-        return List.of(Config.group_provider);
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthenticationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthenticationAnalyzer.java
@@ -151,8 +151,19 @@ public class AuthenticationAnalyzer {
             if (stmt.isAllowRevert()) {
                 throw new SemanticException("`EXECUTE AS` must use with `WITH NO REVERT` for now!");
             }
-            analyzeUser(stmt.getToUser());
-            checkUserExist(stmt.getToUser(), true);
+            UserRef toUser = stmt.getToUser();
+            analyzeUser(toUser);
+
+            // Whether an unregistered target may be impersonated is decided in ExecuteAsExecutor, after
+            // the IMPERSONATE check and immediately before the session is switched - not here. Analysis
+            // runs before authorization (StatementPlanner: analyzeStatement, then Authorizer.check), so
+            // answering "does this name exist / is this person in an allowed group?" at this point would
+            // answer it for a caller who has not been shown to hold any privilege at all.
+            String[] allowedGroups = Config.execute_as_external_user_allowed_groups;
+            if (allowedGroups == null || allowedGroups.length == 0) {
+                // Feature off: reject an unknown target exactly where and how it did before.
+                checkUserExist(toUser, true);
+            }
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AuthorizerStmtVisitor.java
@@ -1504,7 +1504,17 @@ public class AuthorizerStmtVisitor implements AstVisitorExtendInterface<Void, Co
     public Void visitExecuteAsStatement(ExecuteAsStmt statement, ConnectContext context) {
         try {
             UserRef user = statement.getToUser();
-            UserIdentity userIdentity = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+            UserIdentity target = new UserIdentity(user.getUser(), user.getHost(), user.isDomain());
+            // A target with no account gets an ephemeral identity, which only `IMPERSONATE ON ALL USERS`
+            // can cover: a grant naming a user cannot legitimately exist for a name that has none, so a
+            // leftover one from a dropped namesake must not resurrect here.
+            // Read from the registry rather than from the statement on purpose - the admission decision
+            // has not been made yet, so this check is identical for members and non-members of the
+            // allowed groups and cannot be used to probe either.
+            UserIdentity userIdentity =
+                    GlobalStateMgr.getCurrentState().getAuthenticationMgr().doesUserExist(target)
+                            ? target
+                            : UserIdentity.createEphemeralUserIdent(user.getUser(), user.getHost());
             Authorizer.checkUserAction(context, userIdentity, PrivilegeType.IMPERSONATE);
         } catch (AccessDeniedException e) {
             AccessDeniedException.reportAccessDenied(

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/ExecuteAsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/ExecuteAsExecutorTest.java
@@ -19,6 +19,7 @@ import com.starrocks.authorization.AuthorizationMgr;
 import com.starrocks.authorization.DefaultAuthorizationProvider;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorReportException;
@@ -29,6 +30,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.CreateRoleStmt;
 import com.starrocks.sql.ast.CreateUserStmt;
+import com.starrocks.sql.ast.DropUserStmt;
 import com.starrocks.sql.ast.ExecuteAsStmt;
 import com.starrocks.sql.ast.GrantPrivilegeStmt;
 import com.starrocks.sql.ast.GrantRoleStmt;
@@ -301,5 +303,122 @@ public class ExecuteAsExecutorTest {
 
         // Execute as target user should fail
         Assertions.assertThrows(ErrorReportException.class, () -> Authorizer.check(executeAsStmt, context));
+    }
+
+    /**
+     * End to end on the real managers: a member of an allowed group is impersonable with no CREATE USER,
+     * and the roles mapped to its groups are what authorize the session.
+     *
+     * <p>Worth running against real managers rather than mocks because the native path has a gate beyond
+     * the executor's own: {@code AuthorizationMgr.canExecuteAs} builds a {@link
+     * com.starrocks.authorization.UserPEntryObject} for the target, and that used to insist the user
+     * exists. A test that only drove the analyzer and the executor would pass while `EXECUTE AS` still
+     * failed with AccessDenied under native access control.
+     */
+    @Test
+    public void testExecuteAsExternalUserInAllowedGroup() throws Exception {
+        String[] savedAllowedGroups = Config.execute_as_external_user_allowed_groups;
+        try {
+            Config.execute_as_external_user_allowed_groups = new String[] {"group1"};
+
+            authorizationMgr.createRole(new CreateRoleStmt(List.of("r1"), true, ""));
+            long roleId1 = authorizationMgr.getRoleIdByNameAllowNull("r1");
+            authorizationMgr.grantRole(new GrantRoleStmt(List.of("r1"), "group1", GrantType.GROUP, NodePosition.ZERO));
+
+            // Only the impersonator has an account. u1 and u2 exist in the directory alone.
+            authenticationMgr.createUser(
+                    new CreateUserStmt(new UserRef("impersonate_user", "%"), true, null, List.of(), Map.of(),
+                            NodePosition.ZERO));
+            // A per-user grant cannot name a user that does not exist, so ALL USERS is the only option.
+            authorizationMgr.grant((GrantPrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "GRANT IMPERSONATE ON ALL USERS TO USER 'impersonate_user'@'%'", new ConnectContext()));
+
+            ConnectContext context = new ConnectContext();
+            AuthenticationHandler.authenticate(context, "impersonate_user", "%", MysqlPassword.EMPTY_PASSWORD);
+            UserIdentity impersonator = context.getCurrentUserIdentity();
+
+            // u1 is in group1, which is allowed: admitted, and authorized by the group's role.
+            ExecuteAsStmt executeAsStmt = (ExecuteAsStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "EXECUTE AS u1 WITH NO REVERT", context);
+            Authorizer.check(executeAsStmt, context);
+            ExecuteAsExecutor.execute(executeAsStmt, context);
+
+            UserIdentity current = context.getCurrentUserIdentity();
+            Assertions.assertEquals("u1", current.getUser());
+            Assertions.assertTrue(current.isEphemeral(), "a target with no account must be ephemeral");
+            Assertions.assertEquals(Set.of("group1"), context.getGroups());
+            Assertions.assertEquals(Set.of(roleId1), context.getCurrentRoleIds());
+
+            // u2 is only in group2, which is not allowed. The refusal now happens in the executor, after
+            // the IMPERSONATE check, and it must leave the session exactly as it was.
+            ConnectContext other = new ConnectContext();
+            AuthenticationHandler.authenticate(other, "impersonate_user", "%", MysqlPassword.EMPTY_PASSWORD);
+            other.setGroups(Set.of("service-accounts"));
+            ExecuteAsStmt refused = (ExecuteAsStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "EXECUTE AS u2 WITH NO REVERT", other);
+            Authorizer.check(refused, other);
+            DdlException e = Assertions.assertThrows(DdlException.class,
+                    () -> ExecuteAsExecutor.execute(refused, other));
+            Assertions.assertTrue(e.getMessage().contains("cannot find user"), e.getMessage());
+            Assertions.assertEquals(impersonator, other.getCurrentUserIdentity(),
+                    "a refused EXECUTE AS must leave the session as the impersonator");
+            Assertions.assertEquals(Set.of("service-accounts"), other.getGroups(),
+                    "a refused EXECUTE AS must not touch the session's groups");
+
+            // An explicit host is refused even for the admitted member: Ranger uses the identity's host as
+            // the request's client IP, so the text of a statement must not get to choose it.
+            ExecuteAsStmt hosted = (ExecuteAsStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "EXECUTE AS 'u1'@'10.0.0.1' WITH NO REVERT", other);
+            Authorizer.check(hosted, other);
+            Assertions.assertThrows(DdlException.class, () -> ExecuteAsExecutor.execute(hosted, other));
+        } finally {
+            Config.execute_as_external_user_allowed_groups = savedAllowedGroups;
+        }
+    }
+
+    /**
+     * A grant left over from a dropped namesake must not cover the accountless name that replaces it.
+     * `UserIdentity.equals()` ignores the ephemeral flag, so without the check in
+     * {@code UserPEntryObject.match()} the old grant resurrects and `ON ALL USERS` stops being required.
+     */
+    @Test
+    public void testGrantOutlivingItsUserDoesNotCoverTheExternalNamesake() throws Exception {
+        String[] savedAllowedGroups = Config.execute_as_external_user_allowed_groups;
+        try {
+            Config.execute_as_external_user_allowed_groups = new String[] {"group1"};
+
+            authenticationMgr.createUser(
+                    new CreateUserStmt(new UserRef("impersonate_user", "%"), true, null, List.of(), Map.of(),
+                            NodePosition.ZERO));
+            authenticationMgr.createUser(
+                    new CreateUserStmt(new UserRef("u1", "%"), true, null, List.of(), Map.of(), NodePosition.ZERO));
+            authorizationMgr.grant((GrantPrivilegeStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "GRANT IMPERSONATE ON USER u1 TO USER 'impersonate_user'@'%'", new ConnectContext()));
+            authenticationMgr.dropUser(new DropUserStmt(new UserRef("u1", "%"), false, NodePosition.ZERO));
+
+            ConnectContext context = new ConnectContext();
+            AuthenticationHandler.authenticate(context, "impersonate_user", "%", MysqlPassword.EMPTY_PASSWORD);
+
+            // u1 is still in group1 in the directory, and the named grant is still on the books - but the
+            // name has no account now, so only ON ALL USERS may cover it.
+            ExecuteAsStmt executeAsStmt = (ExecuteAsStmt) UtFrameUtils.parseStmtWithNewParser(
+                    "EXECUTE AS u1 WITH NO REVERT", context);
+            Assertions.assertThrows(ErrorReportException.class, () -> Authorizer.check(executeAsStmt, context));
+        } finally {
+            Config.execute_as_external_user_allowed_groups = savedAllowedGroups;
+        }
+    }
+
+    @Test
+    public void testExecuteAsExternalUserIsOffByDefault() {
+        Assertions.assertEquals(0, Config.execute_as_external_user_allowed_groups.length,
+                "the feature must stay off unless an operator opts in");
+
+        ConnectContext context = new ConnectContext();
+        // u1 is in group1 in the directory, but nobody allowed that group and nobody created the user.
+        // With the feature off the analyzer rejects, so this never reaches the executor at all.
+        AnalysisException e = Assertions.assertThrows(AnalysisException.class,
+                () -> UtFrameUtils.parseStmtWithNewParser("EXECUTE AS u1 WITH NO REVERT", context));
+        Assertions.assertTrue(e.getMessage().contains("cannot find user"), e.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/ExternalUserImpersonationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/ExternalUserImpersonationTest.java
@@ -1,0 +1,707 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.authorization.AuthorizationMgr;
+import com.starrocks.authorization.PrivObjNotFoundException;
+import com.starrocks.authorization.PrivilegeException;
+import com.starrocks.authorization.PrivilegeType;
+import com.starrocks.authorization.UserPEntryObject;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ExecuteAsExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AuthorizerStmtVisitor;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.ExecuteAsStmt;
+import com.starrocks.sql.parser.AstBuilder;
+import com.starrocks.sql.parser.SqlParser;
+import mockit.Delegate;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import mockit.Verifications;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * `EXECUTE AS` on a user that was never created with CREATE USER.
+ *
+ * <p>Impersonation is how airflow / zeppelin / superset run a query as the person who asked for it, so
+ * every one of those people used to need a CREATE USER plus a per-user IMPERSONATE grant before they
+ * could be impersonated at all. A member of an allowed AD group now needs neither: the executor gives it
+ * an ephemeral identity whose authorization comes entirely from the roles mapped to its groups.
+ *
+ * <p>Where the decision is made matters as much as what it decides. Admission happens in the executor,
+ * after the IMPERSONATE check and immediately before the session is switched, which is what makes the
+ * refusal indistinguishable to an unprivileged caller and the approved group set identical to the one the
+ * session runs with. The analyzer only rejects when the feature is off, exactly as it did before.
+ */
+public class ExternalUserImpersonationTest {
+
+    private static final String PROVIDER_NAME = "ad";
+    private static final String ALLOWED_GROUP = "zeppelin-public";
+
+    @Mocked
+    private GlobalStateMgr globalStateMgr;
+    @Mocked
+    private AuthenticationMgr auth;
+    @Mocked
+    private AuthorizationMgr authorizationMgr;
+
+    private String[] savedGroupProvider;
+    private String[] savedAllowedGroups;
+
+    /**
+     * Answers group membership from a map instead of a directory, so {@link AuthenticationHandler#getGroups}
+     * still runs for real - provider lookup, null-provider skip, union across providers.
+     */
+    private static class FakeGroupProvider extends GroupProvider {
+        private final Map<String, Set<String>> userToGroups;
+
+        FakeGroupProvider(Map<String, Set<String>> userToGroups) {
+            super(PROVIDER_NAME, Map.of(GROUP_PROVIDER_PROPERTY_TYPE_KEY, "fake"));
+            this.userToGroups = userToGroups;
+        }
+
+        @Override
+        public Set<String> getGroup(UserIdentity userIdentity, String distinguishedName) {
+            return userToGroups.getOrDefault(distinguishedName, Set.of());
+        }
+
+        @Override
+        public void checkProperty() {
+        }
+    }
+
+    @BeforeEach
+    public void setUp() {
+        savedGroupProvider = Config.group_provider;
+        savedAllowedGroups = Config.execute_as_external_user_allowed_groups;
+        Config.group_provider = new String[] {PROVIDER_NAME};
+
+        SqlParser sqlParser = new SqlParser(AstBuilder.getInstance());
+        Analyzer analyzer = new Analyzer(Analyzer.AnalyzerVisitor.getInstance());
+        new Expectations() {
+            {
+                // Recorded on its own rather than as GlobalStateMgr.getCurrentState().getAuthenticationMgr():
+                // in a chained recording `minTimes = 0` binds to the last call only, which would make
+                // getCurrentState() mandatory - and the UserPEntryObject tests below deliberately never
+                // reach it, because skipping that lookup for an ephemeral identity is the point.
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getAuthenticationMgr();
+                minTimes = 0;
+                result = auth;
+
+                globalStateMgr.getSqlParser();
+                minTimes = 0;
+                result = sqlParser;
+
+                globalStateMgr.getAnalyzer();
+                minTimes = 0;
+                result = analyzer;
+            }
+        };
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Config is process-global; leaving it set would leak into whatever runs next in this JVM.
+        Config.group_provider = savedGroupProvider;
+        Config.execute_as_external_user_allowed_groups = savedAllowedGroups;
+    }
+
+    /**
+     * @param directory username -> groups, as the group providers see it
+     */
+    private void givenDirectory(Map<String, Set<String>> directory) {
+        FakeGroupProvider provider = new FakeGroupProvider(directory);
+        new Expectations(auth) {
+            {
+                auth.getGroupProvider(PROVIDER_NAME);
+                minTimes = 0;
+                result = provider;
+            }
+        };
+    }
+
+    private void givenNoRegisteredUsers() {
+        new Expectations(auth) {
+            {
+                auth.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = false;
+            }
+        };
+    }
+
+    private void givenEveryUserRegistered() {
+        new Expectations(auth) {
+            {
+                auth.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = true;
+
+                auth.getUserProperty(anyString);
+                minTimes = 0;
+                result = new UserProperty();
+            }
+        };
+    }
+
+    /**
+     * The caller holds `IMPERSONATE ON ALL USERS`, which is what covers an ephemeral target. Needed by every
+     * test where an external `EXECUTE AS` is expected to succeed, because the executor re-asks the
+     * IMPERSONATE question before switching the session and the real Authorizer would refuse here.
+     */
+    private void givenImpersonatePermitted() {
+        new MockUp<com.starrocks.sql.analyzer.Authorizer>() {
+            @Mock
+            public void checkUserAction(ConnectContext context, UserIdentity impersonateUser,
+                                        PrivilegeType privilegeType) {
+            }
+        };
+    }
+
+    private void givenGroupsMapToNoRoles() {
+        new Expectations(authorizationMgr) {
+            {
+                authorizationMgr.getRoleIdListByGroup(anyString);
+                minTimes = 0;
+                result = new HashSet<Long>();
+            }
+        };
+    }
+
+    private static ExecuteAsStmt analyzeExecuteAs(String user, ConnectContext ctx) {
+        // The sqlMode overload, not the SessionVariable one: ConnectContext builds its SessionVariable
+        // from the mocked VariableMgr, and the cascaded mock answers getSqlDialect() with null.
+        ExecuteAsStmt stmt = (ExecuteAsStmt) SqlParser.parse(
+                "execute as " + user + " with no revert", 1).get(0);
+        Analyzer.analyze(stmt, ctx);
+        return stmt;
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // What must not change
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void testFeatureOffKeepsTheExistingFailureInTheAnalyzer() {
+        // The default is an empty allow-list, and then this whole feature must be invisible: an
+        // unregistered target fails during analysis with the same message and at the same phase as
+        // before. If this regresses, an upgrade silently changes when EXECUTE AS fails.
+        Config.execute_as_external_user_allowed_groups = new String[] {};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+
+        ConnectContext ctx = new ConnectContext();
+        SemanticException e = Assertions.assertThrows(SemanticException.class,
+                () -> analyzeExecuteAs("alice", ctx));
+        Assertions.assertTrue(e.getMessage().contains("cannot find user"), e.getMessage());
+
+        // And no group provider is consulted: with the feature off this costs nothing and observes nothing.
+        new Verifications() {
+            {
+                auth.getGroupProvider(anyString);
+                times = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testRegisteredUserTakesTheNativePath() {
+        // A registered user must keep the native path even when the directory would also vouch for it: the
+        // external branch skips UserProperty and the session-variable restore, so mistaking a real user for
+        // an external one would quietly drop its per-user connection limit.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenEveryUserRegistered();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+        givenGroupsMapToNoRoles();
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        Assertions.assertDoesNotThrow(() -> ExecuteAsExecutor.execute(stmt, ctx));
+
+        Assertions.assertFalse(ctx.getCurrentUserIdentity().isEphemeral(),
+                "a user that exists in AuthenticationMgr must not become an ephemeral identity");
+    }
+
+    @Test
+    public void testAnalyzerDoesNotProbeTheDirectoryWhenTheFeatureIsOn() {
+        // The analyzer must not resolve groups: it runs before Authorizer.check, so anything it decides is
+        // decided for a caller who has not been shown to hold any privilege at all.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+
+        ConnectContext ctx = new ConnectContext();
+        // Neither a member nor a non-member is rejected here - admission has not happened yet.
+        Assertions.assertDoesNotThrow(() -> analyzeExecuteAs("alice", ctx));
+        Assertions.assertDoesNotThrow(() -> analyzeExecuteAs("nobody", ctx));
+
+        new Verifications() {
+            {
+                auth.getGroupProvider(anyString);
+                times = 0;
+            }
+        };
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // The IMPERSONATE check comes first, and it cannot be used to probe membership
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void testUnregisteredTargetIsCheckedAsEphemeralSoOnlyAllUsersCanCoverIt() {
+        // NativeAccessController turns the identity into a UserPEntryObject. Passing a non-ephemeral one for
+        // a name with no account would let a leftover named grant match it; passing the ephemeral one means
+        // only `IMPERSONATE ON ALL USERS` can.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+
+        UserIdentity[] checked = new UserIdentity[1];
+        PrivilegeType[] want = new PrivilegeType[1];
+        new MockUp<com.starrocks.sql.analyzer.Authorizer>() {
+            @Mock
+            public void checkUserAction(ConnectContext context, UserIdentity impersonateUser,
+                                        PrivilegeType privilegeType) {
+                checked[0] = impersonateUser;
+                want[0] = privilegeType;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        new AuthorizerStmtVisitor().visitExecuteAsStatement(stmt, ctx);
+
+        Assertions.assertEquals(PrivilegeType.IMPERSONATE, want[0]);
+        Assertions.assertNotNull(checked[0]);
+        Assertions.assertTrue(checked[0].isEphemeral(),
+                "a target with no account must be checked as an ephemeral identity");
+    }
+
+    @Test
+    public void testRegisteredTargetIsCheckedAsItself() {
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenEveryUserRegistered();
+
+        UserIdentity[] checked = new UserIdentity[1];
+        new MockUp<com.starrocks.sql.analyzer.Authorizer>() {
+            @Mock
+            public void checkUserAction(ConnectContext context, UserIdentity impersonateUser,
+                                        PrivilegeType privilegeType) {
+                checked[0] = impersonateUser;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        new AuthorizerStmtVisitor().visitExecuteAsStatement(stmt, ctx);
+
+        Assertions.assertFalse(checked[0].isEphemeral(),
+                "a registered target must still be coverable by a grant naming it");
+    }
+
+    @Test
+    public void testImpersonateCheckIsIdenticalForMembersAndNonMembers() {
+        // The membership oracle this closes: an unprivileged caller must not be able to tell an allowed
+        // member from a non-member, and the IMPERSONATE check is the only thing they can reach.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("member", Set.of(ALLOWED_GROUP), "outsider", Set.of("finance-only")));
+
+        UserIdentity[] checked = new UserIdentity[2];
+        int[] calls = new int[1];
+        new MockUp<com.starrocks.sql.analyzer.Authorizer>() {
+            @Mock
+            public void checkUserAction(ConnectContext context, UserIdentity impersonateUser,
+                                        PrivilegeType privilegeType) {
+                checked[calls[0]++] = impersonateUser;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        new AuthorizerStmtVisitor().visitExecuteAsStatement(analyzeExecuteAs("member", ctx), ctx);
+        new AuthorizerStmtVisitor().visitExecuteAsStatement(analyzeExecuteAs("outsider", ctx), ctx);
+
+        Assertions.assertEquals(2, calls[0]);
+        Assertions.assertTrue(checked[0].isEphemeral());
+        Assertions.assertTrue(checked[1].isEphemeral());
+        // Nothing consulted the directory on the way to the privilege check.
+        new Verifications() {
+            {
+                auth.getGroupProvider(anyString);
+                times = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testAccountDroppedBetweenTheCheckAndTheSwitchIsRefused() {
+        // AuthorizerStmtVisitor picks the identity to check by asking AuthenticationMgr, and the executor
+        // asks the same question again a moment later. A DROP USER landing in between would otherwise let a
+        // check that passed against a NAMED identity be spent on an EPHEMERAL one - a grant naming a user
+        // authorizing an accountless namesake, which is exactly what UserPEntryObject.match() refuses to do
+        // for a grant that outlives its user. The executor closes the transient version by re-asking.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+        givenGroupsMapToNoRoles();
+
+        boolean[] dropped = {false};
+        new Expectations(auth) {
+            {
+                auth.doesUserExist((UserIdentity) any);
+                minTimes = 0;
+                result = new Delegate<Boolean>() {
+                    @SuppressWarnings("unused")
+                    boolean doesUserExist(UserIdentity ignored) {
+                        return !dropped[0];
+                    }
+                };
+            }
+        };
+
+        // The caller holds `IMPERSONATE ON USER 'alice'` and nothing more: it covers the registered alice,
+        // and an ephemeral identity needs ON ALL USERS.
+        List<UserIdentity> checked = new ArrayList<>();
+        new MockUp<com.starrocks.sql.analyzer.Authorizer>() {
+            @Mock
+            public void checkUserAction(ConnectContext context, UserIdentity impersonateUser,
+                                        PrivilegeType privilegeType) throws AccessDeniedException {
+                checked.add(impersonateUser);
+                if (impersonateUser.isEphemeral()) {
+                    throw new AccessDeniedException();
+                }
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        UserIdentity impersonator = new UserIdentity("svc_datasvc", "%");
+        ctx.setCurrentUserIdentity(impersonator);
+        ctx.setGroups(new HashSet<>(Set.of("service-accounts")));
+        ctx.setCurrentRoleIds(new HashSet<>(Set.of(42L)));
+
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        new AuthorizerStmtVisitor().visitExecuteAsStatement(stmt, ctx);
+        Assertions.assertEquals(1, checked.size());
+        Assertions.assertFalse(checked.get(0).isEphemeral(), "alice still had an account at this point");
+
+        dropped[0] = true;   // DROP USER alice
+
+        DdlException e = Assertions.assertThrows(DdlException.class,
+                () -> ExecuteAsExecutor.execute(stmt, ctx));
+        // Not a euphemism: the account really did just disappear.
+        Assertions.assertEquals("cannot find user 'alice'@'%'!", e.getMessage());
+
+        Assertions.assertEquals(2, checked.size(), "the executor must ask again for the identity it will use");
+        Assertions.assertTrue(checked.get(1).isEphemeral(),
+                "the second question has to be about the identity the session would actually become");
+        Assertions.assertEquals(impersonator, ctx.getCurrentUserIdentity());
+        Assertions.assertEquals(Set.of("service-accounts"), ctx.getGroups());
+        Assertions.assertEquals(Set.of(42L), ctx.getCurrentRoleIds());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Admission, in the executor
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void testMemberOfAllowedGroupGetsAnEphemeralIdentityCarryingItsGroups() {
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of("some-other-group", ALLOWED_GROUP)));
+        givenGroupsMapToNoRoles();
+        givenImpersonatePermitted();
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        Assertions.assertDoesNotThrow(() -> ExecuteAsExecutor.execute(stmt, ctx));
+
+        UserIdentity current = ctx.getCurrentUserIdentity();
+        Assertions.assertEquals(new UserIdentity("alice", "%"), current);
+        Assertions.assertTrue(current.isEphemeral(),
+                "an unregistered target has no privilege collection to merge, so it must be ephemeral");
+        // This is the whole point: group-based Ranger policies and group-mapped roles are evaluated against
+        // the impersonated person's groups, not the service account's.
+        Assertions.assertEquals(Set.of("some-other-group", ALLOWED_GROUP), ctx.getGroups());
+    }
+
+    @Test
+    public void testNonMemberIsRefusedWithTheSameWordingAsAnUnknownUser() {
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("bob", Set.of("finance-only", "payroll-admins")));
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("bob", ctx);
+        DdlException e = Assertions.assertThrows(DdlException.class,
+                () -> ExecuteAsExecutor.execute(stmt, ctx));
+
+        // Indistinguishable from the plain unknown-user rejection, and it names neither the groups nor
+        // the allow-list.
+        Assertions.assertEquals("cannot find user 'bob'@'%'!", e.getMessage());
+        Assertions.assertFalse(e.getMessage().contains("finance-only"), e.getMessage());
+        Assertions.assertFalse(e.getMessage().contains(ALLOWED_GROUP), e.getMessage());
+        Assertions.assertFalse(e.getMessage().contains("execute_as_external_user_allowed_groups"),
+                e.getMessage());
+    }
+
+    @Test
+    public void testRefusalLeavesTheSessionUntouched() {
+        // Atomicity: nothing is applied until the target is admitted and its roles computed, so a refusal
+        // must not leave the session running as the target while carrying the caller's groups and roles.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("bob", Set.of("finance-only")));
+
+        ConnectContext ctx = new ConnectContext();
+        UserIdentity impersonator = new UserIdentity("svc_datasvc", "%");
+        ctx.setCurrentUserIdentity(impersonator);
+        ctx.setGroups(new HashSet<>(Set.of("service-accounts")));
+        ctx.setCurrentRoleIds(new HashSet<>(Set.of(42L)));
+
+        ExecuteAsStmt stmt = analyzeExecuteAs("bob", ctx);
+        Assertions.assertThrows(DdlException.class, () -> ExecuteAsExecutor.execute(stmt, ctx));
+
+        Assertions.assertEquals(impersonator, ctx.getCurrentUserIdentity());
+        Assertions.assertFalse(ctx.getCurrentUserIdentity().isEphemeral());
+        Assertions.assertEquals(Set.of("service-accounts"), ctx.getGroups());
+        Assertions.assertEquals(Set.of(42L), ctx.getCurrentRoleIds());
+    }
+
+    @Test
+    public void testGroupResolutionFailureLeavesTheSessionUntouched() {
+        // Same guarantee when the provider throws rather than the target being refused.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        new Expectations(auth) {
+            {
+                auth.getGroupProvider(PROVIDER_NAME);
+                minTimes = 0;
+                result = new IllegalStateException("group provider is unavailable");
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        UserIdentity impersonator = new UserIdentity("svc_datasvc", "%");
+        ctx.setCurrentUserIdentity(impersonator);
+        ctx.setGroups(new HashSet<>(Set.of("service-accounts")));
+        ctx.setCurrentRoleIds(new HashSet<>(Set.of(42L)));
+
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        // The provider's own failure, not a DdlException: AuthenticationHandler.getGroups() does not catch
+        // and GroupProvider.getGroup() declares nothing checked, so it escapes execute() as it was thrown.
+        // Asserting the type and message is what proves the group-resolution path actually ran - a broader
+        // Exception.class would also be satisfied by a mock that never took effect.
+        IllegalStateException thrown = Assertions.assertThrows(IllegalStateException.class,
+                () -> ExecuteAsExecutor.execute(stmt, ctx));
+        Assertions.assertEquals("group provider is unavailable", thrown.getMessage());
+
+        Assertions.assertEquals(impersonator, ctx.getCurrentUserIdentity());
+        Assertions.assertFalse(ctx.getCurrentUserIdentity().isEphemeral());
+        Assertions.assertEquals(Set.of("service-accounts"), ctx.getGroups());
+        Assertions.assertEquals(Set.of(42L), ctx.getCurrentRoleIds());
+    }
+
+    @Test
+    public void testUserUnknownToTheDirectoryIsRefused() {
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("nobody", ctx);
+        Assertions.assertThrows(DdlException.class, () -> ExecuteAsExecutor.execute(stmt, ctx));
+    }
+
+    @Test
+    public void testGroupProviderThatCannotAnswerRefuses() {
+        // No provider registered under the configured name: getGroups() skips it and returns nothing. The
+        // gate has to read that as "refused", never as "unrestricted".
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        new Expectations(auth) {
+            {
+                auth.getGroupProvider(anyString);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        Assertions.assertThrows(DdlException.class, () -> ExecuteAsExecutor.execute(stmt, ctx));
+    }
+
+    @Test
+    public void testUnresolvableSecurityIntegrationRefusesInsteadOfFallingBack() {
+        // getGroupProviderList falls back to Config.group_provider when the session names a security
+        // integration that cannot be resolved. For the registered-user refresh that is the existing behaviour,
+        // but admission must not accept it: the default provider is a different directory from the one the
+        // session was told to trust. The mocked AuthenticationMgr answers getSecurityIntegration with null,
+        // which is exactly the shape of an integration that was deleted.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+        givenGroupsMapToNoRoles();
+        givenImpersonatePermitted();
+
+        ConnectContext ctx = new ConnectContext();
+        ctx.setSecurityIntegration("partner_oauth");
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        Assertions.assertThrows(DdlException.class, () -> ExecuteAsExecutor.execute(stmt, ctx));
+
+        // And the strictness is scoped: the same user is admitted when no integration is named, because
+        // then Config.group_provider is the configuration rather than a fallback. Without this half, the
+        // assertion above would also pass if admission had simply stopped working.
+        ConnectContext nativeCtx = new ConnectContext();
+        ExecuteAsStmt nativeStmt = analyzeExecuteAs("alice", nativeCtx);
+        Assertions.assertDoesNotThrow(() -> ExecuteAsExecutor.execute(nativeStmt, nativeCtx));
+        Assertions.assertTrue(nativeCtx.getCurrentUserIdentity().isEphemeral());
+    }
+
+    @Test
+    public void testExplicitHostIsRefusedForAnUnregisteredTarget() {
+        // RangerStarRocksAccessRequest uses the identity's host as the request's client IP, so allowing an
+        // explicit host for a name with no account would let SQL text choose the value Ranger policies
+        // match on and audit records show. Only 'user' and 'user'@'%' are eligible.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+        givenGroupsMapToNoRoles();
+        givenImpersonatePermitted();
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt pinned = analyzeExecuteAs("'alice'@'10.0.0.1'", ctx);
+        Assertions.assertThrows(DdlException.class, () -> ExecuteAsExecutor.execute(pinned, ctx));
+
+        ConnectContext domainCtx = new ConnectContext();
+        ExecuteAsStmt domain = analyzeExecuteAs("alice@['corp.example.com']", domainCtx);
+        Assertions.assertThrows(DdlException.class, () -> ExecuteAsExecutor.execute(domain, domainCtx));
+
+        // The wildcard forms stay eligible.
+        ConnectContext wildcardCtx = new ConnectContext();
+        ExecuteAsStmt wildcard = analyzeExecuteAs("'alice'@'%'", wildcardCtx);
+        Assertions.assertDoesNotThrow(() -> ExecuteAsExecutor.execute(wildcard, wildcardCtx));
+        Assertions.assertTrue(wildcardCtx.getCurrentUserIdentity().isEphemeral());
+    }
+
+    @Test
+    public void testGroupRolesAreAppliedAsAMutableSet() {
+        // AuthorizationMgr.loadPrivilegeCollection's ephemeral branch aliases the context's role id set
+        // (validRoleIds = roleIdsSpecified) and then addAll()s the group roles into it, so an immutable set
+        // would arm an UnsupportedOperationException inside an authorization check.
+        Config.execute_as_external_user_allowed_groups = new String[] {ALLOWED_GROUP};
+        givenNoRegisteredUsers();
+        givenDirectory(Map.of("alice", Set.of(ALLOWED_GROUP)));
+        new Expectations(authorizationMgr) {
+            {
+                authorizationMgr.getRoleIdListByGroup(ALLOWED_GROUP);
+                minTimes = 0;
+                result = new HashSet<>(Set.of(7L));
+            }
+        };
+        givenImpersonatePermitted();
+
+        ConnectContext ctx = new ConnectContext();
+        ExecuteAsStmt stmt = analyzeExecuteAs("alice", ctx);
+        Assertions.assertDoesNotThrow(() -> ExecuteAsExecutor.execute(stmt, ctx));
+
+        Assertions.assertEquals(Set.of(7L), ctx.getCurrentRoleIds(),
+                "the roles mapped to the admitted groups are what authorize the session");
+        Assertions.assertDoesNotThrow(() -> ctx.getCurrentRoleIds().add(1L));
+        Assertions.assertDoesNotThrow(() -> ctx.getGroups().add("late-arriving-group"));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // UserPEntryObject: the privilege object of a user that does not exist
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void testEphemeralPrivilegeObjectSkipsTheExistenceCheck() throws PrivilegeException {
+        givenNoRegisteredUsers();
+
+        UserPEntryObject object = UserPEntryObject.generate(
+                UserIdentity.createEphemeralUserIdent("alice", "%"));
+
+        Assertions.assertNotNull(object);
+        Assertions.assertEquals(new UserIdentity("alice", "%"), object.getUserIdentity());
+    }
+
+    @Test
+    public void testNonEphemeralUnknownUserIsStillRejectedAsAPrivilegeObject() {
+        // The grant path builds non-ephemeral identities, so loosening the check must not reach it:
+        // GRANT IMPERSONATE ON USER 'typo' has to keep failing.
+        givenNoRegisteredUsers();
+
+        Assertions.assertThrows(PrivObjNotFoundException.class,
+                () -> UserPEntryObject.generate(new UserIdentity("typo", "%")));
+    }
+
+    @Test
+    public void testOnlyAllUsersCoversAnEphemeralTarget() throws PrivilegeException {
+        givenEveryUserRegistered();
+
+        UserPEntryObject requested = UserPEntryObject.generate(
+                UserIdentity.createEphemeralUserIdent("alice", "%"));
+        UserPEntryObject grantedOnAllUsers = UserPEntryObject.generate(null);
+        UserPEntryObject grantedOnSameName = UserPEntryObject.generate(new UserIdentity("alice", "%"));
+        UserPEntryObject grantedOnSomeoneElse = UserPEntryObject.generate(new UserIdentity("bob", "%"));
+
+        // GRANT IMPERSONATE ON ALL USERS - the only grant that can cover a user nobody created.
+        Assertions.assertTrue(requested.match(grantedOnAllUsers));
+        // A grant naming that same name can only be a leftover from a dropped namesake. It must not come
+        // back to life just because someone with no account now answers to the name.
+        Assertions.assertFalse(requested.match(grantedOnSameName));
+        // Checked the other way too, because PrivilegeCollectionV2.searchObject() swaps the arguments.
+        Assertions.assertFalse(grantedOnSameName.match(requested));
+        Assertions.assertFalse(requested.match(grantedOnSomeoneElse));
+
+        // A registered target is still covered by a grant naming it.
+        UserPEntryObject registered = UserPEntryObject.generate(new UserIdentity("alice", "%"));
+        Assertions.assertTrue(registered.match(grantedOnSameName));
+        Assertions.assertTrue(registered.match(grantedOnAllUsers));
+    }
+
+    @Test
+    public void testAllUsersObjectDoesNotMatchANamedRequest() throws PrivilegeException {
+        // The class documents "this(ALL), other(userx) -> false" but used to dereference a null
+        // userIdentity to get there.
+        givenEveryUserRegistered();
+
+        UserPEntryObject allUsers = UserPEntryObject.generate(null);
+        UserPEntryObject named = UserPEntryObject.generate(new UserIdentity("alice", "%"));
+
+        Assertions.assertFalse(Assertions.assertDoesNotThrow(() -> allUsers.match(named)));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

`UserRef.isExternal`, `ExecuteAsExecutor`'s `createEphemeralUserIdent()` branch, `AuthorizationMgr.loadPrivilegeCollection`'s ephemeral branch and `ConnectContext.getRoleIdsByUser`'s ephemeral branch are all already on main. **Nothing ever sets the flag.** There is no `EXTERNAL` in the grammar (`executeAsStatement: EXECUTE AS user (WITH NO REVERT)?`) and no caller of the 5-arg `UserRef` constructor with `isExternal = true`, so that whole path is unreachable today and `EXECUTE AS` on a user that was not created fails in the analyzer:

```
SemanticException: cannot find user 'alice'@'%'!
```

Impersonation is how a notebook, a scheduler or a BI service runs each query as the person who submitted it, so that person's own privileges and group policies apply. With only the registered-user path available, every one of those people first needs:

```sql
CREATE USER 'alice'@'%' IDENTIFIED WITH authentication_ldap_simple;
GRANT IMPERSONATE ON USER 'alice' TO USER 'notebook_service'@'%';
```

The second line can already be replaced by one wildcard grant — `GRANT IMPERSONATE ON ALL USERS` works on main, because `privObjectTypePlural` includes `USERS`, `AuthorizationAnalyzer.analyzeUserPrivToken` maps `ALL` to `userIdentity = null`, and `UserPEntryObject.match()` returns true when `other.userIdentity == null`. The `CREATE USER` is what remains, and the real cost is not the typing: automating it means building and operating an AD → StarRocks user-provisioning pipeline. If StarRocks can trust the groups the directory already manages, that pipeline does not need to exist.

## What I'm doing:

Marking the target external when it is a member of a group the operator allowed, so the existing ephemeral path becomes reachable. The new `execute_as_external_user_allowed_groups` (`String[]`, mutable, **empty by default**) names those groups; membership is read from the group providers that apply to the session.

**Where the decision is made is the load-bearing part.** `StatementPlanner` runs `analyzeStatement()` first and `Authorizer.check()` after it, so an admission decision taken in the analyzer is taken for a caller who has not been shown to hold *any* privilege. The decision therefore lives in `ExecuteAsExecutor`, after the IMPERSONATE check and immediately before the switch. By then the caller is known to hold IMPERSONATE, so answering "is this person in an allowed group?" tells an unprivileged caller nothing: to them, a registered target, an allowed member and a stranger all return the same `Access denied`. The analyzer keeps exactly one job — when the feature is off, reject an unknown target where and how it always did. That is a net **+15/−2** on `AuthenticationAnalyzer`.

Two consequences fall out of the placement. `AuthorizerStmtVisitor` has to pick the identity to check without consulting the pending decision, so it asks `AuthenticationMgr` instead of the statement — which is what makes the check identical for members and non-members. And the groups are resolved immediately before they are applied, so the set that admitted the target *is* the set the session runs with, with nothing carried on the AST between the two. `ExecuteAsStmt` therefore stays byte-identical to main; no AST mutation, no analyzer-resolved state on a parser node.

**Native access control needed a second fix, not just the analyzer.** `AuthorizationMgr.canExecuteAs` → `UserPEntryObject.generate()` threw `PrivObjNotFoundException`, which `canExecuteAs` catches as `return false`, so the wildcard grant still produced AccessDenied. The IMPERSONATE check now carries the ephemeral flag and `generate()` skips the existence check for an ephemeral identity. Without that half the feature works under Ranger — which resolves policies from the username string and so has no existence check — and silently does not under native access control, which is the default and is also what `fe-auth-unit-tests` runs. The new end-to-end test in `ExecuteAsExecutorTest` pins it:

```
Access denied; you need (at least one of) the IMPERSONATE privilege(s) on USER u1 for this operation.
```

is exactly what that test reports if the `UserPEntryObject` line is reverted.

The relaxation does not reach `GRANT`. All three `generate()` call sites were checked: `AuthorizationMgr:321` passes `null` and returns before the check, `AuthorizationMgr:906` is `canExecuteAs` (the site this must pass), and `AuthorizationAnalyzer:141` is the grant path, which builds a **non**-ephemeral `UserIdentity` and has already run `checkUserExist()` — so `GRANT IMPERSONATE ON USER 'typo'` keeps failing. There is a test for that.

**A grant may not outlive its user into a namesake.** `UserIdentity.equals()` ignores the ephemeral flag, so once an ephemeral *requested* object can exist at all, this sequence grants more than anyone intended:

```sql
CREATE USER alice;
GRANT IMPERSONATE ON USER 'alice' TO USER 'svc';   -- svc may impersonate this alice
DROP USER alice;                                   -- that privilege should end here
EXECUTE AS 'alice';                                -- but alice is still in an allowed group
```

`GRANT` cannot name a user that does not exist and `removeInvalidObject()` only sweeps stale entries on its next pass, so impersonating a name with no account must require `ON ALL USERS`. `UserPEntryObject.match()` now refuses when the two identities disagree on ephemerality, compared in **both** directions because `PrivilegeCollectionV2.searchObject()` also calls `objectMatch()` with the arguments swapped. Honouring the already-documented `this(ALL), other(userx) -> false` case on the way also closes a latent NPE.

Because `AuthorizerStmtVisitor` and the executor each ask `AuthenticationMgr` separately, a `DROP USER` can also land *between* them — the transient form of the same bug, where a check that passed against a named identity gets used for an ephemeral switch. The executor re-asks the IMPERSONATE question against the ephemeral identity it is about to become. On the normal path that is the identical call the authorizer just made, same context and same identity, so it re-reads the merged privilege collection the first one populated. (Worth knowing that the window is genuinely small but real: `PrepareAnalyzer` refuses `!(innerStmt instanceof QueryStatement)` before analyzing the inner statement and `RedirectStatus` is `NO_FORWARD`, so analyze → authorize → execute is always contiguous within one statement — contiguous, but not atomic against another session's `DROP USER`.)

**Everything is applied at once.** For an unregistered target, groups and role ids are resolved into locals and set together with the identity, so a refusal or a failure anywhere leaves the session exactly as it was. The alternative — switching the identity first and then clearing groups on failure — is fail-closed on privileges but presents to a client as "the statement succeeded and nothing works": a scheduler's connection comes up and the task proceeds with zero privileges, and a BI tool's prequery passes and the real query fails with an unrelated-looking error. Failing the statement is what makes the failure visible as one. The **registered** path is deliberately left verbatim, including the fact that it swallows a failed group refresh: those users own privileges of their own, and making a flaky group provider start failing existing `EXECUTE AS` would be a regression. Atomicity applies to the external path only.

**Fail-closed on every "don't know".**

- An unregistered target may only be written as `user` or `'user'@'%'`. `RangerStarRocksAccessRequest` uses the identity's host as the request's client IP, so allowing an explicit host would let the text of a SQL statement choose the value Ranger policies match on and audit records show. `'u'@['domain']` only means something for a registered user anyway.
- `getGroupProviderList` falls back to `Config.group_provider` when the session's security integration cannot be resolved. That is fine for the registered-user refresh, but **admission must not accept it**: the default provider is a different directory from the one the session was told to trust. An unset or `native` integration is *not* a failure — there `Config.group_provider` is the configuration — so only a named-but-unresolvable integration denies.
- Every refusal on this path throws the analyzer's own `cannot find user` wording, so it is indistinguishable from the feature being off. The reason goes to the FE log — and the non-member refusal logs the group **count**, not the names: zero says the directory answered with nothing (a provider or DN problem), non-zero says the target is known but in none of the allowed groups (a policy problem), and that is all a diagnosis needs from an occasion where nothing was authorized. The success path does log the group names, because there they *are* the session's privileges and `AuditEvent` has only `User` and `AuthorizedUser` with no group field, so that line is the only record of what the session's access rested on.
- No reverse lookup is added. `getGroup()` reads the provider cache and does no directory I/O, which matters because `RestBaseAction` takes the same group-resolution path on every HTTP request (stream load) — an on-demand lookup would turn a burst into an LDAP storm.

**A registered target is untouched** — the executor takes the existing branch and keeps its own privileges, its `UserProperty` (so `max_user_connections` still applies) and its session-variable restore. Marking a real user external would quietly drop those, so there is a test asserting a registered user never takes the external path even when the directory would also vouch for it.

### Design point worth reviewing

I gated this on a config item rather than on grammar. `UserRef.isExternal` with no producer suggests an `EXECUTE AS EXTERNAL USER 'alice'` keyword may have been the intent, and a keyword would make the caller's intent explicit at the call site.

The reason I did not take it is client-side, and it is the concrete blocker rather than a preference: impersonation is issued by client integrations, not by hand, and each of the three we run does it differently — a JDBC interpreter hooking `getConnection()`, a scheduler injecting a MySQL `init_command`, and a BI tool emitting a prequery per query. A new keyword means changing and redeploying all three (one of them upstream in another project) before anyone can use the feature, whereas the automatic fallback is completely transparent to them. The config also keeps the decision with the operator rather than with whoever writes the SQL, and doubles as a runtime kill switch.

**Happy to add the keyword instead, or in addition, if maintainers prefer.** Note that with the decision now in the executor, `isExternal` is no longer read on this path at all; if the field is meant to stay, a keyword is the thing that would give it a producer.

### Deliberately out of scope

Two adjacent issues live in pre-existing `AuthorizationMgr` code and would affect **every** authorization check, so they want their own PR and their own test matrix rather than riding along here:

- **Privilege-cache key mutation.** `loadPrivilegeCollection`'s ephemeral branch aliases the context's role-id set (`validRoleIds = roleIdsSpecified`) and then `addAll()`s into it — a `Set` inside a Guava cache key whose `hashCode` changes after insertion. Cross-identity *sharing* is already prevented: `DROP USER → onDropUser → invalidateUserInCache`, plus GRANT/REVOKE invalidation, and `LeaderOpExecutor` sends `user_roles` so the load is normally idempotent. This PR only avoids making it worse: the role-id set handed over is always a fresh mutable `HashSet`.
- **Strict handling when several group providers are configured.** `getGroups` does `continue` on `provider == null`, so one provider answering while another is missing is indistinguishable from a smaller union — and admission would then decide on partial information. This matters the moment more than one provider is configured.

### Tests

| Where | Covers |
|---|---|
| `ExternalUserImpersonationTest` (new, 20 tests) | analyzer probes the directory only when the feature is off; registered target keeps the native path; member admitted with its groups and group-mapped roles; non-member, directory-unknown, unresolvable-integration and explicit-host all refused with the same wording; IMPERSONATE check identical for members and non-members; ephemeral-vs-named `match()` both ways; account dropped between the check and the switch refused; session left untouched by every refusal and by a failing group provider |
| `ExecuteAsExecutorTest` (+3 tests) | end to end on the real `AuthenticationMgr` / `AuthorizationMgr` / `LDAPGroupProvider`: `GRANT IMPERSONATE ON ALL USERS`, then `EXECUTE AS` an uncreated group member → admitted, ephemeral, carrying the role mapped to its group; non-member refused with the session intact; explicit host refused; a grant outliving a dropped namesake does **not** cover the accountless name; feature off by default |
| `ExecuteAsStmtTest`, `AuthorizationMgrTest`, `InvalidateObjectTest`, `PrivilegeStmtAnalyzerV2Test`, `PrivilegeCheckerTest`, `SecurityIntegrationTest`, `GroupProviderPermissionTest`, `AuthenticationHandlerTest` | unmodified, as the regression gate for the previous behavior |

Locally on this branch: 187 tests green on `2893cdbfd`, checkstyle clean on `fe-core` and `fe-parser`.

Reverting each fix fails only the corresponding tests, and `ExecuteAsStmtTest` is never affected. The mutations were applied one at a time, because reverting the placement change masks the others:

| Reverted | Fails |
|---|---|
| ephemeral existence-check skip in `UserPEntryObject` | `ExecuteAsExecutorTest.testExecuteAsExternalUserInAllowedGroup` — AccessDenied on the wildcard grant, i.e. the native-only symptom |
| ephemeral-vs-named distinction in `match()` | `ExecuteAsExecutorTest.testGrantOutlivingItsUserDoesNotCoverTheExternalNamesake` — `Expected ErrorReportException to be thrown, but nothing was thrown` |
| host restriction | `ExecuteAsExecutorTest.testExecuteAsExternalUserInAllowedGroup` — `Expected DdlException to be thrown, but nothing was thrown` |
| admission moved back into the analyzer | `testAnalyzerDoesNotProbeTheDirectoryWhenTheFeatureIsOn` and 11 others |
| IMPERSONATE check always non-ephemeral | `testUnregisteredTargetIsCheckedAsEphemeralSoOnlyAllUsersCanCoverIt`, `testImpersonateCheckIsIdenticalForMembersAndNonMembers` |
| the pre-switch IMPERSONATE re-check | `testAccountDroppedBetweenTheCheckAndTheSwitchIsRefused` only |

One mutation was worth more than the fix it tested: neutralizing the group-provider mock turned `IllegalStateException` into `DdlException`, and the pre-existing `assertThrows(Exception.class)` had been passing either way — it was not actually proving the group-resolution path ran at all. The assertions are now on the specific type and message.

### Verified on a real deployment

This is a `main`-targeted forward port. The same change ran first as a 4.1.4 backport in our own fork, so the following evidence is from that build rather than from this branch — the code is the same, the base is not.

- The fork's full auth suite (`fe-auth-unit-tests`, 35 classes / 394 tests) is green, which matters because `ExecuteAsExecutorTest` cannot run on our dev machines (Mockito's inline mock maker fails there) and it is the only test that directly covers the restructured `execute()`.
- Deployed to a staging cluster with **no** `SECURITY INTEGRATION`, i.e. the `Config.group_provider` path. Confirmed: an unregistered member of an allowed group is impersonated successfully; a non-member and an unknown name are refused with no group information reaching the client; a registered user still takes the native path; `'user'@'10.0.0.1'` is refused while `'user'@'%'` succeeds; the refusal log carries the group count, not the names. Both new refusal paths were confirmed from the FE log:

```
WARN [ExecuteAsExecutor.admitExternalUserOrFail():167]
     EXECUTE AS denied for 'root'@'%': '<user>'@'10.0.0.1' has no account, and an
     unregistered target may only be named as 'user' or 'user'@'%'

WARN [ExecuteAsExecutor.admitExternalUserOrFail():194]
     EXECUTE AS denied for 'root'@'%': 'zz_nonexistent_probe_9x'@'%' is not a registered
     user, and none of its 0 group(s) intersect execute_as_external_user_allowed_groups [...]
```

- Under `access_control = ranger`, `current_role()` is `NONE` for such a session and that is correct: the groups are what Ranger evaluates, and `SHOW DATABASES` returns the expected set.
- Still outstanding on our side, and I will report back rather than claim it: the `SECURITY INTEGRATION` variant of the group-provider resolution (the deny-instead-of-fallback branch) has not yet been exercised on a live cluster, only in tests.

### Known limitations, for the record

- **Group membership is as fresh as the provider cache, with no TTL.** During a prolonged directory outage the last known good membership keeps admitting new sessions indefinitely, so someone removed from a group can still be impersonated until the refresh recovers. This is the deliberate trade from the group-provider side (an expiring cache turns an outage into fleet-wide `Access denied` instead), and the mitigation is operational: alert on the refresh-failure log and use the kill switch. Flagging it because for an *unregistered* target the groups are the entire authorization, so the exposure is larger here than for a registered user.
- **The kill switch stops new impersonations only.** `WITH NO REVERT` means there is nothing to revert, so already-impersonating sessions need `KILL`.
- **The feature being off is not observable in the FE log.** With an empty allow-list the analyzer throws `SemanticException` and logs nothing at all — measured on a live cluster: many refusals over three hours, zero `cannot find user` log lines. `ADMIN SET FRONTEND CONFIG` is volatile, so an operator who does not also write `fe.conf` gets the feature silently disabled by the next FE restart with no log trace. The right detector is a probe reading `ADMIN SHOW FRONTEND CONFIG`, not a log alert; I mention it because it is a property of this design, not a bug to fix here.
- Membership and the group→role snapshot are fixed for the life of the connection.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`execute_as_external_user_allowed_groups` is empty by default, and the feature is entirely off while it is: the analyzer rejects an unknown target before anything else runs, so deploying this changes nothing until an operator opts in. There is no grammar change, no new privilege type, and no persisted-metadata change, so upgrade and downgrade are unaffected. Setting the item back to `""` disables it again at runtime via `ADMIN SET FRONTEND CONFIG`.

Two things change even without opting in, both narrow:

- `UserPEntryObject.match()` now returns false when two identities disagree on ephemerality. Ephemeral identities reach it only from this path, so no existing grant or check is affected — but it is a change in a shared method and worth a reviewer's eye. It also makes the documented `this(ALL), other(userx) -> false` case actually return false instead of dereferencing null.
- The `EXEC AS` FE log line gains ` (external)` and the resolved groups for an external target, so an auditor can find the sessions where `EXECUTE AS` granted privileges nobody granted to a user nobody created. `UserIdentity.toString()` is deliberately unchanged, so the audit log's `authorizedUser` does not distinguish a registered from an external target — changing it would widen the diff and could break existing log parsers. Say the word if you would rather have it in the audit log too.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

`execute_as_external_user_allowed_groups` is documented under "User, role, and privilege" in `docs/en/administration/configuration/FE_parameters/user_query_loading.md`; `build-support/extract_and_diff_params.py --new-params-only` reports nothing missing. `docs/en/sql-reference/sql-statements/account-management/EXECUTE_AS.md` gains an "Impersonating a user that was not created" section covering the host restriction and the `ON ALL USERS` requirement. I left `docs/{zh,ja}/.../EXECUTE_AS.md` untouched rather than machine-translating them — happy to add them if that is preferred.

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Not a bugfix, so no backport is requested. It does apply cleanly to 4.1 if maintainers want it there — that is where our own build runs.

cc/ @HangyuanLiu — this builds directly on the external-group and ephemeral-identity work in #63258 / #63385 / #62337, so I would value your read on whether the config gate is the shape you had in mind for `UserRef.isExternal`, and on the `UserPEntryObject.match()` change in particular.
