### PR TITLE
[UT] Record 4.1 Iceberg mixed-spec scan as 8/8 and wait flat_json ALTER

### DIFF
--- a/test/sql/test_iceberg/T/test_iceberg_partition_evolution_1
+++ b/test/sql/test_iceberg/T/test_iceberg_partition_evolution_1
@@ -37,13 +37,13 @@ SELECT country, COUNT(*) AS c, SUM(score) AS s FROM test_users_bucketed GROUP BY
 -- check partition pruning
 SELECT COUNT(*), SUM(score) FROM test_users_bucketed WHERE user_id IN (1,2,3,4,5,6,7,16,32);
 
--- partitions=7/8
-function: assert_explain_verbose_contains("SELECT COUNT(*), SUM(score) FROM test_users_bucketed WHERE user_id IN (1,2,3,4,5,6,7,16,32);", "partitions=7/8")
+-- partitions=8/8: 4.1 does not prune mixed bucket specs after evolution
+function: assert_explain_verbose_contains("SELECT COUNT(*), SUM(score) FROM test_users_bucketed WHERE user_id IN (1,2,3,4,5,6,7,16,32);", "partitions=8/8")
 
 SELECT COUNT(*), SUM(score) FROM test_users_bucketed WHERE user_id IN (1,2,3,4);
 
--- partitions=3/8
-function: assert_explain_verbose_contains("SELECT COUNT(*), SUM(score) FROM test_users_bucketed WHERE user_id IN (1,2,3,4);", "partitions=3/8")
+-- partitions=8/8
+function: assert_explain_verbose_contains("SELECT COUNT(*), SUM(score) FROM test_users_bucketed WHERE user_id IN (1,2,3,4);", "partitions=8/8")
 
 function: assert_query_contains("analyze table test_users_bucketed;", "OK")
 

--- a/test/sql/test_semi/R/test_flat_json_config
+++ b/test/sql/test_semi/R/test_flat_json_config
@@ -30,6 +30,10 @@ SELECT id, my_json_col FROM test_json_config ORDER BY id;
 ALTER TABLE test_json_config SET ("flat_json.null.factor" = "0.2");
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+[UC]
+-- !result
 INSERT INTO test_json_config VALUES
 (4, parse_json('{"key1": "value4", "key2": 400, "key5": "new"}')),
 (5, parse_json('{"key1": "value5", "key2": 500}'));
@@ -53,6 +57,10 @@ SELECT id, my_json_col->'$.key1' FROM test_json_config ORDER BY id;
 -- !result
 ALTER TABLE test_json_config SET ("flat_json.sparsity.factor" = "0.9");
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+[UC]
 -- !result
 INSERT INTO test_json_config VALUES
 (6, parse_json('{"key1": "value6", "key2": 600, "key6": "sparsity"}')),
@@ -81,6 +89,10 @@ SELECT id, my_json_col->'$.key2' FROM test_json_config ORDER BY id;
 -- !result
 ALTER TABLE test_json_config SET ("flat_json.column.max" = "100");
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+[UC]
 -- !result
 INSERT INTO test_json_config VALUES
 (8, parse_json('{"key1": "value8", "key2": 800, "key3": false, "key7": "max"}')),
@@ -113,6 +125,10 @@ SELECT id, my_json_col->'$.key3' FROM test_json_config ORDER BY id;
 -- !result
 ALTER TABLE test_json_config SET ("flat_json.enable" = "false");
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+[UC]
 -- !result
 INSERT INTO test_json_config VALUES
 (10, parse_json('{"key1": "value10", "key2": 1000, "key8": "disabled"}')),
@@ -154,6 +170,10 @@ SELECT COUNT(*) FROM test_json_config;
 ALTER TABLE test_json_config SET ("flat_json.enable" = "true");
 -- result:
 -- !result
+function: wait_alter_table_finish()
+-- result:
+[UC]
+-- !result
 INSERT INTO test_json_config VALUES
 (12, parse_json('{"key1": "value12", "key2": 1200, "key9": "reenabled"}')),
 (13, parse_json('{"key1": "value13", "key2": 1300}'));
@@ -193,6 +213,10 @@ SELECT id, my_json_col->'$.key2' FROM test_json_config ORDER BY id;
 -- !result
 ALTER TABLE test_json_config SET ("flat_json.enable" = "false");
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+[UC]
 -- !result
 INSERT INTO test_json_config VALUES
 (14, parse_json('{"key1": "value14", "key2": 1400, "key10": "disabled2"}')),
