### PR TITLE
[BugFix] Protect snapshot-owned shared shard groups

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -562,6 +562,7 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
     public boolean syncTableMetaInternal(Database db, OlapTable table, boolean forceDeleteData) throws DdlException {
         StarOSAgent starOSAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
         HashMap<Long, Set<Long>> redundantGroupToShards = new HashMap<>();
+        Set<Long> snapshotProtectedShardGroups = new HashSet<>();
         List<PhysicalPartition> physicalPartitions = new ArrayList<>();
         Locker locker = new Locker();
         // Intensive path: IS on DB + READ on this table. We only need table-scoped
@@ -604,10 +605,8 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
                 for (MaterializedIndex materializedIndex :
                         physicalPartition.getAllMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
                     long groupId = materializedIndex.getShardGroupId();
-                    Set<Long> starmgrShardIdsSet = null;
-                    if (redundantGroupToShards.get(groupId) != null) {
-                        starmgrShardIdsSet = redundantGroupToShards.get(groupId);
-                    } else {
+                    Set<Long> starmgrShardIdsSet = redundantGroupToShards.get(groupId);
+                    if (starmgrShardIdsSet == null) {
                         List<Long> starmgrShardIds;
                         try {
                             starmgrShardIds = starOSAgent.listShard(groupId);
@@ -627,17 +626,16 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
                         starmgrShardIdsSet.remove(tablet.getId());
                     }
 
-                    if (GlobalStateMgr.getCurrentState()
-                                      .getClusterSnapshotMgr().isMaterializedIndexInClusterSnapshotInfo(
-                                            db.getId(), table.getId(), physicalPartition.getParentId(),
-                                                physicalPartition.getId(), materializedIndex.getId())) {
-                        continue;
-                    }
-
-                    if (GlobalStateMgr.getCurrentState()
-                                      .getClusterSnapshotMgr().isShardGroupIdInClusterSnapshotInfo(
-                                            db.getId(), table.getId(), physicalPartition.getParentId(),
-                                                physicalPartition.getId(), materializedIndex.getShardGroupId())) {
+                    boolean indexInSnapshot = GlobalStateMgr.getCurrentState()
+                            .getClusterSnapshotMgr().isMaterializedIndexInClusterSnapshotInfo(
+                                    db.getId(), table.getId(), physicalPartition.getParentId(),
+                                    physicalPartition.getId(), materializedIndex.getId());
+                    boolean shardGroupInSnapshot = GlobalStateMgr.getCurrentState()
+                            .getClusterSnapshotMgr().isShardGroupIdInClusterSnapshotInfo(
+                                    db.getId(), table.getId(), physicalPartition.getParentId(),
+                                    physicalPartition.getId(), groupId);
+                    if (indexInSnapshot || shardGroupInSnapshot) {
+                        snapshotProtectedShardGroups.add(groupId);
                         continue;
                     }
                     // collect shard in starmgr but not in fe
@@ -649,6 +647,8 @@ public class StarMgrMetaSyncer extends LeaderDaemon {
                 locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
             }
         }
+
+        redundantGroupToShards.keySet().removeAll(snapshotProtectedShardGroups);
 
         // try to delete data, if fail, still delete redundant shard meta in starmgr
         Set<Long> shardToDelete = new HashSet<>();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1409,7 +1409,7 @@ public class StarMgrMetaSyncerTest {
             }
         };
 
-        new MockUp<ClusterSnapshotMgrEPack>() {
+        new MockUp<ClusterSnapshotMgr>() {
             @Mock
             public boolean isMaterializedIndexInClusterSnapshotInfo(
                     long ignoredDbId, long ignoredTableId, long ignoredPartId,

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -1362,6 +1362,92 @@ public class StarMgrMetaSyncerTest {
     }
 
     @Test
+    public void testSyncTableMetaProtectsSharedShardGroupInSnapshot() throws Exception {
+        long dbId = 100L;
+        long tableId = 1000L;
+        long parentId = 100L;
+        long oldPhysicalId = 101L;
+        long newPhysicalId = 102L;
+        long sharedGroupId = 200L;
+
+        Database db = new Database(dbId, "db");
+        OlapTable table = new LakeTable(tableId, "table", new ArrayList<>(), KeysType.AGG_KEYS,
+                new PartitionInfo(PartitionType.RANGE), new HashDistributionInfo());
+
+        MaterializedIndex oldIndex = new MaterializedIndex(300L,
+                MaterializedIndex.IndexState.NORMAL, sharedGroupId);
+        oldIndex.addTablet(new LakeTablet(111L), null, false);
+        MaterializedIndex newIndex = new MaterializedIndex(300L,
+                MaterializedIndex.IndexState.NORMAL, sharedGroupId);
+        newIndex.addTablet(new LakeTablet(222L), null, false);
+
+        PhysicalPartition oldPhysical = new PhysicalPartition(oldPhysicalId, parentId, oldIndex);
+        PhysicalPartition newPhysical = new PhysicalPartition(newPhysicalId, parentId, newIndex);
+        final boolean[] protectByIndex = {false};
+        Set<Long> deletedShards = new HashSet<>();
+        List<Partition> metastorePartitions = new ArrayList<>();
+
+        new Expectations(localMetastore) {{
+                localMetastore.getTable(dbId, tableId);
+                minTimes = 0;
+                result = table;
+
+                localMetastore.getAllPartitionsIncludeRecycleBin((OlapTable) any);
+                minTimes = 0;
+                result = metastorePartitions;
+            }};
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> listShard(long groupId) {
+                return Lists.newArrayList(111L, 222L, 333L);
+            }
+
+            @Mock
+            public void deleteShards(Set<Long> shardIds) {
+                deletedShards.addAll(shardIds);
+            }
+        };
+
+        new MockUp<ClusterSnapshotMgrEPack>() {
+            @Mock
+            public boolean isMaterializedIndexInClusterSnapshotInfo(
+                    long ignoredDbId, long ignoredTableId, long ignoredPartId,
+                    long physicalPartId, long ignoredIndexId) {
+                return protectByIndex[0] && physicalPartId == oldPhysicalId;
+            }
+
+            @Mock
+            public boolean isShardGroupIdInClusterSnapshotInfo(
+                    long ignoredDbId, long ignoredTableId, long ignoredPartId,
+                    long physicalPartId, long ignoredShardGroupId) {
+                return !protectByIndex[0] && physicalPartId == oldPhysicalId;
+            }
+        };
+
+        for (boolean protectByIndexValue : new boolean[] {true, false}) {
+            protectByIndex[0] = protectByIndexValue;
+            for (List<PhysicalPartition> physicalPartitionOrder :
+                    Lists.newArrayList(Lists.newArrayList(oldPhysical, newPhysical),
+                            Lists.newArrayList(newPhysical, oldPhysical))) {
+                metastorePartitions.clear();
+                metastorePartitions.add(new Partition(parentId, "p", new HashDistributionInfo()) {
+                    @Override
+                    public Collection<PhysicalPartition> getSubPartitions() {
+                        return physicalPartitionOrder;
+                    }
+                });
+                deletedShards.clear();
+
+                boolean changed = starMgrMetaSyncer.syncTableMetaInternal(db, table, false);
+
+                Assertions.assertFalse(changed);
+                Assertions.assertTrue(deletedShards.isEmpty());
+            }
+        }
+    }
+
+    @Test
     public void testSyncerRejectByClusterSnapshot() {
         final ClusterSnapshotMgr localClusterSnapshotMgr = new ClusterSnapshotMgr();
         final StarMgrMetaSyncer syncer = new StarMgrMetaSyncer();


### PR DESCRIPTION
## Why I'm doing:

When snapshot-protected and post-snapshot physical partitions share a shard group, StarMgr metadata sync can rediscover the group's full shard list while visiting an unprotected partition and delete shards owned by the snapshot-protected partition. This makes snapshot restoration unsafe and can surface as missing tablet errors.

## What I'm doing:

- Keep shard-group snapshot protection sticky for the entire table metadata-sync pass when either the exact materialized index or the exact shard group is present in cluster snapshot metadata.
- Remove all protected shard groups from redundant-shard candidates before any data or StarMgr metadata deletion.
- Add an order-independent regression test covering both snapshot predicates and a stale redundant shard.
- Preserve the existing deletion counter and deletion/error logging for unprotected shard groups. No new observability signal is needed because protected candidates now leave the destructive path before deletion.

Verification:
- `./run-fe-ut.sh --test com.starrocks.lake.StarMgrMetaSyncerTest -j 1` (25 tests, 0 failures, 0 errors, 1 skipped)
- `cd fe && mvn checkstyle:check -pl fe-core`

Fixes StarRocks/StarRocksTest#12110

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5