### PR TITLE
[BugFix] Merge the delete vector when column-upsert publish supersedes its own segments

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -874,6 +874,8 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
     uint64_t total_rows = 0;
     uint64_t total_data_size = 0;
     std::map<uint32_t, size_t> segment_id_to_add_dels_new_acc;
+    // Rows superseded within this load, keyed by the synthesized segment they live in.
+    std::map<uint32_t, std::vector<uint32_t>> new_deletes_by_rssid;
 
     DCHECK_EQ(insert_rowids_by_segment.size(), op_write.rowset().segment_metas_size());
 
@@ -954,15 +956,36 @@ Status UpdateManager::_handle_column_upsert_mode(const TxnLogPB_OpWrite& op_writ
         RETURN_IF_ERROR(index.upsert(rowset_id + new_segment_id, 0, *pk_column_for_upsert, 0,
                                      pk_column_for_upsert->size(), &segment_deletes));
 
+        // These deletes are not necessarily empty. The index probe that classified a row as an
+        // insert runs once, before the first insert, so every occurrence of a key within this load
+        // is classified as an insert and the loop above makes them supersede each other: the upsert
+        // for a later segment returns deletes against an earlier segment of this same load. Collect
+        // them per rssid and write each segment's vector once, after the loop.
         for (auto& [rssid, del_ids] : segment_deletes) {
-            DCHECK(del_ids.empty()) << "del_ids should be empty for new row segments, but got " << del_ids.size()
-                                    << " deletes for rssid=" << rssid;
             if (del_ids.empty()) continue;
-            DelVectorPtr dv = std::make_shared<DelVector>();
-            dv->init(metadata->version(), del_ids.data(), del_ids.size());
-            builder->append_delvec(dv, rssid);
-            segment_id_to_add_dels_new_acc[rssid] += del_ids.size();
+            auto& acc = new_deletes_by_rssid[rssid];
+            acc.insert(acc.end(), del_ids.begin(), del_ids.end());
         }
+    }
+
+    // Merge into the segment's current delete vector rather than writing a fresh one, exactly like
+    // the delete half below: append_delvec() replaces _delvecs[rssid], so a fresh vector would
+    // discard marks already placed on that segment and bring those rows back to life. Collecting
+    // first and appending once per rssid also keeps the publish buffer proportional to the rows
+    // deleted -- append_delvec() only repoints the map entry and never reclaims the bytes an earlier
+    // call wrote, so appending per iteration would leave every intermediate vector in the delvec
+    // file. get_del_vec() returns an empty vector for an rssid that has none, so a segment deleted
+    // from only once is written exactly as before.
+    for (auto& [rssid, del_ids] : new_deletes_by_rssid) {
+        TabletSegmentId tsid;
+        tsid.tablet_id = tablet->id();
+        tsid.segment_id = rssid;
+        DelVectorPtr old_delvec;
+        RETURN_IF_ERROR(get_del_vec(tsid, base_version, builder, false, &old_delvec));
+        DelVectorPtr dv_new;
+        old_delvec->add_dels_as_new_version(del_ids, metadata->version(), &dv_new);
+        builder->append_delvec(dv_new, rssid);
+        segment_id_to_add_dels_new_acc[rssid] += del_ids.size();
     }
 
     new_rows_op.mutable_rowset()->set_num_rows(total_rows);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -3129,6 +3129,131 @@ TEST_F(LakeColumnUpsertModeTest, upsert_existing_rows_generates_dcg_only) {
     EXPECT_GT(md->dcg_meta().dcgs_size(), 0);
 }
 
