### PR TITLE
[BugFix] Generate gtid and partition version epoch only on the leader FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -39,7 +39,6 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.transaction.TransactionType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -94,6 +93,11 @@ public class Partition extends MetaObject implements GsonPostProcessable {
     private Partition() {
     }
 
+    /**
+     * Leaves the default physical partition without a version epoch, because taking one means
+     * calling the GTID generator, which only the leader may do. Creating a partition for a table
+     * goes through the metastore's DDL path, which assigns the epoch after construction.
+     */
     public Partition(long id,
                      long physicalPartitionId,
                      String name,
@@ -111,7 +115,6 @@ public class Partition extends MetaObject implements GsonPostProcessable {
         this.nextVersion = this.visibleVersion + 1;
         this.dataVersion = this.visibleVersion;
         this.nextDataVersion = this.nextVersion;
-        this.versionEpoch = this.nextVersionEpoch();
         this.versionTxnType = TransactionType.TXN_NORMAL;
         this.distributionInfo = distributionInfo;
 
@@ -288,9 +291,6 @@ public class Partition extends MetaObject implements GsonPostProcessable {
         if (nextDataVersion == 0) {
             nextDataVersion = nextVersion;
         }
-        if (versionEpoch == 0) {
-            versionEpoch = nextVersionEpoch();
-        }
         if (versionTxnType == null) {
             versionTxnType = TransactionType.TXN_NORMAL;
         }
@@ -369,8 +369,4 @@ public class Partition extends MetaObject implements GsonPostProcessable {
     private volatile long versionEpoch;
     @SerializedName(value = "versionTxnType")
     private volatile TransactionType versionTxnType;
-
-    public long nextVersionEpoch() {
-        return GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid();
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
 import com.starrocks.persist.gson.GsonPostProcessable;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.transaction.TransactionType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -201,7 +200,6 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         this.nextVersion = this.visibleVersion + 1;
         this.dataVersion = this.visibleVersion;
         this.nextDataVersion = this.nextVersion;
-        this.versionEpoch = this.nextVersionEpoch();
         this.versionTxnType = TransactionType.TXN_NORMAL;
     }
 
@@ -214,10 +212,47 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         this.nextVersion = this.visibleVersion + 1;
         this.dataVersion = this.visibleVersion;
         this.nextDataVersion = this.nextVersion;
-        this.versionEpoch = this.nextVersionEpoch();
         this.versionTxnType = TransactionType.TXN_NORMAL;
     }
 
+<<<<<<< HEAD
+=======
+    /**
+     * Returns a shallow copy stamped with the given visible version, carrying
+     * only the latest base materialized index entry. Older base instances
+     * (tablet-split history) and rollups are dropped to mirror the surrounding
+     * scoped OlapTable, which already prunes to the base.
+     */
+    public PhysicalPartition copyForBookmark(long visibleVersion, long visibleVersionTimeMs) {
+        MaterializedIndex latestBaseIndex = null;
+        List<Long> baseIndexIds = this.indexMetaIdToIndexIds.get(this.baseIndexMetaId);
+        if (baseIndexIds != null && !baseIndexIds.isEmpty()) {
+            latestBaseIndex = this.idToVisibleIndex.get(baseIndexIds.get(baseIndexIds.size() - 1));
+        }
+        return copyForBookmark(latestBaseIndex, visibleVersion, visibleVersionTimeMs);
+    }
+
+    /**
+     * Same as {@link #copyForBookmark(long, long)} but scoped to a caller-chosen base-index
+     * generation -- used by bookmark reads whose anchored generation predates a tablet reshard
+     * (the old generation stays installed until the recycle bin erases it).
+     */
+    public PhysicalPartition copyForBookmark(MaterializedIndex baseIndex, long visibleVersion,
+                                             long visibleVersionTimeMs) {
+        PhysicalPartition copy = new PhysicalPartition();
+        copy.id              = this.id;
+        copy.parentId        = this.parentId;
+        copy.baseIndexMetaId = this.baseIndexMetaId;
+        if (baseIndex != null) {
+            copy.indexMetaIdToIndexIds.put(this.baseIndexMetaId, Lists.newArrayList(baseIndex.getId()));
+            copy.idToVisibleIndex.put(baseIndex.getId(), baseIndex);
+        }
+        copy.visibleVersion     = visibleVersion;
+        copy.visibleVersionTime = visibleVersionTimeMs;
+        return copy;
+    }
+
+>>>>>>> 2ec94237bda ([BugFix] Generate gtid and partition version epoch only on the leader FE (#61820))
     public long getId() {
         return this.id;
     }
@@ -557,10 +592,6 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
 
     public void setVersionEpoch(long versionEpoch) {
         this.versionEpoch = versionEpoch;
-    }
-
-    public long nextVersionEpoch() {
-        return GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid();
     }
 
     public TransactionType getVersionTxnType() {
@@ -941,9 +972,6 @@ public class PhysicalPartition extends MetaObject implements GsonPostProcessable
         }
         if (nextDataVersion == 0) {
             nextDataVersion = nextVersion;
-        }
-        if (versionEpoch == 0) {
-            versionEpoch = nextVersionEpoch();
         }
         if (versionTxnType == null) {
             versionTxnType = TransactionType.TXN_NORMAL;

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1757,6 +1757,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         long id = GlobalStateMgr.getCurrentState().getNextId();
         PhysicalPartition physicalPartition = new PhysicalPartition(
                 id, partition.getId(), indexMap.get(olapTable.getBaseIndexMetaId()));
+        // Assigned here rather than in the constructor: the GTID generator may only be called on
+        // the leader, and constructors also run where a partition is rebuilt from stored metadata.
+        physicalPartition.setVersionEpoch(GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid());
         // set ShardGroupId to partition for rollback to old version
         physicalPartition.setShardGroupId(shardGroupId);
         physicalPartition.setBucketNum(distributionInfo.getBucketNum());
@@ -2069,6 +2072,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         long physicalPartitionId = GlobalStateMgr.getCurrentState().getNextId();
         PhysicalPartition physicalPartition = new PhysicalPartition(
                 physicalPartitionId, partitionId, indexMap.get(table.getBaseIndexMetaId()));
+        // Assigned here rather than in the constructor: the GTID generator may only be called on
+        // the leader, and constructors also run where a partition is rebuilt from stored metadata.
+        physicalPartition.setVersionEpoch(GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid());
         physicalPartition.setBucketNum(distributionInfo.getBucketNum());
 
         logicalPartition.addSubPartition(physicalPartition);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1590,7 +1590,7 @@ public class DatabaseTransactionMgr {
                     // reset data version to visible version
                     partitionCommitInfo.setDataVersion(partitionCommitInfo.getVersion());
                     if (partition.getVersionTxnType() == TransactionType.TXN_REPLICATION) {
-                        partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
+                        partitionCommitInfo.setVersionEpoch(GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid());
                     }
                 } else {
                     // double write logic partition
@@ -1615,7 +1615,7 @@ public class DatabaseTransactionMgr {
                     partitionCommitInfo.setDataVersion(partition.getNextDataVersion());
                     if (transactionState.getSourceType() != TransactionState.LoadJobSourceType.LAKE_COMPACTION &&
                             partition.getVersionTxnType() == TransactionType.TXN_REPLICATION) {
-                        partitionCommitInfo.setVersionEpoch(partition.nextVersionEpoch());
+                        partitionCommitInfo.setVersionEpoch(GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid());
                     }
                     LOG.debug("set partition {} version to {} in transaction {}",
                             partitionId, partitionCommitInfo.getVersion(), transactionState);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GtidGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GtidGenerator.java
@@ -14,7 +14,9 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.server.GlobalStateMgr;
 
 public class GtidGenerator {
     // |-- 1bit --|-- 42bit --|-- 8bit --|-- 13bit --|
@@ -36,11 +38,13 @@ public class GtidGenerator {
     @SerializedName("sequence")
     private long sequence = 0L;
 
-    public GtidGenerator() {
-        nextGtid();
-    }
-
     public synchronized long nextGtid() {
+        // A gtid identifies one operation cluster-wide, and only the leader persists the operations that
+        // carry one. A value handed out on any other node shares the format but nothing keeps it distinct
+        // from what the leader hands out at the same moment.
+        Preconditions.checkState(GlobalStateMgr.getCurrentState().isLeader(),
+                "a gtid can only be generated on the leader");
+
         long timestamp = timeGen();
 
         if (timestamp < lastTimestamp) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PhysicalPartitionTest.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.gson.JsonObject;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
@@ -156,8 +157,30 @@ public class PhysicalPartitionTest {
         p.gsonPostProcess();
         Assertions.assertEquals(p.getDataVersion(), p.getVisibleVersion());
         Assertions.assertEquals(p.getNextDataVersion(), p.getNextVersion());
-        Assertions.assertTrue(p.getVersionEpoch() > 0);
+        Assertions.assertEquals(0, p.getVersionEpoch());
         Assertions.assertEquals(p.getVersionTxnType(), TransactionType.TXN_NORMAL);
+    }
+
+    @Test
+    public void testConstructorLeavesVersionEpochUnassigned() {
+        PhysicalPartition physicalPartition = new PhysicalPartition(1L, 2L, new MaterializedIndex());
+        PhysicalPartition externalTablePartition = new PhysicalPartition(3L, 4L);
+        Partition partition = new Partition(5L, 6L, "p1", new MaterializedIndex(), null);
+
+        Assertions.assertEquals(0, physicalPartition.getVersionEpoch());
+        Assertions.assertEquals(0, externalTablePartition.getVersionEpoch());
+        Assertions.assertEquals(0, partition.getDefaultPhysicalPartition().getVersionEpoch());
+    }
+
+    @Test
+    public void testVersionEpochStaysZeroWhenAbsentFromStoredMetadata() {
+        PhysicalPartition partition = new PhysicalPartition(1L, 2L, new MaterializedIndex());
+        JsonObject json = GsonUtils.GSON.toJsonTree(partition).getAsJsonObject();
+        json.remove("versionEpoch");
+
+        PhysicalPartition restored = GsonUtils.GSON.fromJson(json, PhysicalPartition.class);
+
+        Assertions.assertEquals(0, restored.getVersionEpoch());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -31,6 +31,12 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
+<<<<<<< HEAD
+=======
+import com.starrocks.epack.warehouse.WarehouseManagerEPack;
+import com.starrocks.extension.ExtensionManager;
+import com.starrocks.ha.FrontendNodeType;
+>>>>>>> 2ec94237bda ([BugFix] Generate gtid and partition version epoch only on the leader FE (#61820))
 import com.starrocks.lake.TabletRepairHelper.PhysicalPartitionInfo;
 import com.starrocks.proto.GetTabletMetadatasRequest;
 import com.starrocks.proto.GetTabletMetadatasResponse;
@@ -44,7 +50,11 @@ import com.starrocks.proto.TabletMetadataRepairStatus;
 import com.starrocks.proto.TabletResult;
 import com.starrocks.rpc.LakeServiceWithMetrics;
 import com.starrocks.rpc.RpcException;
+<<<<<<< HEAD
 import com.starrocks.server.WarehouseManager;
+=======
+import com.starrocks.server.GlobalStateMgr;
+>>>>>>> 2ec94237bda ([BugFix] Generate gtid and partition version epoch only on the leader FE (#61820))
 import com.starrocks.sql.ast.AdminRepairTableStmt;
 import com.starrocks.sql.ast.LakeTabletStatus;
 import com.starrocks.sql.ast.PartitionRef;
@@ -92,6 +102,9 @@ public class TabletRepairHelperTest {
 
     @BeforeEach
     public void beforeEach() {
+        // Repairing tablet metadata takes a gtid, which only the leader may do.
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
+
         nodeToTablets = Maps.newHashMap();
         node = new ComputeNode(1L, "127.0.0.1", 9050);
         node.setBrpcPort(8060);

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -141,6 +141,26 @@ public class LocalMetaStoreTest {
     }
 
     @Test
+    public void testVersionEpochAssignedWhenCreatingPartitions() throws Exception {
+        String tableName = "t_version_epoch_ut";
+        starRocksAssert.useDatabase("test").withTable("CREATE TABLE test." + tableName + "(k1 int)"
+                    + " DISTRIBUTED BY RANDOM BUCKETS 3 PROPERTIES('replication_num' = '1')");
+
+        Database db = connectContext.getGlobalStateMgr().getLocalMetastore().getDb("test");
+        OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                    .getTable(db.getFullName(), tableName);
+        Partition partition = table.getPartitions().iterator().next();
+        Assertions.assertTrue(partition.getDefaultPhysicalPartition().getVersionEpoch() > 0);
+
+        LocalMetastore localMetastore = connectContext.getGlobalStateMgr().getLocalMetastore();
+        localMetastore.addSubPartitions(db, table, partition, 1, WarehouseManager.DEFAULT_RESOURCE);
+        Assertions.assertEquals(2, partition.getSubPartitions().size());
+        for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+            Assertions.assertTrue(physicalPartition.getVersionEpoch() > 0);
+        }
+    }
+
+    @Test
     public void testLoadClusterV2() throws Exception {
         LocalMetastore localMetaStore = new LocalMetastore(GlobalStateMgr.getCurrentState(),
                     GlobalStateMgr.getCurrentState().getRecycleBin(),

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/DatabaseTransactionMgrTest.java
@@ -68,6 +68,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.metric.MetricRepo;
@@ -137,6 +138,7 @@ public class DatabaseTransactionMgrTest {
         fakeGlobalStateMgr = new FakeGlobalStateMgr();
         fakeTransactionIDGenerator = new FakeTransactionIDGenerator();
         masterGlobalStateMgr = GlobalStateMgrTestUtil.createTestState();
+        masterGlobalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
         slaveGlobalStateMgr = GlobalStateMgrTestUtil.createTestState();
 
         origin_enable_metric_calculator_value = Config.enable_metric_calculator;
@@ -148,6 +150,8 @@ public class DatabaseTransactionMgrTest {
         slaveTransMgr = slaveGlobalStateMgr.getGlobalTransactionMgr();
 
         lableToTxnId = addTransactionToTransactionMgr();
+        // That helper ends on the follower after replaying; the tests below commit on the leader.
+        FakeGlobalStateMgr.setGlobalStateMgr(masterGlobalStateMgr);
     }
 
     @AfterEach

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -57,6 +57,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.routineload.KafkaProgress;
 import com.starrocks.load.routineload.KafkaRoutineLoadJob;
@@ -137,6 +138,7 @@ public class GlobalTransactionMgrTest {
         fakeGlobalStateMgr = new FakeGlobalStateMgr();
         fakeTransactionIDGenerator = new FakeTransactionIDGenerator();
         masterGlobalStateMgr = GlobalStateMgrTestUtil.createTestState();
+        masterGlobalStateMgr.setFrontendNodeType(FrontendNodeType.LEADER);
         slaveGlobalStateMgr = GlobalStateMgrTestUtil.createTestState();
         masterTransMgr = masterGlobalStateMgr.getGlobalTransactionMgr();
         slaveTransMgr = slaveGlobalStateMgr.getGlobalTransactionMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GtidGeneratorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GtidGeneratorTest.java
@@ -14,6 +14,8 @@
 
 package com.starrocks.transaction;
 
+import com.starrocks.ha.FrontendNodeType;
+import com.starrocks.server.GlobalStateMgr;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,7 +26,20 @@ public class GtidGeneratorTest {
 
     @BeforeEach
     public void setUp() {
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
         gtidGenerator = new GtidGenerator();
+    }
+
+    @Test
+    public void testNextGtidRequiresLeader() {
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.FOLLOWER);
+        // Every FE builds a generator at startup, so construction alone must not generate a gtid.
+        GtidGenerator generator = new GtidGenerator();
+        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class, generator::nextGtid);
+        Assertions.assertTrue(e.getMessage().contains("leader"), e.getMessage());
+
+        GlobalStateMgr.getCurrentState().setFrontendNodeType(FrontendNodeType.LEADER);
+        Assertions.assertTrue(generator.nextGtid() > 0);
     }
 
     @Test
@@ -74,9 +89,11 @@ public class GtidGeneratorTest {
     @Test
     public void testNextGtidWhenSystemClockGoesBackwards() {
         gtidGenerator.setLastGtid(Long.MAX_VALUE); // Simulate a GTID with a far future timestamp
-        Assertions.assertThrows(IllegalStateException.class, () -> {
-            gtidGenerator.nextGtid();
-        }, "Should throw an IllegalStateException when the system clock goes backwards");
+        IllegalStateException e = Assertions.assertThrows(IllegalStateException.class,
+                () -> gtidGenerator.nextGtid(),
+                "Should throw an IllegalStateException when the system clock goes backwards");
+        // The leader guard throws the same type, so pin this to the overflow it is meant to cover.
+        Assertions.assertTrue(e.getMessage().contains("Timestamp overflow"), e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Conflict Info:  
UU fe/fe-core/src/main/java/com/starrocks/catalog/PhysicalPartition.java<br />DU fe/fe-core/src/main/java/com/starrocks/epack/failover/job/CheckReplicatedTableJob.java<br />DU fe/fe-core/src/test/java/com/starrocks/epack/failover/job/CheckReplicatedTableJobTest.java<br />UU fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java

### ⚠ modify/delete (DU): `fe/fe-core/src/main/java/com/starrocks/epack/failover/job/CheckReplicatedTableJob.java`
<details><summary>content dropped by auto-resolve — verify it is ported to its new location</summary>

```
// Copyright 2021-present StarRocks, Inc. All rights reserved.

package com.starrocks.epack.failover.job;

import com.google.common.base.Preconditions;
import com.google.common.collect.Range;
import com.starrocks.catalog.Column;
import com.starrocks.catalog.Database;
import com.starrocks.catalog.DistributionInfo;
import com.starrocks.catalog.ExpressionRangePartitionInfo;
import com.starrocks.catalog.InternalCatalog;
import com.starrocks.catalog.ListPartitionInfo;
import com.starrocks.catalog.MaterializedIndexMeta;
import com.starrocks.catalog.OlapTable;
import com.starrocks.catalog.Partition;
import com.starrocks.catalog.PartitionInfo;
import com.starrocks.catalog.PartitionKey;
import com.starrocks.catalog.PhysicalPartition;
import com.starrocks.catalog.RangePartitionInfo;
import com.starrocks.catalog.Table;
import com.starrocks.common.Config;
import com.starrocks.common.util.concurrent.lock.LockType;
import com.starrocks.common.util.concurrent.lock.Locker;
import com.starrocks.epack.failover.FailoverGroup;
import com.starrocks.replication.ReplicationJob;
import org.apache.logging.log4j.LogManager;
import org.apache.logging.log4j.Logger;

import java.util.HashMap;
import java.util.List;
import java.util.Map;
import java.util.stream.Collectors;

public class CheckReplicatedTableJob extends FailoverGroupJob {
    private static final Logger LOG = LogManager.getLogger(CheckReplicatedTableJob.class);

    private final Database remoteDatabase;
    private final OlapTable remoteTable;
    private final Database localDatabase;
    private final boolean isIncludeObject;

    public CheckReplicatedTableJob(FailoverGroup failoverGroup, Database remoteDatabase,
            OlapTable remoteTable, Database localDatabase, boolean isIncludeObject) {
        super(failoverGroup);
        this.remoteDatabase = remoteDatabase;
        this.remoteTable = remoteTable;
        this.localDatabase = localDatabase;
        this.isIncludeObject = isIncludeObject;
    }

    @Override
    public void execute() {
        Locker locker = new Locker();
        locker.lockDatabase(localDatabase.getId(), LockType.READ);

        try {
            OlapTable localTable = checkTable();
            if (localTable == null) {
                return;
            }

            failoverGroup.getObjectMap().putTableMap(remoteTable.getId(), localTable.getId());

            if (isIncludeObject) {
                failoverGroup.getIncludeMgr().addIncludeTable(InternalCatalog.DEFAULT_INTERNAL_CATALOG_ID,
                        localDatabase.getId(), localTable.getId());
            }

            boolean needReplication = false;
            for (Partition remotePartition : remoteTable.getPartitions()) {
                if (remotePartition.getName().startsWith(ExpressionRangePartitionInfo.SHADOW_PARTITION_PREFIX)) {
                    continue;
                }
                Partition localPartition = checkPartition(localTable, remotePartition);
                if (localPartition == null) {
                    return;
                }

                Map<PhysicalPartition, PhysicalPartition> localToRemotePhysicalPartitions = checkPhysicalPartitions(
                        localTable, localPartition, remotePartition);
                if (localToRemotePhysicalPartitions == null) {
                    return;
                }

                for (Map.Entry<PhysicalPartition, PhysicalPartition> entry : localToRemotePhysicalPartitions
                        .entrySet()) {
                    PhysicalPartition localPhysicalPartition = entry.getKey();
                    PhysicalPartition remotePhysicalPartition = entry.getValue();
                    if (localPhysicalPartition.getCommittedVersion() < remotePhysicalPartition.getVisibleVersion()) {
                        needReplication = true;
                        break;
                    }
                }
            }

            if (needReplication) {
                String jobId = String.format("FAILOVER_GROUP_%s-%d-%d-%d", failoverGroup.getName(),
                        localDatabase.getId(), localTable.getId(), System.currentTimeMillis());
                ReplicationJob job = new ReplicationJob(jobId,
                        failoverGroup.getObjectMeta().getClusterToken(),
                        localDatabase.getId(), localTable, remoteTable,
                        failoverGroup.getObjectMeta().getSystemInfoService());
                if (failoverGroup.getJobExecutor().addReplicationJob(job)) {
                    LOG.info("Succeed to create replication job for {}.{} in failover group {}",
                            localDatabase.getFullName(), localTable.getName(), failoverGroup.getName());
                }
            }

            if (!Config.failover_group_allow_drop_extra_partition) {
                return;
            }

            // Drop extra partitions
            for (Partition localPartition : localTable.getPartitions()) {
                if (remoteTable.getPartition(localPartition.getName(), false) == null) {
                    DropReplicatedPartitionJob job = new DropReplicatedPartitionJob(failoverGroup, null,
                            null, localDatabase, localTable, localPartition.getName(), false, true);
                    job.start();
                }
            }
        } finally {
            locker.unLockDatabase(localDatabase.getId(), LockType.READ);
        }
    }

    private OlapTable checkTable() {
        Table localTable = localDatabase.getTable(remoteTable.getName());
        if (localTable == null) {
            CreateReplicatedTableJob job = new CreateReplicatedTableJob(failoverGroup,
                    remoteDatabase, remoteTable, localDatabase, isIncludeObject);
            job.start();
            return null;
        }

        if (!localTable.isOlapTable()) {
            LOG.warn("Local table {}.{} with type {} is not olap table in failover group {}",
                    localDatabase.getFullName(), localTable.getName(), localTable.getType(),
                    failoverGroup.getName());
            if (Config.failover_group_allow_drop_inconsistent_table) {
                DropReplicatedTableJob job = new DropReplicatedTableJob(failoverGroup, remoteDatabase,
                        remoteTable, localDatabase, localTable, isIncludeObject, true);
                job.start();
            } else {
                LOG.warn("Ignore table {}.{} due to failover_group_allow_drop_inconsistent_table = false",
                        localDatabase.getFullName(), localTable.getName());
            }
            return null;
        }

        OlapTable localOlapTable = (OlapTable) localTable;
        if (!checkTableConsistency(localOlapTable)) {
            if (Config.failover_group_allow_drop_inconsistent_table) {
                if (localTable.getCreateTime() < failoverGroup.getSchedule().getRoundScheduledTimeMs() / 1000) {
                    // If local table is created in previous replication round, drop and create it
                    DropReplicatedTableJob job = new DropReplicatedTableJob(failoverGroup, remoteDatabase,
                            remoteTable, localDatabase, localTable, isIncludeObject, true);
                    job.start();
                } else {
                    LOG.error("Ignore inconsistent table {}.{} to avoid an infinite loop of drop and create",
                            localDatabase.getFullName(), localTable.getName());
                }
            } else {
                LOG.warn("Ignore table {}.{} due to failover_group_allow_drop_inconsistent_table = false",
                        localDatabase.getFullName(), localTable.getName());
            }
            return null;
        }

        return localOlapTable;
    }

    private Partition checkPartition(OlapTable localTable, Partition remotePartition) {
        Partition localPartition = localTable.getPartition(remotePartition.getName(), false);
        if (localPartition == null) {
  
```
</details>

### ⚠ modify/delete (DU): `fe/fe-core/src/test/java/com/starrocks/epack/failover/job/CheckReplicatedTableJobTest.java`
<details><summary>content dropped by auto-resolve — verify it is ported to its new location</summary>

```
// Copyright 2021-present StarRocks, Inc. All rights reserved.

package com.starrocks.epack.failover.job;

import com.starrocks.catalog.MaterializedIndex;
import com.starrocks.catalog.OlapTable;
import com.starrocks.catalog.Partition;
import com.starrocks.catalog.PhysicalPartition;
import com.starrocks.common.io.DeepCopy;
import com.starrocks.common.jmockit.Deencapsulation;
import com.starrocks.epack.failover.FailoverGroup;
import com.starrocks.epack.failover.ReplicatedObjectMeta;
import com.starrocks.epack.failover.ReplicatedObjectMeta.TableMeta;
import com.starrocks.epack.sql.ast.CreatePrimaryFailoverGroupStmt;
import com.starrocks.server.GlobalStateMgr;
import com.starrocks.sql.analyzer.AnalyzeTestUtil;
import com.starrocks.sql.ast.CreateTableStmt;
import com.starrocks.utframe.StarRocksAssert;
import com.starrocks.utframe.UtFrameUtils;
import mockit.Mock;
import mockit.MockUp;
import org.junit.Assert;
import org.junit.BeforeClass;
import org.junit.Test;

import java.util.concurrent.ThreadPoolExecutor;

import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;

public class CheckReplicatedTableJobTest {
    private static StarRocksAssert starRocksAssert;

    @BeforeClass
    public static void beforeClass() throws Exception {
        UtFrameUtils.createMinStarRocksCluster();
        AnalyzeTestUtil.init();
        starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
        starRocksAssert.withDatabase("test").useDatabase("test");

        String sql = "create table CheckReplicatedTableJobTestTable (key1 int, key2 varchar(10))\n" +
                "distributed by hash(key1) buckets 1\n" +
                "properties('replication_num' = '1'); ";
        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
                AnalyzeTestUtil.getConnectContext());
        Assert.assertTrue(GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt));

        new MockUp<ThreadPoolExecutor>() {
            @Mock
            public void execute(Runnable command) {
                command.run();
            }
        };
    }

    @Test
    public void testVersionEpochConsistency() throws Exception {
        CreatePrimaryFailoverGroupStmt stmt = (CreatePrimaryFailoverGroupStmt) analyzeSuccess(
                "CREATE FAILOVER GROUP testVersionEpochConsistencyGroup " +
                        "INCLUDE_TABLES = test.CheckReplicatedTableJobTestTable " +
                        "MEMBERS = " +
                        "'az1:SELF'," +
                        "'az2:192.168.0.1:9090'" +
                        "SCHEDULE = '1h'");

        FailoverGroup failoverGroup = new FailoverGroup(1, stmt);
        ReplicatedObjectMeta objectMeta = failoverGroup.getIncludeMgr().toObjectMeta("test_token");
        TableMeta tableMeta = objectMeta.getTableMetas().values().iterator().next();
        OlapTable localTable = (OlapTable) tableMeta.getTable();
        Partition localPartition = localTable.getPartitions().iterator().next();

        CheckReplicatedTableJob job = new CheckReplicatedTableJob(failoverGroup, tableMeta.getDatabase(),
                localTable, tableMeta.getDatabase(), true);

        // Either side at zero predates the field, so its lineage is unknown and must not be compared.
        Assert.assertTrue(isConsistent(job, localTable, localPartition, 0L, 12L));
        Assert.assertTrue(isConsistent(job, localTable, localPartition, 12L, 0L));
        Assert.assertTrue(isConsistent(job, localTable, localPartition, 0L, 0L));

        Assert.assertTrue(isConsistent(job, localTable, localPartition, 12L, 12L));
        Assert.assertFalse(isConsistent(job, localTable, localPartition, 12L, 13L));
    }

    private static boolean isConsistent(CheckReplicatedTableJob job, OlapTable localTable, Partition localPartition,
                                        long localVersionEpoch, long remoteVersionEpoch) {
        PhysicalPartition local = new PhysicalPartition(1L, localPartition.getId(), new MaterializedIndex(2L));
        PhysicalPartition remote = new PhysicalPartition(1L, localPartition.getId(), new MaterializedIndex(2L));
        local.setVersionEpoch(localVersionEpoch);
        remote.setVersionEpoch(remoteVersionEpoch);
        return Deencapsulation.invoke(job, "checkPhysicalPartitionConsistency",
                localTable, localPartition, remote, local);
    }

    @Test
    public void testCheckTableExisted() throws Exception {
        CreatePrimaryFailoverGroupStmt stmt = (CreatePrimaryFailoverGroupStmt) analyzeSuccess(
                "CREATE FAILOVER GROUP testCheckDatabaseExistedGroup " +
                        "INCLUDE_TABLES = test.CheckReplicatedTableJobTestTable " +
                        "MEMBERS = " +
                                "'az1:SELF'," +
                                "'az2:192.168.0.1:9090'" +
                        "SCHEDULE = '1h'");

        FailoverGroup failoverGroup = new FailoverGroup(1, stmt);
        ReplicatedObjectMeta objectMeta = failoverGroup.getIncludeMgr().toObjectMeta("test_token");

        TableMeta tableMeta = objectMeta.getTableMetas().values().iterator().next();

        CheckReplicatedTableJob job = new CheckReplicatedTableJob(failoverGroup, tableMeta.getDatabase(),
                (OlapTable) tableMeta.getTable(), tableMeta.getDatabase(), true);
        job.execute();

        Assert.assertTrue(!failoverGroup.getJobExecutor().hasFailedJobs());
    }

    @Test
    public void testSkipDefaultPhysicalPartitionById() throws Exception {
        String sql = "create table testSkipDefaultPhysicalPartitionById (key1 int not null)\n" +
                "partition by range(key1)(\n" +
                "partition p1 values [(\"1\"), (\"2\")))\n" +
                "distributed by hash(key1) buckets 1\n" +
                "properties('replication_num' = '1'); ";
        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
                AnalyzeTestUtil.getConnectContext());
        Assert.assertTrue(GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt));

        CreatePrimaryFailoverGroupStmt stmt = (CreatePrimaryFailoverGroupStmt) analyzeSuccess(
                "CREATE FAILOVER GROUP testSkipDefaultPhysicalPartitionByIdGroup " +
                        "INCLUDE_TABLES = test.testSkipDefaultPhysicalPartitionById " +
                        "MEMBERS = " +
                        "'az1:SELF'," +
                        "'az2:192.168.0.1:9090'" +
                        "SCHEDULE = '1h'");

        FailoverGroup failoverGroup = new FailoverGroup(1, stmt);
        ReplicatedObjectMeta objectMeta = failoverGroup.getIncludeMgr().toObjectMeta("test_token");
        TableMeta tableMeta = objectMeta.getTableMetas().values().iterator().next();

        OlapTable localTable = (OlapTable) tableMeta.getTable();
        OlapTable remoteTable = DeepCopy.copyWithGson(localTable, OlapTable.class);

        Partition localPartition = localTable.getPartition("p1");
        int localPhysicalPartitionCount = localPartition.getSubPartitions().size();

        CheckReplicatedTableJob job = new CheckReplicatedTableJob(failoverGroup, tableMeta.getDatabase(),
                remoteTable, tableMeta.getDatabase(), true);
        job.execute();

        Assert.assertEquals(localPhysicalPartitionCount, localPartition.getSubPartitions().size());
        Assert.assertTrue(!failoverGroup.getJobExecutor().hasFailedJobs());
    }

    @Test
    public void testCreatePhysicalPartitionWithSuffix() throws Exception {
        String sql = "create table testCreatePhysicalPartitionWithSuffix (key1 int not null)\n" +
                "partition by range(key1)(\n" +
                "partition p1 values [(\"1\"), (\"2\")))\n" +
                "distributed by random\n" +
                "properties('replication_num' = '1'); ";
        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameU
```
</details>

## Why I'm doing:

A gtid identifies one operation across the whole cluster, and only the leader persists the operations that carry one. A number produced on any other node has the same shape but nothing keeps it distinct from what the leader produces at the same moment.

Three paths produced gtids off the leader:

- `Partition` and `PhysicalPartition` constructors, reached by `ExternalOlapTable.updateMeta` on whichever FE serves the query.
- The `gsonPostProcess` backfill of `versionEpoch` for partitions written before that field existed. Deserialization runs on a follower loading an image or replaying the journal, in the checkpoint instance, and in the failover-group instance.
- Through those constructors and that backfill, the two non-serving `GlobalStateMgr` instances, whose journal is empty.

The backfill also gave the same legacy partition a different epoch on every node, and the replicated-table consistency check compared those invented numbers against each other.

## What I'm doing:

- Constructors no longer assign a version epoch. `LocalMetastore.createPartition` and `LocalMetastore.createPhysicalPartition` assign it, both of which only run while executing DDL on the leader. `DatabaseTransactionMgr`'s two lineage forks call the generator directly.
- Remove the `gsonPostProcess` backfill. A partition that predates `versionEpoch` now reads 0 on every node, in the image, in both non-serving instances, and on a replication target. The assignment that marks a lineage fork on the commit path is unchanged.
- `GtidGenerator.nextGtid()` rejects a call on a non-leader with `IllegalStateException` instead of quietly producing a number, so any remaining path shows up during rollout. The leader check is injectable so a unit test can exercise both sides without standing up a cluster. The constructor no longer generates a gtid, which would otherwise throw on every follower at startup.
- Read a zero epoch as unknown in the replicated-table consistency check. The two halves of the system disagreed about what 0 means: both transaction log appliers already adopt an epoch only when it is greater than zero, while `CheckReplicatedTableJob.checkPhysicalPartitionConsistency` compared the raw values. It now skips the comparison when either side is 0, matching the appliers.
- Tests: `GtidGeneratorTest` covers the leader contract; `PhysicalPartitionTest` covers an unassigned epoch after construction and after deserializing metadata that has no such field; `LocalMetaStoreTest` covers the DDL path assigning it; `CheckReplicatedTableJobTest` covers the epoch comparison with each side zero, both zero, and both non-zero. Three transaction and repair tests now run as a leader.

Why the consistency check had to change in the same PR, for reviewers: dropping the backfill on its own would have broken replication of a legacy partition permanently. The source reports 0, the target that the failover group creates for it takes a real number from the DDL path, the replication transaction carries the source's 0, the appliers drop it because it is not greater than zero, and the check finds the two unequal. With `failover_group_allow_drop_inconsistent_partition` on by default the standby force-drops the partition, re-creates it (taking yet another number) and re-copies the data, on every round, without converging; the round still reports success, so the only signal is a warning in the standby's log.

This is not a mixed-version window. On the previous code the checkpoint instance loaded an image, backfilled a nonzero epoch and saved it again, so the very image a standby pulls carried a stable nonzero value that the appliers accepted, and a cluster converged after at most one spurious re-copy. Without the backfill the checkpoint writes the 0 back instead, and 0 is the one value the appliers cannot carry. Exposure is narrow -- enterprise failover groups, shared-nothing only, and only for a partition whose persisted epoch is still 0, meaning an image written before the field was introduced and not yet rewritten -- but within it the divergence would have been permanent.

The fix belongs in the comparison rather than in the appliers: `PartitionCommitInfo.versionEpoch` is a bare long that none of its constructors initializes, so 0 there is indistinguishable from "never set", and relaxing the appliers' guard would let every ordinary commit that leaves the field alone overwrite a partition's epoch with 0.

**The one-line change in `CheckReplicatedTableJob` needs that module's owners to review it.**

Not in this PR: `ExternalOlapTable.updateMeta` still calls `getNextId()` on a follower, and the legacy field block at the tail of `Partition` is still there.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5