### PR TITLE
[Enhancement] Record the query error message in the audit log

### DIFF
--- a/docs/en/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/en/administration/configuration/FE_parameters/log_server_meta.md
@@ -92,6 +92,15 @@ This topic introduces the following types of FE configurations:
 - Description: When true, the generated Log4j2 configuration appends a ".gz" postfix to rotated audit log filenames (fe.audit.log.*) so that Log4j2 will produce compressed (.gz) archived audit log files on rollover. The setting is read during FE startup in Log4jConfig.initLogging and is applied to the RollingFile appender for audit logs; it only affects rotated/archived files, not the active audit log. Because the value is initialized at startup, changing it requires restarting the FE to take effect. Use alongside audit log rotation settings (`audit_log_dir`, `audit_log_roll_interval`, `audit_roll_maxsize`, `audit_log_roll_num`).
 - Introduced in: 3.2.12
 
+### `audit_log_error_message_max_length`
+
+- Default: 1024
+- Type: Int
+- Unit: Characters
+- Is mutable: Yes
+- Description: The maximum length of the `ErrorMessage` field recorded in the audit log for a failed statement, counted in UTF-16 code units, so a character outside the Basic Multilingual Plane such as an emoji counts as two. A longer message is truncated and suffixed with `... /* truncated, audit_log_error_message_max_length=<value> */`; the suffix is not counted against the limit. Set it to `0` to stop recording error messages altogether, in which case the field is omitted from the audit record. Error messages are also omitted when `enable_sql_desensitize_in_log` is `true` or when `enable_audit_sql` is `false`, because an error message quotes the statement that failed, down to the values and the offending token.
+- Introduced in: 4.2.0
+
 ### `audit_log_json_format`
 
 - Default: false

--- a/docs/en/administration/management/audit_loader.md
+++ b/docs/en/administration/management/audit_loader.md
@@ -39,6 +39,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
   `db` VARCHAR(96) COMMENT "Database where the query runs",
   `state` VARCHAR(8) COMMENT "Query state (EOF, ERR, OK)",
   `errorCode` VARCHAR(512) COMMENT "Error code",
+  `errorMessage` VARCHAR(1048576) NULL COMMENT "Error message returned to the client",
   `queryTime` BIGINT COMMENT "Query execution time (milliseconds)",
   `scanBytes` BIGINT COMMENT "Number of bytes scanned by the query",
   `scanRows` BIGINT COMMENT "Number of rows scanned by the query",