+// A COLUMN_UPSERT_MODE load synthesizes one new-row segment per update segment and upserts each into
+// the primary index in turn, so a key that occurs in more than one of the load's own update segments
+// makes a later iteration return deletes against an earlier iteration's segment. When two later
+// iterations both hit the same earlier segment, that segment's delete vector is written twice inside
+// one publish -- and append_delvec() replaces the entry rather than merging it, so a fresh DelVector
+// drops the first write's marks and those superseded rows go live again, leaving two live rows for one
+// primary key with no error anywhere.
+//
+// The shape below is the minimal one that writes a segment's delete vector twice: twelve brand-new
+// keys in the first update segment, then the even half, then the odd half. Both later segments
+// supersede rows in the first, and neither overlaps the other.
+TEST_F(LakeColumnUpsertModeTest, column_upsert_merges_delvec_across_update_segments) {
+    auto tablet_id = _tablet_metadata->id();
+    auto version = 1;
+    constexpr int kNewKeyBase = 100;
+
+    auto partial_chunk = [this](const std::vector<int>& keys, int multiplier) {
+        std::vector<int> values(keys.size());
+        for (size_t i = 0; i < keys.size(); i++) {
+            values[i] = keys[i] * multiplier;
+        }
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(keys.data(), keys.size() * sizeof(int));
+        c1->append_numbers(values.data(), values.size() * sizeof(int));
+        return Chunk({std::move(c0), std::move(c1)}, _slot_cid_map);
+    };
+
+    std::vector<int> all_keys(kChunkSize);
+    std::vector<int> even_keys;
+    std::vector<int> odd_keys;
+    for (int i = 0; i < kChunkSize; i++) {
+        all_keys[i] = kNewKeyBase + i;
+        (i % 2 == 0 ? even_keys : odd_keys).push_back(all_keys[i]);
+    }
+
+    // Seed the table so the column-upsert load runs against real base data.
+    {
+        auto chunk_full = generate_data(kChunkSize, 0, false, 3);
+        auto indexes = std::vector<uint32_t>(kChunkSize);
+        for (int i = 0; i < kChunkSize; i++) indexes[i] = i;
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk_full, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // One column-upsert load, three update segments: all keys, then the even half, then the odd half.
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(_tablet_schema->id())
+                                                   .set_slot_descriptors(&_slot_pointers)
+                                                   .set_partial_update_mode(PartialUpdateMode::COLUMN_UPSERT_MODE)
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        for (const auto& [keys, multiplier] :
+             std::vector<std::pair<std::vector<int>, int>>{{all_keys, 5}, {even_keys, 7}, {odd_keys, 9}}) {
+            auto chunk = partial_chunk(keys, multiplier);
+            std::vector<uint32_t> indexes(keys.size());
+            for (size_t i = 0; i < keys.size(); i++) indexes[i] = i;
+            ASSERT_OK(delta_writer->write(chunk, indexes.data(), indexes.size()));
+            // Close the memtable so each batch becomes its own update segment.
+            ASSERT_OK(delta_writer->flush());
+        }
+        ASSERT_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+
+    // Every key must be live exactly once, carrying the value of the last segment that wrote it:
+    // the even keys were last written by the second segment, the odd keys by the third. Without the
+    // merge, the first segment's even rows survive as well and those keys have two live rows.
+    std::map<int, std::vector<std::pair<int, int>>> rows_by_key;
+    {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
+        ASSERT_OK(reader->prepare());
+        ASSERT_OK(reader->open(TabletReaderParams()));
+        auto chunk = ChunkFactory::new_chunk(*_schema, 128);
+        while (true) {
+            auto st = reader->get_next(chunk.get());
+            if (st.is_end_of_file()) break;
+            ASSERT_OK(st);
+            auto cols = chunk->columns();
+            for (int i = 0; i < chunk->num_rows(); i++) {
+                rows_by_key[cols[0]->get(i).get_int32()].emplace_back(cols[1]->get(i).get_int32(),
+                                                                      cols[2]->get(i).get_int32());
+            }
+            chunk->reset();
+        }
+    }
+
+    for (int key : all_keys) {
+        const auto& rows = rows_by_key[key];
+        ASSERT_EQ(1, rows.size()) << "primary key " << key << " has " << rows.size() << " live rows";
+        const int expected_multiplier = ((key - kNewKeyBase) % 2 == 0) ? 7 : 9;
+        EXPECT_EQ(key * expected_multiplier, rows[0].first) << "key " << key << " kept a superseded value";
+        EXPECT_EQ(10, rows[0].second) << "key " << key << " should carry c2's default";
+    }
+    EXPECT_EQ(2 * kChunkSize, rows_by_key.size());
+    size_t total_rows = 0;
+    for (const auto& [key, rows] : rows_by_key) {
+        total_rows += rows.size();
+    }
+    EXPECT_EQ(2 * kChunkSize, total_rows) << "a superseded row was resurrected";
+}
+
 TEST_F(LakeColumnUpsertModeTest, partial_update_reads_encrypted_dcg_segments) {
     auto chunk_full = generate_data(kChunkSize, 0, false, 3);
     auto chunk_partial = generate_data(kChunkSize, 0, true, 7);


### PR DESCRIPTION
## Why I'm doing:

A shared-data primary-key table can end up with **two live rows for one primary key**, written by a
load that reported success. Nothing fails at write time; the damage is only noticed much later, when
a CN restart or a tablet re-placement rebuilds the persistent index and
`PersistentIndexMemtable::insert()` returns `Already exist... insert found duplicate key`. Once that
happens every publish retry for the tablet fails.

The producer is the **column-mode partial update** publish path.
`UpdateManager::_handle_column_upsert_mode` synthesizes one new-row segment per update segment of the
load and upserts each into the primary index in turn. When a key occurs in more than one of the
load's own update segments, a later iteration's `index.upsert` returns deletes against an earlier
iteration's segment — and the loop writes those deletes as a **fresh** `DelVector`:

```c++
DelVectorPtr dv = std::make_shared<DelVector>();
dv->init(metadata->version(), del_ids.data(), del_ids.size());
builder->append_delvec(dv, rssid);
```

`MetaFileBuilder::append_delvec()` *replaces* `_delvecs[rssid]` rather than merging into it
(`meta_file.cpp`), so when two later iterations both land deletes on the same earlier segment, the
second silently discards the first's marks and those superseded rows go live again. Every other
delvec producer in the tree first reads the current vector with `get_del_vec()` and merges with
`add_dels_as_new_version()`; the correct sibling is ~40 lines below in this same function, in the
delete half of the same publish.

The `DCHECK(del_ids.empty())` above the loop asserted this could not happen. Its premise is false:
the batched index probe that classifies a row as an insert runs **once, before any insert**
(`column_mode_partial_update_handler.cpp`), so every occurrence of a key within the load is
classified `insert` and the loop itself makes them collide. The DCHECK is compiled out of release
builds, and on a debug build it would abort the CN on a legitimate input.

**Measured**, on a 3-node shared-data cluster with stock configuration, one stream load with
`partial_update_mode:column`, no explicit transaction, 24 M rows / 793 MB / 23 s:

```
total = 19,968,166 distinct primary keys = 12,000,000 -> 7,968,166 duplicated rows
```

Every duplicated key had exactly 2 live rows, and no CN logged anything. Two checks separate the
mechanism from the symptom:

* The per-block fingerprint is **monotone with the last writer winning** — the marks of the last
 block survive everywhere and the earlier blocks' are lost. Wholesale delvec loss would duplicate
 the last block too; a broken insert path would duplicate all of them.
* A **negative control** on the same binary, cluster, load shape and key count, differing only in
 that the later re-writes land in a *single* update segment (so no segment's delete vector is
 written twice), gives `excess = 0`.

Reachability: needs `partial_update_mode=column` on the load (`auto`/unset resolve to row mode, which
takes a different publish implementation and is unaffected) and at least three update segments per
tablet in one load, with a key repeating across them.

Triage signal for an unfixed binary: a publish trace in `cn.INFO` carrying `"pcu_upt_cnt":N` with
`N >= 3` and non-zero `"pcu_insert_rows"` is a load that could have taken this path.

## What I'm doing:

Make the insert half merge like the delete half: read the current vector with `get_del_vec()` and
`add_dels_as_new_version()` before appending, and drop the false `DCHECK`. `get_del_vec()` returns an
empty vector for an rssid that has none, so the first write for a segment is unchanged and only the
second and later ones are corrected; each iteration contributes a disjoint set of rowids.

`update_num_del_stat` needed no change — it already accumulates with `+=` rather than assigning.

**Test.** `LakeColumnUpsertModeTest.column_upsert_merges_delvec_across_update_segments` builds the
minimal shape that writes one segment's delete vector twice in a single publish: one column-upsert
load whose three update segments hold all twelve new keys, then the even half, then the odd half.
Both later segments supersede rows in the first and neither overlaps the other. The test asserts every
key is live exactly once and carries the value of the last segment that wrote it. Without the fix the
even keys have two live rows each.

**Observability:** no signal was added or removed. The path had none — the defect is silent by
construction, which is why it took a rebuild to surface. The existing `pcu_upt_cnt` / `pcu_insert_rows`
publish trace counters are what identify an at-risk load and they are untouched.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5