### PR TITLE
[BugFix] Reject DISTINCT aggregation over a PERCENTILE value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -304,6 +304,24 @@ public class FunctionAnalyzer {
                     functionCallExpr.getPos());
         }
 
+        // DISTINCT aggregation over a PERCENTILE value has no meaning and no rewrite: unlike
+        // count(distinct bitmap) / count(distinct hll) -- which the optimizer rewrites to
+        // bitmap_union_count / hll cardinality -- a PERCENTILE cannot be de-duplicated, so the
+        // call reaches the BE as a raw distinct aggregate. There it is dispatched to the
+        // string/binary distinct path and down_casts the PercentileColumn to a BinaryColumn it is
+        // not, which aborts a debug build (casts.h down_cast on BinaryColumnBase) and dereferences
+        // garbage in a release build (SIGSEGV). Reject it at analysis time instead.
+        if (fnParams.isDistinct()) {
+            for (Expr child : functionCallExpr.getChildren()) {
+                if (child.getType().isPercentile()) {
+                    throw new SemanticException(
+                            "DISTINCT aggregation is not supported for PERCENTILE type: " +
+                                    ExprToSql.toSql(functionCallExpr),
+                            functionCallExpr.getPos());
+                }
+            }
+        }
+
         if (fnName.equals(FunctionSet.COUNT)) {
             // for multiple exprs count must be qualified with distinct
             if (functionCallExpr.getChildren().size() > 1 && !fnParams.isDistinct()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -583,4 +583,19 @@ public class AnalyzeAggregateTest {
         analyzeSuccess("select grouping(v1) from t0 group by all");
         analyzeSuccess("select *, sum(v1) from t0 group by all");
     }
+
+    @Test
+    public void testDistinctOverPercentile() {
+        // count(distinct <PERCENTILE>) has no meaning and no rewrite (unlike count(distinct bitmap)
+        // / count(distinct hll), which the optimizer rewrites to bitmap_union_count / hll
+        // cardinality), so it used to reach the BE as a raw distinct aggregate and crash when the
+        // PercentileColumn was down_cast to a BinaryColumn. It must be rejected up front.
+        analyzeFail("select count(distinct percentile_hash(cast(1 as double)))",
+                "DISTINCT aggregation is not supported for PERCENTILE type");
+        analyzeFail("select count(distinct p1) from test_object",
+                "DISTINCT aggregation is not supported for PERCENTILE type");
+        // count(distinct bitmap) / count(distinct hll) stay supported -- only PERCENTILE is rejected.
+        analyzeSuccess("select count(distinct b1) from test_object");
+        analyzeSuccess("select count(distinct h1) from test_object");
+    }
 }

--- a/test/sql/test_agg_function/R/test_distinct_over_percentile
+++ b/test/sql/test_agg_function/R/test_distinct_over_percentile
@@ -1,0 +1,19 @@
+-- name: test_distinct_over_percentile
+select count(distinct percentile_hash(cast(1 as double)));
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 56. Detail message: DISTINCT aggregation is not supported for PERCENTILE type: count(DISTINCT percentile_hash(CAST(1 AS DOUBLE))).')
+-- !result
+create table t_obj (k int, b bitmap bitmap_union, h hll hll_union) aggregate key(k) distributed by hash(k) buckets 1 properties("replication_num"="1");
+-- result:
+-- !result
+insert into t_obj values (1, to_bitmap(10), hll_hash(10)), (1, to_bitmap(20), hll_hash(20)), (2, to_bitmap(10), hll_hash(10));
+-- result:
+-- !result
+select count(distinct b), count(distinct h) from t_obj;
+-- result:
+2	2
+-- !result
+select count(distinct to_bitmap(v)) from (select 10 v union all select 20 union all select 10) t;
+-- result:
+2
+-- !result

--- a/test/sql/test_agg_function/T/test_distinct_over_percentile
+++ b/test/sql/test_agg_function/T/test_distinct_over_percentile
@@ -1,0 +1,11 @@
+-- name: test_distinct_over_percentile
+-- count(DISTINCT <PERCENTILE>) crashed the BE: a PERCENTILE has no distinct-count rewrite (unlike
+-- count(distinct bitmap) / count(distinct hll)) and no meaning under DISTINCT, so it reached the BE
+-- as a raw distinct aggregate and down_cast the PercentileColumn to a BinaryColumn it is not. It is
+-- now rejected during analysis.
+select count(distinct percentile_hash(cast(1 as double)));
+-- count(distinct bitmap) / count(distinct hll) stay supported (rewritten to bitmap_union_count / hll cardinality)
+create table t_obj (k int, b bitmap bitmap_union, h hll hll_union) aggregate key(k) distributed by hash(k) buckets 1 properties("replication_num"="1");
+insert into t_obj values (1, to_bitmap(10), hll_hash(10)), (1, to_bitmap(20), hll_hash(20)), (2, to_bitmap(10), hll_hash(10));
+select count(distinct b), count(distinct h) from t_obj;
+select count(distinct to_bitmap(v)) from (select 10 v union all select 20 union all select 10) t;


### PR DESCRIPTION
## Why I'm doing:

count(DISTINCT percentile_hash(...)) -- and any DISTINCT aggregate over a PERCENTILE value -- crashed the BE. Unlike count(distinct bitmap) and count(distinct hll), which the optimizer rewrites to bitmap_union_count / hll cardinality, a PERCENTILE has no distinct-count rewrite and no meaning under DISTINCT, so the call reaches the BE as a raw distinct aggregate. There the distinct aggregate is dispatched to the string/binary path and down_casts the PercentileColumn to a BinaryColumn it is not: the assertion aborts a debug build (casts.h down_cast on BinaryColumnBase<unsigned int>) and dereferences garbage in a release build (SIGSEGV in AdaptiveSliceHashSet::emplace).

Reject it during analysis in FunctionAnalyzer, where DISTINCT aggregation over a PERCENTILE argument now raises a SemanticException. bitmap and hll DISTINCT aggregation are unaffected -- only PERCENTILE is rejected.

```
** SIGABRT (@0xea5b1) received by PID 959921 (TID 0x7effa377b6c0) LWP(960567) from PID 959921; stack trace: ***
    @         0x33541647 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f027073aed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x33540e46 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f02706de330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7f0270737b2c pthread_kill
    @     0x7f02706de27e gsignal
    @     0x7f02706c18ff abort
    @     0x7f02706c181b (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2881a)
    @     0x7f02706d4517 __assert_fail
    @         0x1d649efe starrocks::BinaryColumnBase<unsigned int> const* down_cast<starrocks::BinaryColumnBase<unsigned int> const*, starrocks::Column const>(starrocks::Column const*)
    @         0x1e3a9edc starrocks::GetContainer<(starrocks::LogicalType)13>::get_data(starrocks::Column const*)
    @         0x253d85dd starrocks::GetContainer<(starrocks::LogicalType)13>::get_data(starrocks::Column const*, unsigned long)
    @         0x299f746a starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, starrocks::Slice>::update(starrocks::FunctionContext*, starrocks::Column const**, unsigned cha@
    @         0x2935fec7 starrocks::NullableAggregateFunctionUnary<starrocks::TDistinctAggregateFunction<(starrocks::LogicalType)13, (starrocks::LogicalType)13, starrocks::DistinctAggregateStateV2, (starrocks::AggDistinctType)0, starrocks::Slice>*, starrocks::NullableAggregateFunc@
    @         0x1dd93a21 starrocks::AggregateFunction::update_batch_exception_safe(starrocks::FunctionContext*, unsigned long, unsigned long, starrocks::Column const**, unsigned char**) const
    @         0x1db74a5f starrocks::Aggregator::compute_batch_agg_states(starrocks::Chunk*, unsigned long)
    @         0x1efb8321 starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @         0x23bb9c5e starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @         0x1e9b54d3 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x1e9b386a starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x1e9bb574 void std::__invoke_impl<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&)
    @         0x1e9bacba std::enable_if<is_invocable_r_v<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}&>(starrocks::pipeline::GlobalDriver@
    @         0x1e9ba78a std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1ce8707e std::function<void ()>::operator()() const
    @         0x2e998bcc starrocks::FunctionRunnable::run()
    @         0x2e9929d2 starrocks::ThreadPool::dispatch_thread()
    @         0x2e9b3cc2 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2e9b2660 std::__invoke_result<void (starrocks::Thre
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