@@ -74,6 +75,19 @@ SHOW PARTITIONS FROM starrocks_audit_db__.starrocks_audit_tbl__;
 ```
 
 After a partition is created, you can move on to the next step.
+
+:::note
+
+If the table already exists from an earlier version, add the columns that were introduced since, otherwise the corresponding fields are silently dropped when the audit logs are loaded. For example, `errorMessage` is introduced in v4.2.0:
+
+```SQL
+ALTER TABLE starrocks_audit_db__.starrocks_audit_tbl__
+ADD COLUMN `errorMessage` VARCHAR(1048576) NULL COMMENT "Error message returned to the client" AFTER `errorCode`;
+```
+
+Add the column before you configure the `filter` property of AuditLoader to reference it, because that filter is evaluated against the columns of the table.
+
+:::
 
 ## Download and configure AuditLoader
 

--- a/docs/ja/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/ja/administration/configuration/FE_parameters/log_server_meta.md
@@ -92,6 +92,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明：true の場合、生成された Log4j2 設定は、ローテーションされた監査ログファイル名 (fe.audit.log.*) に ".gz" 接尾辞を追加し、Log4j2 がロールオーバー時に圧縮された (.gz) アーカイブ監査ログファイルを生成するようにします。この設定は、FE 起動時に Log4jConfig.initLogging で読み込まれ、監査ログの RollingFile アペンダーに適用されます。アクティブな監査ログではなく、ローテーション/アーカイブされたファイルにのみ影響します。値は起動時に初期化されるため、変更を有効にするには FE の再起動が必要です。監査ログのローテーション設定 (`audit_log_dir`、`audit_log_roll_interval`、`audit_roll_maxsize`、`audit_log_roll_num`) とともに使用します。
 - 導入時期：3.2.12
 
+### `audit_log_error_message_max_length`
+
+- デフォルト：1024
+- タイプ：Int
+- 単位：文字
+- 変更可能：Yes
+- 説明：ステートメントが失敗した場合に監査ログの `ErrorMessage` フィールドへ記録される最大長です。長さは UTF-16 コードユニットで数えるため、絵文字などの基本多言語面外の文字は 2 としてカウントされます。これを超えるエラーメッセージは切り詰められ、末尾に `... /* truncated, audit_log_error_message_max_length=<value> */` が付きます（この接尾辞は上限に含まれません）。`0` に設定するとエラーメッセージは記録されず、監査レコードにこのフィールドは現れません。エラーメッセージはステートメントを失敗させた値やエラー箇所のトークンを含むため、`enable_sql_desensitize_in_log` が `true` の場合、および `enable_audit_sql` が `false` の場合も記録されません。
+- 導入時期：4.2.0
+
 ### `audit_log_json_format`
 
 - デフォルト：false

--- a/docs/ja/administration/management/audit_loader.md
+++ b/docs/ja/administration/management/audit_loader.md
@@ -36,6 +36,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
   `db` VARCHAR(96) COMMENT "クエリが実行されるデータベース",
   `state` VARCHAR(8) COMMENT "クエリ状態（EOF、ERR、OK）",
   `errorCode` VARCHAR(512) COMMENT "エラーコード",
+  `errorMessage` VARCHAR(1048576) NULL COMMENT "クライアントに返されたエラーメッセージ",
   `queryTime` BIGINT COMMENT "クエリ実行時間（ミリ秒）",
   `scanBytes` BIGINT COMMENT "クエリでスキャンされたバイト数",
   `scanRows` BIGINT COMMENT "クエリでスキャンされた行数",
@@ -70,6 +71,19 @@ SHOW PARTITIONS FROM starrocks_audit_db__.starrocks_audit_tbl__;
 ```
 
 パーティションが作成されたら、次のステップに進むことができます。
+
+:::note
+
+テーブルが以前のバージョンで作成済みの場合は、その後に追加されたカラムを追加してください。追加しないと、監査ログのロード時に該当フィールドが通知なく破棄されます。たとえば `errorMessage` は v4.2.0 で導入されました。
+
+```SQL
+ALTER TABLE starrocks_audit_db__.starrocks_audit_tbl__
+ADD COLUMN `errorMessage` VARCHAR(1048576) NULL COMMENT "クライアントに返されたエラーメッセージ" AFTER `errorCode`;
+```
+
+AuditLoader の `filter` プロパティでこのカラムを参照する前に、カラムを追加してください。このフィルタはテーブルのカラムに対して評価されるためです。
+
+:::
 
 ## AuditLoader のダウンロードと設定
 

--- a/docs/zh/administration/configuration/FE_parameters/log_server_meta.md
+++ b/docs/zh/administration/configuration/FE_parameters/log_server_meta.md
@@ -92,6 +92,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当为 true 时，生成的 Log4j2 配置会将 ".gz" 后缀附加到轮转的审计日志文件名 (fe.audit.log.*) 中，以便 Log4j2 在轮转时生成压缩的 (.gz) 归档审计日志文件。此设置在 FE 启动期间在 Log4jConfig.initLogging 中读取，并应用于审计日志的 RollingFile appender；它仅影响轮转/归档文件，而不影响活动审计日志。由于该值在启动时初始化，因此更改它需要重启 FE 才能生效。与审计日志轮转设置 (`audit_log_dir`、`audit_log_roll_interval`、`audit_roll_maxsize`、`audit_log_roll_num`) 一起使用。
 - 引入版本: 3.2.12
 
