### PR TITLE
[BugFix] Create partitions for multi-table transaction stream load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -26,6 +26,7 @@ import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.txn.BeginStmt;
 import com.starrocks.sql.ast.txn.CommitStmt;
@@ -371,10 +372,18 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
         if (context.getExecutionId() == null) {
             context.setExecutionId(loadId);
         }
-        // Also propagate compute resource so the txn carries the same resource context.
-        if (context.getCurrentComputeResource() == null) {
-            context.setCurrentComputeResource(computeResource);
+        // Bind the context to the task's warehouse and compute resource before the transaction is
+        // created: TransactionStmtExecutor.beginStmt stores context.getCurrentComputeResource() in
+        // the TransactionState, and createPartition, updateImmutablePartition and publish derive
+        // tablet locations and nodes from it. In shared-data mode getCurrentComputeResource() never
+        // returns null: it acquires a resource from the context's warehouse (the default one for
+        // this private context) and re-acquires whenever the resource's warehouse differs from the
+        // context's, so a null check left the transaction on the default warehouse while the load's
+        // coordinator runs on the task's warehouse.
+        if (RunMode.isSharedDataMode()) {
+            context.setCurrentWarehouseId(computeResource.getWarehouseId());
         }
+        context.setCurrentComputeResource(computeResource);
 
         TransactionStmtExecutor.beginStmt(context, new BeginStmt(NodePosition.ZERO),
                 TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING, label);
@@ -847,9 +856,19 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
                 if (!checkLoadAllowed(resp)) {
                     return null;
                 }
-                task = taskMaps.putIfAbsent(table.getName(), newTask);
+                task = taskMaps.get(table.getName());
                 if (task == null) {
+                    // Register the transaction with DatabaseTransactionMgr and add this table to it
+                    // before the sub-task exists, as the INSERT path of an explicit transaction does
+                    // before it executes. The BE looks the transaction up there while it writes
+                    // (createPartition for automatic partitioning, updateImmutablePartition for
+                    // automatic bucketing); a transaction that only reaches DatabaseTransactionMgr at
+                    // commit fails those lookups with "txn %d not exist". It also lets a failed
+                    // sub-task abort the shared transaction (StreamLoadTask.cancelTask). If this
+                    // throws, nothing is added to taskMaps and executeLoadTask aborts the transaction.
+                    TransactionStmtExecutor.activateTable(dbId, table.getId(), context);
                     task = newTask;
+                    taskMaps.put(table.getName(), task);
                     boolean isFirstSubTask = taskMaps.size() == 1;
                     LOG.info("Add stream load task {}", task.getShowInfo());
                     task.tryBegin(0, 1, txnId);

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMultiStmtTask.java
@@ -384,6 +384,12 @@ public class StreamLoadMultiStmtTask extends AbstractStreamLoadTask {
             context.setCurrentWarehouseId(computeResource.getWarehouseId());
         }
         context.setCurrentComputeResource(computeResource);
+        // The transaction's timeout is the task's (the HTTP "timeout" header), as for a classic
+        // stream load: TransactionStmtExecutor.beginStmt takes it from context.getExecTimeout(),
+        // i.e. the session's query_timeout, and the transaction is visible to the transaction
+        // timeout checker from the first load. commitStmt's lock and publish waits follow the
+        // same value. Set it after the warehouse binding, which replaces the session variables.
+        context.getSessionVariable().setQueryTimeoutS((int) Math.max(1L, timeoutMs / 1000L));
 
         TransactionStmtExecutor.beginStmt(context, new BeginStmt(NodePosition.ZERO),
                 TransactionState.LoadJobSourceType.MULTI_STATEMENT_STREAMING, label);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -252,6 +252,25 @@ public class TransactionStmtExecutor {
         LOG.info("load database {} table {} item {} txn {}", dbId, tableId, item, context.getTxnId());
     }
 
+    /**
+     * Register the explicit transaction with the database transaction manager and add {@code tableId} to it.
+     * This is the registration the INSERT path above performs before it executes, and a load must perform it
+     * before its coordinator starts as well: while the data is being written, the BE looks the transaction up
+     * through DatabaseTransactionMgr (createPartition for automatic partitioning, updateImmutablePartition for
+     * automatic bucketing), and an abort of the load has to find it there too. A transaction that only lives in
+     * the explicit transaction map until commit fails those lookups with "txn %d not exist". The registration is
+     * idempotent, so the commit-time {@link #loadData(long, long, ExplicitTxnState.ExplicitTxnStateItem,
+     * ConnectContext)} may repeat it.
+     */
+    public static TransactionState activateTable(long dbId, long tableId, ConnectContext context)
+            throws StarRocksException {
+        GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        TransactionState transactionState = globalTransactionMgr.registerExplicitTransactionState(
+                context.getTxnId(), dbId);
+        globalTransactionMgr.activateExplicitTransactionTable(context.getTxnId(), dbId, tableId);
+        return transactionState;
+    }
+
     public static void commitStmt(ConnectContext context, CommitStmt stmt) {
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
         ExplicitTxnState explicitTxnState = globalTransactionMgr.getExplicitTxnState(context.getTxnId());
@@ -390,6 +409,11 @@ public class TransactionStmtExecutor {
 
         if (explicitTxnState.getTransactionStateItems().isEmpty()) {
             TransactionState transactionState = explicitTxnState.getTransactionState();
+            // A load registers the transaction with DatabaseTransactionMgr before it runs (see
+            // activateTable), so the transaction may be registered although no load produced an
+            // item (every load failed or was cancelled). Abort it there as well; otherwise it stays
+            // PREPARE until the transaction timeout and keeps its tables against schema changes.
+            abortRegisteredTransaction(transactionState, "rollback transaction by user");
             globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
             context.setTxnId(0);
             context.getState().setOk(0, 0, buildMessage(transactionState.getLabel(),
@@ -445,6 +469,24 @@ public class TransactionStmtExecutor {
             //clean global explicit transaction state
             globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
             context.setTxnId(0);
+        }
+    }
+
+    /**
+     * Abort the transaction in the database transaction manager it was registered with, if any. A transaction
+     * that already reached a final state (aborted by a failed load or by the timeout checker) is left alone.
+     */
+    private static void abortRegisteredTransaction(TransactionState transactionState, String reason) {
+        if (transactionState.getDbId() == 0 || !transactionState.isRunning()) {
+            return;
+        }
+        try {
+            GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
+                    transactionState.getDbId(), transactionState.getTransactionId(), reason);
+        } catch (TransactionNotFoundException e) {
+            LOG.debug("txn {} already reached a final state before rollback", transactionState.getTransactionId());
+        } catch (StarRocksException e) {
+            LOG.warn("errors when abort txn {} without items", transactionState.getTransactionId(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -289,8 +289,22 @@ public class TransactionStmtExecutor {
 
         if (explicitTxnState.getTransactionStateItems().isEmpty()) {
             TransactionState transactionState = explicitTxnState.getTransactionState();
-            globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
-            context.setTxnId(0);
+            // The INSERT path registers the transaction with DatabaseTransactionMgr before it
+            // executes, so a transaction whose statements all failed is registered without any
+            // item. Abort it there; otherwise it stays PREPARE until the transaction timeout,
+            // holding a running-transaction slot, its label and its tables against schema changes.
+            String abortError = null;
+            try {
+                abortError = abortRegisteredTransaction(transactionState,
+                        "no data loaded in the explicit transaction before commit");
+            } finally {
+                globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
+                context.setTxnId(0);
+            }
+            if (abortError != null) {
+                context.getState().setError(abortError);
+                return;
+            }
             context.getState().setOk(0, 0, buildMessage(transactionState.getLabel(),
                     TransactionStatus.VISIBLE, transactionState.getTransactionId(), -1));
             return;
@@ -413,12 +427,17 @@ public class TransactionStmtExecutor {
             // activateTable), so the transaction may be registered although no load produced an
             // item (every load failed or was cancelled). Abort it there as well; otherwise it stays
             // PREPARE until the transaction timeout and keeps its tables against schema changes.
-            String abortError = abortRegisteredTransaction(transactionState, "rollback transaction by user");
-            globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
-            context.setTxnId(0);
+            String abortError = null;
+            try {
+                abortError = abortRegisteredTransaction(transactionState, "rollback transaction by user");
+            } finally {
+                // Same contract as the branch below: the explicit state is gone whatever the abort
+                // did, a failure is reported to the user, and the transaction timeout checker bounds
+                // the remainder.
+                globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
+                context.setTxnId(0);
+            }
             if (abortError != null) {
-                // Same contract as the branch below: the explicit state is gone, the failure is
-                // reported to the user, and the transaction timeout checker bounds the remainder.
                 context.getState().setError(abortError);
                 return;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStmtExecutor.java
@@ -413,9 +413,15 @@ public class TransactionStmtExecutor {
             // activateTable), so the transaction may be registered although no load produced an
             // item (every load failed or was cancelled). Abort it there as well; otherwise it stays
             // PREPARE until the transaction timeout and keeps its tables against schema changes.
-            abortRegisteredTransaction(transactionState, "rollback transaction by user");
+            String abortError = abortRegisteredTransaction(transactionState, "rollback transaction by user");
             globalTransactionMgr.clearExplicitTxnState(context.getTxnId());
             context.setTxnId(0);
+            if (abortError != null) {
+                // Same contract as the branch below: the explicit state is gone, the failure is
+                // reported to the user, and the transaction timeout checker bounds the remainder.
+                context.getState().setError(abortError);
+                return;
+            }
             context.getState().setOk(0, 0, buildMessage(transactionState.getLabel(),
                     TransactionStatus.ABORTED, transactionState.getTransactionId(), -1));
             return;
@@ -475,10 +481,13 @@ public class TransactionStmtExecutor {
     /**
      * Abort the transaction in the database transaction manager it was registered with, if any. A transaction
      * that already reached a final state (aborted by a failed load or by the timeout checker) is left alone.
+     *
+     * @return null when the transaction is aborted, was never registered or is already final; otherwise the
+     *         error message of the failed abort
      */
-    private static void abortRegisteredTransaction(TransactionState transactionState, String reason) {
+    private static String abortRegisteredTransaction(TransactionState transactionState, String reason) {
         if (transactionState.getDbId() == 0 || !transactionState.isRunning()) {
-            return;
+            return null;
         }
         try {
             GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(
@@ -487,7 +496,9 @@ public class TransactionStmtExecutor {
             LOG.debug("txn {} already reached a final state before rollback", transactionState.getTransactionId());
         } catch (StarRocksException e) {
             LOG.warn("errors when abort txn {} without items", transactionState.getTransactionId(), e);
+            return e.getMessage();
         }
+        return null;
     }
 
     public static String buildMessage(String label, TransactionStatus txnStatus, long transactionId, long databaseId) {

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskAutoPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskAutoPartitionTest.java
@@ -136,6 +136,8 @@ public class StreamLoadMultiStmtTaskAutoPartitionTest {
         Assertions.assertSame(txnMgr.getExplicitTxnState(txnId).getTransactionState(), txnState);
         Assertions.assertEquals(TransactionStatus.PREPARE, txnState.getTransactionStatus());
         Assertions.assertEquals(db.getId(), txnState.getDbId());
+        // the transaction timeout is the task's, not the session default query_timeout
+        Assertions.assertEquals(60_000L, txnState.getTimeoutMs());
         Assertions.assertEquals(List.of(table.getId()), txnState.getTableIdList());
 
         // The BE asks the FE for the partition of a row it cannot place while it is still writing.

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskAutoPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskAutoPartitionTest.java
@@ -1,0 +1,243 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.streamload;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.service.ExecuteEnv;
+import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.thrift.TCreatePartitionRequest;
+import com.starrocks.thrift.TCreatePartitionResult;
+import com.starrocks.thrift.TImmutablePartitionRequest;
+import com.starrocks.thrift.TImmutablePartitionResult;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.transaction.ExplicitTxnState;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.transaction.TransactionStmtExecutor;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A multi-table transaction stream load registers its transaction with DatabaseTransactionMgr when a
+ * table starts loading, not only at commit: the BE looks the transaction up there while it is writing
+ * (createPartition for automatic partitioning, updateImmutablePartition for automatic bucketing), and
+ * the abort of a failed sub-task has to find it there as well.
+ */
+public class StreamLoadMultiStmtTaskAutoPartitionTest {
+    private static final String DB_NAME = "test_multi_stmt_auto_partition";
+
+    @Mocked
+    private ExecuteEnv exeEnv;
+
+    private static Database db;
+    private static GlobalTransactionMgr txnMgr;
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        Config.enable_strict_storage_medium_check = false;
+        UtFrameUtils.createMinStarRocksCluster();
+        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME)
+                .withTable("CREATE TABLE transaction_simple (\n"
+                        + "    company_id LARGEINT NOT NULL,\n"
+                        + "    txn_date DATE NOT NULL,\n"
+                        + "    val STRING NULL\n"
+                        + ")\n"
+                        + "PRIMARY KEY (company_id, txn_date)\n"
+                        + "PARTITION BY date_trunc('month', txn_date)\n"
+                        + "DISTRIBUTED BY HASH(company_id) BUCKETS 6\n"
+                        + "PROPERTIES (\"replication_num\" = \"1\");")
+                .withTable("CREATE TABLE random_bucket (\n"
+                        + "    event_day DATETIME NOT NULL,\n"
+                        + "    site_id INT DEFAULT '10',\n"
+                        + "    pv BIGINT DEFAULT '0'\n"
+                        + ")\n"
+                        + "DUPLICATE KEY(event_day, site_id)\n"
+                        + "DISTRIBUTED BY RANDOM\n"
+                        + "PROPERTIES (\"replication_num\" = \"1\");");
+        db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        txnMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+    }
+
+    private static OlapTable getTable(String name) {
+        return (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(DB_NAME, name);
+    }
+
+    private static StreamLoadMultiStmtTask beginMultiStmtTask(String label) {
+        StreamLoadMultiStmtTask multiTask = new StreamLoadMultiStmtTask(
+                GlobalStateMgr.getCurrentState().getNextId(), db, label, "root", "127.0.0.1",
+                60_000L, System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+        TransactionResult resp = new TransactionResult();
+        multiTask.beginTxn(resp);
+        Assertions.assertTrue(resp.stateOK(), resp.msg);
+        Assertions.assertNotEquals(0L, multiTask.getTxnId());
+        return multiTask;
+    }
+
+    /** Runs a load request up to the point where the coordinator would be started (executeTask). */
+    private static void tryLoad(StreamLoadMultiStmtTask multiTask, String tableName) throws StarRocksException {
+        TransactionResult resp = new TransactionResult();
+        Assertions.assertNull(multiTask.tryLoad(0, tableName, resp));
+        Assertions.assertTrue(resp.stateOK(), resp.msg);
+    }
+
+    private static void rollback(StreamLoadMultiStmtTask multiTask) throws StarRocksException {
+        TransactionResult resp = new TransactionResult();
+        multiTask.manualCancelTask(resp);
+        Assertions.assertTrue(resp.stateOK(), resp.msg);
+        Assertions.assertEquals("CANCELLED", multiTask.getStateName());
+        Assertions.assertNull(txnMgr.getExplicitTxnState(multiTask.getTxnId()));
+    }
+
+    @Test
+    public void testCreatePartitionFindsTransactionBeforeCommit() throws Exception {
+        OlapTable table = getTable("transaction_simple");
+        StreamLoadMultiStmtTask multiTask = beginMultiStmtTask("multi_stmt_auto_partition");
+        long txnId = multiTask.getTxnId();
+        // BEGIN only creates the explicit transaction state.
+        Assertions.assertNull(txnMgr.getTransactionState(db.getId(), txnId));
+
+        tryLoad(multiTask, "transaction_simple");
+        TransactionState txnState = txnMgr.getTransactionState(db.getId(), txnId);
+        Assertions.assertNotNull(txnState);
+        Assertions.assertSame(txnMgr.getExplicitTxnState(txnId).getTransactionState(), txnState);
+        Assertions.assertEquals(TransactionStatus.PREPARE, txnState.getTransactionStatus());
+        Assertions.assertEquals(db.getId(), txnState.getDbId());
+        Assertions.assertEquals(List.of(table.getId()), txnState.getTableIdList());
+
+        // The BE asks the FE for the partition of a row it cannot place while it is still writing.
+        List<List<String>> partitionValues = Lists.newArrayList();
+        partitionValues.add(Lists.newArrayList("2026-10-05"));
+        TCreatePartitionRequest request = new TCreatePartitionRequest();
+        request.setTxn_id(txnId);
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setPartition_values(partitionValues);
+        TCreatePartitionResult result = new FrontendServiceImpl(exeEnv).createPartition(request);
+        Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code(), String.valueOf(result.getStatus()));
+        Assertions.assertNotNull(table.getPartition("p202610"));
+        Assertions.assertEquals(1, result.getPartitions().size());
+        Assertions.assertEquals(1, txnState.getPartitionNameToTPartition(table.getId()).size());
+
+        // A second table joins the same transaction; a repeated load reuses the existing sub-task.
+        OlapTable other = getTable("random_bucket");
+        tryLoad(multiTask, "random_bucket");
+        Assertions.assertEquals(List.of(table.getId(), other.getId()), txnState.getTableIdList());
+        Assertions.assertEquals(2, multiTask.getTasks().size());
+        tryLoad(multiTask, "transaction_simple");
+        Assertions.assertEquals(2, multiTask.getTasks().size());
+
+        // The commit-time registration is idempotent on top of the early one.
+        ConnectContext context = Deencapsulation.getField(multiTask, "context");
+        ExplicitTxnState.ExplicitTxnStateItem item = new ExplicitTxnState.ExplicitTxnStateItem();
+        item.setTabletCommitInfos(Lists.newArrayList());
+        item.setTabletFailInfos(Lists.newArrayList());
+        TransactionStmtExecutor.loadData(db.getId(), table.getId(), item, context);
+        Assertions.assertSame(txnState, txnMgr.getTransactionState(db.getId(), txnId));
+        Assertions.assertEquals(List.of(table.getId(), other.getId()), txnState.getTableIdList());
+
+        // Rollback reaches the registered transaction.
+        rollback(multiTask);
+        Assertions.assertEquals(TransactionStatus.ABORTED,
+                txnMgr.getTransactionState(db.getId(), txnId).getTransactionStatus());
+    }
+
+    @Test
+    public void testUpdateImmutablePartitionFindsTransactionBeforeCommit() throws Exception {
+        OlapTable table = getTable("random_bucket");
+        StreamLoadMultiStmtTask multiTask = beginMultiStmtTask("multi_stmt_immutable_partition");
+        long txnId = multiTask.getTxnId();
+        tryLoad(multiTask, "random_bucket");
+
+        TImmutablePartitionRequest request = new TImmutablePartitionRequest();
+        request.setTxn_id(txnId);
+        request.setDb_id(db.getId());
+        request.setTable_id(table.getId());
+        request.setPartition_ids(table.getPhysicalPartitions().stream()
+                .map(PhysicalPartition::getId).collect(Collectors.toList()));
+        TImmutablePartitionResult result = new FrontendServiceImpl(exeEnv).updateImmutablePartition(request);
+        Assertions.assertEquals(TStatusCode.OK, result.getStatus().getStatus_code(), String.valueOf(result.getStatus()));
+        Assertions.assertEquals(2, table.getPhysicalPartitions().size());
+
+        rollback(multiTask);
+    }
+
+    @Test
+    public void testRollbackAbortsRegisteredTransactionWithoutItems() throws Exception {
+        StreamLoadMultiStmtTask multiTask = beginMultiStmtTask("multi_stmt_rollback_without_items");
+        long txnId = multiTask.getTxnId();
+        tryLoad(multiTask, "transaction_simple");
+        Assertions.assertEquals(TransactionStatus.PREPARE,
+                txnMgr.getTransactionState(db.getId(), txnId).getTransactionStatus());
+
+        // No load reached commit (no explicit transaction item), e.g. the user aborts or the task
+        // times out: the rollback must abort the registered transaction instead of leaving it
+        // PREPARE until the transaction timeout.
+        rollback(multiTask);
+        Assertions.assertEquals(TransactionStatus.ABORTED,
+                txnMgr.getTransactionState(db.getId(), txnId).getTransactionStatus());
+    }
+
+    @Test
+    public void testFailedSubTaskAbortsRegisteredTransaction() throws Exception {
+        StreamLoadMultiStmtTask multiTask = beginMultiStmtTask("multi_stmt_sub_task_abort");
+        long txnId = multiTask.getTxnId();
+        tryLoad(multiTask, "transaction_simple");
+
+        // StreamLoadTask.cancelTask aborts the shared transaction; before the transaction was
+        // registered at load time this failed with "transaction not found".
+        StreamLoadTask subTask = multiTask.getTasks().iterator().next();
+        Assertions.assertNull(subTask.cancelTask("coordinator failed"));
+        Assertions.assertEquals(TransactionStatus.ABORTED,
+                txnMgr.getTransactionState(db.getId(), txnId).getTransactionStatus());
+
+        // The parent's rollback still converges on the already aborted transaction.
+        rollback(multiTask);
+    }
+
+    @Test
+    public void testLoadFailsWithoutSubTaskWhenTransactionIsGone() throws Exception {
+        StreamLoadMultiStmtTask multiTask = beginMultiStmtTask("multi_stmt_txn_gone");
+        long txnId = multiTask.getTxnId();
+        // e.g. removed by the transaction cleaner once the transaction timed out
+        txnMgr.clearExplicitTxnState(txnId);
+
+        Assertions.assertThrows(StarRocksException.class,
+                () -> multiTask.tryLoad(0, "transaction_simple", new TransactionResult()));
+        Assertions.assertTrue(multiTask.getTasks().isEmpty());
+        Assertions.assertNull(txnMgr.getTransactionState(db.getId(), txnId));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
@@ -24,6 +24,7 @@ import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.ExplicitTxnState;
@@ -31,6 +32,8 @@ import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TransactionStmtExecutor;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpHeaders;
 import mockit.Invocation;
@@ -108,6 +111,43 @@ public class StreamLoadMultiStmtTaskTest {
         multiTask.beginTxn(resp);
         Assertions.assertTrue(resp.stateOK());
         Assertions.assertEquals(987654321L, multiTask.getTxnId());
+    }
+
+    @Test
+    public void testBeginTxnBindsContextToTaskWarehouseInSharedDataMode() throws Exception {
+        ComputeResource resource = WarehouseComputeResource.of(4242L);
+        StreamLoadMultiStmtTask task = new StreamLoadMultiStmtTask(2L, db, "label_wh", "u", "127.0.0.1",
+                1000L, System.currentTimeMillis(), resource);
+        List<Long> boundWarehouseIds = new ArrayList<>();
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+        new MockUp<com.starrocks.qe.ConnectContext>() {
+            @Mock
+            public void setCurrentWarehouseId(long warehouseId) {
+                boundWarehouseIds.add(warehouseId);
+            }
+        };
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                // The transaction takes its compute resource from the context: it must be the
+                // task's, not one acquired from the context's default warehouse.
+                Assertions.assertSame(resource, ctx.getCurrentComputeResourceNoAcquire());
+                ctx.setTxnId(42L);
+            }
+        };
+        TransactionResult resp = new TransactionResult();
+        task.beginTxn(resp);
+        Assertions.assertTrue(resp.stateOK());
+        Assertions.assertEquals(42L, task.getTxnId());
+        Assertions.assertEquals(List.of(4242L), boundWarehouseIds);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadMultiStmtTaskTest.java
@@ -151,6 +151,28 @@ public class StreamLoadMultiStmtTaskTest {
     }
 
     @Test
+    public void testBeginTxnUsesTaskTimeoutForTransaction() throws Exception {
+        StreamLoadMultiStmtTask task = new StreamLoadMultiStmtTask(3L, db, "label_timeout", "u", "127.0.0.1",
+                7_200_000L, System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+        new MockUp<TransactionStmtExecutor>() {
+            @Mock
+            public void beginStmt(com.starrocks.qe.ConnectContext ctx,
+                                  com.starrocks.sql.ast.txn.BeginStmt stmt,
+                                  TransactionState.LoadJobSourceType sourceType,
+                                  String labelOverride) {
+                // beginStmt sizes the transaction timeout from the context, so it must carry the
+                // task's HTTP timeout rather than the session default query_timeout.
+                Assertions.assertEquals(7200, ctx.getExecTimeout());
+                ctx.setTxnId(43L);
+            }
+        };
+        TransactionResult resp = new TransactionResult();
+        task.beginTxn(resp);
+        Assertions.assertTrue(resp.stateOK());
+        Assertions.assertEquals(43L, task.getTxnId());
+    }
+
+    @Test
     public void testCheckNeedRemoveAndDurable() throws Exception {
         Assertions.assertFalse(multiTask.checkNeedRemove(System.currentTimeMillis(), false));
         StreamLoadTask sub = new StreamLoadTask(2L, db, new OlapTable(), "label_sub", "u",

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -842,6 +842,29 @@ public class ExplicitTxnTest {
     }
 
     @Test
+    public void testRollbackWithoutItemsReportsAbortFailure() {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long txnId = 990001L;
+        TransactionState state = addExplicitState(mgr, txnId, "rollback-abort-fails", 60_000L);
+        // Registered with a database by a load that produced no item.
+        state.setDbId(12345L);
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public void abortTransaction(long dbId, long transactionId, String reason) throws StarRocksException {
+                throw new StarRocksException("abort failed for test");
+            }
+        };
+        ConnectContext context = new ConnectContext();
+        context.setTxnId(txnId);
+        TransactionStmtExecutor.rollbackStmt(context, new RollbackStmt(NodePosition.ZERO));
+        // The explicit state is cleared as for any rollback, but the failure is reported instead of ABORTED.
+        Assertions.assertEquals(0, context.getTxnId());
+        Assertions.assertNull(mgr.getExplicitTxnState(txnId));
+        Assertions.assertTrue(context.getState().isError());
+        Assertions.assertTrue(context.getState().getErrorMessage().contains("abort failed for test"));
+    }
+
+    @Test
     public void testRollbackWithLostTransactionState() {
         // When txnId is set but explicitTxnState is null (e.g., FE leader switch),
         // rollbackStmt should report an error instead of silently succeeding.

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -865,6 +865,84 @@ public class ExplicitTxnTest {
     }
 
     @Test
+    public void testCommitWithoutItemsAbortsRegisteredTransaction() throws Exception {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        Database db1 = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("db1");
+        Table table1 = GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db1.getFullName(), "tbl1");
+        abortRunningTransactions(mgr, db1.getId());
+        long txnId = mgr.getTransactionIDGenerator().getNextTransactionId();
+        addExplicitState(mgr, txnId, "commit-without-items", 60_000L);
+        // The INSERT path registers the transaction before it executes; a failed INSERT leaves the
+        // transaction registered without an item.
+        mgr.registerExplicitTransactionState(txnId, db1.getId());
+        mgr.activateExplicitTransactionTable(txnId, db1.getId(), table1.getId());
+        Assertions.assertEquals(TransactionStatus.PREPARE,
+                mgr.getTransactionState(db1.getId(), txnId).getTransactionStatus());
+        int runningBefore = mgr.getDatabaseTransactionMgr(db1.getId()).getRunningTxnNums();
+
+        ConnectContext context = new ConnectContext();
+        context.setTxnId(txnId);
+        TransactionStmtExecutor.commitStmt(context, new CommitStmt(NodePosition.ZERO));
+
+        Assertions.assertEquals(0, context.getTxnId());
+        Assertions.assertFalse(context.getState().isError(), context.getState().getErrorMessage());
+        Assertions.assertEquals("{'label':'commit-without-items', 'status':'VISIBLE', 'txnId':'" + txnId + "'}",
+                context.getState().getInfoMessage());
+        Assertions.assertNull(mgr.getExplicitTxnState(txnId));
+        // The registered transaction is aborted instead of lingering PREPARE until its timeout: it no
+        // longer counts as running, no longer blocks the table and its label can be used again.
+        Assertions.assertEquals(TransactionStatus.ABORTED,
+                mgr.getTransactionState(db1.getId(), txnId).getTransactionStatus());
+        Assertions.assertEquals(runningBefore - 1, mgr.getDatabaseTransactionMgr(db1.getId()).getRunningTxnNums());
+        Assertions.assertTrue(mgr.isPreviousTransactionsFinished(txnId + 1, db1.getId(), List.of(table1.getId())));
+        Assertions.assertEquals(TransactionStatus.ABORTED,
+                mgr.getLabelTransactionState(db1.getId(), "commit-without-items").getTransactionStatus());
+    }
+
+    @Test
+    public void testCommitWithoutItemsReportsAbortFailure() {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long txnId = 990002L;
+        TransactionState state = addExplicitState(mgr, txnId, "commit-abort-fails", 60_000L);
+        state.setDbId(12345L);
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public void abortTransaction(long dbId, long transactionId, String reason) throws StarRocksException {
+                throw new StarRocksException("abort failed for test");
+            }
+        };
+        ConnectContext context = new ConnectContext();
+        context.setTxnId(txnId);
+        TransactionStmtExecutor.commitStmt(context, new CommitStmt(NodePosition.ZERO));
+        Assertions.assertEquals(0, context.getTxnId());
+        Assertions.assertNull(mgr.getExplicitTxnState(txnId));
+        Assertions.assertTrue(context.getState().isError());
+        Assertions.assertTrue(context.getState().getErrorMessage().contains("abort failed for test"));
+    }
+
+    @Test
+    public void testRollbackWithoutItemsClearsStateWhenAbortThrowsUnchecked() {
+        GlobalTransactionMgr mgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long txnId = 990003L;
+        TransactionState state = addExplicitState(mgr, txnId, "rollback-abort-unchecked", 60_000L);
+        state.setDbId(12345L);
+        new MockUp<GlobalTransactionMgr>() {
+            @Mock
+            public void abortTransaction(long dbId, long transactionId, String reason) {
+                throw new IllegalStateException("unchecked abort failure for test");
+            }
+        };
+        ConnectContext context = new ConnectContext();
+        context.setTxnId(txnId);
+        Assertions.assertThrows(IllegalStateException.class,
+                () -> TransactionStmtExecutor.rollbackStmt(context, new RollbackStmt(NodePosition.ZERO)));
+        // The session must not stay inside a dead transaction.
+        Assertions.assertEquals(0, context.getTxnId());
+        Assertions.assertNull(mgr.getExplicitTxnState(txnId));
+    }
+
+    @Test
     public void testRollbackWithLostTransactionState() {
         // When txnId is set but explicitTxnState is null (e.g., FE leader switch),
         // rollbackStmt should report an error instead of silently succeeding.

--- a/test/sql/test_stream_load/R/test_stream_load_multi_table_auto_partition
+++ b/test/sql/test_stream_load/R/test_stream_load_multi_table_auto_partition
@@ -52,12 +52,12 @@ select * from site_access order by event_day, site_id;
 -- result:
 2026-10-05	1	100
 -- !result
-select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'transaction_simple' order by PARTITION_NAME;
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'transaction_simple' and PARTITION_NAME like 'p%' order by PARTITION_NAME;
 -- result:
 p202610
 p202611
 -- !result
-select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'site_access' order by PARTITION_NAME;
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'site_access' and PARTITION_NAME like 'p%' order by PARTITION_NAME;
 -- result:
 p20261005
 -- !result

--- a/test/sql/test_stream_load/R/test_stream_load_multi_table_auto_partition
+++ b/test/sql/test_stream_load/R/test_stream_load_multi_table_auto_partition
@@ -1,0 +1,86 @@
+-- name: test_multi_txn_auto_create_partition @sequential
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `transaction_simple` (
+  `company_id` LARGEINT NOT NULL,
+  `txn_date` DATE NOT NULL,
+  `val` STRING NULL
+) ENGINE=OLAP
+PRIMARY KEY (`company_id`, `txn_date`)
+PARTITION BY date_trunc('month', `txn_date`)
+DISTRIBUTED BY HASH(`company_id`) BUCKETS 6;
+-- result:
+-- !result
+CREATE TABLE `site_access` (
+  `event_day` DATE NOT NULL,
+  `site_id` INT NOT NULL,
+  `pv` BIGINT NULL
+) ENGINE=OLAP
+DUPLICATE KEY (`event_day`, `site_id`)
+PARTITION BY date_trunc('day', `event_day`)
+DISTRIBUTED BY HASH(`site_id`) BUCKETS 3;
+-- result:
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:transaction_simple" -H "format:json" -H "strip_outer_array:true" -H "transaction_type:multi" -d '[{"company_id": 12345, "txn_date": "2026-10-05", "val": "val1"}, {"company_id": 12346, "txn_date": "2026-11-20", "val": "val2"}]' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:site_access" -H "column_separator:," -H "transaction_type:multi" -d '2026-10-05,1,100' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+select * from transaction_simple order by company_id;
+-- result:
+12345	2026-10-05	val1
+12346	2026-11-20	val2
+-- !result
+select * from site_access order by event_day, site_id;
+-- result:
+2026-10-05	1	100
+-- !result
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'transaction_simple' order by PARTITION_NAME;
+-- result:
+p202610
+p202611
+-- !result
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'site_access' order by PARTITION_NAME;
+-- result:
+p20261005
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:existing_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+[UC]shell: curl -s --location-trusted -u root: -H "label:existing_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:transaction_simple" -H "format:json" -H "strip_outer_array:true" -H "transaction_type:multi" -d '[{"company_id": 12347, "txn_date": "2026-10-06", "val": "val3"}]' -XPUT ${url}/api/transaction/load
+-- result:
+0
+-- !result
+shell: curl -s --location-trusted -u root: -H "label:existing_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+-- result:
+0
+OK
+-- !result
+select * from transaction_simple order by company_id;
+-- result:
+12345	2026-10-05	val1
+12346	2026-11-20	val2
+12347	2026-10-06	val3
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_stream_load/T/test_stream_load_multi_table_auto_partition
+++ b/test/sql/test_stream_load/T/test_stream_load_multi_table_auto_partition
@@ -1,0 +1,54 @@
+-- name: test_multi_txn_auto_create_partition @sequential
+-- A multi-table transaction stream load into expression-partitioned tables whose rows fall into
+-- partitions that do not exist yet. The BE asks the FE to create them while the transaction is
+-- still open, so the FE has to find the transaction before it is committed.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE `transaction_simple` (
+  `company_id` LARGEINT NOT NULL,
+  `txn_date` DATE NOT NULL,
+  `val` STRING NULL
+) ENGINE=OLAP
+PRIMARY KEY (`company_id`, `txn_date`)
+PARTITION BY date_trunc('month', `txn_date`)
+DISTRIBUTED BY HASH(`company_id`) BUCKETS 6;
+
+CREATE TABLE `site_access` (
+  `event_day` DATE NOT NULL,
+  `site_id` INT NOT NULL,
+  `pv` BIGINT NULL
+) ENGINE=OLAP
+DUPLICATE KEY (`event_day`, `site_id`)
+PARTITION BY date_trunc('day', `event_day`)
+DISTRIBUTED BY HASH(`site_id`) BUCKETS 3;
+
+-- 1. Begin transaction
+shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+-- 2. Load JSON rows that need two new monthly partitions
+[UC]shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:transaction_simple" -H "format:json" -H "strip_outer_array:true" -H "transaction_type:multi" -d '[{"company_id": 12345, "txn_date": "2026-10-05", "val": "val1"}, {"company_id": 12346, "txn_date": "2026-11-20", "val": "val2"}]' -XPUT ${url}/api/transaction/load
+
+-- 3. A second table in the same transaction needs a new daily partition
+[UC]shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:site_access" -H "column_separator:," -H "transaction_type:multi" -d '2026-10-05,1,100' -XPUT ${url}/api/transaction/load
+
+-- 4. Commit (used to fail with "automatic create partition failed. error: txn N not exist")
+shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+-- 5. Rows are visible in the partitions created during the load
+select * from transaction_simple order by company_id;
+select * from site_access order by event_day, site_id;
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'transaction_simple' order by PARTITION_NAME;
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'site_access' order by PARTITION_NAME;
+
+-- 6. A later transaction that loads into an existing partition still works
+shell: curl -s --location-trusted -u root: -H "label:existing_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'
+
+[UC]shell: curl -s --location-trusted -u root: -H "label:existing_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:transaction_simple" -H "format:json" -H "strip_outer_array:true" -H "transaction_type:multi" -d '[{"company_id": 12347, "txn_date": "2026-10-06", "val": "val3"}]' -XPUT ${url}/api/transaction/load
+
+shell: curl -s --location-trusted -u root: -H "label:existing_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/commit | jq -r '.Status'
+
+select * from transaction_simple order by company_id;
+
+drop database db_${uuid0};

--- a/test/sql/test_stream_load/T/test_stream_load_multi_table_auto_partition
+++ b/test/sql/test_stream_load/T/test_stream_load_multi_table_auto_partition
@@ -39,8 +39,8 @@ shell: curl -s --location-trusted -u root: -H "label:auto_partition_${uuid0}" -H
 -- 5. Rows are visible in the partitions created during the load
 select * from transaction_simple order by company_id;
 select * from site_access order by event_day, site_id;
-select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'transaction_simple' order by PARTITION_NAME;
-select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'site_access' order by PARTITION_NAME;
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'transaction_simple' and PARTITION_NAME like 'p%' order by PARTITION_NAME;
+select PARTITION_NAME from information_schema.partitions_meta where DB_NAME = 'db_${uuid0}' and TABLE_NAME = 'site_access' and PARTITION_NAME like 'p%' order by PARTITION_NAME;
 
 -- 6. A later transaction that loads into an existing partition still works
 shell: curl -s --location-trusted -u root: -H "label:existing_partition_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "transaction_type:multi" -XPOST ${url}/api/transaction/begin | jq -r '.Status'


### PR DESCRIPTION
## Why I'm doing:

Loading into an expression-partitioned table (for example `PARTITION BY date_trunc('month', txn_date)`) through the multi-table transaction stream load interface (`/api/transaction/begin|load|commit` with `transaction_type: multi`) fails at commit whenever the BE has to create a partition for a row:

```
BE:  tablet_sink: Failed to automatic create partition, err=Runtime error: automatic create partition failed. error: txn 1296934 not exist
FE:  StreamLoadTask.tryBegin(): stream load ... channel_id 0 begin. ... txn_id: 1296934
     FrontendServiceImpl.createPartition(): Receive create partition: TCreatePartitionRequest(txn_id:1296934, ... partition_values:[[2026-09-01]])
     exec state report failed status=errorCode RUNTIME_ERROR automatic create partition failed. error: txn 1296934 not exist
     StreamLoadTask.cancelTask(): stream load ... abort txn fail, errmsg: transaction not found: 1296934
```

Classic stream load and `INSERT` into the same table work. The only workaround was to pre-open every partition of the table in the load plan (`load_initial_open_partition_number`).

Root cause: `StreamLoadMultiStmtTask.beginTxn` → `TransactionStmtExecutor.beginStmt` only records the `TransactionState` in `GlobalTransactionMgr.explicitTxnStateMap`. The transaction was registered with `DatabaseTransactionMgr` only at commit (`StreamLoadMultiStmtTask.commitTxn` → `TransactionStmtExecutor.loadData` → `registerExplicitTransactionState` / `activateExplicitTransactionTable`). But while the BE is still writing, it calls `FrontendServiceImpl.createPartition` (automatic partitioning) and `updateImmutablePartition` (automatic bucketing), which look the transaction up through `DatabaseTransactionMgr` and answer `txn %d not exist`; `StreamLoadTask.cancelTask` → `abortTransaction` fails the same way. The SQL explicit-transaction path does not have this problem because `loadData(Database, Table, ExecPlan, ...)` registers the transaction *before* it executes the `INSERT`. Present since #61362 (multi-statement stream load), so this is not a regression.

## What I'm doing:

Register the transaction with `DatabaseTransactionMgr` when the load starts instead of at commit, mirroring the `INSERT` path:

- `TransactionStmtExecutor.activateTable(dbId, tableId, context)`: `registerExplicitTransactionState` + `activateExplicitTransactionTable`, called from `StreamLoadMultiStmtTask.tryLoad` when a table's sub-task is created (under the task write lock, before `StreamLoadTask.executeTask` plans and starts the coordinator). Both calls are idempotent, so the commit-time `loadData` is unchanged. Nothing is added to `taskMaps` if the registration throws, and `StreamLoadMgr.executeLoadTask` then aborts the transaction as for any other load failure. Registration writes no edit log (same as the commit-time registration today), so restart/replay behavior is unchanged; the label / running-transaction-limit / quota checks that used to run at commit now run at the first load.
- Because the transaction is now registered before commit, a rollback that never produced a load item (user abort, task timeout, every load failed) took `rollbackStmt`'s empty-item branch, which only cleared the explicit state and would have left the registered transaction `PREPARE` until the transaction timeout, holding its tables against schema changes. `rollbackStmt` now aborts a registered transaction in that branch as well (a transaction that is already final, e.g. aborted by a failed sub-task or the timeout checker, is left alone). If that abort fails, the failure is reported as the statement's error instead of `ABORTED`, the same contract as the branch with items; the explicit state and the session's transaction id are cleared in a `finally`, as in that branch, so an unchecked exception from the abort cannot leave the session inside a dead transaction. The stream-load path never reaches `commitStmt`'s empty-item branch with a registered transaction (`commitTxn` returns before `commitStmt` when a wait fails), but the SQL `INSERT` path does: it registers the transaction before executing, a failed `INSERT` only records an error, and a following `COMMIT` used to clear the explicit state and report `VISIBLE` while the transaction stayed `PREPARE` until the timeout checker, holding a running-transaction slot, its label and its tables. That branch now aborts the registered transaction with the same helper (pre-existing, fixed here because the PR introduces the helper).
- `StreamLoadMultiStmtTask.beginTxn` also gives the transaction the task's timeout (the HTTP `timeout` header, default `stream_load_default_timeout_second`), as a classic stream load does. `TransactionStmtExecutor.beginStmt` sizes the transaction timeout from `context.getExecTimeout()`, which for the task's private context was the session default `query_timeout` (300 s); since the transaction is visible to the transaction timeout checker from the first load, a longer transaction would otherwise be aborted by the checker after 300 s (before this PR the same checker dropped the explicit state after 300 s, so the commit failed instead). `commitStmt`'s lock and publish waits follow the same value.
- Side effect that is now correct rather than accidental: `StreamLoadTask.cancelTask` of a failed sub-task really aborts the shared transaction (with the coordinator's tablet infos) instead of logging `transaction not found`, and the transaction's tables are visible to `isPreviousTransactionsFinished` (schema change / reshard) from the first load, like a classic stream load.
- `StreamLoadMultiStmtTask.beginTxn`: bind the task's private `ConnectContext` to the task's warehouse and compute resource before creating the transaction. `TransactionStmtExecutor.beginStmt` stores `context.getCurrentComputeResource()` in the `TransactionState`, and `createPartition` / `updateImmutablePartition` / publish derive tablet locations and nodes from it. In shared-data mode `getCurrentComputeResource()` never returns `null` (it acquires a resource from the context's warehouse, the default one for this private context, and re-acquires whenever the resource's warehouse differs from the context's), so the previous `== null` check never propagated the task's resource and the transaction was bound to the default warehouse while the load's coordinator ran on the task's warehouse. With partition creation now reachable, that would have placed the new partition's tablet locations and nodes in the wrong warehouse.

Why this rather than a fallback lookup into `explicitTxnStateMap` inside the FE RPC handlers: the RPC handlers would still see an unregistered transaction with `dbId == 0`, abort could still not find it, and every other consumer of `DatabaseTransactionMgr` (schema change / reshard waits, running-transaction accounting, `SHOW TRANSACTION`) would keep ignoring an in-flight load. Registering at load start is the smaller and safer change: it is exactly what the SQL explicit-transaction path already does, it reuses the idempotent registration the commit already relies on, and it needs no change in the RPC handlers.

Observability: reviewed the existing signals on this path (`StreamLoadTask.tryBegin` "begin" log, `Add stream load task` log, `FrontendServiceImpl.createPartition` "Receive create partition" / create-partition metrics, `StreamLoadTask.cancelTask` "abort txn fail" warning, `TransactionStmtExecutor.loadData` "load database ... item ..." log, `TransactionStmtExecutor.rollbackStmt` "errors when abort txn" warning, `SHOW TRANSACTION` / `information_schema` visibility of the transaction). All preserved; the transaction now shows up in `DatabaseTransactionMgr` from the first load instead of at commit, which is the accurate state. Added one `DEBUG` line for a rollback that finds the transaction already final; no metric or config change.

Tests:
- `StreamLoadMultiStmtTaskAutoPartitionTest` (real `GlobalTransactionMgr`, no mock of `getTransactionState`): after `begin` + `load`, `createPartition` for the transaction succeeds and creates `p202610` on a `PRIMARY KEY ... PARTITION BY date_trunc('month', ...)` table; `updateImmutablePartition` succeeds for a `DISTRIBUTED BY RANDOM` table; a second table joins the same transaction; the commit-time `loadData` is idempotent; a failed sub-task's `cancelTask` aborts the transaction and the parent's rollback still converges; a rollback without items aborts the registered transaction; a load whose transaction is gone fails without leaving a sub-task behind.
- `StreamLoadMultiStmtTaskTest.testBeginTxnBindsContextToTaskWarehouseInSharedDataMode` and `testBeginTxnUsesTaskTimeoutForTransaction`; `ExplicitTxnTest.testCommitWithoutItemsAbortsRegisteredTransaction` (registered transaction, failed `INSERT`, `COMMIT`: aborted, running count back, table free, label reusable), `testCommitWithoutItemsReportsAbortFailure`, `testRollbackWithoutItemsReportsAbortFailure`, `testRollbackWithoutItemsClearsStateWhenAbortThrowsUnchecked`.
- SQL-tester `test_stream_load_multi_table_auto_partition`: `transaction_type:multi` begin / JSON load into a `PRIMARY KEY` table partitioned by `date_trunc('month', ...)` needing two new partitions / CSV load into a second table needing a new daily partition / commit succeeds, rows are queryable, partitions `p202610`, `p202611`, `p20261005` exist, and a later transaction into an existing partition still works.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
