### PR TITLE
[BugFix] Fix substr returning bytes of neighboring rows on invalid UTF-8 (backport #78722)

### DIFF
--- a/be/src/exprs/locate.cpp
+++ b/be/src/exprs/locate.cpp
@@ -196,8 +196,7 @@ ColumnPtr haystack_vector_and_needle_vector(const ColumnPtr& haystack_ptr, const
             auto searcher =
                     LocateCaseSensitiveUTF8::createSearcherInSmallHaystack(needle_slice.data, needle_slice.size);
 
-            const char* beg =
-                    skip_leading_utf8(haystack_slice.data, haystack_slice.data + haystack_size - 1, start - 1);
+            const char* beg = skip_leading_utf8(haystack_slice.data, haystack_slice.data + haystack_size, start - 1);
             /// searcher returns a pointer to the found substring or to the end of `haystack`.
             const char* res_pointer = searcher.search(beg, haystack_size - (beg - haystack_slice.data));
             if (!res_pointer) {

--- a/be/src/util/utf8.h
+++ b/be/src/util/utf8.h
@@ -95,10 +95,12 @@ static inline Slice truncate_utf8(const Slice& str, const size_t max_size) {
 template <bool use_skipped_chars>
 static inline const char* skip_leading_utf8(const char* p, const char* end, size_t n,
                                             [[maybe_unused]] size_t* skipped_chars) {
-    int char_size = 0;
+    size_t char_size = 0;
     size_t i = 0;
     for (; i < n && p < end; ++i, p += char_size) {
-        char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<uint8_t>(*p)];
+        // A truncated/invalid UTF-8 lead byte at the tail can claim more bytes than remain;
+        // clamp to the rest of the string so the returned pointer stays within the input.
+        char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<uint8_t>(*p)], static_cast<size_t>(end - p));
     }
     if constexpr (use_skipped_chars) {
         *skipped_chars = i;

--- a/be/src/util/utf8_encoding.h
+++ b/be/src/util/utf8_encoding.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <algorithm>
+
 #include "column/column_hash.h"
 #include "util/slice.h"
 #include "util/utf8.h"
@@ -65,8 +67,10 @@ public:
 };
 
 static inline size_t encode_utf8_chars(const Slice& str, std::vector<EncodedUtf8Char>* encoded_values) {
-    for (int i = 0, char_size = 0; i < str.size; i += char_size) {
-        char_size = UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])];
+    for (size_t i = 0, char_size = 0; i < str.size; i += char_size) {
+        // A truncated/invalid UTF-8 lead byte at the tail can claim more bytes than remain;
+        // clamp to the rest of the string to avoid an out-of-bounds read of adjacent memory.
+        char_size = std::min<size_t>(UTF8_BYTE_LENGTH_TABLE[static_cast<unsigned char>(str.data[i])], str.size - i);
         encoded_values->emplace_back(str.data + i, char_size);
     }
     return encoded_values->size();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -527,6 +527,7 @@ set(EXEC_FILES
         ./util/trim_test.cpp
         ./util/uid_util_test.cpp
         ./util/utf8_check_test.cpp
+        ./util/utf8_encoding_test.cpp
         ./util/int96_test.cpp
         ./util/internal_service_recoverable_stub_test.cpp
         ./util/internal_service_recoverable_stub_parallel_test.cpp

--- a/be/test/exprs/string_fn_locate_test.cpp
+++ b/be/test/exprs/string_fn_locate_test.cpp
@@ -145,6 +145,51 @@ TEST_F(StringFunctionLocateTest, locatePosTest) {
     }
 }
 
+TEST_F(StringFunctionLocateTest, locateStartBeyondLastUtf8CharTest) {
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    Columns columns;
+    auto sub = BinaryColumn::create();
+    auto str = BinaryColumn::create();
+    auto pos = Int32Column::create();
+
+    // a start position past the last character leaves nothing to scan, so the result is 0;
+    // the walk has to step over the whole last character to reach that end
+    str->append("你a");
+    sub->append("a");
+    pos->append(3);
+
+    str->append("你好b");
+    sub->append("b");
+    pos->append(4);
+
+    // a start position on the last character still finds it
+    str->append("你好");
+    sub->append("好");
+    pos->append(2);
+
+    // the 0xF0 lead byte claims four bytes while only two are left, so the walk ends at the end
+    // of the value and the search is left with nothing to scan
+    str->append(
+            Slice("a\xF0"
+                  "b",
+                  3));
+    sub->append("b");
+    pos->append(3);
+
+    columns.emplace_back(std::move(sub));
+    columns.emplace_back(std::move(str));
+    columns.emplace_back(std::move(pos));
+
+    ColumnPtr result = StringFunctions::locate_pos(ctx.get(), columns).value();
+    ASSERT_EQ(4, result->size());
+
+    auto v = ColumnHelper::cast_to<TYPE_INT>(result);
+    ASSERT_EQ(0, v->get_data()[0]);
+    ASSERT_EQ(0, v->get_data()[1]);
+    ASSERT_EQ(2, v->get_data()[2]);
+    ASSERT_EQ(0, v->get_data()[3]);
+}
+
 TEST_F(StringFunctionLocateTest, locateHayStackEqualNeedleTest) {
     std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
     Columns columns;

--- a/be/test/exprs/string_fn_test.cpp
+++ b/be/test/exprs/string_fn_test.cpp
@@ -157,6 +157,30 @@ PARALLEL_TEST(VecStringFunctionsTest, substrConstASCIITest) {
     }
 }
 
+PARALLEL_TEST(VecStringFunctionsTest, substrTruncatedUtf8TailTest) {
+    // a lead byte at the tail that claims more bytes than remain must not extend the result past the input
+    BinaryColumn::Ptr str = BinaryColumn::create();
+    str->append(Slice("A\xF0", 2));
+    str->append(Slice("\xE4\xBD", 2));
+    str->append("壹贰");
+
+    std::unique_ptr<FunctionContext> ctx(FunctionContext::create_test_context());
+    auto state = std::make_unique<SubstrState>();
+    ctx->set_function_state(FunctionContext::FRAGMENT_LOCAL, state.get());
+    state->is_const = true;
+    state->pos = 1;
+    state->len = 2;
+    starrocks::Columns columns;
+    columns.emplace_back(str);
+
+    ColumnPtr result = StringFunctions::substring(ctx.get(), columns).value();
+    auto* binary = down_cast<BinaryColumn*>(result.get());
+    ASSERT_EQ(3, binary->size());
+    ASSERT_EQ(Slice("A\xF0", 2), binary->get_slice(0));
+    ASSERT_EQ(Slice("\xE4\xBD", 2), binary->get_slice(1));
+    ASSERT_EQ("壹贰", binary->get_slice(2).to_string());
+}
+
 PARALLEL_TEST(VecStringFunctionsTest, substrConstZhTest) {
     BinaryColumn::Ptr str = BinaryColumn::create();
     str->append("壹贰叁肆伍陆柒捌玖");

--- a/be/test/util/utf8_encoding_test.cpp
+++ b/be/test/util/utf8_encoding_test.cpp
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "util/utf8_encoding.h"
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+#include <vector>
+
+namespace starrocks {
+
+static std::string_view encoded_value_as_string_view(const EncodedUtf8Char& value) {
+    Slice slice = value;
+    return {slice.data, slice.size};
+}
+
+TEST(Utf8EncodingTest, clampsTruncatedTailLeadByteToInput) {
+    const char input[] = {'a', static_cast<char>(0xF0)};
+    std::vector<EncodedUtf8Char> values;
+
+    EXPECT_EQ(2, encode_utf8_chars(Slice(input, sizeof(input)), &values));
+    ASSERT_EQ(2, values.size());
+
+    EXPECT_EQ(std::string_view(input, 1), encoded_value_as_string_view(values[0]));
+    EXPECT_EQ(std::string_view(input + 1, 1), encoded_value_as_string_view(values[1]));
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Manual backport of #78722 to `branch-3.5` (the Mergify backport #78744 hit a cherry-pick conflict and was closed).

`skip_leading_utf8` (`utf8.h`) and `encode_utf8_chars` (`utf8_encoding.h`) advance by the length the UTF-8 lead byte claims. When the last byte of a value is a truncated or invalid lead byte it claims more bytes than remain, so the walk leaves the value: `substr`, `left`, `right`, `lpad`, `rpad` and `translate` return bytes that belong to the next row of the column, and `locate` searches past the value and can report a position larger than its length. ASAN reports a stack-buffer-overflow read for the first helper and a SEGV for the locate path.

## What I'm doing:

- Clamp the step in both helpers to the bytes that remain, and pass the real end pointer in `haystack_vector_and_needle_vector` (`be/src/exprs/locate.cpp`), which was one byte short and made the remaining-length arithmetic underflow.

Deviations from the main commit, because `branch-3.5` differs:
- The helpers live in `be/src/util/` here, not `be/src/base/string/`, so the change lands in `util/utf8.h` and `util/utf8_encoding.h`; the latter also needs `#include <algorithm>`, which the copy on main already had.
- `be/test/base/string/utf8_encoding_test.cpp` does not exist on this branch, so the `encode_utf8_chars` case goes into a new `be/test/util/utf8_encoding_test.cpp`, registered in `be/test/CMakeLists.txt`.
- The `substr` test follows this branch's column style: `BinaryColumn::Ptr` and a non-const `down_cast`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