+### `audit_log_error_message_max_length`
+
+- 默认值: 1024
+- 类型: Int
+- 单位: 字符
+- 是否可变: Yes
+- 描述: 语句执行失败时，审计日志中 `ErrorMessage` 字段记录的最大长度，按 UTF-16 code unit 计算，因此基本多文种平面之外的字符（例如 emoji）按两个计。超长的错误信息会被截断，并追加 `... /* truncated, audit_log_error_message_max_length=<value> */`，该后缀本身不计入上限。设置为 `0` 表示不再记录错误信息，此时审计记录中不会出现该字段。当 `enable_sql_desensitize_in_log` 为 `true`，或 `enable_audit_sql` 为 `false` 时，同样不记录错误信息，因为错误信息会引用导致语句失败的具体值和出错的 token。
+- 引入版本: 4.2.0
+
 ### `audit_log_json_format`
 
 - 默认值: false

--- a/docs/zh/administration/management/audit_loader.md
+++ b/docs/zh/administration/management/audit_loader.md
@@ -34,6 +34,7 @@ CREATE TABLE starrocks_audit_db__.starrocks_audit_tbl__ (
   `db` VARCHAR(96) COMMENT "查询所在数据库",
   `state` VARCHAR(8) COMMENT "查询状态（EOF，ERR，OK）",
   `errorCode` VARCHAR(512) COMMENT "错误码",
+  `errorMessage` VARCHAR(1048576) NULL COMMENT "返回给客户端的错误信息",
   `queryTime` BIGINT COMMENT "查询执行时间（毫秒）",
   `scanBytes` BIGINT COMMENT "查询扫描的字节数",
   `scanRows` BIGINT COMMENT "查询扫描的记录行数",
@@ -69,6 +70,19 @@ SHOW PARTITIONS FROM starrocks_audit_db__.starrocks_audit_tbl__;
 ```
 
 待分区创建完成后，您可以继续下一步。
+
+:::note
+
+如果该表是由早期版本创建的，请补齐此后新增的列，否则导入审计日志时对应字段会被静默丢弃。例如 `errorMessage` 自 v4.2.0 起引入：
+
+```SQL
+ALTER TABLE starrocks_audit_db__.starrocks_audit_tbl__
+ADD COLUMN `errorMessage` VARCHAR(1048576) NULL COMMENT "返回给客户端的错误信息" AFTER `errorCode`;
+```
+
+请在 AuditLoader 的 `filter` 属性引用该列之前先完成加列，因为该过滤条件是基于表的列进行计算的。
+
+:::
 
 ## 下载并配置 AuditLoader
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -205,6 +205,9 @@ public class Config extends ConfigBase {
     public static int audit_log_delete_count = -1;
     @ConfField(mutable = true)
     public static boolean audit_log_json_format = false;
+    @ConfField(mutable = true, comment = "Max length of the error message recorded in the audit log, truncate " +
+            "messages longer than this specified limit. Set to 0 to stop recording error messages. Default: 1024")
+    public static int audit_log_error_message_max_length = 1024;
     @ConfField
     public static boolean audit_log_enable_compress = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/LogUtil.java
@@ -59,7 +59,10 @@ public class LogUtil {
                 .setFeIp(FrontendOptions.getLocalHostAddress())
                 .setDb(authPacket == null ? "null" : authPacket.getDb())
                 .setState(ctx.getState().toString())
-                .setErrorCode(ctx.getState().getErrorMessage());
+                // Connection audit has always reported the message in ErrorCode; keep doing so
+                // for the users already reading that field, collapsed so it cannot break the record.
+                .setErrorCode(AuditEvent.collapseSeparators(ctx.getState().getErrorMessage()))
+                .setErrorMessage(ctx.getState().getErrorMessage());
         GlobalStateMgr.getCurrentState().getAuditEventProcessor().handleAuditEvent(builder.build());
 
         QueryDetail queryDetail = new QueryDetail();

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -35,6 +35,9 @@
 package com.starrocks.plugin;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.SqlCredentialRedactor;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 
@@ -45,6 +48,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /*
  * AuditEvent contains all information about audit log info.
@@ -97,6 +101,9 @@ public class AuditEvent {
     public String state = "";
     @AuditField(value = "ErrorCode")
     public String errorCode = "";
+    // The message the client received; errorCode alone only carries a coarse category.
+    @AuditField(value = "ErrorMessage", ignore_empty = true)
+    public String errorMessage = "";
     @AuditField(value = "Time")
     public long queryTime = -1;
     @AuditField(value = "ScanBytes")
@@ -189,6 +196,39 @@ public class AuditEvent {
     public long readRemoteCnt = 0;
     @AuditField(value = "CacheHitRatio", ignore_empty = true)
     public String cacheHitRatio = "";
+
+    // NEL, LINE SEPARATOR and PARAGRAPH SEPARATOR. \p{Cntrl} is US-ASCII only, so it covers the line
+    // terminators below 0x7F (LF, VT, FF, CR) but not these three, and a reader that follows the
+    // Unicode rules (java.util.Scanner) starts a new line on them all the same.
+    private static final String NON_ASCII_LINE_TERMINATORS = "\\u0085\\u2028\\u2029";
+
+    // The audit log keeps one record per line with '|' between the fields, so a message may carry neither.
+    private static final Pattern ERROR_MESSAGE_SEPARATORS =
+            Pattern.compile("[\\p{Cntrl}" + NON_ASCII_LINE_TERMINATORS + "|]+");
+
+    public static String collapseSeparators(String value) {
+        return Strings.isNullOrEmpty(value) ? "" : ERROR_MESSAGE_SEPARATORS.matcher(value).replaceAll(" ").trim();
+    }
+
+    public static String normalizeErrorMessage(String errorMessage) {
+        int maxLength = Config.audit_log_error_message_max_length;
+        if (maxLength <= 0 || Strings.isNullOrEmpty(errorMessage)) {
+            return "";
+        }
+        // The message quotes the very values that desensitizing the statement takes out.
+        if (Config.enable_sql_desensitize_in_log) {
+            return "";
+        }
+        // Redact credentials the same way the audited statement itself is, as defense in depth.
+        String normalized = collapseSeparators(SqlCredentialRedactor.redact(errorMessage));
+        if (normalized.length() > maxLength) {
+            // Back off one char rather than cut a surrogate pair in half.
+            int end = Character.isHighSurrogate(normalized.charAt(maxLength - 1)) ? maxLength - 1 : maxLength;
+            normalized = normalized.substring(0, end)
+                    + "... /* truncated, audit_log_error_message_max_length=" + maxLength + " */";
+        }
+        return normalized;
+    }
 
     public void calculateCacheHitRatio() {
         if (!isQuery || RunMode.isSharedNothingMode()) {
@@ -285,6 +325,11 @@ public class AuditEvent {
 
         public AuditEventBuilder setErrorCode(String errorCode) {
             auditEvent.errorCode = errorCode;
+            return this;
+        }
+
+        public AuditEventBuilder setErrorMessage(String errorMessage) {
+            auditEvent.errorMessage = normalizeErrorMessage(errorMessage);
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -285,6 +285,7 @@ public class ConnectProcessor {
         ctx.getAuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                 .setState(ctx.getState().toString())
                 .setErrorCode(ctx.getNormalizedErrorCode())
+                .setErrorMessage(auditedErrorMessage(ctx.getState().getErrorMessage(), origStmt))
                 .setQueryTime(elapseMs)
                 .setReturnRows(ctx.getReturnRows())
                 .setStmtId(ctx.getStmtId())
@@ -392,6 +393,20 @@ public class ConnectProcessor {
             MetricRepo.HISTO_CACHE_MISS_RATIO.update((long) (auditEvent.getCacheMissRatio() * 10));
         }
         GlobalStateMgr.getCurrentState().getAuditEventProcessor().handleAuditEvent(auditEvent);
+    }
+
+    // The statement is redacted with the "key" = value context still in hand, but a parser error
+    // quotes the offending token on its own, where nothing marks it as a credential: for
+    // PROPERTIES ("aws.s3.secret_key" = AKIA...) the statement is audited as *** while the message
+    // would carry the key verbatim. Drop the message instead of recording a secret.
+    static String auditedErrorMessage(String errorMessage, String origStmt) {
+        if (Strings.isNullOrEmpty(errorMessage) || !Config.enable_audit_sql) {
+            return "";
+        }
+        if (origStmt != null && !origStmt.equals(SqlCredentialRedactor.redact(origStmt))) {
+            return "";
+        }
+        return errorMessage;
     }
 
     private String formatStmt(String origStmt, StatementBase parsedStmt) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/LogUtilTest.java
@@ -14,10 +14,15 @@
 
 package com.starrocks.common.util;
 
+import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.plugin.AuditEvent;
+import com.starrocks.qe.AuditEventProcessor;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryDetailQueue;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -43,6 +48,27 @@ public class LogUtilTest {
         Config.audit_log_modules = new String[] {"slow_query", "query", "connection"};
         LogUtil.logConnectionInfoToAuditLogAndQueryQueue(new ConnectContext(), null);
         Assertions.assertFalse(QueryDetailQueue.getQueryDetailsAfterTime(0L).isEmpty());
+    }
+
+    // A failed login reports its message in both ErrorCode (historically) and ErrorMessage.
+    @Test
+    public void testLogConnectionInfoSanitizesErrorFields() {
+        Config.audit_log_modules = new String[] {"slow_query", "query", "connection"};
+        List<AuditEvent> events = Lists.newArrayList();
+        new MockUp<AuditEventProcessor>() {
+            @Mock
+            public void handleAuditEvent(AuditEvent event) {
+                events.add(event);
+            }
+        };
+
+        ConnectContext ctx = new ConnectContext();
+        ctx.getState().setError("Access denied for user 'u'\n|State=OK");
+        LogUtil.logConnectionInfoToAuditLogAndQueryQueue(ctx, null);
+
+        Assertions.assertEquals(1, events.size());
+        Assertions.assertEquals("Access denied for user 'u' State=OK", events.get(0).errorCode);
+        Assertions.assertEquals("Access denied for user 'u' State=OK", events.get(0).errorMessage);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/AuditEventTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.plugin;
 
+import com.starrocks.common.Config;
 import com.starrocks.server.RunMode;
 import mockit.Mock;
 import mockit.MockUp;
@@ -84,5 +85,117 @@ public class AuditEventTest {
         Assertions.assertEquals("50.0%", event.cacheHitRatio);
         Assertions.assertEquals(100, event.writeClientTimeMs);
         Assertions.assertEquals((float) 50, event.getCacheMissRatio());
+    }
+
+    @Test
+    public void testNormalizeErrorMessage() {
+        Assertions.assertEquals("", AuditEvent.normalizeErrorMessage(null));
+        Assertions.assertEquals("", AuditEvent.normalizeErrorMessage(""));
+        Assertions.assertEquals("Unknown table 'db.tbl'.",
+                AuditEvent.normalizeErrorMessage("Unknown table 'db.tbl'."));
+    }
+
+    // The audit log keeps one record per line with '|' between the fields.
+    @Test
+    public void testNormalizeErrorMessageCollapsesSeparators() {
+        Assertions.assertEquals("failed on BE 127.0.0.1 out of memory",
+                AuditEvent.normalizeErrorMessage("failed on BE 127.0.0.1\n\tout of memory"));
+        Assertions.assertEquals("forged State=OK",
+                AuditEvent.normalizeErrorMessage("forged|State=OK"));
+    }
+
+    // \p{Cntrl} is US-ASCII only, so the Unicode line breaks have to be named explicitly. A reader
+    // that honours them (java.util.Scanner) would otherwise see one record as two.
+    @Test
+    public void testNormalizeErrorMessageCollapsesUnicodeLineBreaks() {
+        Assertions.assertEquals("before after",
+                AuditEvent.normalizeErrorMessage("before\u0085after"));
+        Assertions.assertEquals("before after",
+                AuditEvent.normalizeErrorMessage("before\u2028after"));
+        Assertions.assertEquals("before after",
+                AuditEvent.normalizeErrorMessage("before\u2029after"));
+        Assertions.assertEquals("Unknown table 'a b'.",
+                AuditEvent.normalizeErrorMessage("Unknown table 'a\u2028b'."));
+    }
+
+    // The collapsed set has to stay complete: these seven code points are exactly what the JDK
+    // itself calls a line break (the \R construct), and a message keeping any of them can be read
+    // as two audit records. Both entry points must strip them.
+    @Test
+    public void testCollapsesEveryJdkLineBreak() {
+        for (int codePoint : new int[] {0x0A, 0x0B, 0x0C, 0x0D, 0x0085, 0x2028, 0x2029}) {
+            String message = "a" + new String(Character.toChars(codePoint)) + "b";
+            String name = "U+" + Integer.toHexString(codePoint);
+            Assertions.assertEquals("a b", AuditEvent.normalizeErrorMessage(message), name);
+            Assertions.assertEquals("a b", AuditEvent.collapseSeparators(message), name);
+        }
+    }
+
+    // Format characters are not line breaks, and stripping them would corrupt legitimate text
+    // (U+200D joins emoji sequences and Indic clusters), so they are deliberately left alone.
+    @Test
+    public void testKeepsFormatCharacters() {
+        String joined = "a\u200db";
+        Assertions.assertEquals(joined, AuditEvent.normalizeErrorMessage(joined));
+    }
+
+    @Test
+    public void testNormalizeErrorMessageTruncates() {
+        int original = Config.audit_log_error_message_max_length;
+        try {
+            Config.audit_log_error_message_max_length = 10;
+            Assertions.assertEquals("0123456789... /* truncated, audit_log_error_message_max_length=10 */",
+                    AuditEvent.normalizeErrorMessage("0123456789abcdef"));
+            Assertions.assertEquals("0123456789", AuditEvent.normalizeErrorMessage("0123456789"));
+
+            // Truncating must not cut a surrogate pair in half.
+            Config.audit_log_error_message_max_length = 4;
+            Assertions.assertEquals("abc... /* truncated, audit_log_error_message_max_length=4 */",
+                    AuditEvent.normalizeErrorMessage("abc😀def"));
+
+            // 0 turns the field off entirely; combined with ignore_empty the key disappears.
+            Config.audit_log_error_message_max_length = 0;
+            Assertions.assertEquals("", AuditEvent.normalizeErrorMessage("some failure"));
+        } finally {
+            Config.audit_log_error_message_max_length = original;
+        }
+    }
+
+    @Test
+    public void testNormalizeErrorMessageRedactsCredentials() {
+        String redacted = AuditEvent.normalizeErrorMessage(
+                "failed to access \"aws.s3.secret_key\" = \"AKIAsecret\" bucket");
+        Assertions.assertFalse(redacted.contains("AKIAsecret"), redacted);
+    }
+
+    // The message quotes the very literals that desensitizing the statement takes out.
+    @Test
+    public void testNormalizeErrorMessageSuppressedWhenDesensitizing() {
+        boolean original = Config.enable_sql_desensitize_in_log;
+        try {
+            Config.enable_sql_desensitize_in_log = true;
+            Assertions.assertEquals("", AuditEvent.normalizeErrorMessage("Duplicate partition value 'secret'"));
+        } finally {
+            Config.enable_sql_desensitize_in_log = original;
+        }
+    }
+
+    // The connection audit reports the same message in the legacy ErrorCode field.
+    @Test
+    public void testCollapseSeparators() {
+        Assertions.assertEquals("", AuditEvent.collapseSeparators(null));
+        Assertions.assertEquals("", AuditEvent.collapseSeparators(""));
+        Assertions.assertEquals("Access denied for user 'u'",
+                AuditEvent.collapseSeparators("Access denied for user 'u'"));
+        Assertions.assertEquals("denied forged State=OK",
+                AuditEvent.collapseSeparators("denied\n|forged|State=OK"));
+    }
+
+    @Test
+    public void testBuilderNormalizesErrorMessage() {
+        AuditEvent event = new AuditEvent.AuditEventBuilder()
+                .setErrorMessage("line one\nline two")
+                .build();
+        Assertions.assertEquals("line one line two", event.errorMessage);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -1412,6 +1412,110 @@ public class ConnectProcessorTest extends DDLTestBase {
                 auditEvent.queriedRelations);
     }
 
+    // ErrorCode only carries a coarse category, so a failure must also record the message.
+    @Test
+    public void testAuditRecordsErrorMessageOnFailure() throws Exception {
+        auditBuilder.reset();
+
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        serializer.writeInt1(3);
+        serializer.writeEofString("select * from no_such_table_post1799");
+        ConnectContext ctx = initMockContext(mockChannel(serializer.toByteBuffer()), GlobalStateMgr.getCurrentState());
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+        myContext.setCurrentCatalog(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+        myContext.setDatabase("testDb1");
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        processor.processOnce();
+
+        AuditEvent auditEvent = ctx.getAuditEventBuilder().build();
+        Assertions.assertEquals(QueryState.MysqlStateType.ERR.name(), auditEvent.state);
+        Assertions.assertEquals(AuditEvent.normalizeErrorMessage(myContext.getState().getErrorMessage()),
+                auditEvent.errorMessage, "the audit event must carry the message the client received");
+        Assertions.assertTrue(auditEvent.errorMessage.contains("no_such_table_post1799"),
+                "unexpected message: " + auditEvent.errorMessage);
+    }
+
+    // A parser error quotes the offending token with no key beside it, so a credential in it can no
+    // longer be recognised - the audited statement is redacted while the message would not be.
+    @Test
+    public void testAuditedErrorMessageDropsMessageWhenStatementCarriesCredentials() {
+        String stmt = "CREATE EXTERNAL CATALOG c PROPERTIES (\"aws.s3.secret_key\" = AKIA123SECRET)";
+        String message = "Getting syntax error at line 1, column 60. Detail message: Unexpected input "
+                + "'AKIA123SECRET', the most similar input is {SINGLE_QUOTED_TEXT, DOUBLE_QUOTED_TEXT}.";
+        Assertions.assertEquals("", ConnectProcessor.auditedErrorMessage(message, stmt));
+
+        // A statement without credentials keeps its message.
+        String plain = "SELECT * FROM no_such_table";
+        Assertions.assertEquals("Unknown table 'no_such_table'.",
+                ConnectProcessor.auditedErrorMessage("Unknown table 'no_such_table'.", plain));
+
+        // Nothing to record for a successful statement, and nothing when SQL auditing is off.
+        Assertions.assertEquals("", ConnectProcessor.auditedErrorMessage("", plain));
+        Assertions.assertEquals("", ConnectProcessor.auditedErrorMessage(null, plain));
+        boolean original = Config.enable_audit_sql;
+        try {
+            Config.enable_audit_sql = false;
+            Assertions.assertEquals("", ConnectProcessor.auditedErrorMessage("Unknown table 'x'.", plain));
+        } finally {
+            Config.enable_audit_sql = original;
+        }
+    }
+
+    // The message quotes the statement that enable_audit_sql=false withholds.
+    @Test
+    public void testAuditOmitsErrorMessageWhenSqlAuditDisabled() throws Exception {
+        auditBuilder.reset();
+
+        boolean original = Config.enable_audit_sql;
+        try {
+            Config.enable_audit_sql = false;
+
+            MysqlSerializer serializer = MysqlSerializer.newInstance();
+            serializer.writeInt1(3);
+            serializer.writeEofString("select * from no_such_table_post1799");
+            ConnectContext ctx =
+                    initMockContext(mockChannel(serializer.toByteBuffer()), GlobalStateMgr.getCurrentState());
+            ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+            ctx.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+            myContext.setCurrentCatalog(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+            myContext.setDatabase("testDb1");
+
+            ConnectProcessor processor = new ConnectProcessor(ctx);
+            processor.processOnce();
+
+            AuditEvent auditEvent = ctx.getAuditEventBuilder().build();
+            Assertions.assertEquals(QueryState.MysqlStateType.ERR.name(), auditEvent.state);
+            Assertions.assertEquals("?", auditEvent.stmt);
+            Assertions.assertEquals("", auditEvent.errorMessage);
+        } finally {
+            Config.enable_audit_sql = original;
+        }
+    }
+
+    // ignore_empty only helps if a successful statement really leaves the field empty.
+    @Test
+    public void testAuditLeavesErrorMessageEmptyOnSuccess() throws Exception {
+        auditBuilder.reset();
+
+        MysqlSerializer serializer = MysqlSerializer.newInstance();
+        serializer.writeInt1(3);
+        serializer.writeEofString("select 1");
+        ConnectContext ctx = initMockContext(mockChannel(serializer.toByteBuffer()), GlobalStateMgr.getCurrentState());
+        ctx.setCurrentUserIdentity(UserIdentity.ROOT);
+        ctx.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+        myContext.setCurrentCatalog(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+        myContext.setDatabase("testDb1");
+
+        ConnectProcessor processor = new ConnectProcessor(ctx);
+        processor.processOnce();
+
+        AuditEvent auditEvent = ctx.getAuditEventBuilder().build();
+        Assertions.assertNotEquals(QueryState.MysqlStateType.ERR.name(), auditEvent.state);
+        Assertions.assertEquals("", auditEvent.errorMessage);
+    }
+
     // A forwarding follower never analyzes the statement, so its local parse tree still carries
     // CTE aliases and unqualified names. When the Leader resolved the relations and shipped them
     // back, the follower must log the Leader's list rather than its own inaccurate collection.


### PR DESCRIPTION
## Why I'm doing:

An audit event only carries `ErrorCode`, which is a coarse category rather than a description: every failure raised while analyzing a statement reports `ANALYSIS_ERR`, so a syntax error, an unknown table and a privilege failure are indistinguishable in the audit log. A customer troubleshooting failed queries has to correlate every audit row back to `fe.log` by query id, which is exactly the inefficiency the audit table is supposed to remove. The message the client received lives in `QueryState` and is already on the `ConnectContext` when the audit event is built — nothing reads it.

## What I'm doing:

- Add an `ErrorMessage` audit field, populated in `ConnectProcessor.auditAfterExec` and in the connection audit path. `ErrorCode` keeps its current meaning so existing queries over the audit table are unaffected, and the field is annotated `ignore_empty` so a successful statement does not gain an empty one.
- Normalize the message before recording it, since it is free-form text that echoes user input while the audit log keeps one record per line with `|` between the fields: collapse control characters and `|` to spaces, redact credentials the way the audited statement already is, and cap the length with the new `audit_log_error_message_max_length` (default 1024, mutable, `0` disables the field). The truncation suffix names that config so a truncated record says which knob to turn.
- Apply the same collapsing to the message that the connection audit has always reported in `ErrorCode`; otherwise a login failure could still split a record in two or forge a field boundary through that field. Its content is otherwise unchanged.
- Omit the message when `enable_sql_desensitize_in_log` is set, since it quotes the very values that desensitizing the statement takes out, and when `enable_audit_sql` is unset, since it quotes the statement that was withheld, down to the offending token. The second check lives at the `auditAfterExec` call site rather than in the shared normalizer, so a connection failure such as `Access denied` is still reported.
- Document the new config and add the column to the AuditLoader table DDL in all three languages, including an `ALTER TABLE` note for audit tables that already exist.

Note that a matching column in the audit table only gets populated by an AuditLoader that reports the new field; that plugin lives in a separate repo and hard-codes its field list, so a companion change is needed there. Until then this PR only adds the field to `fe.audit.log`.

Prior art: the community PR StarRocks/starrocks#67987 attempted this and was approved, but stalled on a review comment asking for a length limit and was later closed unmerged. This change implements that limit, plus the redaction, separator handling and config coupling that PR did not cover.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A failed statement's audit record gains an `ErrorMessage` field, and the connection audit's `ErrorCode` no longer carries raw newlines or `|`. A successful statement's record is unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
 - [x] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5