### PR TITLE
[BugFix] catch exception in thrift processor

### DIFF
--- a/be/src/common/util/thrift_server.cpp
+++ b/be/src/common/util/thrift_server.cpp
@@ -56,6 +56,54 @@
 
 namespace starrocks {
 
+namespace {
+
+// A TProcessor decorator that stops a single malformed or hostile connection from aborting the
+// whole BE process.
+//
+// thrift's TConnectedClient::run() (used by the threaded/thread-pool servers) only catches
+// TTransportException and TException around processor_->process(). Any *non-thrift* exception --
+// e.g. std::bad_alloc / std::length_error raised while a message with a bogus, huge string or
+// container length field is deserialized -- propagates out of the loop, unwinds through
+// std::terminate() and aborts the entire process (SIGABRT). Because our TBinaryProtocol is
+// configured with thrift_rpc_max_body_size == 0 (unlimited) by default, the protocol never
+// rejects such a length itself: readStringBody/readListBegin skip their size checks when the
+// limit is 0, so a garbage length reaches the unbounded resize()/allocation.
+//
+// Wrapping the real processor lets std::exceptions (and anything else) escaping process() be
+// turned into a clean connection teardown: returning false makes TConnectedClient::run() break
+// out of its loop and cleanup() the connection, exactly as it does for a client that hangs up.
+// Genuine thrift exceptions are re-thrown unchanged so the server keeps its existing handling
+// (and logging) for them.
+class ExceptionSafeProcessor : public apache::thrift::TProcessor {
+public:
+    explicit ExceptionSafeProcessor(std::shared_ptr<apache::thrift::TProcessor> delegate)
+            : _delegate(std::move(delegate)) {}
+
+    bool process(std::shared_ptr<apache::thrift::protocol::TProtocol> in,
+                 std::shared_ptr<apache::thrift::protocol::TProtocol> out, void* connection_context) override {
+        try {
+            return _delegate->process(std::move(in), std::move(out), connection_context);
+        } catch (const apache::thrift::TException&) {
+            // Transport/protocol exceptions are part of thrift's own contract; let
+            // TConnectedClient::run() handle (and log) them as before.
+            throw;
+        } catch (const std::exception& e) {
+            LOG(WARNING) << "Uncaught exception while processing a thrift RPC, closing the connection: "
+                         << e.what();
+            return false;
+        } catch (...) {
+            LOG(WARNING) << "Uncaught non-standard exception while processing a thrift RPC, closing the connection";
+            return false;
+        }
+    }
+
+private:
+    std::shared_ptr<apache::thrift::TProcessor> _delegate;
+};
+
+} // namespace
+
 // Helper class that starts a server in a separate thread, and handles
 // the inter-thread communication to monitor whether it started
 // correctly.
@@ -304,6 +352,10 @@ ThriftServer::ThriftServer(const std::string& name, std::shared_ptr<apache::thri
 
 Status ThriftServer::start() {
     DCHECK(!_started);
+    // Guard every connection handler against a non-thrift exception (e.g. a std::bad_alloc raised
+    // while deserializing a malformed message) aborting the whole BE process. See
+    // ExceptionSafeProcessor for details.
+    _processor = std::make_shared<ExceptionSafeProcessor>(_processor);
     auto protocol_factory = std::make_shared<apache::thrift::protocol::TBinaryProtocolFactory>();
     protocol_factory->setStrict(config::thrift_rpc_strict_mode, true);
     protocol_factory->setStringSizeLimit(config::thrift_rpc_max_body_size);

--- a/be/src/common/util/thrift_server.cpp
+++ b/be/src/common/util/thrift_server.cpp
@@ -89,8 +89,7 @@ public:
             // TConnectedClient::run() handle (and log) them as before.
             throw;
         } catch (const std::exception& e) {
-            LOG(WARNING) << "Uncaught exception while processing a thrift RPC, closing the connection: "
-                         << e.what();
+            LOG(WARNING) << "Uncaught exception while processing a thrift RPC, closing the connection: " << e.what();
             return false;
         } catch (...) {
             LOG(WARNING) << "Uncaught non-standard exception while processing a thrift RPC, closing the connection";


### PR DESCRIPTION
## Why I'm doing:

```
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1788758991 (unix time) try "date -d @1788758991" if you are using GNU date ***
PC: @     0x7ff7eba86c0c pthread_kill
*** SIGABRT (@0x164901) received by PID 1460481 (TID 0x7fee7b9386c0) LWP(1463614) from PID 1460481; stack trace: ***
    @         0x33b752c7 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7ff7eba89fb3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1fb2)
    @         0x33b74ac6 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7ff7eba2d330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7ff7eba86c0c pthread_kill
    @     0x7ff7eba2d27e gsignal
    @     0x7ff7eba108ff abort
    @         0x3cd305ae _Unwind_SetGR.cold
    @         0x3cc4aac4 __gxx_personality_v0
    @     0x7ff7eb75cb06 (/usr/lib/x86_64-linux-gnu/libgcc_s.so.1+0x22b05)
    @     0x7ff7eb75d1f1 _Unwind_RaiseException
    @     0x7ff7eb825384 __cxa_throw
    @         0x3cd3450a __wrap___cxa_throw
    @         0x1b4086f6 unsigned int apache::thrift::transport::readAll<apache::thrift::transport::TBufferBase>(apache::thrift::transport::TBufferBase&, unsigned char*, unsigned int)
    @         0x1b406e45 apache::thrift::transport::TBufferBase::readAll(unsigned char*, unsigned int)
    @         0x1b626cbd apache::thrift::transport::TBufferedTransport::readAll(unsigned char*, unsigned int)
    @         0x1b675cbf apache::thrift::transport::TVirtualTransport<apache::thrift::transport::TBufferedTransport, apache::thrift::transport::TBufferBase>::readAll_virt(unsigned char*, unsigned int)
    @         0x1b6264be apache::thrift::transport::TTransport::readAll(unsigned char*, unsigned int)
    @         0x1b678c18 apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>::readI32(int&)
    @         0x1b676dd3 apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>::readMessageBegin(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, apache::thrift::protocol::TMe@
    @         0x1b675092 apache::thrift::protocol::TVirtualProtocol<apache::thrift::protocol::TBinaryProtocolT<apache::thrift::transport::TTransport, apache::thrift::protocol::TNetworkBigEndian>, apache::thrift::protocol::TProtocolDefaults>::readMessageBegin_virt(std::__cxx11::bas@
    @         0x1b228505 apache::thrift::protocol::TProtocol::readMessageBegin(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, apache::thrift::protocol::TMessageType&, int&)
    @         0x1b22863d apache::thrift::TDispatchProcessor::process(std::shared_ptr<apache::thrift::protocol::TProtocol>, std::shared_ptr<apache::thrift::protocol::TProtocol>, void*)
    @         0x33b57e63 apache::thrift::server::TConnectedClient::run()
    @         0x33b58ba4 apache::thrift::server::TThreadedServer::TConnectedClientRunner::run()
    @         0x33b5b42b apache::thrift::concurrency::Thread::threadMain(std::shared_ptr<apache::thrift::concurrency::Thread>)
    @         0x33b31094 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(std::shared_ptr<apache::thrift::concurrency::Thread>), std::shared_ptr<apache::thrift::concurrency::Thread> > > >::_M_run()
    @         0x3ccdf574 execute_native_thread_routine
    @     0x7ff7eba84b84 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9cb83)
    @     0x7ff7ebb11b64 __clone

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