@@ -259,6 +283,10 @@ SELECT id, my_json_col->'$.key1' FROM test_json_config ORDER BY id;
 -- !result
 ALTER TABLE test_json_config SET ("flat_json.enable" = "true");
 -- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+[UC]
 -- !result
 INSERT INTO test_json_config VALUES
 (16, parse_json('{"key1": "value16", "key2": 1600, "key11": "final"}')),

--- a/test/sql/test_semi/T/test_flat_json_config
+++ b/test/sql/test_semi/T/test_flat_json_config
@@ -29,6 +29,7 @@ SELECT id, my_json_col FROM test_json_config ORDER BY id;
 
 -- Step 2: Modify flat_json.null.factor
 ALTER TABLE test_json_config SET ("flat_json.null.factor" = "0.2");
+function: wait_alter_table_finish()
 
 -- Insert data after changing null.factor
 INSERT INTO test_json_config VALUES
@@ -41,6 +42,7 @@ SELECT id, my_json_col->'$.key1' FROM test_json_config ORDER BY id;
 
 -- Step 3: Modify flat_json.sparsity.factor
 ALTER TABLE test_json_config SET ("flat_json.sparsity.factor" = "0.9");
+function: wait_alter_table_finish()
 
 -- Insert data after changing sparsity.factor
 INSERT INTO test_json_config VALUES
@@ -53,6 +55,7 @@ SELECT id, my_json_col->'$.key2' FROM test_json_config ORDER BY id;
 
 -- Step 4: Modify flat_json.column.max
 ALTER TABLE test_json_config SET ("flat_json.column.max" = "100");
+function: wait_alter_table_finish()
 
 -- Insert data after changing column.max
 INSERT INTO test_json_config VALUES
@@ -65,6 +68,7 @@ SELECT id, my_json_col->'$.key3' FROM test_json_config ORDER BY id;
 
 -- Step 5: Disable flat JSON (critical test - should not throw exception)
 ALTER TABLE test_json_config SET ("flat_json.enable" = "false");
+function: wait_alter_table_finish()
 
 -- Insert data after disabling flat JSON (should work)
 INSERT INTO test_json_config VALUES
@@ -80,6 +84,7 @@ SELECT COUNT(*) FROM test_json_config;
 
 -- Step 6: Re-enable flat JSON
 ALTER TABLE test_json_config SET ("flat_json.enable" = "true");
+function: wait_alter_table_finish()
 
 -- Insert data after re-enabling flat JSON
 INSERT INTO test_json_config VALUES
@@ -92,6 +97,7 @@ SELECT id, my_json_col->'$.key2' FROM test_json_config ORDER BY id;
 
 -- Step 7: Disable flat JSON again
 ALTER TABLE test_json_config SET ("flat_json.enable" = "false");
+function: wait_alter_table_finish()
 
 -- Insert data after disabling again (should work)
 INSERT INTO test_json_config VALUES
@@ -106,6 +112,7 @@ SELECT id, my_json_col->'$.key1' FROM test_json_config ORDER BY id;
 
 -- Step 8: Re-enable and verify all queries still work
 ALTER TABLE test_json_config SET ("flat_json.enable" = "true");
+function: wait_alter_table_finish()
 
 -- Insert data after final re-enable
 INSERT INTO test_json_config VALUES


### PR DESCRIPTION
## Why I'm doing:

4.1.5 sql-tester inspection (dab30b5) still fails `test_iceberg_partition_evolution_1` on all four matrices: explain verbose scans `partitions=8/8` after bucket spec evolution, while T still asserts main's `7/8` / `3/8` (R on branch-4.1 already recorded `8/8` in #77033). `test_flat_json_config` hits schema-change-in-progress on native, and `wait_alter_table_finish()` returns `None` or empty depending on whether `SHOW ALTER` still has the job.

## What I'm doing:

Test-only; no product behavior change.

- `test_iceberg_partition_evolution_1`: sync T asserts with R / inspection (`7/8` → `8/8`, `3/8` → `8/8`). Query COUNT/SUM stay correct.
- `test_flat_json_config`: wait for schema change after each `ALTER TABLE SET`, and `[UC]` the helper return (`None` vs empty).


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4