### PR TITLE
[Enhancement] Make range tablet split and merge metadata stable

### DIFF
--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -23,6 +23,7 @@
 #include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "column/datum_convert.h"
+#include "common/config_exec_fwd.h"
 #include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "fs/fs_factory.h"
@@ -48,6 +49,7 @@
 #include "storage/rowset/short_key_range_option.h"
 #include "storage/seek_range.h"
 #include "storage/tablet_schema_map.h"
+#include "storage_primitive/empty_iterator.h"
 #include "storage_primitive/projection_iterator.h"
 #include "storage_primitive/schema_helper.h"
 #include "storage_primitive/union_iterator.h"
@@ -657,9 +659,10 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
     RETURN_IF_ERROR(load_segments(&segments, file_data_cache));
     // Size the result up front and write each iterator to its segment's position, so the returned
     // vector stays positionally aligned with `segments` (and its size always equals num_segments).
-    // Callers index it by position and assert on the size; a segment that produces no iterator -- a
-    // lost segment (experimental_lake_ignore_lost_segment) or an EndOfFile segment -- is left as the
-    // default null in its own slot. Mirrors get_each_segment_iterator_with_delvec.
+    // Callers index it by position and assert on the size. Plain reads expose zero-row segments as
+    // non-null empty iterators, while lost segments (experimental_lake_ignore_lost_segment) and
+    // EndOfFile segments remain null in their own slots. The delvec-aware API intentionally keeps
+    // zero-row slots null for its positional contract.
     std::vector<ChunkIteratorPtr> seg_iterators(segments.size());
     auto root_loc = _tablet_mgr->tablet_root_location(tablet_id());
     SegmentReadOptions seg_options;
@@ -695,6 +698,13 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator(const 
                                   fmt::format("unexpected null segment in get_each_segment_iterator, "
                                               "tablet:{} rowset:{} segidx:{}",
                                               tablet_id(), metadata().id(), i));
+            continue;
+        }
+        // A zero-row segment cannot initialize a tablet-range iterator because it has no last
+        // block. Return an explicit empty iterator for plain positional reads; the delvec-aware
+        // API below preserves its historical null slot for the same segment.
+        if (seg_ptr->num_rows() == 0) {
+            seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);
             continue;
         }
         RETURN_IF_ERROR(set_segment_tablet_range(segments[i].segment_meta_pos, shared_segment_range, &seg_options));
@@ -762,6 +772,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
             continue;
         }
         if (seg_ptr->num_rows() == 0) {
+            // Delvec-aware positional callers use a null slot to represent a zero-row segment.
             continue;
         }
         // Give the i-th iterator its own stats when requested, so concurrent scans don't race on a

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -761,6 +761,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
                                               tablet_id(), metadata().id(), i));
             continue;
         }
+        if (seg_ptr->num_rows() == 0) {
+            continue;
+        }
         // Give the i-th iterator its own stats when requested, so concurrent scans don't race on a
         // shared stats object; otherwise all segments share `stats`.
         if (per_segment_stats != nullptr && i < static_cast<int>(per_segment_stats->size())) {

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -297,6 +297,7 @@ struct CanonicalAllocationPlan {
     size_t selected_context_index = 0;
     RowsetMetadataPB source_form_rowset;
     std::optional<int64_t> schema_id;
+    std::optional<uint32_t> recovery_target;
     std::vector<TabletRangePB> contributor_ranges;
 };
 
@@ -333,23 +334,38 @@ std::string stable_rowset_mode(RowsetMetadataPB rowset) {
     rowset.clear_segment_metas();
     rowset.clear_range();
     rowset.clear_del_files();
+    rowset.clear_max_compact_input_rowset_id();
     return rowset.SerializeAsString();
+}
+
+Status validate_complete_segment_set(const RowsetMetadataPB& first, const RowsetMetadataPB& other) {
+    if (first.segment_metas_size() != other.segment_metas_size()) {
+        return Status::Corruption("tablet merge rowsets have different complete segment sets");
+    }
+    // Preflight already requires explicit, strictly increasing indices. Compare the
+    // entire immutable declaration at each index; only ownership may differ.
+    for (int i = 0; i < first.segment_metas_size(); ++i) {
+        SegmentMetadataPB a(first.segment_metas(i));
+        SegmentMetadataPB b(other.segment_metas(i));
+        a.clear_shared();
+        b.clear_shared();
+        if (a.SerializeAsString() != b.SerializeAsString()) {
+            return Status::Corruption("tablet merge rowsets have conflicting complete segment declarations");
+        }
+    }
+    return Status::OK();
 }
 
 Status validate_exact_duplicate(const RowsetMetadataPB& first, const RowsetMetadataPB& other) {
     if (first.num_rows() != other.num_rows() || first.data_size() != other.data_size() ||
         first.num_dels() != other.num_dels() ||
         first.has_max_compact_input_rowset_id() != other.has_max_compact_input_rowset_id() ||
-        first.max_compact_input_rowset_id() != other.max_compact_input_rowset_id() ||
         first.segment_metas_size() != other.segment_metas_size()) {
         return Status::Corruption("tablet merge equal-range rowsets disagree on stats, cursor or complete segment set");
     }
     CanonicalAllocationPlan copy;
     copy.source_form_rowset.CopyFrom(first);
-    RETURN_IF_ERROR(reconcile_segments(&copy.source_form_rowset, &other));
-    if (copy.source_form_rowset.segment_metas_size() != first.segment_metas_size()) {
-        return Status::Corruption("tablet merge equal-range rowsets have different complete segment sets");
-    }
+    RETURN_IF_ERROR(validate_complete_segment_set(first, other));
     return reconcile_duplicate_dels(&copy, other);
 }
 
@@ -380,9 +396,14 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
             const auto schema = rowset_schema_id(merge_contexts[first.context_index], first.rowset->id());
             for (const auto& occurrence : occurrences) {
                 if (stable_rowset_mode(*occurrence.rowset) != mode ||
+                    occurrence.rowset->has_max_compact_input_rowset_id() !=
+                            first.rowset->has_max_compact_input_rowset_id() ||
                     occurrence.rowset->del_files().empty() != first.rowset->del_files().empty() ||
                     rowset_schema_id(merge_contexts[occurrence.context_index], occurrence.rowset->id()) != schema) {
                     return Status::Corruption("tablet merge same-uid rowsets have conflicting canonical modes");
+                }
+                if (!first.rowset->del_files().empty()) {
+                    RETURN_IF_ERROR(validate_complete_segment_set(*first.rowset, *occurrence.rowset));
                 }
             }
         }
@@ -925,6 +946,14 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(
         cursor = result.projections[context_index].target_end();
     }
 
+    for (auto& canonical : result.canonicals) {
+        if (canonical.source_form_rowset.has_max_compact_input_rowset_id()) {
+            ASSIGN_OR_RETURN(canonical.recovery_target,
+                             result.projections[canonical.selected_context_index].map_primary_rssid(
+                                     canonical.source_form_rowset.max_compact_input_rowset_id()));
+        }
+    }
+
     for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
         const auto& metadata = *contexts[context_index].metadata();
         for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
@@ -955,8 +984,26 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(
                 }
                 RETURN_IF_ERROR(add_alias(static_cast<uint32_t>(source), uint64_t{canonical_target} + index));
             }
+            if (canonical.recovery_target.has_value()) {
+                RETURN_IF_ERROR(result.projections[context_index].add_occurrence_alias(
+                        occurrence.max_compact_input_rowset_id(), *canonical.recovery_target));
+            }
         }
         result.projections[context_index].finalize_aliases();
+        for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
+            const auto& decision = emission[context_index][rowset_index];
+            const auto& occurrence = metadata.rowsets(rowset_index);
+            if (decision.canonical_index < 0 || occurrence.has_delete_predicate() ||
+                !occurrence.has_max_compact_input_rowset_id())
+                continue;
+            const auto& projection = result.projections[context_index];
+            const uint32_t raw_key = occurrence.max_compact_input_rowset_id();
+            ASSIGN_OR_RETURN(auto mapped, projection.map_occurrence_rssid(raw_key));
+            if (projection.has_divergent_occurrence_alias(raw_key) ||
+                mapped != *result.canonicals[decision.canonical_index].recovery_target) {
+                return Status::Corruption("tablet merge occurrence recovery keys do not remain equivalent");
+            }
+        }
     }
 
     for (const auto& canonical : result.canonicals) {
@@ -968,10 +1015,6 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(
         RETURN_IF_ERROR(validate_primary_affine_span(projection, rowset.id(), extent_end, "canonical extent"));
         ASSIGN_OR_RETURN(auto mapped_id, projection.map_primary_rssid(rowset.id()));
         if (mapped_id >= cursor) return Status::Corruption("tablet merge canonical target is outside cursor");
-        if (rowset.has_max_compact_input_rowset_id()) {
-            ASSIGN_OR_RETURN(auto mapped, projection.map_primary_rssid(rowset.max_compact_input_rowset_id()));
-            (void)mapped;
-        }
         for (const auto& del : rowset.del_files()) {
             const uint32_t offset = del.has_op_offset() ? del.op_offset() : final_max;
             RETURN_IF_ERROR(validate_primary_affine_span(projection, del.origin_rowset_id(),
@@ -988,7 +1031,12 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(
             const auto& rowset = canonical.source_form_rowset;
             const uint32_t raw_key =
                     rowset.has_max_compact_input_rowset_id() ? rowset.max_compact_input_rowset_id() : rowset.id();
-            ASSIGN_OR_RETURN(uint32_t target_key, result.projections[context_index].map_primary_rssid(raw_key));
+            uint32_t target_key;
+            if (canonical.recovery_target.has_value()) {
+                target_key = *canonical.recovery_target;
+            } else {
+                ASSIGN_OR_RETURN(target_key, result.projections[context_index].map_primary_rssid(raw_key));
+            }
             if (result.projections[context_index].has_divergent_occurrence_alias(raw_key)) {
                 return Status::Corruption("tablet merge recovery key has a divergent occurrence alias");
             }
@@ -1023,9 +1071,8 @@ Status materialize_planned_rowsets(const TabletMergeAllocationPlan& plan, Tablet
         const auto& projection = plan.projections[canonical.selected_context_index];
         ASSIGN_OR_RETURN(auto mapped_id, projection.map_primary_rssid(output.id()));
         output.set_id(mapped_id);
-        if (output.has_max_compact_input_rowset_id()) {
-            ASSIGN_OR_RETURN(auto mapped, projection.map_primary_rssid(output.max_compact_input_rowset_id()));
-            output.set_max_compact_input_rowset_id(mapped);
+        if (canonical.recovery_target.has_value()) {
+            output.set_max_compact_input_rowset_id(*canonical.recovery_target);
         }
         for (auto& del : *output.mutable_del_files()) {
             ASSIGN_OR_RETURN(auto mapped, projection.map_primary_rssid(del.origin_rowset_id()));

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -686,8 +686,7 @@ Status validate_canonical_rowset(const RowsetMetadataPB& rowset, const TabletMet
     if (!tablet_reshard_helper::has_valid_uid(rowset)) {
         return Status::Corruption("tablet merge source rowset has no valid uid");
     }
-    if (rowset.num_rows() < 0 || rowset.data_size() < 0 || rowset.num_dels() < 0 ||
-        rowset.num_dels() > rowset.num_rows()) {
+    if (rowset.num_rows() < 0 || rowset.data_size() < 0 || rowset.num_dels() < 0) {
         return Status::Corruption("tablet merge source rowset has invalid statistics");
     }
     if (rowset.has_delete_predicate() &&
@@ -878,12 +877,18 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(
             RETURN_IF_ERROR(union_canonical_range(&canonical, occurrence_range));
             if (decision.role == RowsetOccurrenceRole::CONTRIBUTOR) {
                 canonical.contributor_ranges.emplace_back(occurrence_range);
-                canonical.source_form_rowset.set_num_rows(canonical.source_form_rowset.num_rows() +
-                                                          occurrence.num_rows());
-                canonical.source_form_rowset.set_data_size(canonical.source_form_rowset.data_size() +
-                                                           occurrence.data_size());
-                canonical.source_form_rowset.set_num_dels(canonical.source_form_rowset.num_dels() +
-                                                          occurrence.num_dels());
+                int64_t num_rows = 0;
+                int64_t data_size = 0;
+                int64_t num_dels = 0;
+                if (__builtin_add_overflow(canonical.source_form_rowset.num_rows(), occurrence.num_rows(), &num_rows) ||
+                    __builtin_add_overflow(canonical.source_form_rowset.data_size(), occurrence.data_size(),
+                                           &data_size) ||
+                    __builtin_add_overflow(canonical.source_form_rowset.num_dels(), occurrence.num_dels(), &num_dels)) {
+                    return Status::Corruption("tablet merge contributor statistics overflow int64");
+                }
+                canonical.source_form_rowset.set_num_rows(num_rows);
+                canonical.source_form_rowset.set_data_size(data_size);
+                canonical.source_form_rowset.set_num_dels(num_dels);
             }
             RETURN_IF_ERROR(reconcile_segments(&canonical.source_form_rowset, &occurrence));
             RETURN_IF_ERROR(reconcile_duplicate_dels(&canonical, occurrence));

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <map>
 #include <optional>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -58,6 +59,7 @@
 #include "storage/sstable/options.h"
 #include "storage/sstable/table_builder.h"
 #include "storage/storage_metrics.h"
+#include "storage/tablet_range.h"
 #include "storage/tablet_schema.h"
 #include "storage_primitive/schema_helper.h"
 
@@ -162,22 +164,20 @@ void union_delvec(DelVector* target, DelVector& source, int64_t version) {
     target->union_with(version, source.roaring() != nullptr ? *source.roaring() : empty);
 }
 
-// Duplicate detection for merge: two rowsets are the same logical rowset across
-// split siblings iff they carry the same global uid. The uid is minted once at
-// rowset creation and carried verbatim by CopyFrom across SPLIT and cross-publish,
-// so siblings descended from one logical rowset (split-pruned, or a concurrent
-// write cross-published to every old tablet) compare equal, while an independently
-// produced rowset (e.g. a post-split local compaction output) carries a fresh uid
-// and never aliases. A rowset without a valid uid is never treated as a duplicate.
-bool is_duplicate_rowset(const RowsetMetadataPB& a, const RowsetMetadataPB& b) {
-    return tablet_reshard_helper::same_rowset_uid(a, b);
-}
+enum class RowsetOccurrenceRole { CONTRIBUTOR, EXACT_DUPLICATE };
 
 struct RowsetEmissionDecision {
     int canonical_index = -1;
     bool emit = false;
-    bool discard = false;
+    RowsetOccurrenceRole role = RowsetOccurrenceRole::CONTRIBUTOR;
     bool non_pk_skip_dedup_fired = false;
+};
+
+struct RowsetOccurrenceRef {
+    size_t context_index;
+    int rowset_index;
+    const RowsetMetadataPB* rowset;
+    TabletRangePB effective_range;
 };
 
 using RowsetEmissionPlan = std::vector<std::vector<RowsetEmissionDecision>>;
@@ -309,101 +309,137 @@ struct TabletMergeAllocationPlan {
 
 DEFINE_FAIL_POINT(tablet_merge_before_delete_predicate_range);
 
-struct PlannedCanonicalRowset {
-    const RowsetMetadataPB* rowset = nullptr;
-    TabletRangePB range;
-    int output_index = -1;
-};
+Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* occurrence);
+Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, const RowsetMetadataPB& occurrence);
 
-// Plan the exact rowsets that materialization will emit in (version, old-tablet-index)
-// order. This is the single source of truth for duplicate decisions: allocation
-// planning reconciles sibling occurrences into canonical atoms and occurrence
-// aliases, then materialization uses the recorded canonical index directly.
+Status validate_exact_duplicate(const RowsetMetadataPB& first, const RowsetMetadataPB& other) {
+    if (first.num_rows() != other.num_rows() || first.data_size() != other.data_size() ||
+        first.num_dels() != other.num_dels() ||
+        first.has_max_compact_input_rowset_id() != other.has_max_compact_input_rowset_id() ||
+        first.max_compact_input_rowset_id() != other.max_compact_input_rowset_id() ||
+        first.segment_metas_size() != other.segment_metas_size()) {
+        return Status::Corruption("tablet merge equal-range rowsets disagree on stats, cursor or complete segment set");
+    }
+    CanonicalAllocationPlan copy;
+    copy.source_form_rowset.CopyFrom(first);
+    RETURN_IF_ERROR(reconcile_segments(&copy.source_form_rowset, &other));
+    if (copy.source_form_rowset.segment_metas_size() != first.segment_metas_size()) {
+        return Status::Corruption("tablet merge equal-range rowsets have different complete segment sets");
+    }
+    return reconcile_duplicate_dels(&copy, other);
+}
+
+// Decide every occurrence globally before allocating RSSIDs or performing I/O.
+// Array order is not a version-order guarantee (compaction can make it nonmonotonic).
 StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<TabletMergeContext>& merge_contexts,
                                                         bool discard_empty_rowsets) {
     RowsetEmissionPlan plan(merge_contexts.size());
-    std::vector<int> current_indices(merge_contexts.size(), 0);
+    using GroupKey = std::tuple<int, int64_t, int64_t>;
+    std::map<GroupKey, std::vector<RowsetOccurrenceRef>> groups;
     for (size_t i = 0; i < merge_contexts.size(); ++i) {
-        plan[i].resize(merge_contexts[i].metadata()->rowsets_size());
-    }
-
-    const bool is_pk = is_primary_key(*merge_contexts.front().metadata());
-    int64_t current_version = -1;
-    int next_output_index = 0;
-    std::vector<PlannedCanonicalRowset> canonicals;
-
-    for (;;) {
-        int source_index = -1;
-        int64_t min_version = std::numeric_limits<int64_t>::max();
-        for (int i = 0; i < static_cast<int>(merge_contexts.size()); ++i) {
-            if (current_indices[i] >= merge_contexts[i].metadata()->rowsets_size()) continue;
-            const int64_t version = merge_contexts[i].metadata()->rowsets(current_indices[i]).version();
-            if (version < min_version) {
-                min_version = version;
-                source_index = i;
+        const auto& source = *merge_contexts[i].metadata();
+        plan[i].resize(source.rowsets_size());
+        RETURN_IF_ERROR(TabletRangeHelper::validate_tablet_range(source.range()));
+        for (int j = 0; j < source.rowsets_size(); ++j) {
+            const auto& rowset = source.rowsets(j);
+            if (!tablet_reshard_helper::has_valid_uid(rowset)) {
+                return Status::Corruption("tablet merge source rowset has no valid uid");
             }
-        }
-        if (source_index < 0) break;
-
-        const int rowset_index = current_indices[source_index]++;
-        const auto& source_metadata = *merge_contexts[source_index].metadata();
-        const auto& rowset = source_metadata.rowsets(rowset_index);
-        if (discard_empty_rowsets && rowset.segment_metas_size() == 0 && rowset.del_files_size() == 0 &&
-            !rowset.has_delete_predicate()) {
-            plan[source_index][rowset_index].discard = true;
-            continue;
-        }
-        if (rowset.version() != current_version) {
-            current_version = rowset.version();
-            canonicals.clear();
-        }
-
-        // Search the current version's canonical rowsets. Delete predicates dedup
-        // by version, normal rowsets by uid; non-PK same-uid siblings dedup only
-        // when their ranges are contiguous, so the canonical range cannot span a
-        // gap left by a compacted sibling.
-        int canonical_plan_index = -1;
-        bool non_pk_skip_dedup_fired = false;
-        for (int i = 0; i < static_cast<int>(canonicals.size()); ++i) {
-            if (rowset.has_delete_predicate()) {
-                if (canonicals[i].rowset->has_delete_predicate()) {
-                    canonical_plan_index = i;
-                    break;
+            for (int k = 0; k < rowset.segment_metas_size(); ++k) {
+                const auto& segment = rowset.segment_metas(k);
+                if (!segment.has_segment_idx()) {
+                    return Status::Corruption("tablet merge source segment has no explicit segment_idx");
                 }
+            }
+            auto range = tablet_reshard_helper::effective_old_tablet_local_range(rowset, source);
+            RETURN_IF_ERROR(TabletRangeHelper::validate_tablet_range(range));
+            TabletRange decoded;
+            RETURN_IF_ERROR(decoded.from_proto(range));
+            if (decoded.is_empty()) return Status::Corruption("tablet merge source rowset has an empty range");
+            if (discard_empty_rowsets && rowset.segment_metas_size() == 0 && rowset.del_files_size() == 0 &&
+                !rowset.has_delete_predicate())
                 continue;
-            }
-            if (!is_duplicate_rowset(rowset, *canonicals[i].rowset)) continue;
-
-            const auto& incoming_range =
-                    tablet_reshard_helper::effective_old_tablet_local_range(rowset, source_metadata);
-            if (is_pk || tablet_reshard_helper::ranges_are_contiguous(canonicals[i].range, incoming_range)) {
-                canonical_plan_index = i;
-                if (!is_pk) {
-                    ASSIGN_OR_RETURN(canonicals[i].range,
-                                     tablet_reshard_helper::union_range(canonicals[i].range, incoming_range));
+            const auto key = rowset.has_delete_predicate() ? GroupKey{1, rowset.version(), 0}
+                                                           : GroupKey{0, rowset.uid().hi(), rowset.uid().lo()};
+            groups[key].push_back({i, j, &rowset, std::move(range)});
+        }
+    }
+    const bool is_pk = is_primary_key(*merge_contexts.front().metadata());
+    using CanonicalOrderKey = std::tuple<int64_t, int, int64_t, int64_t, std::string, int64_t>;
+    std::map<CanonicalOrderKey, std::vector<RowsetOccurrenceRef>> canonicals;
+    for (auto& [key, occurrences] : groups) {
+        auto occurrence_key = [&](const auto& ref) {
+            return std::tuple{ref.effective_range.lower_bound().SerializeAsString(),
+                              ref.effective_range.upper_bound().SerializeAsString(),
+                              ref.effective_range.SerializeAsString(),
+                              merge_contexts[ref.context_index].metadata()->id(), ref.rowset_index};
+        };
+        std::sort(occurrences.begin(), occurrences.end(),
+                  [&](const auto& a, const auto& b) { return occurrence_key(a) < occurrence_key(b); });
+        // Components use boundary adjacency, not serialized-byte ordering, which
+        // need not be the typed ordering of the range keys.
+        std::vector<size_t> components(occurrences.size());
+        for (size_t i = 0; i < components.size(); ++i) components[i] = i;
+        auto root = [&](size_t i) {
+            while (components[i] != i) i = components[i];
+            return i;
+        };
+        for (size_t i = 0; i < occurrences.size(); ++i) {
+            const auto& incoming = occurrences[i];
+            for (size_t j = 0; j < i; ++j) {
+                const auto& earlier = occurrences[j];
+                bool adjacent = true;
+                if (!incoming.rowset->has_delete_predicate()) {
+                    const bool equal =
+                            incoming.effective_range.SerializeAsString() == earlier.effective_range.SerializeAsString();
+                    if (equal) {
+                        RETURN_IF_ERROR(validate_exact_duplicate(*earlier.rowset, *incoming.rowset));
+                        plan[incoming.context_index][incoming.rowset_index].role =
+                                RowsetOccurrenceRole::EXACT_DUPLICATE;
+                    } else {
+                        ASSIGN_OR_RETURN(auto intersection, tablet_reshard_helper::intersect_range(
+                                                                    earlier.effective_range, incoming.effective_range));
+                        TabletRange decoded;
+                        RETURN_IF_ERROR(decoded.from_proto(intersection));
+                        if (!decoded.is_empty()) {
+                            return Status::Corruption("tablet merge same-uid rowset ranges strictly overlap");
+                        }
+                    }
+                    adjacent = is_pk || tablet_reshard_helper::ranges_are_contiguous(earlier.effective_range,
+                                                                                     incoming.effective_range);
                 }
-                break;
+                if (adjacent) components[root(i)] = root(j);
             }
-            non_pk_skip_dedup_fired = true;
         }
-
-        auto& decision = plan[source_index][rowset_index];
-        if (canonical_plan_index >= 0) {
-            decision.canonical_index = canonicals[canonical_plan_index].output_index;
-            continue;
+        std::map<size_t, std::vector<RowsetOccurrenceRef>> parts;
+        for (size_t i = 0; i < occurrences.size(); ++i) parts[root(i)].emplace_back(occurrences[i]);
+        bool skipped = false;
+        for (auto& [component, refs] : parts) {
+            const auto& first = refs.front();
+            TabletRangePB range = first.effective_range;
+            for (size_t i = 1; i < refs.size(); ++i) {
+                ASSIGN_OR_RETURN(range, tablet_reshard_helper::union_range(range, refs[i].effective_range));
+            }
+            const auto& rowset = *first.rowset;
+            const CanonicalOrderKey order{rowset.version(),
+                                          std::get<0>(key),
+                                          std::get<1>(key),
+                                          std::get<2>(key),
+                                          range.lower_bound().SerializeAsString(),
+                                          merge_contexts[first.context_index].metadata()->id()};
+            plan[first.context_index][first.rowset_index].non_pk_skip_dedup_fired = skipped;
+            skipped = true;
+            canonicals.emplace(order, std::move(refs));
         }
-
-        decision.emit = true;
-        decision.canonical_index = next_output_index++;
-        decision.non_pk_skip_dedup_fired = non_pk_skip_dedup_fired;
-        PlannedCanonicalRowset canonical;
-        canonical.rowset = &rowset;
-        canonical.output_index = decision.canonical_index;
-        RowsetMetadataPB canonical_copy;
-        canonical_copy.CopyFrom(rowset);
-        RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(&canonical_copy, source_metadata.range()));
-        canonical.range.CopyFrom(canonical_copy.range());
-        canonicals.emplace_back(std::move(canonical));
+    }
+    int output_index = 0;
+    for (const auto& [key, refs] : canonicals) {
+        for (size_t i = 0; i < refs.size(); ++i) {
+            auto& decision = plan[refs[i].context_index][refs[i].rowset_index];
+            decision.canonical_index = output_index;
+            decision.emit = i == 0;
+        }
+        ++output_index;
     }
 
     return plan;
@@ -694,7 +730,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
         const auto& metadata = *contexts[context_index].metadata();
         for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
             const auto& decision = emission[context_index][rowset_index];
-            if (decision.discard || decision.emit) continue;
+            if (decision.canonical_index < 0 || decision.emit) continue;
             const auto& occurrence = metadata.rowsets(rowset_index);
             DCHECK(tablet_reshard_helper::has_valid_uid(occurrence))
                     << "rowset reaching reshard merge must carry a valid uid: rowset_id=" << occurrence.id()
@@ -718,12 +754,16 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
                 RETURN_IF_ERROR(union_canonical_range(&canonical, occurrence_range));
                 continue;
             }
-            canonical.contributor_ranges.emplace_back(occurrence_range);
             RETURN_IF_ERROR(union_canonical_range(&canonical, occurrence_range));
-            canonical.source_form_rowset.set_num_rows(canonical.source_form_rowset.num_rows() + occurrence.num_rows());
-            canonical.source_form_rowset.set_data_size(canonical.source_form_rowset.data_size() +
-                                                       occurrence.data_size());
-            canonical.source_form_rowset.set_num_dels(canonical.source_form_rowset.num_dels() + occurrence.num_dels());
+            if (decision.role == RowsetOccurrenceRole::CONTRIBUTOR) {
+                canonical.contributor_ranges.emplace_back(occurrence_range);
+                canonical.source_form_rowset.set_num_rows(canonical.source_form_rowset.num_rows() +
+                                                          occurrence.num_rows());
+                canonical.source_form_rowset.set_data_size(canonical.source_form_rowset.data_size() +
+                                                           occurrence.data_size());
+                canonical.source_form_rowset.set_num_dels(canonical.source_form_rowset.num_dels() +
+                                                          occurrence.num_dels());
+            }
             RETURN_IF_ERROR(reconcile_segments(&canonical.source_form_rowset, &occurrence));
             RETURN_IF_ERROR(reconcile_duplicate_dels(&canonical, occurrence));
         }
@@ -765,7 +805,11 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
 
     result.projections.resize(contexts.size());
     uint32_t cursor = 1;
-    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+    std::vector<size_t> context_order;
+    for (size_t i = 0; i < contexts.size(); ++i) context_order.push_back(i);
+    std::sort(context_order.begin(), context_order.end(),
+              [&](size_t a, size_t b) { return contexts[a].metadata()->id() < contexts[b].metadata()->id(); });
+    for (size_t context_index : context_order) {
         if (force_context_span_projection && !atoms[context_index].empty()) {
             atoms[context_index] = {{0, contexts[context_index].metadata()->next_rowset_id()}};
         }
@@ -778,7 +822,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
         for (int rowset_index = 0; rowset_index < metadata.rowsets_size(); ++rowset_index) {
             const auto& decision = emission[context_index][rowset_index];
             const auto& occurrence = metadata.rowsets(rowset_index);
-            if (decision.discard || decision.emit || occurrence.has_delete_predicate()) continue;
+            if (decision.canonical_index < 0 || decision.emit || occurrence.has_delete_predicate()) continue;
             const auto& canonical = result.canonicals[decision.canonical_index];
             const auto& canonical_rowset = canonical.source_form_rowset;
             ASSIGN_OR_RETURN(
@@ -829,7 +873,7 @@ StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std
     }
 
     std::optional<uint32_t> previous_recovery_target;
-    for (size_t context_index = 0; context_index < contexts.size(); ++context_index) {
+    for (size_t context_index : context_order) {
         std::map<uint32_t, uint32_t> groups;
         for (const auto& canonical : result.canonicals) {
             if (canonical.selected_context_index != context_index) continue;
@@ -3454,7 +3498,7 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
 
     FAIL_POINT_TRIGGER_RETURN_ERROR(tablet_merge_after_rssid_reassign);
 
-    // Phase 2: Merge rowsets (version-driven k-way merge with dedup).
+    // Phase 2: Materialize the globally ordered canonical rowsets.
     // canonical_contribs collects each canonical rowset's contributing
     // old tablets' old-tablet-local ranges; consumed by the PK fail-fast coverage
     // check below and by gap-delvec synthesis.

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -390,18 +390,25 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
                 const auto& earlier = occurrences[j];
                 bool adjacent = true;
                 if (!incoming.rowset->has_delete_predicate()) {
-                    const bool equal =
-                            incoming.effective_range.SerializeAsString() == earlier.effective_range.SerializeAsString();
+                    TabletRange incoming_range;
+                    TabletRange earlier_range;
+                    RETURN_IF_ERROR(incoming_range.from_proto(incoming.effective_range));
+                    RETURN_IF_ERROR(earlier_range.from_proto(earlier.effective_range));
+                    // Encoding differences do not change ownership. Inclusion
+                    // flags on an unbounded endpoint have no semantic effect.
+                    const bool equal = incoming_range.lower_bound() == earlier_range.lower_bound() &&
+                                       incoming_range.upper_bound() == earlier_range.upper_bound() &&
+                                       (incoming_range.is_minimum() || incoming_range.lower_bound_included() ==
+                                                                               earlier_range.lower_bound_included()) &&
+                                       (incoming_range.is_maximum() ||
+                                        incoming_range.upper_bound_included() == earlier_range.upper_bound_included());
                     if (equal) {
                         RETURN_IF_ERROR(validate_exact_duplicate(*earlier.rowset, *incoming.rowset));
                         plan[incoming.context_index][incoming.rowset_index].role =
                                 RowsetOccurrenceRole::EXACT_DUPLICATE;
                     } else {
-                        ASSIGN_OR_RETURN(auto intersection, tablet_reshard_helper::intersect_range(
-                                                                    earlier.effective_range, incoming.effective_range));
-                        TabletRange decoded;
-                        RETURN_IF_ERROR(decoded.from_proto(intersection));
-                        if (!decoded.is_empty()) {
+                        ASSIGN_OR_RETURN(auto intersection, earlier_range.intersect(incoming_range));
+                        if (!intersection.is_empty()) {
                             return Status::Corruption("tablet merge same-uid rowset ranges strictly overlap");
                         }
                     }

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -709,6 +709,12 @@ Status validate_canonical_rowset(const RowsetMetadataPB& rowset, const TabletMet
     }
     for (int i = 0; i < rowset.segment_metas_size(); ++i) {
         const auto& segment = rowset.segment_metas(i);
+        if (!segment.has_num_rows()) {
+            return Status::Corruption("tablet merge source segment has no explicit row count");
+        }
+        if (segment.num_rows() < 0 || segment.size() < 0) {
+            return Status::Corruption("tablet merge source segment has negative statistics");
+        }
         if (!segment.has_segment_idx()) {
             return Status::Corruption("tablet merge source segment has no explicit segment_idx");
         }

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -2887,9 +2887,14 @@ PersistentIndexSstablePB normalized_preflight_sstable_form(const PersistentIndex
     normalized.clear_version();
     normalized.clear_filename();
     normalized.clear_filesize();
+    normalized.clear_max_rss_rowid();
     normalized.clear_encryption_meta();
     normalized.clear_shared();
+    normalized.clear_shared_rssid();
+    normalized.clear_shared_version();
+    normalized.clear_delvec();
     normalized.clear_fileset_id();
+    normalized.clear_rssid_offset();
     normalized.clear_generation_version();
     return normalized;
 }

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -312,6 +312,30 @@ DEFINE_FAIL_POINT(tablet_merge_before_delete_predicate_range);
 Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* occurrence);
 Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, const RowsetMetadataPB& occurrence);
 
+std::optional<int64_t> rowset_schema_id(const TabletMergeContext& context, uint32_t rowset_id) {
+    const auto& mapping = context.metadata()->rowset_to_schema();
+    auto iter = mapping.find(rowset_id);
+    if (iter == mapping.end()) return std::nullopt;
+    return iter->second;
+}
+
+std::string stable_rowset_mode(RowsetMetadataPB rowset) {
+    rowset.clear_id();
+    rowset.clear_overlapped();
+    rowset.clear_deprecated_segments();
+    rowset.clear_deprecated_segment_size();
+    rowset.clear_deprecated_segment_encryption_metas();
+    rowset.clear_deprecated_bundle_file_offsets();
+    rowset.clear_deprecated_shared_segments();
+    rowset.clear_num_rows();
+    rowset.clear_data_size();
+    rowset.clear_num_dels();
+    rowset.clear_segment_metas();
+    rowset.clear_range();
+    rowset.clear_del_files();
+    return rowset.SerializeAsString();
+}
+
 Status validate_exact_duplicate(const RowsetMetadataPB& first, const RowsetMetadataPB& other) {
     if (first.num_rows() != other.num_rows() || first.data_size() != other.data_size() ||
         first.num_dels() != other.num_dels() ||
@@ -331,34 +355,16 @@ Status validate_exact_duplicate(const RowsetMetadataPB& first, const RowsetMetad
 
 // Decide every occurrence globally before allocating RSSIDs or performing I/O.
 // Array order is not a version-order guarantee (compaction can make it nonmonotonic).
-StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<TabletMergeContext>& merge_contexts,
-                                                        bool discard_empty_rowsets) {
+StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<TabletMergeContext>& merge_contexts) {
     RowsetEmissionPlan plan(merge_contexts.size());
     using GroupKey = std::tuple<int, int64_t, int64_t>;
     std::map<GroupKey, std::vector<RowsetOccurrenceRef>> groups;
     for (size_t i = 0; i < merge_contexts.size(); ++i) {
         const auto& source = *merge_contexts[i].metadata();
         plan[i].resize(source.rowsets_size());
-        RETURN_IF_ERROR(TabletRangeHelper::validate_tablet_range(source.range()));
         for (int j = 0; j < source.rowsets_size(); ++j) {
             const auto& rowset = source.rowsets(j);
-            if (!tablet_reshard_helper::has_valid_uid(rowset)) {
-                return Status::Corruption("tablet merge source rowset has no valid uid");
-            }
-            for (int k = 0; k < rowset.segment_metas_size(); ++k) {
-                const auto& segment = rowset.segment_metas(k);
-                if (!segment.has_segment_idx()) {
-                    return Status::Corruption("tablet merge source segment has no explicit segment_idx");
-                }
-            }
             auto range = tablet_reshard_helper::effective_old_tablet_local_range(rowset, source);
-            RETURN_IF_ERROR(TabletRangeHelper::validate_tablet_range(range));
-            TabletRange decoded;
-            RETURN_IF_ERROR(decoded.from_proto(range));
-            if (decoded.is_empty()) return Status::Corruption("tablet merge source rowset has an empty range");
-            if (discard_empty_rowsets && rowset.segment_metas_size() == 0 && rowset.del_files_size() == 0 &&
-                !rowset.has_delete_predicate())
-                continue;
             const auto key = rowset.has_delete_predicate() ? GroupKey{1, rowset.version(), 0}
                                                            : GroupKey{0, rowset.uid().hi(), rowset.uid().lo()};
             groups[key].push_back({i, j, &rowset, std::move(range)});
@@ -368,6 +374,18 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
     using CanonicalOrderKey = std::tuple<int64_t, int, int64_t, int64_t, std::string, int64_t>;
     std::map<CanonicalOrderKey, std::vector<RowsetOccurrenceRef>> canonicals;
     for (auto& [key, occurrences] : groups) {
+        if (!occurrences.front().rowset->has_delete_predicate()) {
+            const auto& first = occurrences.front();
+            const auto mode = stable_rowset_mode(*first.rowset);
+            const auto schema = rowset_schema_id(merge_contexts[first.context_index], first.rowset->id());
+            for (const auto& occurrence : occurrences) {
+                if (stable_rowset_mode(*occurrence.rowset) != mode ||
+                    occurrence.rowset->del_files().empty() != first.rowset->del_files().empty() ||
+                    rowset_schema_id(merge_contexts[occurrence.context_index], occurrence.rowset->id()) != schema) {
+                    return Status::Corruption("tablet merge same-uid rowsets have conflicting canonical modes");
+                }
+            }
+        }
         auto occurrence_key = [&](const auto& ref) {
             return std::tuple{ref.effective_range.lower_bound().SerializeAsString(),
                               ref.effective_range.upper_bound().SerializeAsString(),
@@ -450,13 +468,6 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
     }
 
     return plan;
-}
-
-std::optional<int64_t> rowset_schema_id(const TabletMergeContext& context, uint32_t rowset_id) {
-    const auto& mapping = context.metadata()->rowset_to_schema();
-    auto iter = mapping.find(rowset_id);
-    if (iter == mapping.end()) return std::nullopt;
-    return iter->second;
 }
 
 std::string normalized_physical_base_key(const SegmentMetadataPB& segment) {
@@ -639,6 +650,96 @@ Status validate_del_replay_span(uint32_t origin, uint32_t offset) {
     return Status::OK();
 }
 
+Status validate_del_coordinate(const RowsetMetadataPB& containing_rowset, const DelfileWithRowsetId& del) {
+    const uint32_t offset = del.has_op_offset() ? del.op_offset() : get_max_segment_idx(containing_rowset);
+    RETURN_IF_ERROR(validate_del_replay_span(del.origin_rowset_id(), offset));
+    if (del.origin_rowset_id() != containing_rowset.id()) return Status::OK();
+    if (containing_rowset.segment_metas_size() == 0) {
+        return offset == 0 ? Status::OK() : Status::Corruption("segmentless self-origin del offset is not zero");
+    }
+    for (int i = 0; i < containing_rowset.segment_metas_size(); ++i) {
+        if (get_segment_idx(containing_rowset, i) == offset) return Status::OK();
+    }
+    return Status::Corruption("self-origin del offset does not name a current segment");
+}
+
+bool same_range(const TabletRange& a, const TabletRange& b) {
+    return a.lower_bound() == b.lower_bound() && a.upper_bound() == b.upper_bound() &&
+           (a.is_minimum() || a.lower_bound_included() == b.lower_bound_included()) &&
+           (a.is_maximum() || a.upper_bound_included() == b.upper_bound_included());
+}
+
+Status validate_canonical_rowset(const RowsetMetadataPB& rowset, const TabletMetadataPB& source) {
+    if (!tablet_reshard_helper::has_valid_uid(rowset)) {
+        return Status::Corruption("tablet merge source rowset has no valid uid");
+    }
+    if (rowset.num_rows() < 0 || rowset.data_size() < 0 || rowset.num_dels() < 0 ||
+        rowset.num_dels() > rowset.num_rows()) {
+        return Status::Corruption("tablet merge source rowset has invalid statistics");
+    }
+    if (rowset.has_delete_predicate() &&
+        (rowset.segment_metas_size() != 0 || rowset.del_files_size() != 0 || rowset.num_rows() != 0 ||
+         rowset.data_size() != 0 || rowset.num_dels() != 0)) {
+        return Status::Corruption("tablet merge predicate rowset has a noncanonical payload");
+    }
+    if (!rowset.has_delete_predicate() && rowset.segment_metas_size() == 0 && rowset.del_files_size() == 0) {
+        return Status::Corruption("tablet merge source has an empty ordinary rowset");
+    }
+    TabletRange effective;
+    TabletRange parent;
+    const auto& range = tablet_reshard_helper::effective_old_tablet_local_range(rowset, source);
+    RETURN_IF_ERROR(TabletRangeHelper::validate_tablet_range(range));
+    RETURN_IF_ERROR(effective.from_proto(range));
+    RETURN_IF_ERROR(parent.from_proto(source.range()));
+    ASSIGN_OR_RETURN(auto intersection, effective.intersect(parent));
+    if (effective.is_empty() || !same_range(effective, intersection)) {
+        return Status::Corruption("tablet merge rowset range is empty or outside its source tablet");
+    }
+    for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+        const auto& segment = rowset.segment_metas(i);
+        if (!segment.has_segment_idx()) {
+            return Status::Corruption("tablet merge source segment has no explicit segment_idx");
+        }
+        if (i > 0 && segment.segment_idx() <= rowset.segment_metas(i - 1).segment_idx()) {
+            return Status::Corruption("tablet merge source segment indices are not strictly increasing");
+        }
+        if (uint64_t{rowset.id()} + segment.segment_idx() > UINT32_MAX) {
+            return Status::Corruption("tablet merge source segment RSSID overflows uint32");
+        }
+    }
+    for (const auto& del : rowset.del_files()) RETURN_IF_ERROR(validate_del_coordinate(rowset, del));
+    return Status::OK();
+}
+
+Status validate_merge_inputs(const std::vector<TabletMergeContext>& contexts, const TabletRangePB& target_range) {
+    std::vector<TabletRange> ranges(contexts.size());
+    for (size_t i = 0; i < contexts.size(); ++i) {
+        const auto& source = *contexts[i].metadata();
+        RETURN_IF_ERROR(TabletRangeHelper::validate_tablet_range(source.range()));
+        RETURN_IF_ERROR(ranges[i].from_proto(source.range()));
+        if (ranges[i].is_empty()) return Status::Corruption("tablet merge source tablet range is empty");
+        for (const auto& rowset : source.rowsets()) RETURN_IF_ERROR(validate_canonical_rowset(rowset, source));
+    }
+    std::sort(ranges.begin(), ranges.end(), [](const auto& a, const auto& b) {
+        if (a.is_minimum() != b.is_minimum()) return a.is_minimum();
+        return a.lower_bound().compare(b.lower_bound()) < 0;
+    });
+    TabletRange cover = ranges.front();
+    for (size_t i = 1; i < ranges.size(); ++i) {
+        const auto& left = ranges[i - 1];
+        const auto& right = ranges[i];
+        if (left.is_maximum() || right.is_minimum() || left.upper_bound() != right.lower_bound() ||
+            left.upper_bound_included() == right.lower_bound_included()) {
+            return Status::Corruption("tablet merge source ranges are not a nonoverlapping contiguous cover");
+        }
+        cover = cover.union_with(right);
+    }
+    TabletRange target;
+    RETURN_IF_ERROR(target.from_proto(target_range));
+    if (!same_range(cover, target)) return Status::Corruption("tablet merge source ranges do not cover target");
+    return Status::OK();
+}
+
 Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, const RowsetMetadataPB& occurrence) {
     auto* selected = &canonical->source_form_rowset;
     if (selected->del_files_size() != occurrence.del_files_size()) {
@@ -689,15 +790,15 @@ Status validate_primary_affine_span(const RssidProjection& projection, uint64_t 
     return Status::OK();
 }
 
-StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(const std::vector<TabletMergeContext>& contexts,
-                                                                       bool discard_empty_rowsets) {
+StatusOr<TabletMergeAllocationPlan> build_tablet_merge_allocation_plan(
+        const std::vector<TabletMergeContext>& contexts) {
     bool force_context_span_projection = false;
     TEST_SYNC_POINT_CALLBACK("tablet_merge_test:force_context_span_projection", &force_context_span_projection);
     bool drop_primary_atom = false;
     TEST_SYNC_POINT_CALLBACK("tablet_merge_test:drop_primary_atom", &drop_primary_atom);
 
     TabletMergeAllocationPlan result;
-    ASSIGN_OR_RETURN(auto emission, build_rowset_emission_plan(contexts, discard_empty_rowsets));
+    ASSIGN_OR_RETURN(auto emission, build_rowset_emission_plan(contexts));
     int canonical_count = 0;
     for (const auto& decisions : emission) {
         for (const auto& decision : decisions) {
@@ -3490,9 +3591,6 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // build task never skips another source's unbuilt rowsets (see the helper for the invariant).
     reconcile_vector_index_built_version(merge_contexts, new_tablet_metadata.get());
 
-    const bool discard_empty_rowsets = !skip_sstable_merge && is_primary_key(*merge_contexts.front().metadata());
-    ASSIGN_OR_RETURN(auto allocation_plan, build_tablet_merge_allocation_plan(merge_contexts, discard_empty_rowsets));
-
     // Merge tablet-level range via union_range
     TabletRangePB merged_range = merge_contexts.front().metadata()->range();
     for (size_t i = 1; i < merge_contexts.size(); ++i) {
@@ -3500,6 +3598,9 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
                          tablet_reshard_helper::union_range(merged_range, merge_contexts[i].metadata()->range()));
     }
     new_tablet_metadata->mutable_range()->CopyFrom(merged_range);
+
+    RETURN_IF_ERROR(validate_merge_inputs(merge_contexts, merged_range));
+    ASSIGN_OR_RETURN(auto allocation_plan, build_tablet_merge_allocation_plan(merge_contexts));
 
     RETURN_IF_ERROR(preflight_merge_sources(merge_contexts, allocation_plan, *new_tablet_metadata));
 

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -671,10 +671,9 @@ Status validate_del_coordinate(const RowsetMetadataPB& containing_rowset, const 
     if (containing_rowset.segment_metas_size() == 0) {
         return offset == 0 ? Status::OK() : Status::Corruption("segmentless self-origin del offset is not zero");
     }
-    for (int i = 0; i < containing_rowset.segment_metas_size(); ++i) {
-        if (get_segment_idx(containing_rowset, i) == offset) return Status::OK();
-    }
-    return Status::Corruption("self-origin del offset does not name a current segment");
+    return offset <= get_max_segment_idx(containing_rowset)
+                   ? Status::OK()
+                   : Status::Corruption("self-origin del offset exceeds rowset replay span");
 }
 
 bool same_range(const TabletRange& a, const TabletRange& b) {

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -312,6 +312,7 @@ DEFINE_FAIL_POINT(tablet_merge_before_delete_predicate_range);
 
 Status reconcile_segments(RowsetMetadataPB* canonical, const RowsetMetadataPB* occurrence);
 Status reconcile_duplicate_dels(CanonicalAllocationPlan* canonical, const RowsetMetadataPB& occurrence);
+bool same_range(const TabletRange& a, const TabletRange& b);
 
 std::optional<int64_t> rowset_schema_id(const TabletMergeContext& context, uint32_t rowset_id) {
     const auto& mapping = context.metadata()->rowset_to_schema();
@@ -433,15 +434,7 @@ StatusOr<RowsetEmissionPlan> build_rowset_emission_plan(const std::vector<Tablet
                     TabletRange earlier_range;
                     RETURN_IF_ERROR(incoming_range.from_proto(incoming.effective_range));
                     RETURN_IF_ERROR(earlier_range.from_proto(earlier.effective_range));
-                    // Encoding differences do not change ownership. Inclusion
-                    // flags on an unbounded endpoint have no semantic effect.
-                    const bool equal = incoming_range.lower_bound() == earlier_range.lower_bound() &&
-                                       incoming_range.upper_bound() == earlier_range.upper_bound() &&
-                                       (incoming_range.is_minimum() || incoming_range.lower_bound_included() ==
-                                                                               earlier_range.lower_bound_included()) &&
-                                       (incoming_range.is_maximum() ||
-                                        incoming_range.upper_bound_included() == earlier_range.upper_bound_included());
-                    if (equal) {
+                    if (same_range(incoming_range, earlier_range)) {
                         RETURN_IF_ERROR(validate_exact_duplicate(*earlier.rowset, *incoming.rowset));
                         plan[incoming.context_index][incoming.rowset_index].role =
                                 RowsetOccurrenceRole::EXACT_DUPLICATE;

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -93,35 +93,49 @@ static StatusOr<TabletMetadataPtr> get_old_tablet_base_metadata(TabletManager* t
                                                /*expected_gtid=*/0, /*fs=*/nullptr, order);
 }
 
+TabletMetadataPtr lookup_exact_cached_metadata(TabletManager* tablet_manager, int64_t tablet_id, int64_t version,
+                                                int64_t gtid) {
+    if (gtid <= 0) return nullptr;
+    auto metadata = tablet_manager->metacache()->lookup_tablet_metadata(
+            tablet_manager->tablet_metadata_location(tablet_id, version));
+    if (metadata != nullptr && metadata->id() == tablet_id && metadata->version() == version &&
+        metadata->gtid() == gtid) return metadata;
+    return nullptr;
+}
+
 Status handle_splitting_tablet(TabletManager* tablet_manager, const SplittingTabletInfoPB& splitting_tablet,
                                int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,
                                std::unordered_map<int64_t, TabletMetadataPtr>& new_metadatas,
                                std::unordered_map<int64_t, TabletRangePB>& tablet_ranges,
                                InitialMetadataOrder base_version_order) {
     {
-        auto old_tablet_new_metadata_location =
-                tablet_manager->tablet_metadata_location(splitting_tablet.old_tablet_id(), new_version);
-        auto cached_old_tablet_new_metadata =
-                tablet_manager->metacache()->lookup_tablet_metadata(old_tablet_new_metadata_location);
-        if (cached_old_tablet_new_metadata == nullptr) {
-            goto CONTINUE_HANDLE_SPLITTING_TABLET;
-        }
-
-        new_metadatas.emplace(splitting_tablet.old_tablet_id(), std::move(cached_old_tablet_new_metadata));
+        std::unordered_map<int64_t, TabletMetadataPtr> cached_metadatas;
+        std::unordered_map<int64_t, TabletRangePB> cached_ranges;
+        auto source = lookup_exact_cached_metadata(tablet_manager, splitting_tablet.old_tablet_id(), new_version,
+                                                   txn_info.gtid());
+        if (source == nullptr) goto CONTINUE_HANDLE_SPLITTING_TABLET;
+        cached_metadatas.emplace(splitting_tablet.old_tablet_id(), source);
         for (auto new_tablet_id : splitting_tablet.new_tablet_ids()) {
-            auto new_tablet_new_metadata_location =
-                    tablet_manager->tablet_metadata_location(new_tablet_id, new_version);
-            auto cached_new_tablet_new_metadata =
-                    tablet_manager->metacache()->lookup_tablet_metadata(new_tablet_new_metadata_location);
-            if (cached_new_tablet_new_metadata == nullptr) {
-                new_metadatas.clear();
-                tablet_ranges.clear();
-                goto CONTINUE_HANDLE_SPLITTING_TABLET;
-            }
-            tablet_ranges.emplace(new_tablet_id, cached_new_tablet_new_metadata->range());
-            new_metadatas.emplace(new_tablet_id, std::move(cached_new_tablet_new_metadata));
+            auto child = lookup_exact_cached_metadata(tablet_manager, new_tablet_id, new_version, txn_info.gtid());
+            if (child == nullptr) break;
+            cached_ranges.emplace(new_tablet_id, child->range());
+            cached_metadatas.emplace(new_tablet_id, std::move(child));
         }
-        return Status::OK();
+        bool complete = cached_metadatas.size() == static_cast<size_t>(splitting_tablet.new_tablet_ids_size() + 1);
+        if (!complete && splitting_tablet.new_tablet_ids_size() > 0 && cached_metadatas.size() == 2 &&
+            source->range().SerializeAsString() ==
+                    cached_metadatas.at(splitting_tablet.new_tablet_ids(0))->range().SerializeAsString()) {
+            complete = true;
+            for (int i = 1; i < splitting_tablet.new_tablet_ids_size(); ++i) {
+                complete &= tablet_manager->metacache()->lookup_tablet_metadata(tablet_manager->tablet_metadata_location(
+                                    splitting_tablet.new_tablet_ids(i), new_version)) == nullptr;
+            }
+        }
+        if (complete) {
+            new_metadatas.swap(cached_metadatas);
+            tablet_ranges.swap(cached_ranges);
+            return Status::OK();
+        }
     }
 
 CONTINUE_HANDLE_SPLITTING_TABLET:
@@ -191,27 +205,18 @@ Status handle_merging_tablet(TabletManager* tablet_manager, const MergingTabletI
                              std::unordered_map<int64_t, TabletRangePB>& tablet_ranges,
                              InitialMetadataOrder base_version_order) {
     {
+        std::unordered_map<int64_t, TabletMetadataPtr> cached_metadatas;
         for (auto old_tablet_id : merging_tablet.old_tablet_ids()) {
-            auto old_tablet_new_metadata_location =
-                    tablet_manager->tablet_metadata_location(old_tablet_id, new_version);
-            auto cached_old_tablet_new_metadata =
-                    tablet_manager->metacache()->lookup_tablet_metadata(old_tablet_new_metadata_location);
-            if (cached_old_tablet_new_metadata == nullptr) {
-                goto CONTINUE_HANDLE_MERGING_TABLET;
-            }
-            new_metadatas.emplace(old_tablet_id, std::move(cached_old_tablet_new_metadata));
+            auto metadata = lookup_exact_cached_metadata(tablet_manager, old_tablet_id, new_version, txn_info.gtid());
+            if (metadata == nullptr) goto CONTINUE_HANDLE_MERGING_TABLET;
+            cached_metadatas.emplace(old_tablet_id, std::move(metadata));
         }
-
-        auto new_tablet_new_metadata_location =
-                tablet_manager->tablet_metadata_location(merging_tablet.new_tablet_id(), new_version);
-        auto cached_new_tablet_new_metadata =
-                tablet_manager->metacache()->lookup_tablet_metadata(new_tablet_new_metadata_location);
-        if (cached_new_tablet_new_metadata == nullptr) {
-            new_metadatas.clear();
-            goto CONTINUE_HANDLE_MERGING_TABLET;
-        }
-        tablet_ranges.emplace(merging_tablet.new_tablet_id(), cached_new_tablet_new_metadata->range());
-        new_metadatas.emplace(merging_tablet.new_tablet_id(), std::move(cached_new_tablet_new_metadata));
+        auto target = lookup_exact_cached_metadata(tablet_manager, merging_tablet.new_tablet_id(), new_version,
+                                                   txn_info.gtid());
+        if (target == nullptr) goto CONTINUE_HANDLE_MERGING_TABLET;
+        cached_metadatas.emplace(merging_tablet.new_tablet_id(), std::move(target));
+        new_metadatas.swap(cached_metadatas);
+        tablet_ranges.emplace(merging_tablet.new_tablet_id(), new_metadatas.at(merging_tablet.new_tablet_id())->range());
         return Status::OK();
     }
 
@@ -285,26 +290,16 @@ Status handle_identical_tablet(TabletManager* tablet_manager, const IdenticalTab
                                std::unordered_map<int64_t, TabletMetadataPtr>& new_metadatas,
                                InitialMetadataOrder base_version_order) {
     {
-        auto old_tablet_new_metadata_location =
-                tablet_manager->tablet_metadata_location(identical_tablet.old_tablet_id(), new_version);
-        auto cached_old_tablet_new_metadata =
-                tablet_manager->metacache()->lookup_tablet_metadata(old_tablet_new_metadata_location);
-        if (cached_old_tablet_new_metadata == nullptr) {
-            goto CONTINUE_HANDLE_IDENTICAL_TABLET;
-        }
-
-        new_metadatas.emplace(identical_tablet.old_tablet_id(), std::move(cached_old_tablet_new_metadata));
-
-        auto new_tablet_new_metadata_location =
-                tablet_manager->tablet_metadata_location(identical_tablet.new_tablet_id(), new_version);
-        auto cached_new_tablet_new_metadata =
-                tablet_manager->metacache()->lookup_tablet_metadata(new_tablet_new_metadata_location);
-        if (cached_new_tablet_new_metadata == nullptr) {
-            new_metadatas.clear();
-            goto CONTINUE_HANDLE_IDENTICAL_TABLET;
-        }
-
-        new_metadatas.emplace(identical_tablet.new_tablet_id(), std::move(cached_new_tablet_new_metadata));
+        auto source = lookup_exact_cached_metadata(tablet_manager, identical_tablet.old_tablet_id(), new_version,
+                                                   txn_info.gtid());
+        if (source == nullptr) goto CONTINUE_HANDLE_IDENTICAL_TABLET;
+        auto target = lookup_exact_cached_metadata(tablet_manager, identical_tablet.new_tablet_id(), new_version,
+                                                   txn_info.gtid());
+        if (target == nullptr) goto CONTINUE_HANDLE_IDENTICAL_TABLET;
+        std::unordered_map<int64_t, TabletMetadataPtr> cached_metadatas{
+                {identical_tablet.old_tablet_id(), std::move(source)},
+                {identical_tablet.new_tablet_id(), std::move(target)}};
+        new_metadatas.swap(cached_metadatas);
         return Status::OK();
     }
 

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -94,12 +94,13 @@ static StatusOr<TabletMetadataPtr> get_old_tablet_base_metadata(TabletManager* t
 }
 
 TabletMetadataPtr lookup_exact_cached_metadata(TabletManager* tablet_manager, int64_t tablet_id, int64_t version,
-                                                int64_t gtid) {
+                                               int64_t gtid) {
     if (gtid <= 0) return nullptr;
     auto metadata = tablet_manager->metacache()->lookup_tablet_metadata(
             tablet_manager->tablet_metadata_location(tablet_id, version));
     if (metadata != nullptr && metadata->id() == tablet_id && metadata->version() == version &&
-        metadata->gtid() == gtid) return metadata;
+        metadata->gtid() == gtid)
+        return metadata;
     return nullptr;
 }
 
@@ -127,8 +128,9 @@ Status handle_splitting_tablet(TabletManager* tablet_manager, const SplittingTab
                     cached_metadatas.at(splitting_tablet.new_tablet_ids(0))->range().SerializeAsString()) {
             complete = true;
             for (int i = 1; i < splitting_tablet.new_tablet_ids_size(); ++i) {
-                complete &= tablet_manager->metacache()->lookup_tablet_metadata(tablet_manager->tablet_metadata_location(
-                                    splitting_tablet.new_tablet_ids(i), new_version)) == nullptr;
+                complete &=
+                        tablet_manager->metacache()->lookup_tablet_metadata(tablet_manager->tablet_metadata_location(
+                                splitting_tablet.new_tablet_ids(i), new_version)) == nullptr;
             }
         }
         if (complete) {
@@ -216,7 +218,8 @@ Status handle_merging_tablet(TabletManager* tablet_manager, const MergingTabletI
         if (target == nullptr) goto CONTINUE_HANDLE_MERGING_TABLET;
         cached_metadatas.emplace(merging_tablet.new_tablet_id(), std::move(target));
         new_metadatas.swap(cached_metadatas);
-        tablet_ranges.emplace(merging_tablet.new_tablet_id(), new_metadatas.at(merging_tablet.new_tablet_id())->range());
+        tablet_ranges.emplace(merging_tablet.new_tablet_id(),
+                              new_metadatas.at(merging_tablet.new_tablet_id())->range());
         return Status::OK();
     }
 

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -849,7 +849,6 @@ Status validate_split_inputs(const TabletMetadataPB& source, SplitMetadataVisitB
                 return Status::Corruption("tablet split effective rowset range lies outside source tablet");
             }
         }
-        std::unordered_set<uint32_t> indices;
         uint32_t previous = 0;
         bool first = true;
         for (const auto& segment : rowset.segment_metas()) {
@@ -858,7 +857,7 @@ Status validate_split_inputs(const TabletMetadataPB& source, SplitMetadataVisitB
                 fallback = Status::NotSupported("tablet split segment index is absent");
             } else {
                 const uint32_t index = segment.segment_idx();
-                if (!indices.insert(index).second || (!first && index <= previous)) {
+                if (!first && index <= previous) {
                     return Status::Corruption("tablet split segment indices are not strictly increasing");
                 }
                 if (uint64_t{rowset.id()} + index > UINT32_MAX) {
@@ -1518,8 +1517,16 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
         if (std::none_of(emit.begin(), emit.end(), [](bool value) { return value; })) {
             return Status::Corruption("tablet split rowset has no emitted child");
         }
-        if (separate_sort || rowset.segment_metas_size() == 0) {
+        const bool zero_row_replay =
+                anchor.num_rows == 0 && anchor.num_dels == 0 && anchor.data_size > 0 && rowset.del_files_size() > 0 &&
+                rowset.segment_metas_size() > 0 &&
+                std::all_of(rowset.segment_metas().begin(), rowset.segment_metas().end(), [](const auto& segment) {
+                    return segment.has_num_rows() && segment.num_rows() == 0 &&
+                           segment.sort_key_min().values_size() == 0 && segment.sort_key_max().values_size() == 0;
+                });
+        if (separate_sort || rowset.segment_metas_size() == 0 || zero_row_replay) {
             for (size_t c = 0; c < child_count; ++c) row_weights[c] = byte_weights[c] = emit[c] ? 1 : 0;
+            if (zero_row_replay) std::fill(row_weights.begin(), row_weights.end(), 0);
         } else {
             // Only this rowset's segment/sample weights are live. Include sinks outside
             // its effective range, so clipping never donates out-of-range samples to a child.

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -788,8 +788,7 @@ StatusOr<RowsetAnchor> rowset_anchor(const RowsetMetadataPB& rowset) {
         if (!rowset.has_num_rows()) rows += segment.num_rows();
         if (!rowset.has_data_size()) bytes += segment.size();
     }
-    if (rows < 0 || bytes < 0 || rows > INT64_MAX || bytes > INT64_MAX || rowset.num_dels() < 0 ||
-        rowset.num_dels() > rows) {
+    if (rows < 0 || bytes < 0 || rows > INT64_MAX || bytes > INT64_MAX || rowset.num_dels() < 0) {
         return Status::Corruption("tablet split has invalid rowset statistics");
     }
     return RowsetAnchor{static_cast<int64_t>(rows), static_cast<int64_t>(bytes), rowset.num_dels()};
@@ -1638,7 +1637,6 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
         tablet_reshard_helper::allocate_proportionally(anchor.num_rows, row_weights, &rows);
         tablet_reshard_helper::allocate_proportionally(anchor.data_size, byte_weights, &bytes);
         tablet_reshard_helper::allocate_proportionally(anchor.num_dels, row_weights, &dels);
-        tablet_reshard_helper::cap_and_redistribute_dels(rows, &dels);
         for (size_t c = 0; c < child_count; ++c) {
             if (emit[c]) (*split_ranges)[c].rowset_stats[rowset.id()] = {rows[c], bytes[c], dels[c]};
         }

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1634,9 +1634,17 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
             }
             return Status::Corruption("tablet split positive rowset anchor has zero emitted weight");
         }
+        auto delete_weights = row_weights;
+        if (anchor.num_dels > 0 && std::none_of(delete_weights.begin(), delete_weights.end(), positive)) {
+            // Row counts are estimates but deletes are exact. Integer geometry can assign every
+            // physical row to clipped sink ranges while this rowset is emitted only to later
+            // children. Restrict the deterministic fallback to those emitted children so none of
+            // the delete anchor is allocated to a child that will drop the rowset below.
+            for (size_t c = 0; c < child_count; ++c) delete_weights[c] = emit[c] ? 1 : 0;
+        }
         tablet_reshard_helper::allocate_proportionally(anchor.num_rows, row_weights, &rows);
         tablet_reshard_helper::allocate_proportionally(anchor.data_size, byte_weights, &bytes);
-        tablet_reshard_helper::allocate_proportionally(anchor.num_dels, row_weights, &dels);
+        tablet_reshard_helper::allocate_proportionally(anchor.num_dels, delete_weights, &dels);
         for (size_t c = 0; c < child_count; ++c) {
             if (emit[c]) (*split_ranges)[c].rowset_stats[rowset.id()] = {rows[c], bytes[c], dels[c]};
         }
@@ -1875,14 +1883,6 @@ static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, co
         std::vector<Rowset::LoadedSegment> loaded_segments; // keeps the Segments alive for this rowset's scope
         Schema rowset_schema;
         std::vector<uint32_t> sort_key_idxes;
-        std::unordered_set<int> zero_row_segment_positions;
-        for (int meta_pos = 0; meta_pos < rowset_meta.segment_metas_size(); ++meta_pos) {
-            const auto& segment_meta = rowset_meta.segment_metas(meta_pos);
-            if (segment_meta.has_num_rows() && segment_meta.num_rows() == 0) {
-                zero_row_segment_positions.insert(meta_pos);
-            }
-        }
-
         // Two cheap protobuf-only gates, evaluated BEFORE constructing the Rowset or
         // touching the loader:
         //   * rowset_has_sampleless_segment -- skip the loader when every segment already
@@ -1894,6 +1894,13 @@ static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, co
         //     unset, so only construct the Rowset when the schema resolves safely.
         if (tablet_manager != nullptr && rowset_has_sampleless_segment(rowset_meta) &&
             rowset_schema_resolves_to_valid_id(*tablet_metadata, rowset_meta.id())) {
+            std::unordered_set<int> zero_row_segment_positions;
+            for (int meta_pos = 0; meta_pos < rowset_meta.segment_metas_size(); ++meta_pos) {
+                const auto& segment_meta = rowset_meta.segment_metas(meta_pos);
+                if (segment_meta.has_num_rows() && segment_meta.num_rows() == 0) {
+                    zero_row_segment_positions.insert(meta_pos);
+                }
+            }
             Rowset rowset(tablet_manager, tablet_metadata, rowset_index, /*compaction_segment_limit=*/0);
             SegmentReadOptions read_options;
             read_options.lake_io_opts.fill_data_cache = false;

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1517,13 +1517,18 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
         if (std::none_of(emit.begin(), emit.end(), [](bool value) { return value; })) {
             return Status::Corruption("tablet split rowset has no emitted child");
         }
-        const bool zero_row_replay =
-                anchor.num_rows == 0 && anchor.num_dels == 0 && anchor.data_size > 0 && rowset.del_files_size() > 0 &&
-                rowset.segment_metas_size() > 0 &&
-                std::all_of(rowset.segment_metas().begin(), rowset.segment_metas().end(), [](const auto& segment) {
-                    return segment.has_num_rows() && segment.num_rows() == 0 &&
-                           segment.sort_key_min().values_size() == 0 && segment.sort_key_max().values_size() == 0;
-                });
+        bool zero_row_replay = anchor.num_rows == 0 && anchor.num_dels == 0 && anchor.data_size > 0 &&
+                               rowset.del_files_size() > 0 && rowset.segment_metas_size() > 0;
+        if (zero_row_replay) {
+            for (const auto& segment : rowset.segment_metas()) {
+                RETURN_IF_ERROR(budget->consume(1, "projector zero-row replay classification"));
+                if (!segment.has_num_rows() || segment.num_rows() != 0 || segment.sort_key_min().values_size() != 0 ||
+                    segment.sort_key_max().values_size() != 0) {
+                    zero_row_replay = false;
+                    break;
+                }
+            }
+        }
         if (separate_sort || rowset.segment_metas_size() == 0 || zero_row_replay) {
             for (size_t c = 0; c < child_count; ++c) row_weights[c] = byte_weights[c] = emit[c] ? 1 : 0;
             if (zero_row_replay) std::fill(row_weights.begin(), row_weights.end(), 0);

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -2111,33 +2111,38 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     }
 
     SplitMetadataVisitBudget budget;
-    Status status = validate_split_inputs(*tablet_metadata, &budget);
     auto can_fallback_identical = [](const Status& outcome) {
         return outcome.is_not_supported() || outcome.is_capacity_limit_exceeded();
     };
-    if (!status.ok() && !can_fallback_identical(status)) return status;
     ASSIGN_OR_RETURN(const auto split_schema, materialize_sort_key_schema(tablet_metadata->schema()));
+    const bool is_external_boundaries = splitting_tablet.new_tablet_ranges_size() > 0;
+    std::vector<TabletRangeInfo> split_ranges;
+    Status status;
+    // Validate FE input before source preflight can select identical fallback or
+    // exhaust the shared budget. A source-level no-split outcome must not hide
+    // malformed external structure, bound types, or arity.
+    if (is_external_boundaries) {
+        if (splitting_tablet.new_tablet_ranges_size() != splitting_tablet.new_tablet_ids_size()) {
+            return Status::InvalidArgument("new_tablet_ranges count does not match new_tablet_ids");
+        }
+        status = compute_split_ranges_from_external_boundaries_impl(
+                tablet_manager, tablet_metadata, splitting_tablet.new_tablet_ranges(), &split_ranges, &budget);
+    }
+    if (status.ok()) status = validate_split_inputs(*tablet_metadata, &budget);
+    if (!status.ok() && !can_fallback_identical(status)) return status;
     const bool separate_sort = split_schema->keys_type() == PRIMARY_KEYS && split_schema->has_separate_sort_key();
     if (separate_sort && ((tablet_metadata->has_dcg_meta() && !tablet_metadata->dcg_meta().dcgs().empty()) ||
                           (tablet_metadata->has_idg_meta() && !tablet_metadata->idg_meta().idgs().empty()))) {
         return Status::NotSupported("range-tablet split with ORDER BY != PK does not support DCG or IDG yet");
     }
-    const bool is_external_boundaries = splitting_tablet.new_tablet_ranges_size() > 0;
-    std::vector<TabletRangeInfo> split_ranges;
     std::vector<RowsetOwnership> ownership;
     std::vector<bool> prunable;
     RowsetEmissionMask emission;
 
     // Paths 1/2 finish range validation and projection against the input metadata.
     // Path 3 validates source coordinates/stats here but needs the flushed PK SSTs.
-    if (is_external_boundaries && splitting_tablet.new_tablet_ranges_size() != splitting_tablet.new_tablet_ids_size()) {
-        return Status::InvalidArgument("new_tablet_ranges count does not match new_tablet_ids");
-    }
     if (status.ok() && (is_external_boundaries || !separate_sort)) {
-        if (is_external_boundaries) {
-            status = compute_split_ranges_from_external_boundaries_impl(
-                    tablet_manager, tablet_metadata, splitting_tablet.new_tablet_ranges(), &split_ranges, &budget);
-        } else {
+        if (!is_external_boundaries) {
             status = get_tablet_split_ranges_impl(tablet_manager, tablet_metadata,
                                                   splitting_tablet.new_tablet_ids_size(), &split_ranges,
                                                   txn_info.colocate_column_count(), &budget);

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -876,8 +876,8 @@ Status validate_split_inputs(const TabletMetadataPB& source, SplitMetadataVisitB
                 return Status::Corruption("tablet split delete replay span overflows uint32");
             }
             if (del.origin_rowset_id() == rowset.id() &&
-                (rowset.segment_metas_size() == 0 ? offset != 0 : !indices.contains(offset))) {
-                fallback = Status::NotSupported("tablet split self-origin delete offset is not a current segment");
+                (rowset.segment_metas_size() == 0 ? offset != 0 : offset > previous)) {
+                fallback = Status::NotSupported("tablet split self-origin delete offset exceeds rowset replay span");
             }
         }
     }
@@ -1489,6 +1489,8 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
     ASSIGN_OR_RETURN(const auto schema, materialize_sort_key_schema(source.schema()));
     const bool separate_sort = schema->keys_type() == PRIMARY_KEYS && schema->has_separate_sort_key();
     ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(*schema));
+    TabletRange source_range;
+    RETURN_IF_ERROR(source_range.from_proto(source.range()));
     for (int r = 0; r < source.rowsets_size(); ++r) {
         const auto& rowset = source.rowsets(r);
         RETURN_IF_ERROR(budget->consume(child_count, "projector intersections"));
@@ -1603,8 +1605,22 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
             }
         }
         const auto positive = [](int64_t weight) { return weight > 0; };
-        if ((anchor.num_rows > 0 && std::none_of(row_weights.begin(), row_weights.end(), positive)) ||
-            (anchor.data_size > 0 && std::none_of(byte_weights.begin(), byte_weights.end(), positive))) {
+        const bool zero_row_weight =
+                anchor.num_rows > 0 && std::none_of(row_weights.begin(), row_weights.end(), positive);
+        const bool zero_byte_weight =
+                anchor.data_size > 0 && std::none_of(byte_weights.begin(), byte_weights.end(), positive);
+        if (zero_row_weight || zero_byte_weight) {
+            const bool same_source_range =
+                    effective.lower_bound() == source_range.lower_bound() &&
+                    effective.upper_bound() == source_range.upper_bound() &&
+                    (effective.is_minimum() ||
+                     effective.lower_bound_included() == source_range.lower_bound_included()) &&
+                    (effective.is_maximum() || effective.upper_bound_included() == source_range.upper_bound_included());
+            const bool all_shared = std::all_of(rowset.segment_metas().begin(), rowset.segment_metas().end(),
+                                                [](const auto& segment) { return segment.shared(); });
+            if (rowset.has_range() && rowset.segment_metas_size() > 0 && same_source_range && all_shared) {
+                return Status::NotSupported("tablet split cross-published rowset has no active physical weight");
+            }
             return Status::Corruption("tablet split positive rowset anchor has zero emitted weight");
         }
         tablet_reshard_helper::allocate_proportionally(anchor.num_rows, row_weights, &rows);

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1875,6 +1875,13 @@ static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, co
         std::vector<Rowset::LoadedSegment> loaded_segments; // keeps the Segments alive for this rowset's scope
         Schema rowset_schema;
         std::vector<uint32_t> sort_key_idxes;
+        std::unordered_set<int> zero_row_segment_positions;
+        for (int meta_pos = 0; meta_pos < rowset_meta.segment_metas_size(); ++meta_pos) {
+            const auto& segment_meta = rowset_meta.segment_metas(meta_pos);
+            if (segment_meta.has_num_rows() && segment_meta.num_rows() == 0) {
+                zero_row_segment_positions.insert(meta_pos);
+            }
+        }
 
         // Two cheap protobuf-only gates, evaluated BEFORE constructing the Rowset or
         // touching the loader:
@@ -1888,7 +1895,12 @@ static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, co
         if (tablet_manager != nullptr && rowset_has_sampleless_segment(rowset_meta) &&
             rowset_schema_resolves_to_valid_id(*tablet_metadata, rowset_meta.id())) {
             Rowset rowset(tablet_manager, tablet_metadata, rowset_index, /*compaction_segment_limit=*/0);
-            if (rowset.load_segments(&loaded_segments, /*fill_cache=*/false).ok()) {
+            SegmentReadOptions read_options;
+            read_options.lake_io_opts.fill_data_cache = false;
+            read_options.lake_io_opts.fill_metadata_cache = false;
+            read_options.lake_io_opts.buffer_size = -1;
+            const auto* skip_positions = zero_row_segment_positions.empty() ? nullptr : &zero_row_segment_positions;
+            if (rowset.load_segments(&loaded_segments, read_options, nullptr, skip_positions).ok()) {
                 if (auto historical_schema = rowset.tablet_schema(); historical_schema != nullptr) {
                     rowset_schema = ChunkHelper::convert_schema(historical_schema);
                     const auto& idxes = historical_schema->sort_key_idxes();

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -1634,7 +1634,9 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
             }
             return Status::Corruption("tablet split positive rowset anchor has zero emitted weight");
         }
-        auto delete_weights = row_weights;
+        tablet_reshard_helper::allocate_proportionally(anchor.num_rows, row_weights, &rows);
+        tablet_reshard_helper::allocate_proportionally(anchor.data_size, byte_weights, &bytes);
+        auto delete_weights = std::move(row_weights);
         if (anchor.num_dels > 0 && std::none_of(delete_weights.begin(), delete_weights.end(), positive)) {
             // Row counts are estimates but deletes are exact. Integer geometry can assign every
             // physical row to clipped sink ranges while this rowset is emitted only to later
@@ -1642,8 +1644,6 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
             // the delete anchor is allocated to a child that will drop the rowset below.
             for (size_t c = 0; c < child_count; ++c) delete_weights[c] = emit[c] ? 1 : 0;
         }
-        tablet_reshard_helper::allocate_proportionally(anchor.num_rows, row_weights, &rows);
-        tablet_reshard_helper::allocate_proportionally(anchor.data_size, byte_weights, &bytes);
         tablet_reshard_helper::allocate_proportionally(anchor.num_dels, delete_weights, &dels);
         for (size_t c = 0; c < child_count; ++c) {
             if (emit[c]) (*split_ranges)[c].rowset_stats[rowset.id()] = {rows[c], bytes[c], dels[c]};

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -18,10 +18,14 @@
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <limits>
+#include <map>
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include "base/testutil/sync_point.h"
 #include "column/binary_column.h"
 #include "column/chunk_factory.h"
 #include "column/schema.h"
@@ -177,12 +181,35 @@ VariantTuple build_canonical_boundary(const VariantTuple& source, int32_t coloca
     return canonical;
 }
 
+constexpr size_t kMaxSplitMetadataVisits = 1'000'000;
+
+class SplitMetadataVisitBudget {
+public:
+    SplitMetadataVisitBudget() { TEST_SYNC_POINT_CALLBACK("tablet_splitter:set_metadata_visit_limit", &_remaining); }
+    Status consume(size_t count, std::string_view description) {
+        if (count > _remaining) {
+            return Status::CapacityLimitExceed(
+                    fmt::format("tablet split metadata visit budget exhausted: {}", description));
+        }
+        _remaining -= count;
+        return Status::OK();
+    }
+    size_t remaining() const { return _remaining; }
+
+private:
+    size_t _remaining = kMaxSplitMetadataVisits;
+};
+
+Status consume_metadata_visits(SplitMetadataVisitBudget* budget, size_t count, std::string_view description) {
+    return budget == nullptr ? Status::OK() : budget->consume(count, description);
+}
+
 struct RangeInfo {
     VariantTuple min;
     VariantTuple max;
     int64_t num_rows = 0;
     int64_t data_size = 0;
-    SourceStats source_stats;
+    std::unique_ptr<SourceStats> source_stats;
 };
 
 // Find ordered_ranges overlapping [sub_min, sub_max].
@@ -190,28 +217,32 @@ struct RangeInfo {
 // ownership: non-last range owns x iff r.min <= x < r.max; last range owns x
 // iff r.min <= x <= r.max. For non-zero-width sub-segments, uses the standard
 // two-comparator binary-search overlap rule.
-void find_overlapping_ranges(const VariantTuple& sub_min, const VariantTuple& sub_max,
-                             std::vector<RangeInfo>& ordered_ranges, std::vector<RangeInfo*>& result) {
+Status find_overlapping_ranges(const VariantTuple& sub_min, const VariantTuple& sub_max,
+                               std::vector<RangeInfo>& ordered_ranges, std::vector<RangeInfo*>& result,
+                               SplitMetadataVisitBudget* budget) {
     result.clear();
+    if (ordered_ranges.empty()) return Status::OK();
     const size_t last_range_index = ordered_ranges.size() - 1;
 
     if (sub_min.compare(sub_max) == 0) {
         // Zero-width: point ownership matching split output [lower, upper).
         for (size_t i = 0; i < ordered_ranges.size(); ++i) {
+            RETURN_IF_ERROR(consume_metadata_visits(budget, 1, "point overlap"));
             auto& r = ordered_ranges[i];
             bool owns = (i != last_range_index) ? (r.min.compare(sub_min) <= 0 && sub_min.compare(r.max) < 0)
                                                 : (r.min.compare(sub_min) <= 0 && sub_min.compare(r.max) <= 0);
             if (owns) {
                 result.push_back(&r);
-                return;
+                return Status::OK();
             }
         }
-        return;
+        return Status::OK();
     }
 
     // Non-zero-width: binary search for the first overlapping range.
     size_t lo = 0, hi = ordered_ranges.size();
     while (lo < hi) {
+        RETURN_IF_ERROR(consume_metadata_visits(budget, 1, "overlap search"));
         size_t mid = lo + (hi - lo) / 2;
         int cmp = ordered_ranges[mid].max.compare(sub_min);
         if ((mid == last_range_index) ? (cmp < 0) : (cmp <= 0)) {
@@ -221,11 +252,13 @@ void find_overlapping_ranges(const VariantTuple& sub_min, const VariantTuple& su
         }
     }
     for (size_t i = lo; i < ordered_ranges.size(); i++) {
+        RETURN_IF_ERROR(consume_metadata_visits(budget, 1, "range overlap"));
         auto& r = ordered_ranges[i];
         if (r.min.compare(sub_max) > 0) break;
         if (i != last_range_index && r.min.compare(sub_max) >= 0) break;
         result.push_back(&r);
     }
+    return Status::OK();
 }
 
 // Distribute num_rows/data_size evenly across overlapping ranges with remainder
@@ -240,9 +273,11 @@ void distribute_to_ranges(const std::vector<RangeInfo*>& overlapping, int64_t nu
         overlapping[i]->num_rows += delta_rows;
         overlapping[i]->data_size += delta_size;
         if (track_sources) {
-            auto& stats = overlapping[i]->source_stats[source_id];
-            stats.first += delta_rows;
-            stats.second += delta_size;
+            auto& stats = overlapping[i]->source_stats;
+            if (stats == nullptr) stats = std::make_unique<SourceStats>();
+            auto& value = (*stats)[source_id];
+            value.first += delta_rows;
+            value.second += delta_size;
         }
     }
 }
@@ -250,17 +285,17 @@ void distribute_to_ranges(const std::vector<RangeInfo*>& overlapping, int64_t nu
 // Distribute one segment's data across ordered_ranges. When the segment has
 // sort-key samples, it is split into N+1 sub-segments with known row counts;
 // otherwise, the entire segment is treated as a single [min_key, max_key] range.
-void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<RangeInfo>& ordered_ranges,
-                                  bool track_sources) {
-    if (segment.num_rows == 0 && segment.data_size == 0) return;
+Status distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<RangeInfo>& ordered_ranges,
+                                    bool track_sources, SplitMetadataVisitBudget* budget = nullptr) {
+    if (segment.num_rows == 0 && segment.data_size == 0) return Status::OK();
 
     std::vector<RangeInfo*> overlapping;
     const int64_t num_samples = static_cast<int64_t>(segment.sort_key_samples.size());
 
     if (num_samples == 0) {
-        find_overlapping_ranges(segment.min_key, segment.max_key, ordered_ranges, overlapping);
+        RETURN_IF_ERROR(find_overlapping_ranges(segment.min_key, segment.max_key, ordered_ranges, overlapping, budget));
         distribute_to_ranges(overlapping, segment.num_rows, segment.data_size, segment.source_id, track_sources);
-        return;
+        return Status::OK();
     }
 
     // Sampled path: N+1 sub-segments with known row counts.
@@ -285,10 +320,11 @@ void distribute_segment_to_ranges(const SegmentSplitInfo& segment, std::vector<R
         DCHECK_GT(sub_rows, 0);
         const int64_t sub_bytes = (k == num_samples) ? (segment.data_size - bytes_assigned) : bytes_for(sub_rows);
         bytes_assigned += sub_bytes;
-        find_overlapping_ranges(bound(k), bound(k + 1), ordered_ranges, overlapping);
+        RETURN_IF_ERROR(find_overlapping_ranges(bound(k), bound(k + 1), ordered_ranges, overlapping, budget));
         distribute_to_ranges(overlapping, sub_rows, sub_bytes, segment.source_id, track_sources);
     }
     DCHECK_EQ(bytes_assigned, segment.data_size);
+    return Status::OK();
 }
 
 // Resolves the sort key a split must speak: the TabletSchema for |schema_pb|, which applies the
@@ -453,11 +489,10 @@ Status validate_split_ranges(const std::vector<TabletRangeInfo>& split_ranges, c
 // Core range split algorithm (public API)
 // ================================================================================
 
-StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<SegmentSplitInfo>& segments,
-                                                            int32_t target_split_count, int64_t target_value_per_split,
-                                                            bool use_num_rows, bool track_sources,
-                                                            const TabletRange* tablet_range,
-                                                            int32_t colocate_column_count) {
+static StatusOr<RangeSplitResult> calculate_range_split_boundaries_impl(
+        const std::vector<SegmentSplitInfo>& segments, int32_t target_split_count, int64_t target_value_per_split,
+        bool use_num_rows, bool track_sources, const TabletRange* tablet_range, int32_t colocate_column_count,
+        SplitMetadataVisitBudget* budget) {
     RangeSplitResult result;
 
     if (segments.empty() || target_split_count <= 1) {
@@ -469,6 +504,7 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
     // colocate boundaries that don't exist in any segment.
     std::vector<VariantTuple> ordered_boundary_values;
     for (const auto& segment : segments) {
+        RETURN_IF_ERROR(consume_metadata_visits(budget, 2 + segment.sort_key_samples.size(), "boundary values"));
         ordered_boundary_values.push_back(segment.min_key);
         ordered_boundary_values.push_back(segment.max_key);
         for (const auto& sample : segment.sort_key_samples) {
@@ -484,6 +520,7 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
     // all, so a partial-crossing range is kept whole and its full data_size /
     // num_rows is summed into one of the new splits.
     if (tablet_range != nullptr) {
+        RETURN_IF_ERROR(consume_metadata_visits(budget, 2, "tablet boundaries"));
         if (!tablet_range->is_minimum()) {
             ordered_boundary_values.push_back(tablet_range->lower_bound());
         }
@@ -511,6 +548,7 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
                 // canonical can equal curr when curr already has the (k, NULL...) shape.
                 DCHECK_GT(canonical.compare(ordered_boundary_values[i - 1]), 0);
                 if (canonical.compare(ordered_boundary_values[i]) <= 0) {
+                    RETURN_IF_ERROR(consume_metadata_visits(budget, 1, "canonical boundary"));
                     with_canonical.push_back(std::move(canonical));
                 }
             }
@@ -540,7 +578,7 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
 
     // Step 3: Distribute segment data across overlapping ranges.
     for (const auto& segment : segments) {
-        distribute_segment_to_ranges(segment, ordered_ranges, track_sources);
+        RETURN_IF_ERROR(distribute_segment_to_ranges(segment, ordered_ranges, track_sources, budget));
     }
 
     // Step 4: Calculate split boundaries using a greedy algorithm.
@@ -706,7 +744,8 @@ StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<Se
             result.range_num_rows[group_index] += range->num_rows;
 
             if (track_sources) {
-                for (const auto& [source_id, stats_pair] : range->source_stats) {
+                if (range->source_stats == nullptr) continue;
+                for (const auto& [source_id, stats_pair] : *range->source_stats) {
                     auto& dest = result.range_source_stats[group_index][source_id];
                     dest.first += stats_pair.first;
                     dest.second += stats_pair.second;
@@ -730,119 +769,149 @@ static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, co
 
 namespace {
 
-// Per-rowset anchor totals taken from the old tablet's recorded metadata. Used to
-// renormalize per-split-group estimates so Σ new tablets equals the old tablet exactly,
-// preserving stat conservation across re-splits regardless of how the
-// underlying segment-distribution model approximates straddling sub-segments.
+using RowsetEmissionMask = std::vector<std::vector<bool>>;
+
 struct RowsetAnchor {
     int64_t num_rows = 0;
     int64_t data_size = 0;
     int64_t num_dels = 0;
 };
 
-// Build the per-rowset anchor map from the old tablet metadata. For PK
-// tablets without a populated num_dels field on the rowset (legacy
-// metadata), derive num_dels from the delvec — same fallback as the
-// pre-anchor code path. If a rowset reports num_dels > num_rows
-// (pathological metadata), clamp up front with a WARNING; the
-// cap-and-redistribute contract assumes the old tablet's num_dels <= num_rows.
-std::unordered_map<uint32_t, RowsetAnchor> build_rowset_anchor(const TabletMetadataPB& metadata,
-                                                               TabletManager* tablet_manager) {
-    std::unordered_map<uint32_t, RowsetAnchor> anchor;
-    anchor.reserve(metadata.rowsets_size());
-    const bool pk = is_primary_key(metadata);
-    for (const auto& rowset : metadata.rowsets()) {
-        RowsetAnchor a;
-        // Anchor totals: prefer the rowset-level fields. When legacy /
-        // incomplete metadata omits them, fall back to summing the
-        // segment-level fields. Without this fallback, anchor=0 collapses
-        // every new tablet's stat to 0 even though segment metadata still
-        // carries real values — the pre-anchor path implicitly used the
-        // segment-derived numbers via range_source_stats, so we preserve
-        // that property explicitly here.
-        if (rowset.has_num_rows()) {
-            a.num_rows = rowset.num_rows();
-        } else {
-            for (const auto& sm : rowset.segment_metas()) {
-                a.num_rows += sm.num_rows();
-            }
+StatusOr<RowsetAnchor> rowset_anchor(const RowsetMetadataPB& rowset) {
+    __int128 rows = rowset.num_rows(), bytes = rowset.data_size();
+    for (const auto& segment : rowset.segment_metas()) {
+        if (segment.num_rows() < 0 || segment.size() < 0) {
+            return Status::Corruption("tablet split has negative segment statistics");
         }
-        if (rowset.has_data_size()) {
-            a.data_size = rowset.data_size();
-        } else {
-            for (const auto& sm : rowset.segment_metas()) {
-                a.data_size += sm.size();
-            }
-        }
-        if (rowset.has_num_dels()) {
-            a.num_dels = rowset.num_dels();
-        } else if (pk && tablet_manager != nullptr) {
-            // Legacy fallback: derive num_dels from the delvec. Costs one
-            // delvec read per rowset, acceptable on the one-shot split path.
-            a.num_dels = static_cast<int64_t>(tablet_manager->update_mgr()->get_rowset_num_deletes(metadata, rowset));
-        }
-        if (a.num_dels > a.num_rows) {
-            LOG(WARNING) << "rowset id=" << rowset.id() << " has num_dels=" << a.num_dels
-                         << " > num_rows=" << a.num_rows << "; clamping for split allocation";
-            a.num_dels = a.num_rows;
-        }
-        anchor.emplace(rowset.id(), a);
+        if (!rowset.has_num_rows()) rows += segment.num_rows();
+        if (!rowset.has_data_size()) bytes += segment.size();
     }
-    return anchor;
+    if (rows < 0 || bytes < 0 || rows > INT64_MAX || bytes > INT64_MAX || rowset.num_dels() < 0 ||
+        rowset.num_dels() > rows) {
+        return Status::Corruption("tablet split has invalid rowset statistics");
+    }
+    return RowsetAnchor{static_cast<int64_t>(rows), static_cast<int64_t>(bytes), rowset.num_dels()};
 }
 
-// Anchor each split group's per-rowset stats to the old tablet's recorded totals
-// using the Hare-Niemeyer helper. Σ new tablets stat == old tablet stat exactly for
-// num_rows, data_size, and num_dels per rowset (modulo cap-and-redistribute
-// for invalid old tablets — see tablet_reshard_helper.h contracts).
-//
-// Replaces the pre-anchor flow which wrote per-source weights raw into
-// rowset_stats and ran a separate num_dels Hare-Niemeyer pass after.
-void apply_rowset_anchor(const std::unordered_map<uint32_t, RowsetAnchor>& anchor, const RangeSplitResult& split_result,
-                         std::vector<TabletRangeInfo>* split_ranges) {
-    DCHECK(split_ranges != nullptr);
-    const int64_t num_splits = static_cast<int64_t>(split_ranges->size());
-    if (num_splits == 0) return;
+using PhysicalSlices = std::map<std::pair<std::string, int64_t>, std::string>;
 
-    for (const auto& [source_id, ra] : anchor) {
-        // Gather per-group weights for this source. Missing entries
-        // contribute weight 0; zero-weight buckets receive zero allocation
-        // (or share the uniform fallback when every weight is zero).
-        std::vector<int64_t> rows_w(num_splits, 0);
-        std::vector<int64_t> bytes_w(num_splits, 0);
-        for (int64_t g = 0; g < num_splits; ++g) {
-            if (g >= static_cast<int64_t>(split_result.range_source_stats.size())) break;
-            auto it = split_result.range_source_stats[g].find(source_id);
-            if (it != split_result.range_source_stats[g].end()) {
-                rows_w[g] = it->second.first;
-                bytes_w[g] = it->second.second;
+StatusOr<bool> insert_physical_slice(const SegmentMetadataPB& segment, PhysicalSlices* slices) {
+    auto declaration = segment;
+    declaration.clear_segment_idx();
+    declaration.clear_shared();
+    const auto serialized = declaration.SerializeAsString();
+    auto [it, inserted] = slices->emplace(std::make_pair(segment.filename(), segment.bundle_file_offset()), serialized);
+    if (!inserted && it->second != serialized) {
+        return Status::Corruption("tablet split has conflicting physical segment declarations");
+    }
+    return inserted;
+}
+
+Status validate_split_inputs(const TabletMetadataPB& source, SplitMetadataVisitBudget* budget) {
+    // Bound the live-file reference set used during child cleanup as part of the
+    // same operation budget, before any flush or child metadata allocation.
+    RETURN_IF_ERROR(budget->consume(static_cast<size_t>(source.delvec_meta().delvecs_size()) +
+                                            source.delvec_meta().version_to_file_size() +
+                                            source.sstable_meta().sstables_size(),
+                                    "source sidecar declarations"));
+    TabletRange parent;
+    RETURN_IF_ERROR(parent.from_proto(source.range()));
+    Status fallback;
+    PhysicalSlices slices;
+    for (const auto& rowset : source.rowsets()) {
+        RETURN_IF_ERROR(budget->consume(1, "source rowset"));
+        if (!tablet_reshard_helper::has_valid_uid(rowset)) {
+            return Status::Corruption("tablet split rowset has no valid UID");
+        }
+        RETURN_IF_ERROR(budget->consume(rowset.segment_metas_size(), "source segment declarations"));
+        ASSIGN_OR_RETURN(auto anchor, rowset_anchor(rowset));
+        if (rowset.has_delete_predicate() && (rowset.segment_metas_size() != 0 || rowset.del_files_size() != 0 ||
+                                              anchor.num_rows != 0 || anchor.data_size != 0 || anchor.num_dels != 0)) {
+            return Status::Corruption("tablet split has invalid delete predicate shape");
+        }
+        TabletRange effective;
+        RETURN_IF_ERROR(effective.from_proto(rowset.has_range() ? rowset.range() : source.range()));
+        if (effective.is_empty()) {
+            fallback = Status::NotSupported("tablet split effective rowset range is empty");
+        } else {
+            ASSIGN_OR_RETURN(auto intersection, effective.intersect(parent));
+            if ((!parent.is_minimum() &&
+                 (effective.is_minimum() || effective.lower_bound().compare(parent.lower_bound()) < 0 ||
+                  (effective.lower_bound() == parent.lower_bound() && effective.lower_bound_included() &&
+                   parent.lower_bound_excluded()))) ||
+                (!parent.is_maximum() &&
+                 (effective.is_maximum() || effective.upper_bound().compare(parent.upper_bound()) > 0 ||
+                  (effective.upper_bound() == parent.upper_bound() && effective.upper_bound_included() &&
+                   parent.upper_bound_excluded()))) ||
+                intersection.is_empty()) {
+                return Status::Corruption("tablet split effective rowset range lies outside source tablet");
             }
         }
-
-        std::vector<int64_t> rows_alloc(num_splits, 0);
-        std::vector<int64_t> bytes_alloc(num_splits, 0);
-        std::vector<int64_t> dels_alloc(num_splits, 0);
-        tablet_reshard_helper::allocate_proportionally(ra.num_rows, rows_w, &rows_alloc);
-        tablet_reshard_helper::allocate_proportionally(ra.data_size, bytes_w, &bytes_alloc);
-        // num_dels follows the row distribution: deletes are per-row, not
-        // per-byte, so byte weights would skew the split when row and byte
-        // distributions disagree (e.g. compressed columns).
-        tablet_reshard_helper::allocate_proportionally(ra.num_dels, rows_w, &dels_alloc);
-        tablet_reshard_helper::cap_and_redistribute_dels(rows_alloc, &dels_alloc);
-
-        for (int64_t g = 0; g < num_splits; ++g) {
-            // Skip writes that would create an empty entry — keeps the
-            // rowset_stats map sparse, identical to the pre-anchor behavior
-            // for sources with no representation in the group.
-            if (rows_alloc[g] == 0 && bytes_alloc[g] == 0 && dels_alloc[g] == 0) {
-                continue;
+        std::unordered_set<uint32_t> indices;
+        uint32_t previous = 0;
+        bool first = true;
+        for (const auto& segment : rowset.segment_metas()) {
+            RETURN_IF_ERROR(budget->consume(segment.deprecated_sort_key_samples_size(), "source metadata samples"));
+            if (!segment.has_segment_idx()) {
+                fallback = Status::NotSupported("tablet split segment index is absent");
+            } else {
+                const uint32_t index = segment.segment_idx();
+                if (!indices.insert(index).second || (!first && index <= previous)) {
+                    return Status::Corruption("tablet split segment indices are not strictly increasing");
+                }
+                if (uint64_t{rowset.id()} + index > UINT32_MAX) {
+                    return Status::Corruption("tablet split segment RSSID overflows uint32");
+                }
+                previous = index;
+                first = false;
             }
-            auto& dst = (*split_ranges)[g].rowset_stats[source_id];
-            dst.num_rows = rows_alloc[g];
-            dst.data_size = bytes_alloc[g];
-            dst.num_dels = dels_alloc[g];
+            RETURN_IF_ERROR(insert_physical_slice(segment, &slices).status());
+        }
+        for (const auto& del : rowset.del_files()) {
+            RETURN_IF_ERROR(budget->consume(1, "source delete declaration"));
+            const uint64_t offset = del.has_op_offset() ? del.op_offset() : previous;
+            if (uint64_t{del.origin_rowset_id()} + offset > UINT32_MAX) {
+                return Status::Corruption("tablet split delete replay span overflows uint32");
+            }
+            if (del.origin_rowset_id() == rowset.id() &&
+                (rowset.segment_metas_size() == 0 ? offset != 0 : !indices.contains(offset))) {
+                fallback = Status::NotSupported("tablet split self-origin delete offset is not a current segment");
+            }
         }
     }
+    return fallback;
+}
+
+// Count-only reshard planning consumes metadata once per immutable physical slice.
+// The public segment loader retains its full-index sampling contract.
+Status build_unique_boundary_segments(TabletManager* tablet_manager, const TabletMetadataPtr& metadata,
+                                      const TabletSchema& schema, SplitMetadataVisitBudget* budget,
+                                      std::vector<SegmentSplitInfo>* segments) {
+    TEST_SYNC_POINT_CALLBACK("tablet_splitter:boundary_planner", nullptr);
+    ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(schema));
+    PhysicalSlices slices;
+    for (const auto& rowset : metadata->rowsets()) {
+        RETURN_IF_ERROR(budget->consume(1, "boundary rowset"));
+        for (const auto& sm : rowset.segment_metas()) {
+            RETURN_IF_ERROR(budget->consume(1 + sm.deprecated_sort_key_samples_size(), "boundary segment samples"));
+            if (sm.num_rows() < 0 || sm.size() < 0) {
+                return Status::Corruption("tablet split has negative physical segment statistics");
+            }
+            ASSIGN_OR_RETURN(bool inserted, insert_physical_slice(sm, &slices));
+            if (!inserted) continue;
+            SegmentSplitInfo segment;
+            RETURN_IF_ERROR(segment.min_key.from_proto(sm.sort_key_min()));
+            RETURN_IF_ERROR(segment.max_key.from_proto(sm.sort_key_max()));
+            segment.num_rows = sm.num_rows();
+            segment.data_size = sm.size();
+            RETURN_IF_ERROR(segment.load_sort_key_samples(sm));
+            projection.project(&segment.min_key);
+            projection.project(&segment.max_key);
+            for (auto& sample : segment.sort_key_samples) projection.project(&sample);
+            segments->push_back(std::move(segment));
+        }
+    }
+    return Status::OK();
 }
 
 Status build_split_ranges_from_boundaries(const TabletMetadataPtr& tablet_metadata,
@@ -889,19 +958,18 @@ Status build_split_ranges_from_boundaries(const TabletMetadataPtr& tablet_metada
 // Postcondition on Status::OK: split_ranges->size() == split_count.
 // When the algorithm cannot produce exactly that many ranges (insufficient
 // boundary points given the segment key distribution), returns
-// Status::InvalidArgument with split_ranges cleared. The caller (split_tablet)
+// Status::NotSupported with split_ranges cleared. The caller (split_tablet)
 // is expected to fall back to identical-tablet publish; only new_tablet_ids(0)
 // is consumed in that case, and FE is responsible for reclaiming the remaining
 // preallocated tablet ids.
 //
 // colocate_column_count > 0 enables colocate-aware boundary canonicalization (see
 // calculate_range_split_boundaries). A malformed FE that sends colocate_column_count
-// larger than the sort-key arity returns Status::InvalidArgument here, which triggers
-// the same identical-tablet fallback as "no boundaries" — preserves the publish loop
-// instead of hard-failing.
+// larger than the sort-key arity returns Status::InvalidArgument and propagates;
+// malformed input is not a safe no-split outcome.
 Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
                                     int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
-                                    int32_t colocate_column_count) {
+                                    int32_t colocate_column_count, SplitMetadataVisitBudget* budget) {
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
@@ -936,9 +1004,9 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     }
 
     std::vector<SegmentSplitInfo> segments;
-    RETURN_IF_ERROR(build_segments_from_rowsets_impl(tablet_manager, tablet_metadata, *tablet_schema, &segments));
+    RETURN_IF_ERROR(build_unique_boundary_segments(tablet_manager, tablet_metadata, *tablet_schema, budget, &segments));
     if (segments.empty()) {
-        return Status::InvalidArgument("No segments found in tablet metadata");
+        return Status::NotSupported("No segments found in tablet metadata");
     }
 
     // Step 2: Calculate split boundaries with tablet range filtering.
@@ -947,17 +1015,20 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
 
     int64_t total_num_rows = 0;
     for (const auto& segment : segments) {
+        if (segment.num_rows > INT64_MAX - total_num_rows) {
+            return Status::Corruption("tablet split physical row count exceeds int64");
+        }
         total_num_rows += segment.num_rows;
     }
     int64_t avg_num_rows = std::max<int64_t>(1, total_num_rows / split_count);
 
-    ASSIGN_OR_RETURN(auto split_result,
-                     calculate_range_split_boundaries(segments, split_count, avg_num_rows,
-                                                      /*use_num_rows=*/true,
-                                                      /*track_sources=*/true, &tablet_range, colocate_column_count));
+    ASSIGN_OR_RETURN(auto split_result, calculate_range_split_boundaries_impl(segments, split_count, avg_num_rows,
+                                                                              /*use_num_rows=*/true,
+                                                                              /*track_sources=*/false, &tablet_range,
+                                                                              colocate_column_count, budget));
 
     if (split_result.boundaries.empty()) {
-        return Status::InvalidArgument("Not enough split ranges available");
+        return Status::NotSupported("Not enough split ranges available");
     }
 
     // Step 3: Build TabletRangeInfo directly from result.
@@ -969,7 +1040,7 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
                      << " produced=" << split_ranges->size();
         auto produced = split_ranges->size();
         split_ranges->clear();
-        return Status::InvalidArgument(
+        return Status::NotSupported(
                 fmt::format("Insufficient split boundaries: requested {}, produced {}", split_count, produced));
     }
 
@@ -980,17 +1051,6 @@ Status get_tablet_split_ranges_impl(TabletManager* tablet_manager, const TabletM
     // remaining arity skew into an aborted reshard rather than corrupt metadata.
     RETURN_IF_ERROR(validate_split_ranges(*split_ranges, *tablet_schema, tablet_metadata->id()));
 
-    // Anchor per-split per-rowset stats to the old tablet's recorded totals so
-    // that Σ new tablets stat == old tablet stat exactly for num_rows / data_size /
-    // num_dels. The segment-level distribution from
-    // calculate_range_split_boundaries is used as relative weights only;
-    // absolute values come from the old tablet metadata. This eliminates the
-    // residual drift seen across multi-level splits when the algorithm
-    // re-runs on the same physical segments under a different
-    // ordered_boundaries set.
-    auto anchor = build_rowset_anchor(*tablet_metadata, tablet_manager);
-    apply_rowset_anchor(anchor, split_result, split_ranges);
-
     return Status::OK();
 }
 
@@ -998,7 +1058,8 @@ Status get_tablet_split_ranges_from_pk_index_samples_impl(TabletManager* tablet_
                                                           const TabletMetadataPtr& tablet_metadata, int32_t split_count,
                                                           std::vector<std::string> encoded_samples,
                                                           std::vector<TabletRangeInfo>* split_ranges,
-                                                          int32_t colocate_column_count) {
+                                                          int32_t colocate_column_count,
+                                                          SplitMetadataVisitBudget* budget) {
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
@@ -1034,6 +1095,7 @@ Status get_tablet_split_ranges_from_pk_index_samples_impl(TabletManager* tablet_
     };
     std::sort(encoded_samples.begin(), encoded_samples.end(), encoded_less);
     encoded_samples.erase(std::unique(encoded_samples.begin(), encoded_samples.end()), encoded_samples.end());
+    RETURN_IF_ERROR(budget->consume(encoded_samples.size(), "PK unique boundary values"));
     encoded_samples.erase(std::remove_if(encoded_samples.begin(), encoded_samples.end(),
                                          [&](const std::string& key) {
                                              if (key.empty()) return true;
@@ -1046,7 +1108,7 @@ Status get_tablet_split_ranges_from_pk_index_samples_impl(TabletManager* tablet_
                                          }),
                           encoded_samples.end());
     if (encoded_samples.size() < static_cast<size_t>(split_count)) {
-        return Status::InvalidArgument(
+        return Status::NotSupported(
                 fmt::format("Not enough distinct PK-index samples: requested {} splits, got {} "
                             "strict-interior keys",
                             split_count, encoded_samples.size()));
@@ -1099,30 +1161,18 @@ Status get_tablet_split_ranges_from_pk_index_samples_impl(TabletManager* tablet_
 
     RETURN_IF_ERROR(build_split_ranges_from_boundaries(tablet_metadata, boundaries, split_ranges));
 
-    // SST samples approximate PK density but cannot safely attribute individual historical rowsets.
-    // Keep FE statistics conservative and exact by distributing every old rowset uniformly, while
-    // anchoring the totals so their sum is unchanged across children.
-    const auto anchor = build_rowset_anchor(*tablet_metadata, tablet_manager);
-    RangeSplitResult uniform_result;
-    uniform_result.range_source_stats.resize(split_count);
-    for (auto& range_stats : uniform_result.range_source_stats) {
-        for (const auto& anchor_entry : anchor) {
-            range_stats[anchor_entry.first] = {1, 1};
-        }
-    }
-    apply_rowset_anchor(anchor, uniform_result, split_ranges);
     return Status::OK();
 }
 
 Status get_tablet_split_ranges_from_pk_index_impl(TabletManager* tablet_manager,
                                                   const TabletMetadataPtr& tablet_metadata, int32_t split_count,
                                                   std::vector<TabletRangeInfo>* split_ranges,
-                                                  int32_t colocate_column_count) {
+                                                  int32_t colocate_column_count, SplitMetadataVisitBudget* budget) {
     if (split_count < 2) {
         return Status::InvalidArgument("Invalid split count, it is less than 2");
     }
     if (!tablet_metadata->has_sstable_meta() || tablet_metadata->sstable_meta().sstables().empty()) {
-        return Status::InvalidArgument("Cloud-native PK index has no SSTs to sample");
+        return Status::NotSupported("Cloud-native PK index has no SSTs to sample");
     }
 
     // Sampling is scoped to THIS tablet's range, not to the SSTs' own extent: a tablet produced by an
@@ -1138,6 +1188,7 @@ Status get_tablet_split_ranges_from_pk_index_impl(TabletManager* tablet_manager,
     std::vector<const PersistentIndexSstablePB*> overlapping_sstables;
     size_t overlapping_bytes = 0;
     for (const auto& sstable_pb : tablet_metadata->sstable_meta().sstables()) {
+        RETURN_IF_ERROR(budget->consume(1, "PK SST declaration"));
         if (!sstable_pb.has_range() || sstable_pb.range().start_key().empty() || sstable_pb.range().end_key().empty()) {
             return Status::Corruption(fmt::format("PK-index SST {} has no usable key range", sstable_pb.filename()));
         }
@@ -1147,7 +1198,7 @@ Status get_tablet_split_ranges_from_pk_index_impl(TabletManager* tablet_manager,
         }
     }
     if (overlapping_sstables.empty()) {
-        return Status::InvalidArgument("No PK-index SST overlaps the tablet range");
+        return Status::NotSupported("No PK-index SST overlaps the tablet range");
     }
 
     constexpr size_t kSamplesPerSplit = 32;
@@ -1156,8 +1207,6 @@ Status get_tablet_split_ranges_from_pk_index_impl(TabletManager* tablet_manager,
     std::vector<std::string> encoded_samples;
     auto* block_cache = tablet_manager->update_mgr()->block_cache();
     for (const auto* sstable_pb : overlapping_sstables) {
-        encoded_samples.push_back(sstable_pb->range().start_key());
-        encoded_samples.push_back(sstable_pb->range().end_key());
         // Weight each SST's share of the sample budget by its size, so the quantiles picked downstream
         // stay data-volume weighted the way the previous byte-interval sampling made them. Within one
         // SST the samples are spread evenly over the part of its index that lies in the tablet range.
@@ -1165,6 +1214,12 @@ Status get_tablet_split_ranges_from_pk_index_impl(TabletManager* tablet_manager,
                 overlapping_bytes == 0
                         ? target_sample_count
                         : std::max<size_t>(1, target_sample_count * sstable_pb->filesize() / overlapping_bytes);
+        RETURN_IF_ERROR(budget->consume(3 + sst_sample_count, "PK SST sampling"));
+        TEST_SYNC_POINT_CALLBACK("tablet_splitter:pk_sampler", nullptr);
+        encoded_samples.push_back(sstable_pb->range().start_key());
+        encoded_samples.push_back(sstable_pb->range().end_key());
+        const size_t sample_count_before = encoded_samples.size();
+        TEST_SYNC_POINT_CALLBACK("tablet_splitter:sst_open", nullptr);
         ASSIGN_OR_RETURN(
                 auto sstable,
                 PersistentIndexSstable::new_sstable(
@@ -1172,11 +1227,14 @@ Status get_tablet_split_ranges_from_pk_index_impl(TabletManager* tablet_manager,
                         block_cache ? block_cache->cache() : nullptr, false, nullptr, tablet_metadata, tablet_manager));
         RETURN_IF_ERROR(sstable->sample_data_keys(&encoded_samples, Slice(tablet_sst_range.seek_key),
                                                   Slice(tablet_sst_range.stop_key), sst_sample_count));
+        if (encoded_samples.size() - sample_count_before > 2 + sst_sample_count) {
+            return Status::InternalError("PK SST sampler exceeded its requested metadata bound");
+        }
     }
 
     return get_tablet_split_ranges_from_pk_index_samples_impl(tablet_manager, tablet_metadata, split_count,
                                                               std::move(encoded_samples), split_ranges,
-                                                              colocate_column_count);
+                                                              colocate_column_count, budget);
 }
 
 // Builds a single new-tablet metadata that is "identical" to the old tablet —
@@ -1210,9 +1268,8 @@ MutableTabletMetadataPtr make_identical_new_tablet_metadata(const TabletMetadata
 
 // external-boundaries peer of get_tablet_split_ranges: produces a vector<TabletRangeInfo>
 // from FE-supplied boundaries instead of computing them from segment
-// distribution. Reuses distribute_segment_to_ranges, build_rowset_anchor, and
-// apply_rowset_anchor so the per-rowset stat math is identical to the
-// data-driven path. Inline numbered step tags document each phase.
+// distribution. This phase validates ranges only; the shared rowset-local projector
+// supplies weights and anchors for both external and data-driven paths.
 //
 // Non-OK return is caller-handled (split_tablet) by routing to the symmetric
 // identical-fallback path with the external-boundaries bvar bumped. The helper does NOT
@@ -1220,7 +1277,9 @@ MutableTabletMetadataPtr make_identical_new_tablet_metadata(const TabletMetadata
 Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_manager,
                                                           const TabletMetadataPtr& old_tablet_metadata,
                                                           const RepeatedPtrField<TabletRangePB>& external_ranges,
-                                                          std::vector<TabletRangeInfo>* split_ranges) {
+                                                          std::vector<TabletRangeInfo>* split_ranges,
+                                                          SplitMetadataVisitBudget* budget) {
+    RETURN_IF_ERROR(budget->consume(external_ranges.size(), "external ranges"));
     DCHECK(split_ranges != nullptr);
     DCHECK(split_ranges->empty());
 
@@ -1324,8 +1383,7 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
         }
     }
 
-    // 2. Seed K TabletRangeInfo from external_ranges; rowset_stats stays empty
-    //    for now (filled by apply_rowset_anchor in step 10).
+    // 2. Seed K TabletRangeInfo; the final-range projector fills rowset_stats.
     split_ranges->reserve(external_ranges.size());
     for (const auto& external_range : external_ranges) {
         auto& range_info = split_ranges->emplace_back();
@@ -1378,173 +1436,197 @@ Status compute_split_ranges_from_external_boundaries_impl(TabletManager* tablet_
         }
     }
 
-    // 4. Empty old tablet fast-path: no rowsets to distribute, K
-    //    TabletRangeInfo with empty rowset_stats is the correct output.
-    //    build_new_tablets_from_split_ranges will produce K new tablets with
-    //    no rowsets. Runs AFTER FE-input validation so empty tablets via external boundaries
-    //    cannot accept semantically-invalid ranges either.
-    if (old_tablet_metadata->rowsets_size() == 0) {
-        return Status::OK();
-    }
-
-    // For ORDER BY != PK, segment min/max and sampling metadata are in sort-key
-    // space and cannot estimate a PK-space child distribution. Correctness only
-    // requires every inherited rowset to remain shared until UNSHARE. Use uniform
-    // weights for transitional FE statistics and avoid comparing the two domains.
-    if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && tablet_schema->has_separate_sort_key()) {
-        RangeSplitResult uniform_result;
-        uniform_result.range_source_stats.resize(external_ranges.size());
-        const auto anchor = build_rowset_anchor(*old_tablet_metadata, tablet_manager);
-        for (size_t i = 0; i < uniform_result.range_source_stats.size(); ++i) {
-            for (const auto& anchor_entry : anchor) {
-                uniform_result.range_source_stats[i][anchor_entry.first] = {1, 1};
-            }
-        }
-        apply_rowset_anchor(anchor, uniform_result, split_ranges);
-        return Status::OK();
-    }
-
-    // 5. Build SegmentSplitInfo from rowsets via shared helper. Empty-segments
-    //    here is corruption (we already short-circuited the empty-rowsets case
-    //    at step 4); external boundaries uses a distinct error message vs the data-driven path.
-    std::vector<SegmentSplitInfo> segments;
-    RETURN_IF_ERROR(build_segments_from_rowsets(tablet_manager, old_tablet_metadata, &segments));
-    if (segments.empty()) {
-        return Status::InvalidArgument("rowsets present but no segments derived (possibly corrupt metadata)");
-    }
-
-    // 6. Compute segment envelope and effective envelope.
-    VariantTuple seg_min = segments.front().min_key;
-    VariantTuple seg_max = segments.front().max_key;
-    for (const auto& s : segments) {
-        if (s.min_key.compare(seg_min) < 0) seg_min = s.min_key;
-        if (s.max_key.compare(seg_max) > 0) seg_max = s.max_key;
-    }
-    VariantTuple effective_lo = seg_min;
-    VariantTuple effective_hi = seg_max;
-    if (old_tablet_metadata->range().has_lower_bound()) {
-        VariantTuple parent_lo;
-        RETURN_IF_ERROR(parent_lo.from_proto(old_tablet_metadata->range().lower_bound()));
-        if (parent_lo.compare(effective_lo) > 0) effective_lo = parent_lo;
-    }
-    if (old_tablet_metadata->range().has_upper_bound()) {
-        VariantTuple parent_hi;
-        RETURN_IF_ERROR(parent_hi.from_proto(old_tablet_metadata->range().upper_bound()));
-        if (parent_hi.compare(effective_hi) < 0) effective_hi = parent_hi;
-    }
-    // '>=' covers both empty (lo > hi) and degenerate-point (lo == hi)
-    // envelopes. Half-open range math cannot K-way split a point; for P0
-    // both cases return InvalidArgument and the caller falls back.
-    if (effective_lo.compare(effective_hi) >= 0) {
-        return Status::InvalidArgument(
-                "effective envelope empty or degenerate-point (segments don't overlap old tablet's range or collapse "
-                "to "
-                "a single key)");
-    }
-
-    // 7. Build distribution vector covering the FULL segment envelope.
-    //    dist_to_final[j] == -1 for sinks, otherwise the index into split_ranges.
-    //    Non-explicit ±infinity sides clip to the effective envelope edge.
-    std::vector<RangeInfo> dist_ranges;
-    std::vector<int> dist_to_final;
-    dist_ranges.reserve(external_ranges.size() + 2);
-    dist_to_final.reserve(external_ranges.size() + 2);
-    if (seg_min.compare(effective_lo) < 0) {
-        RangeInfo sink;
-        sink.min = seg_min;
-        sink.max = effective_lo;
-        dist_ranges.push_back(std::move(sink));
-        dist_to_final.push_back(-1);
-    }
-    for (int i = 0; i < external_ranges.size(); ++i) {
-        const VariantTuple clipped_lo =
-                parsed[i].lo_explicit ? ((parsed[i].lo.compare(effective_lo) < 0) ? effective_lo : parsed[i].lo)
-                                      : effective_lo;
-        const VariantTuple clipped_hi =
-                parsed[i].hi_explicit ? ((parsed[i].hi.compare(effective_hi) > 0) ? effective_hi : parsed[i].hi)
-                                      : effective_hi;
-        // Skip on '>=' (zero-width too): [x,x) cannot contain any row under
-        // closed-open semantics; including would risk closed-last-range edge.
-        if (clipped_lo.compare(clipped_hi) >= 0) continue;
-        RangeInfo ri;
-        ri.min = clipped_lo;
-        ri.max = clipped_hi;
-        dist_ranges.push_back(std::move(ri));
-        dist_to_final.push_back(i);
-    }
-    if (seg_max.compare(effective_hi) > 0) {
-        RangeInfo sink;
-        sink.min = effective_hi;
-        sink.max = seg_max;
-        dist_ranges.push_back(std::move(sink));
-        dist_to_final.push_back(-1);
-    }
-    // Defense-in-depth: should be unreachable under v20 invariants (envelope
-    // check at step 5 ensures effective_lo < effective_hi; FE ranges tile
-    // the old tablet's range; at least one FE range must overlap effective envelope).
-    // Asserted at runtime so a future regression in invariants doesn't OOB
-    // find_overlapping_ranges' last_range_index = size()-1.
-    if (dist_ranges.empty()) {
-        return Status::InvalidArgument("distribution vector empty (degenerate envelope or all active slots skipped)");
-    }
-
-    // 8. Distribute segments into the full distribution vector. Out-of-old-tablet
-    //    data flows into sink buckets; sink stats are discarded at step 10.
-    for (const auto& seg : segments) {
-        distribute_segment_to_ranges(seg, dist_ranges, /*track_sources=*/true);
-    }
-
-    // 9. Build anchor BEFORE the sanity check. anchor's per-rowset totals
-    //    fall back to summing segment_metas when rowset-level num_rows /
-    //    data_size are absent on legacy metadata, so the sanity check below
-    //    using anchor totals catches legacy rowsets that direct
-    //    rowset.num_rows() access would miss.
-    auto anchor = build_rowset_anchor(*old_tablet_metadata, tablet_manager);
-
-    // 10. Per-axis all-zero sanity check. For each rowset where anchor totals
-    //     are positive, require Σ over active slots > 0 on the matching axis.
-    //     allocate_proportionally falls back to uniform allocation when all
-    //     weights are zero, which would silently invent stats.
-    for (const auto& [rowset_id, ra] : anchor) {
-        const bool need_row_weight = (ra.num_rows > 0);
-        const bool need_byte_weight = (ra.data_size > 0);
-        if (!need_row_weight && !need_byte_weight) continue;
-        int64_t active_rows_w = 0;
-        int64_t active_bytes_w = 0;
-        for (size_t j = 0; j < dist_ranges.size(); ++j) {
-            if (dist_to_final[j] < 0) continue; // skip sinks
-            auto it = dist_ranges[j].source_stats.find(rowset_id);
-            if (it != dist_ranges[j].source_stats.end()) {
-                active_rows_w += it->second.first;
-                active_bytes_w += it->second.second;
-            }
-        }
-        if (need_row_weight && active_rows_w == 0) {
-            return Status::InvalidArgument(fmt::format(
-                    "rowset id={} has anchor.num_rows={} but no active row weight (possibly corrupt metadata)",
-                    rowset_id, ra.num_rows));
-        }
-        if (need_byte_weight && active_bytes_w == 0) {
-            return Status::InvalidArgument(fmt::format(
-                    "rowset id={} has anchor.data_size={} but no active byte weight (possibly corrupt metadata)",
-                    rowset_id, ra.data_size));
-        }
-    }
-
-    // 11. Synthesize RangeSplitResult with K slots; active slots get their
-    //     accumulated source_stats, sinks discarded, skipped slots stay empty.
-    RangeSplitResult fake_result;
-    fake_result.range_source_stats.resize(external_ranges.size());
-    for (size_t j = 0; j < dist_ranges.size(); ++j) {
-        if (dist_to_final[j] < 0) continue;
-        fake_result.range_source_stats[dist_to_final[j]] = dist_ranges[j].source_stats;
-    }
-
-    // 12. Anchor: Σ new tablets stat == old tablet stat exactly for num_rows /
-    //     data_size / num_dels. Writes split_ranges[i].rowset_stats.
-    apply_rowset_anchor(anchor, fake_result, split_ranges);
-
     return Status::OK();
+}
+
+Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<TabletRange>& parsed_ranges,
+                            const std::vector<RowsetOwnership>& ownership, const std::vector<bool>& rowset_prunable,
+                            SplitMetadataVisitBudget* budget, std::vector<TabletRangeInfo>* split_ranges,
+                            RowsetEmissionMask* emission) {
+    const size_t child_count = parsed_ranges.size();
+    RETURN_IF_ERROR(budget->consume(source.rowsets_size(), "projector rowsets"));
+    emission->resize(source.rowsets_size());
+    ASSIGN_OR_RETURN(const auto schema, materialize_sort_key_schema(source.schema()));
+    const bool separate_sort = schema->keys_type() == PRIMARY_KEYS && schema->has_separate_sort_key();
+    ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(*schema));
+    for (int r = 0; r < source.rowsets_size(); ++r) {
+        const auto& rowset = source.rowsets(r);
+        RETURN_IF_ERROR(budget->consume(child_count, "projector intersections"));
+        ASSIGN_OR_RETURN(auto anchor, rowset_anchor(rowset));
+        TabletRange effective;
+        RETURN_IF_ERROR(effective.from_proto(rowset.has_range() ? rowset.range() : source.range()));
+        auto& emit = (*emission)[r];
+        emit.assign(child_count, false);
+        std::vector<int64_t> row_weights(child_count, 0), byte_weights(child_count, 0);
+        std::vector<int64_t> rows(child_count, 0), bytes(child_count, 0), dels(child_count, 0);
+        for (size_t c = 0; c < child_count; ++c) {
+            ASSIGN_OR_RETURN(auto intersection, effective.intersect(parsed_ranges[c]));
+            emit[c] = !intersection.is_empty();
+            if (emit[c] && rowset_prunable[r]) {
+                emit[c] = false;
+                for (const auto& segment : ownership[r].segments) {
+                    RETURN_IF_ERROR(budget->consume(1, "projector segment ownership"));
+                    if (segment.keep[c]) {
+                        emit[c] = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (std::none_of(emit.begin(), emit.end(), [](bool value) { return value; })) {
+            return Status::Corruption("tablet split rowset has no emitted child");
+        }
+        if (separate_sort || rowset.segment_metas_size() == 0) {
+            for (size_t c = 0; c < child_count; ++c) row_weights[c] = byte_weights[c] = emit[c] ? 1 : 0;
+        } else {
+            // Only this rowset's segment/sample weights are live. Include sinks outside
+            // its effective range, so clipping never donates out-of-range samples to a child.
+            std::vector<SegmentSplitInfo> segments;
+            for (const auto& sm : rowset.segment_metas()) {
+                RETURN_IF_ERROR(
+                        budget->consume(1 + sm.deprecated_sort_key_samples_size(), "projector segment samples"));
+                SegmentSplitInfo segment;
+                RETURN_IF_ERROR(segment.min_key.from_proto(sm.sort_key_min()));
+                RETURN_IF_ERROR(segment.max_key.from_proto(sm.sort_key_max()));
+                segment.num_rows = sm.num_rows();
+                segment.data_size = sm.size();
+                RETURN_IF_ERROR(segment.load_sort_key_samples(sm));
+                projection.project(&segment.min_key);
+                projection.project(&segment.max_key);
+                for (auto& sample : segment.sort_key_samples) projection.project(&sample);
+                segments.push_back(std::move(segment));
+            }
+            VariantTuple lo = segments.front().min_key, hi = segments.front().max_key;
+            for (const auto& segment : segments) {
+                if (segment.min_key.compare(lo) < 0) lo = segment.min_key;
+                if (segment.max_key.compare(hi) > 0) hi = segment.max_key;
+            }
+            RETURN_IF_ERROR(budget->consume(2, "projector envelope"));
+            std::vector<VariantTuple> cuts{lo, hi};
+            auto add_cut = [&](const VariantTuple& cut) -> Status {
+                if (cut.compare(lo) > 0 && cut.compare(hi) < 0) {
+                    RETURN_IF_ERROR(budget->consume(1, "projector cut"));
+                    cuts.push_back(cut);
+                }
+                return Status::OK();
+            };
+            if (!effective.is_minimum()) RETURN_IF_ERROR(add_cut(effective.lower_bound()));
+            if (!effective.is_maximum()) RETURN_IF_ERROR(add_cut(effective.upper_bound()));
+            for (const auto& range : parsed_ranges) {
+                if (!range.is_minimum()) RETURN_IF_ERROR(add_cut(range.lower_bound()));
+                if (!range.is_maximum()) RETURN_IF_ERROR(add_cut(range.upper_bound()));
+            }
+            std::sort(cuts.begin(), cuts.end());
+            cuts.erase(std::unique(cuts.begin(), cuts.end()), cuts.end());
+            std::vector<RangeInfo> distribution;
+            std::vector<int> destinations;
+            const size_t interval_count = std::max<size_t>(1, cuts.size() - 1);
+            for (size_t i = 0; i < interval_count; ++i) {
+                auto& range = distribution.emplace_back();
+                range.min = cuts[i];
+                range.max = cuts[std::min(i + 1, cuts.size() - 1)];
+                int destination = -1;
+                for (size_t c = 0; c < child_count; ++c) {
+                    RETURN_IF_ERROR(budget->consume(1, "projector interval intersection"));
+                    if (emit[c] && effective.contains(range.min) && parsed_ranges[c].contains(range.min)) {
+                        destination = c;
+                        break;
+                    }
+                }
+                destinations.push_back(destination);
+            }
+            // The physical maximum can itself belong to the next child (or to a
+            // sink at an excluded parent edge). Give that point its own last bucket
+            // only when its owner differs, preserving the ordinary interval weights.
+            int endpoint_destination = -1;
+            for (size_t c = 0; c < child_count; ++c) {
+                RETURN_IF_ERROR(budget->consume(1, "projector endpoint intersection"));
+                if (emit[c] && effective.contains(hi) && parsed_ranges[c].contains(hi)) {
+                    endpoint_destination = c;
+                    break;
+                }
+            }
+            if (endpoint_destination != destinations.back()) {
+                RETURN_IF_ERROR(budget->consume(1, "projector endpoint bucket"));
+                auto& endpoint = distribution.emplace_back();
+                endpoint.min = hi;
+                endpoint.max = hi;
+                destinations.push_back(endpoint_destination);
+            }
+            for (const auto& segment : segments) {
+                RETURN_IF_ERROR(distribute_segment_to_ranges(segment, distribution, false, budget));
+            }
+            for (size_t i = 0; i < distribution.size(); ++i) {
+                if (destinations[i] < 0) continue;
+                row_weights[destinations[i]] += distribution[i].num_rows;
+                byte_weights[destinations[i]] += distribution[i].data_size;
+            }
+        }
+        const auto positive = [](int64_t weight) { return weight > 0; };
+        if ((anchor.num_rows > 0 && std::none_of(row_weights.begin(), row_weights.end(), positive)) ||
+            (anchor.data_size > 0 && std::none_of(byte_weights.begin(), byte_weights.end(), positive))) {
+            return Status::Corruption("tablet split positive rowset anchor has zero emitted weight");
+        }
+        tablet_reshard_helper::allocate_proportionally(anchor.num_rows, row_weights, &rows);
+        tablet_reshard_helper::allocate_proportionally(anchor.data_size, byte_weights, &bytes);
+        tablet_reshard_helper::allocate_proportionally(anchor.num_dels, row_weights, &dels);
+        tablet_reshard_helper::cap_and_redistribute_dels(rows, &dels);
+        for (size_t c = 0; c < child_count; ++c) {
+            if (emit[c]) (*split_ranges)[c].rowset_stats[rowset.id()] = {rows[c], bytes[c], dels[c]};
+        }
+    }
+    return Status::OK();
+}
+
+Status prepare_split_projection(const TabletMetadataPB& source, SplitMetadataVisitBudget* budget,
+                                std::vector<TabletRangeInfo>* split_ranges, std::vector<RowsetOwnership>* ownership,
+                                std::vector<bool>* prunable, RowsetEmissionMask* emission) {
+    RETURN_IF_ERROR(budget->consume(split_ranges->size() + source.rowsets_size(), "projection shape"));
+    std::vector<TabletRange> ranges(split_ranges->size());
+    for (size_t c = 0; c < split_ranges->size(); ++c) RETURN_IF_ERROR(ranges[c].from_proto((*split_ranges)[c].range));
+    ASSIGN_OR_RETURN(const auto schema, materialize_sort_key_schema(source.schema()));
+    const bool compatible = !(schema->keys_type() == PRIMARY_KEYS && schema->has_separate_sort_key());
+    ownership->resize(source.rowsets_size());
+    prunable->assign(source.rowsets_size(), false);
+    for (int r = 0; r < source.rowsets_size(); ++r) {
+        const auto& rowset = source.rowsets(r);
+        if (!compatible || rowset.segment_metas_size() == 0 || rowset.del_files_size() != 0 ||
+            !can_prune_rowset_segments(rowset, raw_sort_key_arity(source.schema())))
+            continue;
+        for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+            RETURN_IF_ERROR(budget->consume(ranges.size(), "ownership intersections"));
+        }
+        ASSIGN_OR_RETURN((*ownership)[r], compute_rowset_segment_ownership(rowset, ranges));
+        (*prunable)[r] = true;
+    }
+    return project_rowset_stats(source, ranges, *ownership, *prunable, budget, split_ranges, emission);
+}
+
+void erase_omitted_rowset_state(const RowsetMetadataPB& rowset, TabletMetadataPB* child) {
+    auto erase = [&](uint32_t rssid) {
+        if (child->has_delvec_meta()) child->mutable_delvec_meta()->mutable_delvecs()->erase(rssid);
+        if (child->has_dcg_meta()) child->mutable_dcg_meta()->mutable_dcgs()->erase(rssid);
+        if (child->has_idg_meta()) child->mutable_idg_meta()->mutable_idgs()->erase(rssid);
+    };
+    if (rowset.segment_metas_size() == 0) erase(rowset.id());
+    for (const auto& segment : rowset.segment_metas()) erase(rowset.id() + segment.segment_idx());
+    child->mutable_rowset_to_schema()->erase(rowset.id());
+}
+
+void prune_unreferenced_delvec_files(TabletMetadataPB* child) {
+    if (!child->has_delvec_meta()) return;
+    std::unordered_set<int64_t> versions;
+    for (const auto& [rssid, page] : child->delvec_meta().delvecs()) versions.insert(page.version());
+    for (const auto& sst : child->sstable_meta().sstables()) {
+        if (sst.has_delvec()) versions.insert(sst.delvec().version());
+    }
+    auto* files = child->mutable_delvec_meta()->mutable_version_to_file();
+    for (auto it = files->begin(); it != files->end();) {
+        if (versions.contains(it->first))
+            ++it;
+        else
+            it = files->erase(it);
+    }
 }
 
 // Build K new-tablet metadata entries from a pre-computed split_ranges vector.
@@ -1601,170 +1683,50 @@ void propagate_pruned_ownership_to_non_segment_files(const RowsetMetadataPB& row
 }
 
 // Precondition: split_ranges.size() == splitting_tablet.new_tablet_ids_size().
-// Per-rowset stats are honored when present in split_ranges[i].rowset_stats;
-// otherwise the rowset is preserved in the new tablet's metadata (still
-// referencing the same shared segment files) but with num_rows / data_size /
-// num_dels set to 0, signaling "rowset is visible in this new tablet's metadata
-// but contributes no rows here under the new tablet's range".
+// The emission mask is the sole rowset-retention decision. Every emitted rowset
+// has projected statistics, including genuinely zero-valued anchors.
 StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablets_from_split_ranges(
-        const TabletMetadataPtr& old_tablet_metadata, const SplittingTabletInfoPB& splitting_tablet,
-        int64_t new_version, const TxnInfoPB& txn_info, const std::vector<TabletRangeInfo>& split_ranges) {
-    // Defense-in-depth: callers (get_tablet_split_ranges and external-boundaries helper) are
-    // contracted to return split_ranges.size() == new_tablet_ids_size() on OK,
-    // but a runtime check here prevents OOB reads if the contract is ever
-    // broken by a future refactor (Release builds strip DCHECK).
+        const TabletMetadataPtr& source, const SplittingTabletInfoPB& splitting_tablet, int64_t new_version,
+        const TxnInfoPB& txn_info, const std::vector<TabletRangeInfo>& split_ranges,
+        const std::vector<RowsetOwnership>& ownership, const std::vector<bool>& prunable,
+        const RowsetEmissionMask& emission) {
     if (split_ranges.size() != static_cast<size_t>(splitting_tablet.new_tablet_ids_size())) {
-        return Status::InternalError(fmt::format("split_ranges size mismatch: expected={}, actual={}",
-                                                 splitting_tablet.new_tablet_ids_size(), split_ranges.size()));
+        return Status::InternalError("tablet split range count does not match child count");
     }
-
-    std::unordered_map<int64_t, MutableTabletMetadataPtr> new_metadatas;
-    new_metadatas.reserve(splitting_tablet.new_tablet_ids_size());
-    // Per-segment ownership compares each segment's stored sort-key bounds against the new tablets'
-    // ranges, so it is only sound while the two live in the same key space. TabletRangeHelper::
-    // range_key_idxes keeps a non-PK tablet's range in sort-key space whatever its ORDER BY, so those
-    // stay comparable; only a PRIMARY KEY tablet moves its range into primary-key space, and there a
-    // segment's sort-key bounds say nothing about which child owns its rows.
-    const auto old_tablet_schema = TabletSchema::create(old_tablet_metadata->schema());
-    const bool can_prune_by_segment_sort_bounds =
-            !(old_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && old_tablet_schema->has_separate_sort_key());
-
-    // The full set of new-tablet ranges, used by per-segment ownership to test
-    // overlap/containment of each segment against every sibling's range.
-    std::vector<TabletRangePB> new_tablet_ranges(split_ranges.size());
-    for (size_t new_tablet_index = 0; new_tablet_index < split_ranges.size(); ++new_tablet_index) {
-        new_tablet_ranges[new_tablet_index] = split_ranges[new_tablet_index].range;
-    }
-
-    // Per-segment ownership depends only on (source rowset, new_tablet_ranges),
-    // not on which new tablet we build, so compute it ONCE per source rowset before
-    // the per-new-tablet loop. This keeps the bvar counters per-decision (not
-    // per-new-tablet) and avoids recomputing the geometry split_count times.
-    // rowset_prunable[rowset_index] is false when the rowset is non-pruneable OR
-    // was degraded to all-shared on an unparseable sort key.
-    //
-    // Parse new_tablet_ranges into TabletRange ONCE before the per-rowset loop;
-    // the parsed form is invariant across rowsets, so this saves N redundant
-    // proto parses for a tablet with N pruneable rowsets.
-    ASSIGN_OR_RETURN(auto parsed_new_tablet_ranges, parse_tablet_ranges(new_tablet_ranges));
-    // Ownership compares a segment's stored sort-key bounds against the new tablets' ranges, which
-    // are at the tablet's current sort-key arity. A rowset written before a metadata-only trailing
-    // sort-key ADD stores narrower bounds and must not be pruned with them (see
-    // can_prune_rowset_segments); it degrades to all-shared instead.
-    const size_t sort_key_arity = raw_sort_key_arity(old_tablet_metadata->schema());
-    const int rowset_count = old_tablet_metadata->rowsets_size();
-    std::vector<RowsetOwnership> rowset_ownership(rowset_count);
-    std::vector<bool> rowset_prunable(rowset_count, false);
-    for (int rowset_index = 0; rowset_index < rowset_count; ++rowset_index) {
-        const auto& source_rowset = old_tablet_metadata->rowsets(rowset_index);
-        if (!can_prune_by_segment_sort_bounds || !can_prune_rowset_segments(source_rowset, sort_key_arity)) continue;
-        auto ownership_or = compute_rowset_segment_ownership(source_rowset, parsed_new_tablet_ranges);
-        if (ownership_or.ok()) {
-            rowset_ownership[rowset_index] = std::move(ownership_or.value());
-            rowset_prunable[rowset_index] = true;
-        } else {
-            // Unparseable sort key: degrade the whole rowset to all-shared below.
-            g_tablet_reshard_split_anomaly_total << 1;
-        }
-    }
-
-    for (int32_t i = 0; i < splitting_tablet.new_tablet_ids_size(); ++i) {
-        auto new_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_metadata);
-        new_tablet_new_metadata->set_id(splitting_tablet.new_tablet_ids(i));
-        new_tablet_new_metadata->set_version(new_version);
-        new_tablet_new_metadata->set_commit_time(txn_info.commit_time());
-        new_tablet_new_metadata->set_gtid(txn_info.gtid());
-        new_tablet_new_metadata->clear_compaction_inputs();
-        new_tablet_new_metadata->clear_orphan_files();
-        new_tablet_new_metadata->clear_prev_garbage_version();
-        new_tablet_new_metadata->mutable_range()->CopyFrom(split_ranges[i].range);
-        // Non-segment files (delvec/dcg/sstable) stay all-shared; each rowset's
-        // per-segment shared flags are (re)written below by exactly one branch per rowset.
-        tablet_reshard_helper::set_non_segment_files_shared(new_tablet_new_metadata.get());
-
-        // The copy preserves rowset order, so rowset_index aligns with old_tablet_metadata.
-        // keep_rowset[idx] is cleared for a rowset whose every segment was pruned from
-        // this new tablet (and which carries no other semantics); such rowsets are
-        // compacted out of rowsets[] after the loop.
-        const int rowset_count = new_tablet_new_metadata->rowsets_size();
-        std::vector<bool> keep_rowset(rowset_count, true);
-        std::vector<uint32_t> removed_rowset_ids;
-        int rowset_index = 0;
-        for (auto& rowset_metadata : *new_tablet_new_metadata->mutable_rowsets()) {
-            RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(&rowset_metadata, split_ranges[i].range));
-
-            // Phase-1 per-segment shared. The uid (logical rowset identity for a later MERGE) is
-            // preserved verbatim by the metadata copy, identical across new tablets. Segments
-            // are then pruned to those overlapping this new tablet (shared=false where provably
-            // exclusive+contained), or for non-pruneable / degraded rowsets stay all-shared.
-            if (rowset_prunable[rowset_index]) {
-                propagate_pruned_ownership_to_non_segment_files(rowset_metadata, rowset_ownership[rowset_index], i,
-                                                                new_tablet_new_metadata.get());
-
-                RETURN_IF_ERROR(apply_segment_ownership_to_new_tablet_rowset(&rowset_metadata,
-                                                                             rowset_ownership[rowset_index], i));
-                // del_files stay shared (per-segment pruning operates on segments, not del_files).
-                for (auto& del_file : *rowset_metadata.mutable_del_files()) del_file.set_shared(true);
-
-                // A rowset whose every segment was pruned from this new tablet carries no
-                // data here. Remove it (and its rowset_to_schema mapping) unless it still
-                // holds a delete predicate or del_files.
-                if (rowset_metadata.segment_metas_size() == 0 && !rowset_metadata.has_delete_predicate() &&
-                    rowset_metadata.del_files_size() == 0) {
-                    keep_rowset[rowset_index] = false;
-                    removed_rowset_ids.push_back(rowset_metadata.id());
-                }
+    std::unordered_map<int64_t, MutableTabletMetadataPtr> children;
+    for (size_t c = 0; c < split_ranges.size(); ++c) {
+        auto child =
+                make_identical_new_tablet_metadata(source, splitting_tablet.new_tablet_ids(c), new_version, txn_info);
+        *child->mutable_range() = split_ranges[c].range;
+        tablet_reshard_helper::set_non_segment_files_shared(child.get());
+        child->clear_rowsets();
+        uint32_t cumulative_point = 0;
+        for (int r = 0; r < source->rowsets_size(); ++r) {
+            const auto& source_rowset = source->rowsets(r);
+            if (!emission[r][c]) {
+                erase_omitted_rowset_state(source_rowset, child.get());
+                continue;
+            }
+            auto* rowset = child->add_rowsets();
+            *rowset = source_rowset;
+            RETURN_IF_ERROR(tablet_reshard_helper::update_rowset_range(rowset, split_ranges[c].range));
+            if (prunable[r] && rowset->del_files_size() == 0) {
+                propagate_pruned_ownership_to_non_segment_files(*rowset, ownership[r], c, child.get());
+                RETURN_IF_ERROR(apply_segment_ownership_to_new_tablet_rowset(rowset, ownership[r], c));
             } else {
-                tablet_reshard_helper::set_all_data_files_shared(&rowset_metadata);
+                tablet_reshard_helper::set_all_data_files_shared(rowset);
             }
-
-            const auto it = split_ranges[i].rowset_stats.find(rowset_metadata.id());
-            if (it != split_ranges[i].rowset_stats.end()) {
-                // apply_rowset_anchor + cap_and_redistribute_dels guarantee
-                // num_dels <= num_rows for every (rowset, new tablet). The std::min
-                // below is defense-in-depth against an upstream regression.
-                DCHECK_LE(it->second.num_dels, it->second.num_rows);
-                int64_t scaled_num_dels = std::min<int64_t>(it->second.num_dels, it->second.num_rows);
-                rowset_metadata.set_num_rows(it->second.num_rows);
-                rowset_metadata.set_data_size(it->second.data_size);
-                rowset_metadata.set_num_dels(scaled_num_dels);
-            } else {
-                rowset_metadata.set_num_rows(0);
-                rowset_metadata.set_data_size(0);
-                rowset_metadata.set_num_dels(0);
-            }
-            ++rowset_index;
+            const auto& projected = split_ranges[c].rowset_stats.at(rowset->id());
+            rowset->set_num_rows(projected.num_rows);
+            rowset->set_data_size(projected.data_size);
+            rowset->set_num_dels(projected.num_dels);
+            if (r < source->cumulative_point()) ++cumulative_point;
         }
-
-        // Compact out removed (fully-pruned) rowsets, preserving order, and drop their
-        // rowset_to_schema mappings. Move survivors into a fresh field then swap — the
-        // order-stable RepeatedPtrField idiom (positional swap-compaction would desync
-        // from the original-position keep_rowset[] vector).
-        if (!removed_rowset_ids.empty()) {
-            // cumulative_point indexes into rowsets[] (base rowsets are [0, cp), cumulative
-            // [cp, size)) for non-PK base+cumulative compaction. Removing rowsets shifts
-            // positions, so recompute the point as the number of SURVIVING rowsets that
-            // were originally in the base region [0, old_cp); otherwise the inherited point
-            // could misclassify rowsets or exceed rowsets_size().
-            const int old_cumulative_point = static_cast<int>(new_tablet_new_metadata->cumulative_point());
-            google::protobuf::RepeatedPtrField<RowsetMetadataPB> survivors;
-            auto* rowsets = new_tablet_new_metadata->mutable_rowsets();
-            uint32_t new_cumulative_point = 0;
-            for (int idx = 0; idx < rowsets->size(); ++idx) {
-                if (!keep_rowset[idx]) continue;
-                if (idx < old_cumulative_point) ++new_cumulative_point;
-                survivors.Add()->Swap(rowsets->Mutable(idx));
-            }
-            rowsets->Swap(&survivors);
-            new_tablet_new_metadata->set_cumulative_point(new_cumulative_point);
-            auto* rowset_to_schema = new_tablet_new_metadata->mutable_rowset_to_schema();
-            for (uint32_t id : removed_rowset_ids) rowset_to_schema->erase(id);
-        }
-
-        new_metadatas.emplace(new_tablet_new_metadata->id(), std::move(new_tablet_new_metadata));
+        child->set_cumulative_point(cumulative_point);
+        prune_unreferenced_delvec_files(child.get());
+        children.emplace(child->id(), std::move(child));
     }
-
-    return new_metadatas;
+    return children;
 }
 
 } // namespace
@@ -1925,35 +1887,53 @@ Status build_segments_from_rowsets(TabletManager* tablet_manager, const TabletMe
     return build_segments_from_rowsets_impl(tablet_manager, tablet_metadata, *tablet_schema, segments);
 }
 
-// Public wrapper for the anon-namespace implementation. Exposed via
-// tablet_splitter.h so unit tests can drive the validation paths directly
-// without spinning up a TabletManager/filesystem fixture.
-Status compute_split_ranges_from_external_boundaries(TabletManager* tablet_manager,
-                                                     const TabletMetadataPtr& old_tablet_metadata,
+// Focused SPLIT helpers create one bounded budget; the generic calculator used by
+// parallel compaction remains unlimited, including explicitly source-tracked calls.
+StatusOr<RangeSplitResult> calculate_range_split_boundaries(const std::vector<SegmentSplitInfo>& segments,
+                                                            int32_t target_split_count, int64_t target_value_per_split,
+                                                            bool use_num_rows, bool track_sources,
+                                                            const TabletRange* tablet_range,
+                                                            int32_t colocate_column_count) {
+    return calculate_range_split_boundaries_impl(segments, target_split_count, target_value_per_split, use_num_rows,
+                                                 track_sources, tablet_range, colocate_column_count, nullptr);
+}
+
+Status compute_split_ranges_from_external_boundaries(TabletManager* tablet_manager, const TabletMetadataPtr& metadata,
                                                      const RepeatedPtrField<TabletRangePB>& external_ranges,
                                                      std::vector<TabletRangeInfo>* split_ranges) {
-    return compute_split_ranges_from_external_boundaries_impl(tablet_manager, old_tablet_metadata, external_ranges,
-                                                              split_ranges);
+    SplitMetadataVisitBudget budget;
+    RETURN_IF_ERROR(compute_split_ranges_from_external_boundaries_impl(tablet_manager, metadata, external_ranges,
+                                                                       split_ranges, &budget));
+    std::vector<RowsetOwnership> ownership;
+    std::vector<bool> prunable;
+    RowsetEmissionMask emission;
+    return prepare_split_projection(*metadata, &budget, split_ranges, &ownership, &prunable, &emission);
 }
 
-// Public wrapper for the data-driven split-ranges helper. Exposed for parity
-// testing against compute_split_ranges_from_external_boundaries; production
-// call site is split_tablet().
-Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
-                               int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
-                               int32_t colocate_column_count) {
-    return get_tablet_split_ranges_impl(tablet_manager, tablet_metadata, split_count, split_ranges,
-                                        colocate_column_count);
+Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& metadata, int32_t split_count,
+                               std::vector<TabletRangeInfo>* split_ranges, int32_t colocate_column_count) {
+    SplitMetadataVisitBudget budget;
+    RETURN_IF_ERROR(get_tablet_split_ranges_impl(tablet_manager, metadata, split_count, split_ranges,
+                                                 colocate_column_count, &budget));
+    std::vector<RowsetOwnership> ownership;
+    std::vector<bool> prunable;
+    RowsetEmissionMask emission;
+    return prepare_split_projection(*metadata, &budget, split_ranges, &ownership, &prunable, &emission);
 }
 
-Status get_tablet_split_ranges_from_pk_index_samples(TabletManager* tablet_manager,
-                                                     const TabletMetadataPtr& tablet_metadata, int32_t split_count,
-                                                     std::vector<std::string> encoded_samples,
+Status get_tablet_split_ranges_from_pk_index_samples(TabletManager* tablet_manager, const TabletMetadataPtr& metadata,
+                                                     int32_t split_count, std::vector<std::string> encoded_samples,
                                                      std::vector<TabletRangeInfo>* split_ranges,
                                                      int32_t colocate_column_count) {
-    return get_tablet_split_ranges_from_pk_index_samples_impl(tablet_manager, tablet_metadata, split_count,
-                                                              std::move(encoded_samples), split_ranges,
-                                                              colocate_column_count);
+    SplitMetadataVisitBudget budget;
+    RETURN_IF_ERROR(budget.consume(encoded_samples.size(), "PK samples"));
+    RETURN_IF_ERROR(get_tablet_split_ranges_from_pk_index_samples_impl(tablet_manager, metadata, split_count,
+                                                                       std::move(encoded_samples), split_ranges,
+                                                                       colocate_column_count, &budget));
+    std::vector<RowsetOwnership> ownership;
+    std::vector<bool> prunable;
+    RowsetEmissionMask emission;
+    return prepare_split_projection(*metadata, &budget, split_ranges, &ownership, &prunable, &emission);
 }
 
 // -----------------------------------------------------------------------------
@@ -2130,54 +2110,60 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
         return Status::InvalidArgument("splitting tablet has no new tablet");
     }
 
-    auto split_schema = TabletSchema::create(tablet_metadata->schema());
-    if (split_schema->keys_type() == KeysType::PRIMARY_KEYS && split_schema->has_separate_sort_key() &&
-        ((tablet_metadata->has_dcg_meta() && !tablet_metadata->dcg_meta().dcgs().empty()) ||
-         (tablet_metadata->has_idg_meta() && !tablet_metadata->idg_meta().idgs().empty()))) {
+    SplitMetadataVisitBudget budget;
+    Status status = validate_split_inputs(*tablet_metadata, &budget);
+    auto can_fallback_identical = [](const Status& outcome) {
+        return outcome.is_not_supported() || outcome.is_capacity_limit_exceeded();
+    };
+    if (!status.ok() && !can_fallback_identical(status)) return status;
+    ASSIGN_OR_RETURN(const auto split_schema, materialize_sort_key_schema(tablet_metadata->schema()));
+    const bool separate_sort = split_schema->keys_type() == PRIMARY_KEYS && split_schema->has_separate_sort_key();
+    if (separate_sort && ((tablet_metadata->has_dcg_meta() && !tablet_metadata->dcg_meta().dcgs().empty()) ||
+                          (tablet_metadata->has_idg_meta() && !tablet_metadata->idg_meta().idgs().empty()))) {
         return Status::NotSupported("range-tablet split with ORDER BY != PK does not support DCG or IDG yet");
     }
+    const bool is_external_boundaries = splitting_tablet.new_tablet_ranges_size() > 0;
+    std::vector<TabletRangeInfo> split_ranges;
+    std::vector<RowsetOwnership> ownership;
+    std::vector<bool> prunable;
+    RowsetEmissionMask emission;
 
-    // Flush the old tablet's PK-index memtable into sstables before propagating
-    // metadata to the new tablets, so every new tablet inherits an sstable_meta that
-    // already covers its rowsets' live data. This is the pre-split half of
-    // the "reshard inputs must have full sstable coverage" invariant; merge
-    // does the post-split half in merge_sstables.
+    // Paths 1/2 finish range validation and projection against the input metadata.
+    // Path 3 validates source coordinates/stats here but needs the flushed PK SSTs.
+    if (is_external_boundaries && splitting_tablet.new_tablet_ranges_size() != splitting_tablet.new_tablet_ids_size()) {
+        return Status::InvalidArgument("new_tablet_ranges count does not match new_tablet_ids");
+    }
+    if (status.ok() && (is_external_boundaries || !separate_sort)) {
+        if (is_external_boundaries) {
+            status = compute_split_ranges_from_external_boundaries_impl(
+                    tablet_manager, tablet_metadata, splitting_tablet.new_tablet_ranges(), &split_ranges, &budget);
+        } else {
+            status = get_tablet_split_ranges_impl(tablet_manager, tablet_metadata,
+                                                  splitting_tablet.new_tablet_ids_size(), &split_ranges,
+                                                  txn_info.colocate_column_count(), &budget);
+        }
+        if (status.ok()) {
+            status = prepare_split_projection(*tablet_metadata, &budget, &split_ranges, &ownership, &prunable,
+                                              &emission);
+        }
+    }
+    if (!status.ok() && !can_fallback_identical(status)) return status;
+
+    // Exactly one required flush, including typed no-split outcomes. Identical
+    // fallback must inherit this flushed metadata rather than the input snapshot.
+    TEST_SYNC_POINT_CALLBACK("tablet_splitter:pk_flush", nullptr);
     ASSIGN_OR_RETURN(TabletMetadataPtr old_tablet_metadata,
                      tablet_manager->update_mgr()->flush_pk_memtable(tablet_metadata, new_version));
-
-    // Dispatch on FE-supplied new_tablet_ranges. When set, FE has computed the K-1 boundaries
-    // externally and BE computes per-rowset stats only. Otherwise ORDER BY != PK tablets sample
-    // their cloud-native PK-index SSTs; tablets whose physical order is the range key keep using
-    // the segment-driven boundary search.
-    //
-    // Symmetric identical-fallback: either path's non-OK Status routes through
-    // make_identical_new_tablet_metadata to produce a single identical new
-    // tablet that inherits the old tablet's data. Distinct bvar counters distinguish
-    // the failure root cause for ops alerting.
-    std::vector<TabletRangeInfo> split_ranges;
-    // colocate_column_count is carried at the txn level (single split job = single txn) since
-    // every SplittingTabletInfoPB in the same job would carry the same value. See lake_types.proto.
-    // External-boundaries path skips boundary computation entirely (FE-supplied), so it does not consume the
-    // colocate_column_count signal.
-    const bool is_external_boundaries = splitting_tablet.new_tablet_ranges_size() > 0;
-    // For external boundaries, FE supplies two parallel lists (new_tablet_ids and new_tablet_ranges);
-    // they must agree in size, since downstream code zips them per index.
-    Status status;
-    if (is_external_boundaries && splitting_tablet.new_tablet_ranges_size() != splitting_tablet.new_tablet_ids_size()) {
-        status = Status::InvalidArgument(fmt::format("new_tablet_ranges.size={} != new_tablet_ids.size={}",
-                                                     splitting_tablet.new_tablet_ranges_size(),
-                                                     splitting_tablet.new_tablet_ids_size()));
-    } else if (is_external_boundaries) {
-        status = compute_split_ranges_from_external_boundaries(tablet_manager, old_tablet_metadata,
-                                                               splitting_tablet.new_tablet_ranges(), &split_ranges);
-    } else if (split_schema->keys_type() == KeysType::PRIMARY_KEYS && split_schema->has_separate_sort_key()) {
+    if (status.ok() && !is_external_boundaries && separate_sort) {
         status = get_tablet_split_ranges_from_pk_index_impl(tablet_manager, old_tablet_metadata,
                                                             splitting_tablet.new_tablet_ids_size(), &split_ranges,
-                                                            txn_info.colocate_column_count());
-    } else {
-        status = get_tablet_split_ranges(tablet_manager, old_tablet_metadata, splitting_tablet.new_tablet_ids_size(),
-                                         &split_ranges, txn_info.colocate_column_count());
+                                                            txn_info.colocate_column_count(), &budget);
+        if (status.ok()) {
+            status = prepare_split_projection(*old_tablet_metadata, &budget, &split_ranges, &ownership, &prunable,
+                                              &emission);
+        }
     }
+    if (!status.ok() && !can_fallback_identical(status)) return status;
     if (!status.ok()) {
         if (is_external_boundaries) {
             g_tablet_reshard_split_external_boundaries_fallback_total << 1;
@@ -2198,7 +2184,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> split_tablet(
     }
 
     return build_new_tablets_from_split_ranges(old_tablet_metadata, splitting_tablet, new_version, txn_info,
-                                               split_ranges);
+                                               split_ranges, ownership, prunable, emission);
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -766,6 +766,8 @@ static StatusOr<RangeSplitResult> calculate_range_split_boundaries_impl(
 static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
                                                const TabletSchema& tablet_schema,
                                                std::vector<SegmentSplitInfo>* segments);
+static bool rowset_has_sampleless_segment(const RowsetMetadataPB& rowset);
+static bool rowset_schema_resolves_to_valid_id(const TabletMetadataPB& tablet_metadata, uint32_t rowset_id);
 
 namespace {
 
@@ -882,18 +884,24 @@ Status validate_split_inputs(const TabletMetadataPB& source, SplitMetadataVisitB
     return fallback;
 }
 
-// Count-only reshard planning consumes metadata once per immutable physical slice.
-// The public segment loader retains its full-index sampling contract.
+// Count-only reshard planning samples each immutable physical slice once. Preserve
+// the existing loader's opportunistic full-index sampling and metadata fallback,
+// but charge the shared SPLIT budget before opens and full-key sample decoding.
 Status build_unique_boundary_segments(TabletManager* tablet_manager, const TabletMetadataPtr& metadata,
                                       const TabletSchema& schema, SplitMetadataVisitBudget* budget,
                                       std::vector<SegmentSplitInfo>* segments) {
     TEST_SYNC_POINT_CALLBACK("tablet_splitter:boundary_planner", nullptr);
     ASSIGN_OR_RETURN(const auto projection, SortKeyProjection::create(schema));
     PhysicalSlices slices;
-    for (const auto& rowset : metadata->rowsets()) {
-        RETURN_IF_ERROR(budget->consume(1, "boundary rowset"));
-        for (const auto& sm : rowset.segment_metas()) {
-            RETURN_IF_ERROR(budget->consume(1 + sm.deprecated_sort_key_samples_size(), "boundary segment samples"));
+    for (int rowset_index = 0; rowset_index < metadata->rowsets_size(); ++rowset_index) {
+        const auto& rowset = metadata->rowsets(rowset_index);
+        RETURN_IF_ERROR(budget->consume(1 + rowset.segment_metas_size(), "boundary rowset and segment declarations"));
+        const bool may_load = tablet_manager != nullptr && rowset_has_sampleless_segment(rowset) &&
+                              rowset_schema_resolves_to_valid_id(*metadata, rowset.id());
+        TabletSchemaPtr historical_schema;
+        for (int meta_pos = 0; meta_pos < rowset.segment_metas_size(); ++meta_pos) {
+            const auto& sm = rowset.segment_metas(meta_pos);
+            RETURN_IF_ERROR(budget->consume(sm.deprecated_sort_key_samples_size(), "boundary metadata samples"));
             if (sm.num_rows() < 0 || sm.size() < 0) {
                 return Status::Corruption("tablet split has negative physical segment statistics");
             }
@@ -904,7 +912,39 @@ Status build_unique_boundary_segments(TabletManager* tablet_manager, const Table
             RETURN_IF_ERROR(segment.max_key.from_proto(sm.sort_key_max()));
             segment.num_rows = sm.num_rows();
             segment.data_size = sm.size();
-            RETURN_IF_ERROR(segment.load_sort_key_samples(sm));
+            bool loaded_full_samples = false;
+            if (may_load) {
+                RETURN_IF_ERROR(budget->consume(1, "boundary segment open"));
+                if (historical_schema == nullptr) {
+                    historical_schema = Rowset(tablet_manager, metadata, rowset_index, 0).tablet_schema();
+                }
+                FileInfo file_info{.path = tablet_manager->segment_location(metadata->id(), sm.filename())};
+                if (sm.has_size()) file_info.size = sm.size();
+                if (sm.has_bundle_file_offset()) file_info.bundle_file_offset = sm.bundle_file_offset();
+                if (sm.has_encryption_meta()) file_info.encryption_meta = sm.encryption_meta();
+                const int segment_id = sm.has_segment_idx() ? sm.segment_idx() : meta_pos;
+                TEST_SYNC_POINT_CALLBACK("tablet_splitter:segment_open", nullptr);
+                auto opened = tablet_manager->load_segment(file_info, segment_id, LakeIOOptions{},
+                                                           /*fill_meta_cache=*/false, historical_schema);
+                if (opened.ok()) {
+                    RETURN_IF_ERROR(budget->consume(1, "boundary short-key index"));
+                    if (opened.value()->load_index().ok() && opened.value()->has_full_sort_key_index_page()) {
+                        // Full-page geometry is validated against the legacy index.
+                        // Charge that known bound before loading/decoding the full page.
+                        const size_t item_count = opened.value()->decoder()->num_items();
+                        RETURN_IF_ERROR(budget->consume(std::max<size_t>(1, item_count), "boundary full-key samples"));
+                        if (opened.value()->ensure_full_sort_key_index_usable()) {
+                            const auto rowset_schema = ChunkHelper::convert_schema(historical_schema);
+                            ASSIGN_OR_RETURN(loaded_full_samples, segment.load_samples_from_short_key_index(
+                                                                          *opened.value(), rowset_schema,
+                                                                          historical_schema->sort_key_idxes()));
+                        }
+                    }
+                }
+                // Missing/legacy/unusable optional index data retains the existing
+                // metadata/coarse fallback. Outward loader statuses still propagate.
+            }
+            if (!loaded_full_samples) RETURN_IF_ERROR(segment.load_sort_key_samples(sm));
             projection.project(&segment.min_key);
             projection.project(&segment.max_key);
             for (auto& sample : segment.sort_key_samples) projection.project(&sample);

--- a/be/src/storage/lake/tablet_splitter.cpp
+++ b/be/src/storage/lake/tablet_splitter.cpp
@@ -852,6 +852,9 @@ Status validate_split_inputs(const TabletMetadataPB& source, SplitMetadataVisitB
         bool first = true;
         for (const auto& segment : rowset.segment_metas()) {
             RETURN_IF_ERROR(budget->consume(segment.deprecated_sort_key_samples_size(), "source metadata samples"));
+            if (!segment.has_num_rows()) {
+                fallback = Status::NotSupported("tablet split segment row count is absent");
+            }
             if (!segment.has_segment_idx()) {
                 fallback = Status::NotSupported("tablet split segment index is absent");
             } else {
@@ -905,6 +908,7 @@ Status build_unique_boundary_segments(TabletManager* tablet_manager, const Table
             }
             ASSIGN_OR_RETURN(bool inserted, insert_physical_slice(sm, &slices));
             if (!inserted) continue;
+            if (sm.has_num_rows() && sm.num_rows() == 0) continue;
             SegmentSplitInfo segment;
             RETURN_IF_ERROR(segment.min_key.from_proto(sm.sort_key_min()));
             RETURN_IF_ERROR(segment.max_key.from_proto(sm.sort_key_max()));
@@ -1516,21 +1520,8 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
         if (std::none_of(emit.begin(), emit.end(), [](bool value) { return value; })) {
             return Status::Corruption("tablet split rowset has no emitted child");
         }
-        bool zero_row_replay = anchor.num_rows == 0 && anchor.num_dels == 0 && anchor.data_size > 0 &&
-                               rowset.del_files_size() > 0 && rowset.segment_metas_size() > 0;
-        if (zero_row_replay) {
-            for (const auto& segment : rowset.segment_metas()) {
-                RETURN_IF_ERROR(budget->consume(1, "projector zero-row replay classification"));
-                if (!segment.has_num_rows() || segment.num_rows() != 0 || segment.sort_key_min().values_size() != 0 ||
-                    segment.sort_key_max().values_size() != 0) {
-                    zero_row_replay = false;
-                    break;
-                }
-            }
-        }
-        if (separate_sort || rowset.segment_metas_size() == 0 || zero_row_replay) {
+        if (separate_sort || rowset.segment_metas_size() == 0) {
             for (size_t c = 0; c < child_count; ++c) row_weights[c] = byte_weights[c] = emit[c] ? 1 : 0;
-            if (zero_row_replay) std::fill(row_weights.begin(), row_weights.end(), 0);
         } else {
             // Only this rowset's segment/sample weights are live. Include sinks outside
             // its effective range, so clipping never donates out-of-range samples to a child.
@@ -1538,6 +1529,7 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
             for (const auto& sm : rowset.segment_metas()) {
                 RETURN_IF_ERROR(
                         budget->consume(1 + sm.deprecated_sort_key_samples_size(), "projector segment samples"));
+                if (sm.has_num_rows() && sm.num_rows() == 0) continue;
                 SegmentSplitInfo segment;
                 RETURN_IF_ERROR(segment.min_key.from_proto(sm.sort_key_min()));
                 RETURN_IF_ERROR(segment.max_key.from_proto(sm.sort_key_max()));
@@ -1549,73 +1541,81 @@ Status project_rowset_stats(const TabletMetadataPB& source, const std::vector<Ta
                 for (auto& sample : segment.sort_key_samples) projection.project(&sample);
                 segments.push_back(std::move(segment));
             }
-            VariantTuple lo = segments.front().min_key, hi = segments.front().max_key;
-            for (const auto& segment : segments) {
-                if (segment.min_key.compare(lo) < 0) lo = segment.min_key;
-                if (segment.max_key.compare(hi) > 0) hi = segment.max_key;
-            }
-            RETURN_IF_ERROR(budget->consume(2, "projector envelope"));
-            std::vector<VariantTuple> cuts{lo, hi};
-            auto add_cut = [&](const VariantTuple& cut) -> Status {
-                if (cut.compare(lo) > 0 && cut.compare(hi) < 0) {
-                    RETURN_IF_ERROR(budget->consume(1, "projector cut"));
-                    cuts.push_back(cut);
+            if (segments.empty()) {
+                for (size_t c = 0; c < child_count; ++c) row_weights[c] = byte_weights[c] = emit[c] ? 1 : 0;
+            } else {
+                VariantTuple lo = segments.front().min_key, hi = segments.front().max_key;
+                for (const auto& segment : segments) {
+                    if (segment.min_key.compare(lo) < 0) lo = segment.min_key;
+                    if (segment.max_key.compare(hi) > 0) hi = segment.max_key;
                 }
-                return Status::OK();
-            };
-            if (!effective.is_minimum()) RETURN_IF_ERROR(add_cut(effective.lower_bound()));
-            if (!effective.is_maximum()) RETURN_IF_ERROR(add_cut(effective.upper_bound()));
-            for (const auto& range : parsed_ranges) {
-                if (!range.is_minimum()) RETURN_IF_ERROR(add_cut(range.lower_bound()));
-                if (!range.is_maximum()) RETURN_IF_ERROR(add_cut(range.upper_bound()));
-            }
-            std::sort(cuts.begin(), cuts.end());
-            cuts.erase(std::unique(cuts.begin(), cuts.end()), cuts.end());
-            std::vector<RangeInfo> distribution;
-            std::vector<int> destinations;
-            const size_t interval_count = std::max<size_t>(1, cuts.size() - 1);
-            for (size_t i = 0; i < interval_count; ++i) {
-                auto& range = distribution.emplace_back();
-                range.min = cuts[i];
-                range.max = cuts[std::min(i + 1, cuts.size() - 1)];
-                int destination = -1;
+                RETURN_IF_ERROR(budget->consume(2, "projector envelope"));
+                std::vector<VariantTuple> cuts{lo, hi};
+                auto add_cut = [&](const VariantTuple& cut) -> Status {
+                    if (cut.compare(lo) > 0 && cut.compare(hi) < 0) {
+                        RETURN_IF_ERROR(budget->consume(1, "projector cut"));
+                        cuts.push_back(cut);
+                    }
+                    return Status::OK();
+                };
+                if (!effective.is_minimum()) RETURN_IF_ERROR(add_cut(effective.lower_bound()));
+                if (!effective.is_maximum()) RETURN_IF_ERROR(add_cut(effective.upper_bound()));
+                for (const auto& range : parsed_ranges) {
+                    if (!range.is_minimum()) RETURN_IF_ERROR(add_cut(range.lower_bound()));
+                    if (!range.is_maximum()) RETURN_IF_ERROR(add_cut(range.upper_bound()));
+                }
+                std::sort(cuts.begin(), cuts.end());
+                cuts.erase(std::unique(cuts.begin(), cuts.end()), cuts.end());
+                std::vector<RangeInfo> distribution;
+                std::vector<int> destinations;
+                const size_t interval_count = std::max<size_t>(1, cuts.size() - 1);
+                for (size_t i = 0; i < interval_count; ++i) {
+                    auto& range = distribution.emplace_back();
+                    range.min = cuts[i];
+                    range.max = cuts[std::min(i + 1, cuts.size() - 1)];
+                    int destination = -1;
+                    for (size_t c = 0; c < child_count; ++c) {
+                        RETURN_IF_ERROR(budget->consume(1, "projector interval intersection"));
+                        if (emit[c] && effective.contains(range.min) && parsed_ranges[c].contains(range.min)) {
+                            destination = c;
+                            break;
+                        }
+                    }
+                    destinations.push_back(destination);
+                }
+                // The physical maximum can itself belong to the next child (or to a
+                // sink at an excluded parent edge). Give that point its own last bucket
+                // only when its owner differs, preserving the ordinary interval weights.
+                int endpoint_destination = -1;
                 for (size_t c = 0; c < child_count; ++c) {
-                    RETURN_IF_ERROR(budget->consume(1, "projector interval intersection"));
-                    if (emit[c] && effective.contains(range.min) && parsed_ranges[c].contains(range.min)) {
-                        destination = c;
+                    RETURN_IF_ERROR(budget->consume(1, "projector endpoint intersection"));
+                    if (emit[c] && effective.contains(hi) && parsed_ranges[c].contains(hi)) {
+                        endpoint_destination = c;
                         break;
                     }
                 }
-                destinations.push_back(destination);
-            }
-            // The physical maximum can itself belong to the next child (or to a
-            // sink at an excluded parent edge). Give that point its own last bucket
-            // only when its owner differs, preserving the ordinary interval weights.
-            int endpoint_destination = -1;
-            for (size_t c = 0; c < child_count; ++c) {
-                RETURN_IF_ERROR(budget->consume(1, "projector endpoint intersection"));
-                if (emit[c] && effective.contains(hi) && parsed_ranges[c].contains(hi)) {
-                    endpoint_destination = c;
-                    break;
+                if (endpoint_destination != destinations.back()) {
+                    RETURN_IF_ERROR(budget->consume(1, "projector endpoint bucket"));
+                    auto& endpoint = distribution.emplace_back();
+                    endpoint.min = hi;
+                    endpoint.max = hi;
+                    destinations.push_back(endpoint_destination);
                 }
-            }
-            if (endpoint_destination != destinations.back()) {
-                RETURN_IF_ERROR(budget->consume(1, "projector endpoint bucket"));
-                auto& endpoint = distribution.emplace_back();
-                endpoint.min = hi;
-                endpoint.max = hi;
-                destinations.push_back(endpoint_destination);
-            }
-            for (const auto& segment : segments) {
-                RETURN_IF_ERROR(distribute_segment_to_ranges(segment, distribution, false, budget));
-            }
-            for (size_t i = 0; i < distribution.size(); ++i) {
-                if (destinations[i] < 0) continue;
-                row_weights[destinations[i]] += distribution[i].num_rows;
-                byte_weights[destinations[i]] += distribution[i].data_size;
+                for (const auto& segment : segments) {
+                    RETURN_IF_ERROR(distribute_segment_to_ranges(segment, distribution, false, budget));
+                }
+                for (size_t i = 0; i < distribution.size(); ++i) {
+                    if (destinations[i] < 0) continue;
+                    row_weights[destinations[i]] += distribution[i].num_rows;
+                    byte_weights[destinations[i]] += distribution[i].data_size;
+                }
             }
         }
         const auto positive = [](int64_t weight) { return weight > 0; };
+        if (anchor.data_size > 0 && std::none_of(byte_weights.begin(), byte_weights.end(), positive) &&
+            std::any_of(row_weights.begin(), row_weights.end(), positive)) {
+            byte_weights = row_weights;
+        }
         const bool zero_row_weight =
                 anchor.num_rows > 0 && std::none_of(row_weights.begin(), row_weights.end(), positive);
         const bool zero_byte_weight =
@@ -1805,6 +1805,7 @@ StatusOr<std::unordered_map<int64_t, MutableTabletMetadataPtr>> build_new_tablet
 // is skipped. A rowset with no segments returns false (nothing to open).
 static bool rowset_has_sampleless_segment(const RowsetMetadataPB& rowset) {
     for (const auto& segment_meta : rowset.segment_metas()) {
+        if (segment_meta.has_num_rows() && segment_meta.num_rows() == 0) continue;
         if (segment_meta.deprecated_sort_key_samples_size() == 0) return true;
     }
     return false;
@@ -1906,6 +1907,7 @@ static Status build_segments_from_rowsets_impl(TabletManager* tablet_manager, co
 
         for (int meta_pos = 0; meta_pos < rowset_meta.segment_metas_size(); ++meta_pos) {
             const auto& segment_meta = rowset_meta.segment_metas(meta_pos);
+            if (segment_meta.has_num_rows() && segment_meta.num_rows() == 0) continue;
             SegmentSplitInfo segment;
             segment.source_id = rowset_meta.id();
             RETURN_IF_ERROR(segment.min_key.from_proto(segment_meta.sort_key_min()));
@@ -2013,6 +2015,7 @@ bool can_prune_rowset_segments(const RowsetMetadataPB& rowset, size_t sort_key_a
     // travel with it), so a bundled rowset prunes uniformly with any other — no separate
     // parallel-array shape check is needed.
     for (const auto& segment_meta : rowset.segment_metas()) {
+        if (!segment_meta.has_num_rows() || segment_meta.num_rows() == 0) return false;
         if (!segment_meta.has_sort_key_min() || !segment_meta.has_sort_key_max()) return false;
         // (c) those bounds must be comparable with the new tablets' ranges, which are at the
         // CURRENT sort-key arity. A rowset written before a metadata-only trailing sort-key ADD

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -117,6 +117,7 @@ struct RangeSplitResult {
 //
 // Returns RangeSplitResult with boundaries and per-range estimates, or empty boundaries if
 // splitting is not possible (e.g., not enough data or segments).
+// This generic calculator is unlimited. SPLIT operations use a separate bounded internal path.
 //
 // colocate_column_count > 0 enables colocate-aware boundary canonicalization: when the
 // selected boundary crosses a colocate-prefix transition between adjacent candidate ranges,
@@ -177,9 +178,9 @@ struct TabletRangeInfo {
 // testing (parity comparison with the external-boundaries path); the production call site
 // is in split_tablet().
 //
-// `tablet_manager` is only dereferenced by build_rowset_anchor's primary-key
-// delvec fallback. For tests using DUP_KEYS metadata with num_dels populated
-// directly, `tablet_manager` may be nullptr.
+// Uses unique physical segment metadata for boundaries, then projects each rowset's
+// recorded statistics onto eligible children. This metadata-only helper accepts a null manager
+// and applies the SPLIT metadata-visit budget; it does not load segment or delvec files.
 Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
                                int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
                                int32_t colocate_column_count = 0);
@@ -201,9 +202,8 @@ Status get_tablet_split_ranges_from_pk_index_samples(TabletManager* tablet_manag
 // distribution. Exposed for unit testing of the validation paths; the
 // production call site is in split_tablet().
 //
-// `tablet_manager` is only dereferenced when the old tablet has rowsets
-// (build_rowset_anchor at step 9). For empty-tablet validation tests
-// `tablet_manager` may be nullptr.
+// Skips boundary planning entirely. Projection uses metadata-only weights, or uniform
+// eligible-child weights for separate-sort PK and segmentless rowsets. The manager may be null.
 Status compute_split_ranges_from_external_boundaries(
         TabletManager* tablet_manager, const TabletMetadataPtr& old_tablet_metadata,
         const google::protobuf::RepeatedPtrField<TabletRangePB>& external_ranges,

--- a/be/src/storage/lake/tablet_splitter.h
+++ b/be/src/storage/lake/tablet_splitter.h
@@ -178,9 +178,9 @@ struct TabletRangeInfo {
 // testing (parity comparison with the external-boundaries path); the production call site
 // is in split_tablet().
 //
-// Uses unique physical segment metadata for boundaries, then projects each rowset's
-// recorded statistics onto eligible children. This metadata-only helper accepts a null manager
-// and applies the SPLIT metadata-visit budget; it does not load segment or delvec files.
+// Uses unique physical segments for boundaries, then projects each rowset's recorded
+// statistics onto eligible children. With a manager it may sample on-disk full sort-key
+// indexes under the SPLIT metadata-visit budget; null uses metadata only. Delvecs are not read.
 Status get_tablet_split_ranges(TabletManager* tablet_manager, const TabletMetadataPtr& tablet_metadata,
                                int32_t split_count, std::vector<TabletRangeInfo>* split_ranges,
                                int32_t colocate_column_count = 0);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -167,6 +167,7 @@ protected:
         segment_meta->mutable_sort_key_min()->CopyFrom(generate_sort_key(lower_key));
         segment_meta->mutable_sort_key_max()->CopyFrom(generate_sort_key(upper_key - 1));
         segment_meta->set_num_rows(10);
+        segment_meta->set_segment_idx(0);
 
         auto* range = metadata->mutable_range();
         range->mutable_lower_bound()->CopyFrom(generate_sort_key(lower_key));
@@ -197,6 +198,7 @@ protected:
         segment_meta->mutable_sort_key_min()->CopyFrom(generate_sort_key(lower_key));
         segment_meta->mutable_sort_key_max()->CopyFrom(generate_sort_key(upper_key - 1));
         segment_meta->set_num_rows(10);
+        segment_meta->set_segment_idx(0);
 
         auto* range = metadata->mutable_range();
         range->mutable_lower_bound()->CopyFrom(generate_sort_key(lower_key));
@@ -237,10 +239,13 @@ protected:
             sort_key += 100;
             segment_meta->mutable_sort_key_max()->CopyFrom(generate_sort_key(sort_key));
             segment_meta->set_num_rows(100);
+            segment_meta->set_segment_idx(i);
         }
-        log.mutable_op_write()->mutable_rowset()->set_data_size(data_size);
-        log.mutable_op_write()->mutable_rowset()->set_num_rows(num_rows);
-        log.mutable_op_write()->mutable_rowset()->set_overlapped(num_segments > 1);
+        auto* rowset = log.mutable_op_write()->mutable_rowset();
+        rowset->set_data_size(data_size);
+        rowset->set_num_rows(num_rows);
+        rowset->set_overlapped(num_segments > 1);
+        lake::tablet_reshard_helper::ensure_rowset_uid(rowset);
         return log;
     }
 
@@ -266,12 +271,15 @@ protected:
             segment_meta->mutable_sort_key_min()->CopyFrom(generate_sort_key(min_keys[i]));
             segment_meta->mutable_sort_key_max()->CopyFrom(generate_sort_key(max_keys[i]));
             segment_meta->set_num_rows(segment_num_rows[i]);
+            segment_meta->set_segment_idx(i);
             total_rows += segment_num_rows[i];
             total_size += segment_sizes[i];
         }
-        log.mutable_op_write()->mutable_rowset()->set_data_size(total_size);
-        log.mutable_op_write()->mutable_rowset()->set_num_rows(total_rows);
-        log.mutable_op_write()->mutable_rowset()->set_overlapped(min_keys.size() > 1);
+        auto* rowset = log.mutable_op_write()->mutable_rowset();
+        rowset->set_data_size(total_size);
+        rowset->set_num_rows(total_rows);
+        rowset->set_overlapped(min_keys.size() > 1);
+        lake::tablet_reshard_helper::ensure_rowset_uid(rowset);
         return log;
     }
 
@@ -1508,6 +1516,8 @@ TEST_F(LakeServiceTest, test_splitting_tablet_pk_with_delvec_stats) {
     rowset->set_overlapped(false);
     rowset->set_num_rows(150);
     rowset->set_data_size(1500);
+    rowset->set_num_dels(50);
+    lake::tablet_reshard_helper::ensure_rowset_uid(rowset);
 
     auto* segment_meta0 = rowset->add_segment_metas();
     segment_meta0->set_filename("seg_0");
@@ -1515,6 +1525,7 @@ TEST_F(LakeServiceTest, test_splitting_tablet_pk_with_delvec_stats) {
     segment_meta0->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
     segment_meta0->mutable_sort_key_max()->CopyFrom(generate_sort_key(50));
     segment_meta0->set_num_rows(100);
+    segment_meta0->set_segment_idx(0);
 
     auto* segment_meta1 = rowset->add_segment_metas();
     segment_meta1->set_filename("seg_1");
@@ -1522,6 +1533,7 @@ TEST_F(LakeServiceTest, test_splitting_tablet_pk_with_delvec_stats) {
     segment_meta1->mutable_sort_key_min()->CopyFrom(generate_sort_key(100));
     segment_meta1->mutable_sort_key_max()->CopyFrom(generate_sort_key(150));
     segment_meta1->set_num_rows(50);
+    segment_meta1->set_segment_idx(1);
 
     _tablet_id = metadata->id();
     auto tablet = std::make_shared<lake::Tablet>(_tablet_mgr, _tablet_id);
@@ -1550,6 +1562,9 @@ TEST_F(LakeServiceTest, test_splitting_tablet_pk_with_delvec_stats) {
     builder.append_delvec(ndv1, rowset->id() + 1);
 
     ASSERT_OK(builder.finalize(next_id()));
+    ASSIGN_OR_ABORT(auto persisted_metadata, _tablet_mgr->get_tablet_metadata(_tablet_id, metadata->version()));
+    ASSERT_TRUE(persisted_metadata->rowsets(0).has_num_dels());
+    ASSERT_EQ(50, persisted_metadata->rowsets(0).num_dels());
 
     ReshardingTabletInfoPB resharding_tablet_info;
     auto* splitting_tablet_info = resharding_tablet_info.mutable_splitting_tablet_info();
@@ -1592,9 +1607,8 @@ TEST_F(LakeServiceTest, test_splitting_tablet_pk_with_delvec_stats) {
     }
     EXPECT_EQ(150, total_rows);
     EXPECT_EQ(1500, total_size);
-    // Parent had 40 deletes on seg_0 and 10 on seg_1 = 50 total. The split reads those
-    // through UpdateManager::get_rowset_num_deletes (num_dels unset on the parent rowset)
-    // and the largest-remainder allocator must conserve the sum.
+    // Parent had 40 deletes on seg_0 and 10 on seg_1 = 50 total. Current publish materializes
+    // that rowset-level anchor, and the largest-remainder allocator must conserve the sum.
     EXPECT_EQ(50, total_num_dels);
 }
 
@@ -1754,10 +1768,13 @@ TEST_F(LakeServiceTest, test_publish_merging_tablet) {
                       generate_sort_key(100).SerializeAsString());
             ASSERT_TRUE(new_metadata->rowsets(0).has_range());
             ASSERT_TRUE(new_metadata->rowsets(1).has_range());
-            EXPECT_EQ(new_metadata->rowsets(0).range().SerializeAsString(),
-                      old_metadata_1->range().SerializeAsString());
-            EXPECT_EQ(new_metadata->rowsets(1).range().SerializeAsString(),
-                      old_metadata_2->range().SerializeAsString());
+            std::set<std::string> actual_ranges;
+            for (const auto& rowset : new_metadata->rowsets()) {
+                actual_ranges.insert(rowset.range().SerializeAsString());
+            }
+            EXPECT_EQ((std::set<std::string>{old_metadata_1->range().SerializeAsString(),
+                                             old_metadata_2->range().SerializeAsString()}),
+                      actual_ranges);
         }
 
         {
@@ -1788,9 +1805,12 @@ TEST_F(LakeServiceTest, test_publish_merging_tablet) {
         seg_meta1->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
         seg_meta1->mutable_sort_key_max()->CopyFrom(generate_sort_key(10));
         seg_meta1->set_num_rows(10);
-        log1.mutable_op_write()->mutable_rowset()->set_data_size(100);
-        log1.mutable_op_write()->mutable_rowset()->set_num_rows(10);
-        log1.mutable_op_write()->mutable_rowset()->set_overlapped(false);
+        seg_meta1->set_segment_idx(0);
+        auto* rowset1 = log1.mutable_op_write()->mutable_rowset();
+        rowset1->set_data_size(100);
+        rowset1->set_num_rows(10);
+        rowset1->set_overlapped(false);
+        lake::tablet_reshard_helper::ensure_rowset_uid(rowset1);
         ASSERT_OK(_tablet_mgr->put_txn_log(log1));
 
         TxnLog log2;
@@ -1803,9 +1823,12 @@ TEST_F(LakeServiceTest, test_publish_merging_tablet) {
         seg_meta2->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
         seg_meta2->mutable_sort_key_max()->CopyFrom(generate_sort_key(60));
         seg_meta2->set_num_rows(10);
-        log2.mutable_op_write()->mutable_rowset()->set_data_size(100);
-        log2.mutable_op_write()->mutable_rowset()->set_num_rows(10);
-        log2.mutable_op_write()->mutable_rowset()->set_overlapped(false);
+        seg_meta2->set_segment_idx(0);
+        auto* rowset2 = log2.mutable_op_write()->mutable_rowset();
+        rowset2->set_data_size(100);
+        rowset2->set_num_rows(10);
+        rowset2->set_overlapped(false);
+        lake::tablet_reshard_helper::ensure_rowset_uid(rowset2);
         ASSERT_OK(_tablet_mgr->put_txn_log(log2));
 
         publish_request.add_txn_ids(txn_id);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -189,6 +189,7 @@ protected:
         rowset->set_overlapped(false);
         rowset->set_num_rows(10);
         rowset->set_data_size(100);
+        rowset->set_num_dels(3);
         // Production rowset producers mint a uid; emulate that here so the
         // strict-uid invariant in tablet_merger holds when MERGE later runs.
         lake::tablet_reshard_helper::ensure_rowset_uid(rowset);

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -42,6 +42,7 @@
 #include "storage/lake/txn_log.h"
 #include "storage/lake/update_manager.h"
 #include "storage/storage_metrics.h"
+#include "types/type_descriptor.h"
 
 namespace starrocks::lake {
 
@@ -194,13 +195,23 @@ protected:
             auto* segment = rowset->add_segment_metas();
             segment->set_filename(fmt::format("atomic_shared_{}.dat", i));
             segment->set_size(100);
+            segment->set_num_rows(10);
+            segment->set_segment_idx(i);
             segment->set_shared(true);
         }
         return metadata;
     }
 
-    Status publish_delvec_merge(const std::vector<TabletMetadataPtr>& sources, int64_t merged_tablet, int64_t txn_id,
-                                std::unordered_map<int64_t, TabletMetadataPtr>* published_metadatas) {
+    Status publish_delvec_merge(const std::vector<std::shared_ptr<TabletMetadataPB>>& sources, int64_t merged_tablet,
+                                int64_t txn_id, std::unordered_map<int64_t, TabletMetadataPtr>* published_metadatas) {
+        CHECK_EQ(2, sources.size());
+        auto* split_key = sources[0]->mutable_range()->mutable_upper_bound()->add_values();
+        split_key->mutable_type()->CopyFrom(TypeDescriptor(TYPE_INT).to_protobuf());
+        split_key->set_value("0");
+        split_key->set_variant_type(VariantTypePB::NORMAL_VALUE);
+        sources[0]->mutable_range()->set_upper_bound_included(false);
+        sources[1]->mutable_range()->mutable_lower_bound()->CopyFrom(sources[0]->range().upper_bound());
+        sources[1]->mutable_range()->set_lower_bound_included(true);
         for (const auto& source : sources) {
             RETURN_IF_ERROR(_tablet_manager->put_tablet_metadata(source));
         }

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -1282,8 +1282,7 @@ TEST_F(LakeRowsetTest, test_zero_row_segment_positional_iterator_contracts) {
     EXPECT_TRUE(plain_iters[0]->get_next(empty_result.get()).is_end_of_file());
     EXPECT_EQ(count_rows_from_iters({plain_iters[1]}), keys.size());
 
-    ASSIGN_OR_ABORT(auto delvec_iters,
-                    rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats));
+    ASSIGN_OR_ABORT(auto delvec_iters, rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats));
     ASSERT_EQ(delvec_iters.size(), 2);
     EXPECT_EQ(delvec_iters[0], nullptr);
     ASSERT_NE(delvec_iters[1], nullptr);

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -1229,6 +1229,72 @@ TEST_F(LakeRowsetTest, test_get_each_segment_iterator_with_delvec_respects_table
     ASSERT_EQ(count_rows_from_iters(seg_iters), 3 * 2);
 }
 
+TEST_F(LakeRowsetTest, test_zero_row_segment_positional_iterator_contracts) {
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSERT_OK(writer->open());
+
+    auto empty_c0 = Int32Column::create();
+    auto empty_c1 = Int32Column::create();
+    Chunk empty_chunk({std::move(empty_c0), std::move(empty_c1)}, _schema);
+    ASSERT_OK(writer->write(empty_chunk));
+    ASSERT_OK(writer->finish());
+
+    std::vector<int> keys{1, 2, 3};
+    std::vector<int> values{10, 20, 30};
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(keys.data(), keys.size() * sizeof(int));
+    c1->append_numbers(values.data(), values.size() * sizeof(int));
+    Chunk data_chunk({std::move(c0), std::move(c1)}, _schema);
+    ASSERT_OK(writer->write(data_chunk));
+    ASSERT_OK(writer->finish());
+    ASSERT_EQ(2, writer->segments().size());
+
+    auto* rowset_meta = _tablet_metadata->add_rowsets();
+    rowset_meta->set_overlapped(true);
+    rowset_meta->set_id(next_id());
+    rowset_meta->set_num_rows(keys.size());
+    for (size_t i = 0; i < writer->segments().size(); ++i) {
+        auto* segment_meta = rowset_meta->add_segment_metas();
+        segment_meta->set_filename(writer->segments()[i].path);
+        segment_meta->set_num_rows(i == 0 ? 0 : keys.size());
+        segment_meta->set_segment_idx(i);
+        segment_meta->set_shared(true);
+    }
+    set_tablet_range_int(_tablet_metadata.get(), 1, true, 4, false);
+    writer->close();
+    _tablet_metadata->set_version(_tablet_metadata->version() + 1);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    auto rowset = std::make_shared<lake::Rowset>(_tablet_mgr.get(), _tablet_metadata, 0, 0);
+    OlapReaderStatistics stats;
+    auto input_schema = ChunkHelper::convert_schema(_tablet_schema, std::vector<ColumnId>{0, 1});
+
+    ASSIGN_OR_ABORT(auto plain_iters, rowset->get_each_segment_iterator(input_schema, false, &stats));
+    ASSERT_EQ(plain_iters.size(), 2);
+    ASSERT_NE(plain_iters[0], nullptr);
+    ASSERT_NE(plain_iters[1], nullptr);
+    ASSERT_OK(plain_iters[0]->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS));
+    ASSERT_OK(plain_iters[0]->init_output_schema(std::unordered_set<uint32_t>()));
+    auto empty_result = ChunkFactory::new_chunk(plain_iters[0]->schema(), 1024);
+    EXPECT_TRUE(plain_iters[0]->get_next(empty_result.get()).is_end_of_file());
+    EXPECT_EQ(count_rows_from_iters({plain_iters[1]}), keys.size());
+
+    ASSIGN_OR_ABORT(auto delvec_iters,
+                    rowset->get_each_segment_iterator_with_delvec(input_schema, 1, nullptr, &stats));
+    ASSERT_EQ(delvec_iters.size(), 2);
+    EXPECT_EQ(delvec_iters[0], nullptr);
+    ASSERT_NE(delvec_iters[1], nullptr);
+    EXPECT_EQ(count_rows_from_iters({delvec_iters[1]}), keys.size());
+
+    for (auto& iter : plain_iters) {
+        iter->close();
+    }
+    delvec_iters[1]->close();
+}
+
 // Test class for segment metadata filter and parallel load with skip_segment_idxs
 class LakeRowsetSegmentMetadataFilterTest : public TestBase {
 public:

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -359,7 +359,7 @@ protected:
         rowset->set_max_compact_input_rowset_id(max_compact_input_rowset_id);
         {
             auto* sm = rowset->add_segment_metas();
-            sm->set_filename("segment.dat");
+            sm->set_filename(fmt::format("segment-{}-{}.dat", metadata->id(), rowset_id));
             sm->set_size(128);
         }
         auto* del_file = rowset->add_del_files();
@@ -385,9 +385,10 @@ protected:
             }
             rowset->set_num_rows(1);
             rowset->set_data_size(128);
-            // Match production: every lake writer mints a unique uid, so distinct
-            // per-tablet data rowsets never alias across tablets at merge.
-            lake::tablet_reshard_helper::set_rowset_uid(rowset);
+            // Stable, distinct producer UIDs make order assertions follow the
+            // canonical UID key instead of the order of the source list.
+            rowset->mutable_uid()->set_hi(metadata->id());
+            rowset->mutable_uid()->set_lo(rowset_id);
             return rowset;
         }
 
@@ -406,13 +407,60 @@ protected:
         return rowset;
     }
 
+    std::vector<TabletMetadataPtr> merge_fixture_sources(const std::vector<TabletMetadataPtr>& sources) {
+        const bool assign_ranges =
+                std::all_of(sources.begin(), sources.end(), [](const auto& source) { return !source->has_range(); });
+        std::vector<int64_t> ids;
+        for (const auto& source : sources) ids.push_back(source->id());
+        std::sort(ids.begin(), ids.end());
+        std::vector<TabletMetadataPtr> result;
+        for (const auto& source : sources) {
+            auto copy = std::make_shared<TabletMetadataPB>(*source);
+            if (assign_ranges) {
+                if (copy->has_schema() && copy->schema().column_size() == 0) {
+                    auto* column = copy->mutable_schema()->add_column();
+                    column->set_unique_id(1);
+                    column->set_name("c0");
+                    column->set_type("INT");
+                    column->set_is_key(true);
+                    column->set_is_nullable(false);
+                }
+                const int position = std::lower_bound(ids.begin(), ids.end(), source->id()) - ids.begin();
+                auto* range = copy->mutable_range();
+                if (position > 0) {
+                    *range->mutable_lower_bound() = generate_sort_key(position);
+                    range->set_lower_bound_included(true);
+                }
+                if (position + 1 < ids.size()) {
+                    *range->mutable_upper_bound() = generate_sort_key(position + 1);
+                    range->set_upper_bound_included(false);
+                }
+            } else if (!source->has_range()) {
+                CHECK(source->has_range()) << "explicit merge fixtures must provide every source range";
+            }
+            result.emplace_back(std::move(copy));
+        }
+        return result;
+    }
+
+    static TabletMetadataPtr merge_fixture_copy(const TabletMetadataPB& source) {
+        return std::make_shared<TabletMetadataPB>(source);
+    }
+    static TabletMetadataPtr merge_fixture_copy(const TabletMetadataPtr& source) { return source; }
+
+    template <typename... Sources>
+    Status put_merge_sources(const Sources&... sources) {
+        for (const auto& source : merge_fixture_sources({merge_fixture_copy(sources)...})) {
+            RETURN_IF_ERROR(put_tablet_metadata(source));
+        }
+        return Status::OK();
+    }
+
     Status publish_resharding_merge(const std::vector<TabletMetadataPtr>& sources, int64_t merged_tablet,
                                     int64_t base_version, int64_t new_version, int64_t txn_id,
                                     std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
                                     const std::function<void()>& before_merge = {}) {
-        for (const auto& source : sources) {
-            RETURN_IF_ERROR(put_tablet_metadata(source));
-        }
+        for (const auto& source : merge_fixture_sources(sources)) RETURN_IF_ERROR(put_tablet_metadata(source));
         if (before_merge) before_merge();
         ReshardingTabletInfoPB resharding_tablet;
         auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -704,15 +752,22 @@ protected:
             sync->DisableProcessing();
         });
 
-        MergingTabletInfoPB merging;
-        for (const auto& source : sources) merging.add_old_tablet_ids(source->id());
-        merging.set_new_tablet_id(target_tablet_id);
+        ReshardingTabletInfoPB resharding;
+        auto* merging = resharding.mutable_merging_tablet_info();
+        for (const auto& source : merge_fixture_sources(sources)) {
+            RETURN_IF_ERROR(_tablet_manager->put_tablet_metadata(source));
+            merging->add_old_tablet_ids(source->id());
+        }
+        merging->set_new_tablet_id(target_tablet_id);
         TxnInfoPB txn_info;
         txn_info.set_txn_id(next_id());
         txn_info.set_commit_time(1);
         txn_info.set_gtid(1);
-        return lake::merge_tablet(_tablet_manager.get(), sources, merging, target_version, txn_info,
-                                  /*skip_sstable_merge=*/false);
+        std::unordered_map<int64_t, TabletMetadataPtr> published;
+        std::unordered_map<int64_t, TabletRangePB> ranges;
+        RETURN_IF_ERROR(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, sources.front()->version(),
+                                                        target_version, txn_info, false, published, ranges));
+        return std::make_shared<TabletMetadataPB>(*published.at(target_tablet_id));
     }
 
     Status expect_physical_preflight_rejection(const std::vector<TabletMetadataPtr>& sources, int64_t target_tablet_id,
@@ -720,6 +775,9 @@ protected:
         std::vector<std::string> source_pbs;
         std::map<int64_t, std::set<std::string>> segment_inventories;
         std::map<int64_t, std::set<std::string>> metadata_inventories;
+        for (const auto& source : merge_fixture_sources(sources)) {
+            CHECK_OK(_tablet_manager->put_tablet_metadata(source));
+        }
         for (const auto& source : sources) {
             prepare_tablet_dirs(source->id());
             source_pbs.emplace_back(source->SerializeAsString());
@@ -6764,7 +6822,6 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);
     add_rowset_with_predicate(&meta_a, 2, 10, true);
     add_rowset_with_predicate(&meta_a, 3, 11, false);
-    EXPECT_OK(put_tablet_metadata(meta_a));
 
     TabletMetadataPB meta_b;
     meta_b.set_id(tablet_b);
@@ -6773,7 +6830,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_reorder_by_predicate_version) {
     add_rowset_with_predicate(&meta_b, 1, 1, false);
     add_rowset_with_predicate(&meta_b, 2, 10, true);
     add_rowset_with_predicate(&meta_b, 3, 11, false);
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -6840,7 +6897,6 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_different_predicate_versions) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);  // data
     add_rowset_with_predicate(&meta_a, 2, 10, true);  // predicate v10
     add_rowset_with_predicate(&meta_a, 3, 11, false); // data
-    EXPECT_OK(put_tablet_metadata(meta_a));
 
     // Tablet B: data(v1) -> predicate(v10) -> data(v11) -> predicate(v20) -> data(v21)
     TabletMetadataPB meta_b;
@@ -6852,7 +6908,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_different_predicate_versions) {
     add_rowset_with_predicate(&meta_b, 3, 11, false); // data
     add_rowset_with_predicate(&meta_b, 4, 20, true);  // predicate v20 (only in tablet_b)
     add_rowset_with_predicate(&meta_b, 5, 21, false); // data
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -6922,7 +6978,6 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);
     add_rowset_with_predicate(&meta_a, 2, 2, false);
     add_rowset_with_predicate(&meta_a, 3, 3, false);
-    EXPECT_OK(put_tablet_metadata(meta_a));
 
     TabletMetadataPB meta_b;
     meta_b.set_id(tablet_b);
@@ -6931,7 +6986,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_no_predicates) {
     add_rowset_with_predicate(&meta_b, 1, 1, false);
     add_rowset_with_predicate(&meta_b, 2, 2, false);
     add_rowset_with_predicate(&meta_b, 3, 3, false);
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -6995,7 +7050,6 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_single_tablet_predicate) {
     add_rowset_with_predicate(&meta_a, 1, 1, false);  // data
     add_rowset_with_predicate(&meta_a, 2, 10, true);  // predicate v10
     add_rowset_with_predicate(&meta_a, 3, 11, false); // data
-    EXPECT_OK(put_tablet_metadata(meta_a));
 
     // Tablet B: data(v1) -> data(v2) -> data(v3) (no predicates)
     TabletMetadataPB meta_b;
@@ -7005,7 +7059,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_single_tablet_predicate) {
     add_rowset_with_predicate(&meta_b, 1, 1, false);
     add_rowset_with_predicate(&meta_b, 2, 2, false);
     add_rowset_with_predicate(&meta_b, 3, 3, false);
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7068,7 +7122,6 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_all_predicates) {
     meta_a.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_a, 1, 10, true); // predicate v10
     add_rowset_with_predicate(&meta_a, 2, 20, true); // predicate v20
-    EXPECT_OK(put_tablet_metadata(meta_a));
 
     // Tablet B: predicate(v10) -> predicate(v20) (same versions)
     TabletMetadataPB meta_b;
@@ -7077,7 +7130,7 @@ TEST_F(LakeTabletReshardTest, test_merge_rowsets_all_predicates) {
     meta_b.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_b, 1, 10, true); // predicate v10
     add_rowset_with_predicate(&meta_b, 2, 20, true); // predicate v20
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7155,8 +7208,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
     materialize_tombstone_sstables(meta1.get());
     materialize_tombstone_sstables(meta2.get());
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7183,7 +7235,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
         if (rowset.id() == expected_rowset_id) {
             found_rowset = true;
             ASSERT_TRUE(rowset.has_range());
-            EXPECT_EQ(rowset.range().SerializeAsString(), meta2->range().SerializeAsString());
+            EXPECT_EQ(rowset.range().SerializeAsString(),
+                      tablet_metadatas.at(old_tablet_id_2)->range().SerializeAsString());
             ASSERT_TRUE(rowset.has_max_compact_input_rowset_id());
             EXPECT_EQ(4, rowset.max_compact_input_rowset_id());
             ASSERT_EQ(1, rowset.del_files_size());
@@ -7198,7 +7251,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
         if (rowset.id() == 2) {
             found_rowset_from_meta1 = true;
             ASSERT_TRUE(rowset.has_range());
-            EXPECT_EQ(rowset.range().SerializeAsString(), meta1->range().SerializeAsString());
+            EXPECT_EQ(rowset.range().SerializeAsString(),
+                      tablet_metadatas.at(old_tablet_id_1)->range().SerializeAsString());
             break;
         }
     }
@@ -7251,8 +7305,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_basic) {
 // rowset specifically so fixtures behave like production — which means this gate is
 // otherwise never exercised. Here we bypass the wrapper (persist via _tablet_manager
 // directly) AND clear the uid that add_rowset stamps, driving a genuinely uid-less
-// rowset into merge_rowsets. The gate is DCHECK-first (fail-fast abort in debug) with
-// a Status::InternalError fallback for release, so the assertion is build-conditional.
+// rowset into the global planner, which returns Corruption before allocation or I/O.
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rowset_without_uid_fails) {
     const int64_t base_version = 1;
     const int64_t new_version = 2;
@@ -7281,6 +7334,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rowset_without_uid_fails) {
     (*meta2->mutable_rowset_to_schema())[1] = 2002;
 
     // Persist directly, bypassing the uid-auto-stamping fixture wrapper.
+    meta1->mutable_rowsets(0)->mutable_segment_metas(0)->set_segment_idx(0);
+    meta2->mutable_rowsets(0)->mutable_segment_metas(0)->set_segment_idx(0);
+    *meta1->mutable_range()->mutable_upper_bound() = generate_sort_key(1);
+    meta1->mutable_range()->set_upper_bound_included(false);
+    *meta2->mutable_range()->mutable_lower_bound() = generate_sort_key(1);
+    meta2->mutable_range()->set_lower_bound_included(true);
     ASSERT_OK(_tablet_manager->put_tablet_metadata(meta1));
     ASSERT_OK(_tablet_manager->put_tablet_metadata(meta2));
 
@@ -7299,13 +7358,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rowset_without_uid_fails) {
         return lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
                                                txn_info, false, tablet_metadatas, tablet_ranges);
     };
-#if DCHECK_IS_ON()
-    ASSERT_DEATH({ (void)do_merge(); }, "rowset reaching reshard merge must carry a valid uid");
-#else
     auto st = do_merge();
-    EXPECT_TRUE(st.is_internal_error()) << st.to_string();
-    EXPECT_NE(std::string::npos, st.to_string().find("rowset reaching reshard merge has no uid")) << st.to_string();
-#endif
+    EXPECT_TRUE(st.is_corruption()) << st;
+    EXPECT_TRUE(st.message().contains("uid")) << st;
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_without_delvec) {
@@ -7333,8 +7388,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_without_delvec) {
     set_primary_key_schema(meta2.get(), 1002);
     add_rowset(meta2.get(), 2, 2, 2);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7379,8 +7433,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_missing_delvec_meta) {
     set_primary_key_schema(meta2.get(), 1002);
     add_rowset(meta2.get(), 2, 2, 2);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7431,8 +7484,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_version_missing) {
     page.set_size(1);
     (*delvec_meta->mutable_delvecs())[2] = page;
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7479,8 +7531,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_missing_tablet_offset) 
     add_rowset(meta2.get(), 2, 2, 2);
     add_delvec(meta2.get(), old_tablet_id_2, base_version, 2, "delvec-2", "bbb");
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7523,8 +7574,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cache_miss_fallback) {
     meta2->set_next_rowset_id(5);
     add_rowset(meta2.get(), 2, 2, 2);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     auto cached_meta1 = std::make_shared<TabletMetadataPB>(*meta1);
     cached_meta1->set_version(new_version);
@@ -7585,9 +7635,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_base_version_not_found) {
     meta_new->set_next_rowset_id(5);
     meta_new->set_gtid(100);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
-    EXPECT_OK(put_tablet_metadata(meta_new));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
+    ASSERT_OK(put_tablet_metadata(meta_new));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -7660,8 +7709,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_segment_overflow) {
     add_rowset(meta2.get(), 90, 90, 90);
     add_dcg_with_columns(meta2.get(), std::numeric_limits<uint32_t>::max() - 5, "dcg-overflow", {301}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8027,8 +8075,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8056,15 +8103,11 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
     // num_rows/data_size should be accumulated from both children
     EXPECT_EQ(20, merged->rowsets(0).num_rows());
     EXPECT_EQ(200, merged->rowsets(0).data_size());
-    // These hand-built sources both claim the unbounded tablet range, so the partition proof is uncertain even
-    // though their rowsets deduplicate. The complete shared cohort is omitted and folded once; its future
-    // generation (7 > merge version 2) conservatively becomes unknown.
-    EXPECT_EQ(0, merged->sstable_meta().sstables_size());
-    ASSERT_EQ(1, merged->orphan_files_size());
-    EXPECT_EQ("shared_sst.sst", merged->orphan_files(0).name());
-    EXPECT_EQ(512, merged->orphan_files(0).size());
-    EXPECT_TRUE(merged->orphan_files(0).shared());
-    EXPECT_EQ(0, merged->orphan_files(0).version());
+    // The contiguous producer ranges prove the identical shared cohort reusable.
+    ASSERT_EQ(1, merged->sstable_meta().sstables_size());
+    EXPECT_EQ("shared_sst.sst", merged->sstable_meta().sstables(0).filename());
+    EXPECT_EQ(7, merged->sstable_meta().sstables(0).generation_version());
+    EXPECT_EQ(0, merged->orphan_files_size());
 }
 
 // The merged tablet's async vector-index build watermark must be the MIN over all
@@ -8106,8 +8149,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_vector_index_built_version_min) 
     // source[0] has the HIGHER watermark; buggy code would inherit 100 and skip child_b's unbuilt tail.
     auto meta_a = make_child(child_a, 100);
     auto meta_b = make_child(child_b, 50);
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8171,8 +8213,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_vector_index_built_version_mixed
 
     auto meta_a = make_child(child_a, /*set_built_version=*/true, 100);
     auto meta_b = make_child(child_b, /*set_built_version=*/false, 0);
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8231,8 +8272,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_vector_index_built_version_none)
 
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8307,8 +8347,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_segment_union_preserves_ownershi
         rowset->mutable_uid()->set_lo(777);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, "a_private.dat", 1)));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, "b_private.dat", 2)));
+    ASSERT_OK(put_merge_sources(make_child(child_a, "a_private.dat", 1), make_child(child_b, "b_private.dat", 2)));
 
     ReshardingTabletInfoPB resharding;
     auto& merging = *resharding.mutable_merging_tablet_info();
@@ -8405,8 +8444,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_multi_level_disjoint_all_shared_
         rowset->mutable_uid()->set_lo(2024);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, "ancestor_seg_0.dat", 0)));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, "ancestor_seg_1.dat", 1)));
+    ASSERT_OK(put_merge_sources(make_child(child_a, "ancestor_seg_0.dat", 0),
+                                make_child(child_b, "ancestor_seg_1.dat", 1)));
 
     ReshardingTabletInfoPB resharding;
     auto& merging = *resharding.mutable_merging_tablet_info();
@@ -8478,8 +8517,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_bundled_segments_union_offsets) 
         rowset->mutable_uid()->set_lo(2024);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, 0, 0, 1, 1024)));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, 2, 2048, 3, 3072)));
+    ASSERT_OK(put_merge_sources(make_child(child_a, 0, 0, 1, 1024), make_child(child_b, 2, 2048, 3, 3072)));
 
     ReshardingTabletInfoPB resharding;
     auto& merging = *resharding.mutable_merging_tablet_info();
@@ -8552,8 +8590,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_multi_level_unequal_count_all_sh
         rowset->mutable_uid()->set_lo(2025);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, {"seg_0.dat", "seg_1.dat"}, {0, 1})));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, {"seg_2.dat"}, {2})));
+    ASSERT_OK(put_merge_sources(make_child(child_a, {"seg_0.dat", "seg_1.dat"}, {0, 1}),
+                                make_child(child_b, {"seg_2.dat"}, {2})));
 
     ReshardingTabletInfoPB resharding;
     auto& merging = *resharding.mutable_merging_tablet_info();
@@ -8620,8 +8658,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_num_dels) {
     auto meta_a = make_child(child_a, /*num_rows=*/4, /*data_size=*/40, /*num_dels=*/3);
     auto meta_b = make_child(child_b, /*num_rows=*/6, /*data_size=*/60, /*num_dels=*/3);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -8719,8 +8756,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         sm->set_size(30);
     }
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -8803,8 +8839,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_compaction) {
         sm->set_shared(true);
     }
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    set_two_column_pk_schema(meta_a.get(), 1001);
+    set_two_column_pk_schema(meta_b.get(), 1001);
+    const auto shared_size = write_two_column_segment(child_b, "shared_seg.dat", 100, [](int key) { return key; });
+    shared_b->mutable_segment_metas(0)->set_size(shared_size);
+    shared_b->mutable_segment_metas(0)->set_num_rows(100);
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -8871,8 +8911,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_rowset_on_non_first_chi
         sm->set_shared(true);
     }
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -8929,8 +8968,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delete_only_shared_rowset) {
     auto meta_a = make_del_only_child(child_a);
     auto meta_b = make_del_only_child(child_b);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9000,8 +9038,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_different_split_families) {
         sm->set_shared(true);
     }
 
-    EXPECT_OK(put_tablet_metadata(meta_c));
-    EXPECT_OK(put_tablet_metadata(meta_d));
+    ASSERT_OK(put_merge_sources(meta_c, meta_d));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9074,8 +9111,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_publish_different_id) {
     }
     stamp_physical_identity_uid(rowset_b, "cross_pub.dat"); // same uid as A (cross-publish)
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9150,8 +9186,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_fail_fast) {
     // DCG from child B's different independent partial update
     add_dcg_with_columns(meta_b.get(), 1, "dcg_b.cols", {1}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9191,7 +9226,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_predicate_dedup) {
     meta_a.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_a, 1, 5, true);  // predicate v5
     add_rowset_with_predicate(&meta_a, 2, 6, false); // data v6
-    EXPECT_OK(put_tablet_metadata(meta_a));
 
     TabletMetadataPB meta_b;
     meta_b.set_id(child_b);
@@ -9199,7 +9233,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_predicate_dedup) {
     meta_b.set_next_rowset_id(3);
     add_rowset_with_predicate(&meta_b, 1, 5, true);  // same predicate v5
     add_rowset_with_predicate(&meta_b, 2, 6, false); // data v6
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    EXPECT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9267,8 +9301,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_dcg_dedup) {
     auto meta_a = make_child_with_dcg(child_a);
     auto meta_b = make_child_with_dcg(child_b);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -9403,6 +9436,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_compacts_only_live_page
     // second output must stay page-sized; a whole-object copy would reintroduce
     // the dead prefix/suffix on every remerge.
     auto split_parent = std::make_shared<TabletMetadataPB>(*merged);
+    split_parent->clear_schema();
     set_two_column_pk_schema(split_parent.get(), /*schema_id=*/1001);
     split_parent->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
     split_parent->mutable_range()->set_lower_bound_included(true);
@@ -9676,8 +9710,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_duplicate_source_metada
             auto* conflicting_file = &(*conflicting->mutable_delvec_meta()->mutable_version_to_file())[/*version=*/10];
             mismatch.apply(conflicting_file);
 
-            ASSERT_OK(put_tablet_metadata(baseline));
-            ASSERT_OK(put_tablet_metadata(conflicting));
+            ASSERT_OK(put_merge_sources(baseline, conflicting));
             ASSIGN_OR_ABORT(auto inventory_before, delvec_inventory(merged_tablet));
 
             ReshardingTabletInfoPB resharding;
@@ -9797,8 +9830,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_union_rejecte
         (*stale->mutable_delvec_meta()->mutable_version_to_file())[11].set_encryption_meta(
                 std::string(1, static_cast<char>(0xff)));
 
-        ASSERT_OK(put_tablet_metadata(plain));
-        ASSERT_OK(put_tablet_metadata(stale));
+        ASSERT_OK(put_merge_sources(plain, stale));
         ReshardingTabletInfoPB resharding;
         auto& merging = *resharding.mutable_merging_tablet_info();
         const std::vector<int64_t> sources = stale_first ? std::vector<int64_t>{stale_tablet, plain_tablet}
@@ -9999,9 +10031,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_merged_duplicate_source
             y_delvec.init(/*version=*/11, &y_deleted_rowid, 1);
             add_delvec(middle_y.get(), middle_y_tablet, /*version=*/11, /*segment_id=*/1, y_filename, y_delvec.save());
 
-            ASSERT_OK(put_tablet_metadata(baseline_x));
-            ASSERT_OK(put_tablet_metadata(middle_y));
-            ASSERT_OK(put_tablet_metadata(conflicting_x));
+            ASSERT_OK(put_merge_sources(baseline_x, middle_y, conflicting_x));
             ASSIGN_OR_ABORT(auto inventory_before, delvec_inventory(merged_tablet));
 
             ReshardingTabletInfoPB resharding;
@@ -10265,8 +10295,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_independent_delete) {
     // Delvec from child_b's different independent delete
     add_delvec(meta_b.get(), child_b, 2, 1, "delvec_b.dv", dv_b_data);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -10438,8 +10467,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_multi_target_union) {
         write_file(_tablet_manager->delvec_location(child_b, "delvec_b.dv"), combined_b);
     }
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -10551,9 +10579,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_three_way_union) {
     auto meta_b = make_child_meta(child_b, 2, "delvec_b.dv", dv_b_data);
     auto meta_c = make_child_meta(child_c, 3, "delvec_c.dv", dv_c_data);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
-    EXPECT_OK(put_tablet_metadata(meta_c));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b, meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -10653,8 +10679,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_no_independent_delete) 
     // Same file name, same offset/size -> page-ref dedup
     add_delvec(meta_b.get(), child_b, 1, 1, "shared_delvec.dv", dv_data);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -11052,8 +11077,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_target_same_base_sidecar
     TabletMetadataPB compacted(*reopened);
     compacted.set_version(reopened->version() + 1);
     ASSERT_EQ(2, compacted.rowsets_size());
-    RowsetMetadataPB retired(compacted.rowsets(0));
-    RowsetMetadataPB retained(compacted.rowsets(1));
+    const int retired_index =
+            compacted.rowsets(0).range().lower_bound().SerializeAsString() == generate_sort_key(0).SerializeAsString()
+                    ? 0
+                    : 1;
+    RowsetMetadataPB retired(compacted.rowsets(retired_index));
+    RowsetMetadataPB retained(compacted.rowsets(1 - retired_index));
     compacted.clear_rowsets();
     compacted.add_rowsets()->CopyFrom(retained);
     compacted.clear_compaction_inputs();
@@ -11449,7 +11478,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_adjacent_and_disjoint_
             EXPECT_EQ(1, counts.materialize);
             EXPECT_EQ(0, counts.dcg_writes);
             EXPECT_EQ(0, counts.delvec_writes);
-            EXPECT_EQ(0, counts.source_flushes);
+            EXPECT_EQ(2, counts.source_flushes);
         }
     }
 }
@@ -11485,7 +11514,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_uniform_bundle_presenc
             EXPECT_EQ(1, counts.materialize);
             EXPECT_EQ(0, counts.dcg_writes);
             EXPECT_EQ(0, counts.delvec_writes);
-            EXPECT_EQ(0, counts.source_flushes);
+            EXPECT_EQ(2, counts.source_flushes);
         }
     }
 }
@@ -11807,8 +11836,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns) {
     auto meta_b = make_child(child_b);
     add_dcg_with_columns(meta_b.get(), 1, "b.cols", {3, 4}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -11886,8 +11914,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup) {
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -11954,8 +11981,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_same_column_conflict) {
     auto meta_b = make_child(child_b);
     add_dcg_with_columns(meta_b.get(), 1, "b.cols", {1}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -12014,8 +12040,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_partial_overlap) {
     auto meta_b = make_child(child_b);
     add_dcg_with_columns(meta_b.get(), 1, "b.cols", {2, 3}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -12840,6 +12865,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_sstable_merge_accepts_sig
     rowset->set_num_rows(1);
     rowset->set_data_size(1);
     rowset->add_segment_metas()->set_filename("skip_source_segment.dat");
+    rowset->mutable_segment_metas(0)->set_segment_idx(0);
     lake::tablet_reshard_helper::set_rowset_uid(rowset);
     auto* sst = source->mutable_sstable_meta()->add_sstables();
     sst->set_filename("skip_sign_bit.sst");
@@ -12924,6 +12950,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_rowset_zero_before_any
             segment->set_filename(segment_name);
             segment->set_size(segment_size);
             segment->set_num_rows(kNumRows);
+            segment->set_segment_idx(0);
             segment->set_shared(true);
             stamp_physical_identity_uid(rowset, segment_name);
             (*metadata->mutable_rowset_to_schema())[rowset_id] = metadata->schema().id();
@@ -13139,8 +13166,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_hot_sibling_id_space_does_not_
     add_rowset(hot_meta.get(), /*rowset_id=*/860, /*max_compact_input_rowset_id=*/859,
                /*del_origin_rowset_id=*/860);
 
-    ASSERT_OK(put_tablet_metadata(cold_meta));
-    ASSERT_OK(put_tablet_metadata(hot_meta));
+    ASSERT_OK(put_merge_sources(cold_meta, hot_meta));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -13234,8 +13260,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dead_reference_does_not_collid
     add_rowset(later_meta.get(), /*rowset_id=*/803, /*max_compact_input_rowset_id=*/765,
                /*del_origin_rowset_id=*/766);
 
-    ASSERT_OK(put_tablet_metadata(earlier_meta));
-    ASSERT_OK(put_tablet_metadata(later_meta));
+    ASSERT_OK(put_merge_sources(earlier_meta, later_meta));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -13306,14 +13331,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_duplicate_does_not_l
     auto* duplicate = add_rowset(later_meta.get(), /*rowset_id=*/kBaseRowsetId,
                                  /*max_compact_input_rowset_id=*/0, /*del_origin_rowset_id=*/0);
     duplicate->mutable_uid()->CopyFrom(canonical->uid());
+    duplicate->mutable_segment_metas(0)->CopyFrom(canonical->segment_metas(0));
 
     constexpr uint32_t kHighRowsetId = std::numeric_limits<int32_t>::max() - 1;
     add_rowset(later_meta.get(), /*rowset_id=*/kHighRowsetId,
                /*max_compact_input_rowset_id=*/kHighRowsetId,
                /*del_origin_rowset_id=*/kHighRowsetId);
 
-    ASSERT_OK(put_tablet_metadata(earlier_meta));
-    ASSERT_OK(put_tablet_metadata(later_meta));
+    ASSERT_OK(put_merge_sources(earlier_meta, later_meta));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -13372,7 +13397,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     low_meta.set_next_rowset_id(3);
     add_rowset_with_predicate(&low_meta, /*rowset_id=*/1, /*version=*/1, /*has_predicate=*/false);
     add_rowset_with_predicate(&low_meta, /*rowset_id=*/2, /*version=*/10, /*has_predicate=*/true);
-    ASSERT_OK(put_tablet_metadata(low_meta));
 
     // ctx[1]: the same v10 delete predicate, cross-published onto a sibling whose id
     // counter ran far ahead. Predicates dedup by version, so this context contributes
@@ -13383,7 +13407,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     predicate_only_meta.set_version(base_version);
     predicate_only_meta.set_next_rowset_id(kFarAheadPredicateId + 1);
     add_rowset_with_predicate(&predicate_only_meta, kFarAheadPredicateId, /*version=*/10, /*has_predicate=*/true);
-    ASSERT_OK(put_tablet_metadata(predicate_only_meta));
 
     // ctx[2]: two live rowsets ~1e8 ids apart. They form two singleton runs, so the
     // numeric gap and ctx[1]'s unused raw predicate id do not consume target space.
@@ -13394,7 +13417,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     wide_meta.set_next_rowset_id(kWideSpanTopId + 1);
     add_rowset_with_predicate(&wide_meta, /*rowset_id=*/5, /*version=*/20, /*has_predicate=*/false);
     add_rowset_with_predicate(&wide_meta, kWideSpanTopId, /*version=*/21, /*has_predicate=*/false);
-    ASSERT_OK(put_tablet_metadata(wide_meta));
+    ASSERT_OK(put_merge_sources(low_meta, predicate_only_meta, wide_meta));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -13436,6 +13459,142 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_discarded_predicate_does_not_i
     // and 4, and the authoritative cursor advances to exactly 5.
     EXPECT_EQ((std::vector<uint32_t>{1, 2, 3, 4}), rowset_ids);
     EXPECT_EQ(5, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_groups_same_uid_across_nonmonotonic_versions) {
+    auto first = make_allocator_source(next_id(), 40);
+    auto second = make_allocator_source(next_id(), 40);
+    for (auto* source : {first.get(), second.get()}) {
+        source->mutable_schema()->set_keys_type(DUP_KEYS);
+        const bool left = source == first.get();
+        auto* range = source->mutable_range();
+        *range->mutable_lower_bound() = generate_sort_key(left ? 0 : 10);
+        *range->mutable_upper_bound() = generate_sort_key(left ? 10 : 20);
+        range->set_lower_bound_included(true);
+        range->set_upper_bound_included(false);
+        const std::vector<int> versions = left ? std::vector<int>{1, 5, 3} : std::vector<int>{1, 4, 3};
+        for (int i = 0; i < 3; ++i) {
+            auto* r =
+                    add_allocator_rowset(source, 10 * (i + 1), versions[i], fmt::format("global-{}.dat", versions[i]));
+            r->mutable_uid()->set_hi(1);
+            r->mutable_uid()->set_lo(versions[i]);
+            r->set_num_rows(10 * versions[i]);
+            r->set_data_size(100 * versions[i]);
+            r->set_num_dels(versions[i]);
+        }
+    }
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second}));
+    ASSERT_EQ(4, merged->rowsets_size());
+    for (int i = 0; i < 4; ++i) {
+        const int versions[] = {1, 3, 4, 5};
+        const int totals[] = {2, 6, 4, 5};
+        EXPECT_EQ(versions[i], merged->rowsets(i).version());
+        EXPECT_EQ(versions[i], merged->rowsets(i).uid().lo());
+        EXPECT_EQ(10 * totals[i], merged->rowsets(i).num_rows());
+        EXPECT_EQ(100 * totals[i], merged->rowsets(i).data_size());
+        EXPECT_EQ(totals[i], merged->rowsets(i).num_dels());
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_same_range_exact_duplicate_counts_once) {
+    auto first = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(first.get(), 10, 1, "exact.dat", 7);
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->set_num_dels(3);
+    auto second = std::make_shared<TabletMetadataPB>(*first);
+    second->set_id(next_id());
+    // Explicit identical unbounded ranges are deliberate duplicate occurrences.
+    first->mutable_range();
+    second->mutable_range();
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({second, first}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(10, merged->rowsets(0).num_rows());
+    EXPECT_EQ(100, merged->rowsets(0).data_size());
+    EXPECT_EQ(3, merged->rowsets(0).num_dels());
+    EXPECT_EQ(7, merged->rowsets(0).segment_metas(0).segment_idx());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_distinct_ranges_contribute_once) {
+    auto first = make_allocator_source(next_id(), 20);
+    auto* r = add_allocator_rowset(first.get(), 10, 1, "contributor.dat", 7);
+    r->set_num_rows(10);
+    r->set_data_size(100);
+    r->set_num_dels(3);
+    auto second = std::make_shared<TabletMetadataPB>(*first);
+    second->set_id(next_id());
+    *first->mutable_range()->mutable_upper_bound() = generate_sort_key(10);
+    first->mutable_range()->set_upper_bound_included(false);
+    *second->mutable_range()->mutable_lower_bound() = generate_sort_key(10);
+    second->mutable_range()->set_lower_bound_included(true);
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({second, first}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(20, merged->rowsets(0).num_rows());
+    EXPECT_EQ(200, merged->rowsets(0).data_size());
+    EXPECT_EQ(6, merged->rowsets(0).num_dels());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_same_range_requires_complete_segment_set) {
+    auto first = make_allocator_source(next_id(), 20);
+    auto* r = add_allocator_rowset(first.get(), 10, 1, "complete-0.dat");
+    auto second = std::make_shared<TabletMetadataPB>(*first);
+    second->set_id(next_id());
+    add_allocator_segment(second->mutable_rowsets(0), "complete-7.dat", 7);
+    second->mutable_rowsets(0)->set_num_rows(r->num_rows());
+    second->mutable_rowsets(0)->set_data_size(r->data_size());
+    first->mutable_range();
+    second->mutable_range();
+    auto result = publish_allocator_merge({first, second});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_strictly_overlapping_uid_ranges) {
+    auto first = make_allocator_source(next_id(), 20);
+    add_allocator_rowset(first.get(), 10, 1, "overlapping.dat");
+    auto second = std::make_shared<TabletMetadataPB>(*first);
+    second->set_id(next_id());
+    *first->mutable_range()->mutable_upper_bound() = generate_sort_key(20);
+    first->mutable_range()->set_upper_bound_included(false);
+    *second->mutable_range()->mutable_lower_bound() = generate_sort_key(10);
+    second->mutable_range()->set_lower_bound_included(true);
+    auto result = publish_allocator_merge({first, second});
+    EXPECT_TRUE(result.status().is_corruption()) << result.status();
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_source_permutation_is_canonical) {
+    auto first = make_allocator_source(next_id(), 20);
+    auto second = make_allocator_source(next_id(), 20);
+    for (auto* source : {first.get(), second.get()}) {
+        auto* r = add_allocator_rowset(source, 10, 1, source == first.get() ? "order-a.dat" : "order-b.dat");
+        r->mutable_uid()->set_hi(1);
+        r->mutable_uid()->set_lo(source == first.get() ? 2 : 1);
+    }
+    ASSIGN_OR_ABORT(auto forward, publish_allocator_merge({first, second}));
+    ASSIGN_OR_ABORT(auto reverse, publish_allocator_merge({second, first}));
+    ASSERT_EQ(2, forward->rowsets_size());
+    ASSERT_EQ(2, reverse->rowsets_size());
+    for (int i = 0; i < 2; ++i) {
+        EXPECT_EQ(i + 1, forward->rowsets(i).uid().lo());
+        EXPECT_EQ(forward->rowsets(i).SerializeAsString(), reverse->rowsets(i).SerializeAsString());
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_non_pk_true_gap_remains_distinct) {
+    auto first = make_allocator_source(next_id(), 20);
+    first->mutable_schema()->set_keys_type(DUP_KEYS);
+    add_allocator_rowset(first.get(), 10, 1, "gap.dat", 7);
+    auto second = std::make_shared<TabletMetadataPB>(*first);
+    second->set_id(next_id());
+    *first->mutable_range()->mutable_upper_bound() = generate_sort_key(10);
+    first->mutable_range()->set_upper_bound_included(false);
+    *second->mutable_range()->mutable_lower_bound() = generate_sort_key(20);
+    second->mutable_range()->set_lower_bound_included(true);
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({second, first}));
+    ASSERT_EQ(2, merged->rowsets_size());
+    for (const auto& r : merged->rowsets()) {
+        EXPECT_EQ(1, r.num_rows());
+        EXPECT_EQ(7, r.segment_metas(0).segment_idx());
+    }
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_packs_sparse_contexts) {
@@ -13746,7 +13905,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_segment_declaration_co
     }
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_absent_and_explicit_zero_segment_idx) {
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_absent_segment_idx_before_io) {
     auto selected_source = make_allocator_source(next_id(), 11);
     auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "segment_presence.dat", 0, false);
     selected->mutable_segment_metas(0)->set_shared(false);
@@ -13754,17 +13913,25 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_absent_and_explicit
     auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "segment_presence.dat", 0, true);
     duplicate->mutable_uid()->CopyFrom(selected->uid());
     duplicate->mutable_segment_metas(0)->set_shared(true);
+    *selected_source->mutable_range()->mutable_upper_bound() = generate_sort_key(1);
+    selected_source->mutable_range()->set_upper_bound_included(false);
+    *duplicate_source->mutable_range()->mutable_lower_bound() = generate_sort_key(1);
+    duplicate_source->mutable_range()->set_lower_bound_included(true);
 
-    auto merged_or = publish_allocator_merge({selected_source, duplicate_source});
-    ASSERT_OK(merged_or.status());
-    auto merged = std::move(merged_or).value();
-    ASSERT_EQ(1, merged->rowsets_size());
-    ASSERT_EQ(1, merged->rowsets(0).segment_metas_size());
-    EXPECT_TRUE(merged->rowsets(0).segment_metas(0).has_segment_idx());
-    EXPECT_EQ(0, merged->rowsets(0).segment_metas(0).segment_idx());
-    EXPECT_TRUE(merged->rowsets(0).segment_metas(0).shared());
-    EXPECT_EQ(1, merged->rowsets(0).id());
-    EXPECT_EQ(2, merged->next_rowset_id());
+    int materialized = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++materialized; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    std::unordered_map<int64_t, TabletMetadataPtr> published;
+    auto status = publish_resharding_merge({selected_source, duplicate_source}, next_id(), 1, 2, next_id(), published,
+                                           [&] { CHECK_OK(_tablet_manager->put_tablet_metadata(selected_source)); });
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_TRUE(status.message().contains("explicit segment_idx")) << status;
+    EXPECT_EQ(0, materialized);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_reconciles_segment_shared_flag) {
@@ -14022,6 +14189,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preserves_strict_recovery_orde
     first_rowset->mutable_segment_metas(0)->set_size(first_size);
     auto* second_rowset = add_allocator_rowset(second.get(), 20, 2, "recovery_strict_20.dat", 0);
     second_rowset->mutable_segment_metas(0)->set_size(second_size);
+    *first->mutable_range()->mutable_upper_bound() = generate_sort_key(50);
+    first->mutable_range()->set_upper_bound_included(false);
+    *second->mutable_range()->mutable_lower_bound() = generate_sort_key(50);
+    second->mutable_range()->set_lower_bound_included(true);
 
     ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second}));
     ASSERT_EQ(2, merged->rowsets_size());
@@ -14488,8 +14659,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cloud_native_pk_flush_path) {
     auto meta_a = make_child(child_a);
     auto meta_b = make_child(child_b);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -14705,8 +14875,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_preserves_pass
     (*meta2->mutable_rowset_to_schema())[1] = 1001;
     add_dcg_with_columns(meta2.get(), /*segment_id=*/1, "shared.cols", {101, 102}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -14761,8 +14930,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns_append) {
     (*meta2->mutable_rowset_to_schema())[1] = 2001;
     add_dcg_with_columns(meta2.get(), 1, "b.cols", {301, 302}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -14824,8 +14992,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_triggers_rebuild_
     // Column 401 overlaps with child1.cols => rebuild triggered.
     add_dcg_with_columns(meta2.get(), 1, "child2.cols", {401, 403}, 1);
 
-    EXPECT_OK(put_tablet_metadata(meta1));
-    EXPECT_OK(put_tablet_metadata(meta2));
+    ASSERT_OK(put_merge_sources(meta1, meta2));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -15008,8 +15175,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_two_children_same_
     auto meta_a = build_child(child_a, 0, kBoundary, cols_a_name);
     auto meta_b = build_child(child_b, kBoundary, kNumRows, cols_b_name);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     // 4. Run merge.
     ReshardingTabletInfoPB resharding_tablet;
@@ -15113,8 +15279,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_consistency_fa
     auto meta_a = make_child(tablet_a, {601, 602});
     auto meta_b = make_child(tablet_b, {603}); // differs from A
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -15179,8 +15344,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_missing_uid_falls_
     auto meta_a = make_child(child_a, "a_missing.cols");
     auto meta_b = make_child(child_b, "b_missing.cols");
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -15301,8 +15465,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_cleanup_on_failure
     auto meta_a = build_child(child_a, 0, kBoundary, cols_a, "bad_a.cols");
     auto meta_b = build_child(child_b, kBoundary, kNumRows, cols_b, "bad_b.cols");
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     // Snapshot merged tablet's segment dir so we can detect leftover files.
     const std::string merged_segment_dir = _location_provider->segment_root_location(merged_tablet);
@@ -15712,8 +15875,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_synthesized_delvec_survives_la
     meta_b->mutable_rowsets(0)->set_data_size(compacted_size);
     meta_b->mutable_rowsets(0)->mutable_segment_metas(0)->set_size(compacted_size);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -15856,9 +16018,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_pk_no_gap_passthrough) {
     auto meta_b = make_shared_child(child_b, base_version, 10, PRIMARY_KEYS, 10, 20);
     auto meta_c = make_shared_child(child_c, base_version, 10, PRIMARY_KEYS, 20, 30);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
-    EXPECT_OK(put_tablet_metadata(meta_c));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b, meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -15902,9 +16062,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dup_keys_skip_dedup_on_gap) {
     auto meta_b = make_compacted_child(child_b, base_version, 11, DUP_KEYS, 10, 20, "cb.dat");
     auto meta_c = make_shared_child(child_c, base_version, 10, DUP_KEYS, 20, 30);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
-    EXPECT_OK(put_tablet_metadata(meta_c));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b, meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -15961,9 +16119,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_agg_keys_skip_dedup_on_gap) {
     auto meta_b = make_compacted_child(child_b, base_version, 11, AGG_KEYS, 10, 20, "cb.dat");
     auto meta_c = make_shared_child(child_c, base_version, 10, AGG_KEYS, 20, 30);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
-    EXPECT_OK(put_tablet_metadata(meta_c));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b, meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16000,9 +16156,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_unique_keys_skip_dedup_on_gap)
     auto meta_b = make_compacted_child(child_b, base_version, 11, UNIQUE_KEYS, 10, 20, "cb.dat");
     auto meta_c = make_shared_child(child_c, base_version, 10, UNIQUE_KEYS, 20, 30);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
-    EXPECT_OK(put_tablet_metadata(meta_c));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b, meta_c));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16038,8 +16192,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_pk_contiguous_still_dedups
     auto meta_a = make_shared_child(child_a, base_version, 10, DUP_KEYS, 0, 10);
     auto meta_b = make_shared_child(child_b, base_version, 10, DUP_KEYS, 10, 20);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16068,8 +16221,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_pk_skips_pk_sstable_pipeli
     prepare_tablet_dirs(child_a);
     prepare_tablet_dirs(child_b);
     prepare_tablet_dirs(merged_tablet);
-    ASSERT_OK(put_tablet_metadata(make_shared_child(child_a, base_version, 10, DUP_KEYS, 0, 10)));
-    ASSERT_OK(put_tablet_metadata(make_shared_child(child_b, base_version, 10, DUP_KEYS, 10, 20)));
+    ASSERT_OK(put_merge_sources(make_shared_child(child_a, base_version, 10, DUP_KEYS, 0, 10),
+                                make_shared_child(child_b, base_version, 10, DUP_KEYS, 10, 20)));
 
     int source_flush_count = 0;
     int classifier_count = 0;
@@ -16151,8 +16304,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_canonical_range_extends_for_du
     auto meta_a = make_no_rowset_range_child(child_a, 0, 10);
     auto meta_b = make_no_rowset_range_child(child_b, 10, 20);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16222,8 +16374,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delete_predicate_dedup_unchang
     auto meta_a = make_pred_child(child_a, 0, 10);
     auto meta_b = make_pred_child(child_b, 10, 20);
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16378,8 +16529,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_idg_dedup) {
         add_idg_with_key(meta.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child_with_idg(child_a)));
-    EXPECT_OK(put_tablet_metadata(make_child_with_idg(child_b)));
+    ASSERT_OK(put_merge_sources(make_child_with_idg(child_a), make_child_with_idg(child_b)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16437,8 +16587,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_unions_divergent_tombstone
         if (drop_col5) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, /*drop_col5=*/false)));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, /*drop_col5=*/true)));
+    ASSERT_OK(put_merge_sources(make_child(child_a, /*drop_col5=*/false), make_child(child_b, /*drop_col5=*/true)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16492,8 +16641,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_drops_fully_tombstoned) {
         if (drop_col5) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, /*drop_col5=*/false)));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, /*drop_col5=*/true)));
+    ASSERT_OK(put_merge_sources(make_child(child_a, /*drop_col5=*/false), make_child(child_b, /*drop_col5=*/true)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16549,8 +16697,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_global_tombstone_orphans_w
         if (tombstone) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, /*tombstone=*/false)));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, /*tombstone=*/true)));
+    ASSERT_OK(put_merge_sources(make_child(child_a, /*tombstone=*/false), make_child(child_b, /*tombstone=*/true)));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16628,8 +16775,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_derives_shared_from_segmen
         stamp_physical_identity_uid(rowset, "seg_b.dat");
     }
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16705,8 +16851,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_skips_stale_source_entry) 
         stamp_physical_identity_uid(rowset, "seg_b.dat"); // distinct uid => not deduped
     }
 
-    EXPECT_OK(put_tablet_metadata(meta_a));
-    EXPECT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -16760,8 +16905,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_remaps_private_segments) {
         add_idg_with_key(meta.get(), 1, idx, /*col_uid=*/5, BITMAP, 1, /*shared_file=*/false);
         return meta;
     };
-    EXPECT_OK(put_tablet_metadata(make_child(child_a, "seg_a.dat", "a.idx")));
-    EXPECT_OK(put_tablet_metadata(make_child(child_b, "seg_b.dat", "b.idx")));
+    ASSERT_OK(put_merge_sources(make_child(child_a, "seg_a.dat", "a.idx"), make_child(child_b, "seg_b.dat", "b.idx")));
 
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -17193,14 +17337,13 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_rssid_reassign) {
         meta_a.set_next_rowset_id(3);
         add_rowset_with_predicate(&meta_a, 1, 1, false);
         add_rowset_with_predicate(&meta_a, 2, 2, false);
-        CHECK_OK(put_tablet_metadata(meta_a));
 
         TabletMetadataPB meta_b;
         meta_b.set_id(tablet_b);
         meta_b.set_version(base_version);
         meta_b.set_next_rowset_id(2);
         add_rowset_with_predicate(&meta_b, 1, 1, false);
-        CHECK_OK(put_tablet_metadata(meta_b));
+        CHECK_OK(put_merge_sources(meta_a, meta_b));
 
         ReshardingTabletInfoPB resharding_tablet;
         auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -17249,7 +17392,6 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_before_delete_predicate_range
         meta_a.set_next_rowset_id(3);
         add_rowset_with_predicate(&meta_a, 1, 1, false); // data
         add_rowset_with_predicate(&meta_a, 2, 2, true);  // delete predicate
-        CHECK_OK(put_tablet_metadata(meta_a));
 
         TabletMetadataPB meta_b;
         meta_b.set_id(tablet_b);
@@ -17257,7 +17399,7 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_before_delete_predicate_range
         meta_b.set_next_rowset_id(3);
         add_rowset_with_predicate(&meta_b, 1, 1, false); // data
         add_rowset_with_predicate(&meta_b, 2, 2, true);  // delete predicate
-        CHECK_OK(put_tablet_metadata(meta_b));
+        CHECK_OK(put_merge_sources(meta_a, meta_b));
 
         ReshardingTabletInfoPB resharding_tablet;
         auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
@@ -17424,8 +17566,7 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     expected_merged_delvec.init(/*version=*/kNewVersion, expected_deleted, std::size(expected_deleted));
     auto meta_a = build(tablet_a, 10, 1001, "delvec-a", delvec_a.save());
     auto meta_b = build(tablet_b, 1, 2002, "delvec-b", delvec_b.save());
-    ASSERT_OK(put_tablet_metadata(meta_a));
-    ASSERT_OK(put_tablet_metadata(meta_b));
+    ASSERT_OK(put_merge_sources(meta_a, meta_b));
     ReshardingTabletInfoPB resharding_tablet;
     auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
     merging_tablet.add_old_tablet_ids(tablet_a);
@@ -17469,10 +17610,15 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     EXPECT_TRUE(retry_file.name().starts_with("0000000000000003_"));
     const auto retry_files = txn_files(/*txn_id=*/3);
     ASSERT_EQ(1, retry_files.size());
+    const auto source_a_output =
+            std::find_if(retry_metadata->rowsets().begin(), retry_metadata->rowsets().end(), [&](const auto& rowset) {
+                return lake::tablet_reshard_helper::same_rowset_uid(rowset, meta_a->rowsets(0));
+            });
+    ASSERT_NE(retry_metadata->rowsets().end(), source_a_output);
+    const uint32_t source_a_rssid = source_a_output->id();
     DelVector loaded;
     LakeIOOptions options;
-    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, retry_metadata->rowsets(0).id(), false, options,
-                          &loaded));
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *retry_metadata, source_a_rssid, false, options, &loaded));
     EXPECT_EQ(expected_merged_delvec.save(), loaded.save());
 
     VacuumFullRequest request;
@@ -17495,8 +17641,7 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_delvec) {
     EXPECT_TRUE(post_vacuum_file.name().starts_with("0000000000000003_"));
     for (const auto& failed : failed_files) EXPECT_NE(failed, post_vacuum_file.name());
     DelVector reloaded;
-    ASSERT_OK(get_del_vec(_tablet_manager.get(), *post_vacuum_metadata, post_vacuum_metadata->rowsets(0).id(), false,
-                          options, &reloaded));
+    ASSERT_OK(get_del_vec(_tablet_manager.get(), *post_vacuum_metadata, source_a_rssid, false, options, &reloaded));
     EXPECT_EQ(expected_merged_delvec.save(), reloaded.save());
 }
 
@@ -17576,8 +17721,7 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_dcg_cols) {
 
         auto meta_a = build_child(child_a, 0, kBoundary, cols_a_name);
         auto meta_b = build_child(child_b, kBoundary, kNumRows, cols_b_name);
-        CHECK_OK(put_tablet_metadata(meta_a));
-        CHECK_OK(put_tablet_metadata(meta_b));
+        CHECK_OK(put_merge_sources(meta_a, meta_b));
 
         ReshardingTabletInfoPB resharding_tablet;
         auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -2662,12 +2662,391 @@ protected:
         return fixture;
     }
 
+    // Canonicalize logical state, not the protobuf's allocation/serialization choices.
+    // Segment filenames and bundle offsets remain physical identity; generated sidecar
+    // names, projected RSSIDs and the SST representation deliberately do not.
+    StatusOr<std::string> semantic_reshard_signature(const TabletMetadataPtr& metadata) {
+        _update_manager->unload_and_remove_primary_index(metadata->id());
+        _tablet_manager->prune_metacache();
+        ASSIGN_OR_RETURN(auto cold, _tablet_manager->get_tablet_metadata(metadata->id(), metadata->version()));
+        std::vector<std::string> records;
+        auto append = [](std::string* out, const std::string& value) {
+            *out += fmt::format("{}:", value.size()) + value;
+        };
+        for (const auto& rowset : cold->rowsets()) {
+            std::string record =
+                    fmt::format("uid={}:{};version={};", rowset.uid().hi(), rowset.uid().lo(), rowset.version());
+            const auto& range = rowset.has_range() ? rowset.range() : cold->range();
+            append(&record, range.SerializeAsString());
+            if (rowset.has_delete_predicate()) {
+                record = fmt::format("predicate-version={};", rowset.version());
+                append(&record, rowset.delete_predicate().SerializeAsString());
+            }
+            for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+                const auto& segment = rowset.segment_metas(i);
+                const uint32_t original_idx = segment.has_segment_idx() ? segment.segment_idx() : i;
+                const uint32_t rssid = rowset.id() + original_idx;
+                record += fmt::format("segment={};slice={}:{};rows={};", original_idx, segment.bundle_file_offset(),
+                                      segment.size(), segment.num_rows());
+                append(&record, segment.filename());
+                if (cold->delvec_meta().delvecs().contains(rssid)) {
+                    DelVector delvec;
+                    RETURN_IF_ERROR(_update_manager->get_del_vec_in_meta(TabletSegmentId(cold->id(), rssid),
+                                                                         cold->version(), false, &delvec));
+                    record += "delvec={";
+                    if (delvec.roaring() != nullptr) {
+                        for (uint32_t rowid : *delvec.roaring()) record += fmt::format("{},", rowid);
+                    }
+                    record += "};";
+                }
+                if (auto dcg = cold->dcg_meta().dcgs().find(rssid); dcg != cold->dcg_meta().dcgs().end()) {
+                    std::set<uint32_t> active_columns;
+                    for (int j = 0; j < dcg->second.column_files_size(); ++j) {
+                        if (dcg->second.versions(j) > cold->version()) continue;
+                        for (auto uid : dcg->second.unique_column_ids(j).column_ids()) {
+                            if (!active_columns.insert(uid).second) continue;
+                            // These fixtures have one integer value column. Read the actual .cols
+                            // segment including rows masked by delvec, not merely the scan output.
+                            if (uid != 1002) return Status::InvalidArgument("unexpected fixed-point DCG column");
+                            record += fmt::format("dcg-column={};values=", uid);
+                            for (int32_t value : read_c1_only_cols_file(cold->id(), dcg->second.column_files(j))) {
+                                record += fmt::format("{},", value);
+                            }
+                        }
+                    }
+                }
+                lake::LakeIndexDeltaGroupLoader loader(cold);
+                lake::IndexDeltaGroupList active;
+                RETURN_IF_ERROR(loader.load(TabletSegmentId(cold->id(), rssid), cold->version(), &active));
+                std::set<std::pair<int32_t, int>> active_keys;
+                for (const auto& entry : active) {
+                    ASSIGN_OR_RETURN(auto payload, read_sidecar_payload(_tablet_manager->segment_location(
+                                                                                cold->id(), entry.index_file),
+                                                                        entry.encryption_meta));
+                    for (const auto& key : entry.keys) {
+                        active_keys.emplace(key.col_unique_id, key.index_type);
+                        record += fmt::format("idg-active={}:{};", key.col_unique_id, int(key.index_type));
+                        append(&record, payload);
+                    }
+                }
+                if (auto idg = cold->idg_meta().idgs().find(rssid); idg != cold->idg_meta().idgs().end()) {
+                    for (const auto& entry : idg->second.entries()) {
+                        for (const auto& key : entry.dropped_keys()) {
+                            if (active_keys.contains({key.col_unique_id(), key.index_type()})) {
+                                return Status::Corruption("cold IDG lookup returned a dropped key");
+                            }
+                            record += fmt::format("idg-dropped={}:{};", key.col_unique_id(), int(key.index_type()));
+                        }
+                    }
+                }
+            }
+            for (const auto& del : rowset.del_files()) {
+                // op_offset is a stable operation ordinal; origin_rowset_id is projected.
+                record += fmt::format("del-version={};op={};", del.version(), del.op_offset());
+                append(&record, del.name());
+            }
+            records.emplace_back(std::move(record));
+        }
+        std::sort(records.begin(), records.end());
+        std::string result;
+        for (const auto& record : records) append(&result, record);
+        ASSIGN_OR_RETURN(auto rows, read_two_column_rows(cold));
+        for (const auto& [key, value] : rows) result += fmt::format("row={}:{};", key, value);
+        return result;
+    }
+
+    struct ReshardInventory {
+        size_t rowsets;
+        size_t segments;
+        size_t dels;
+        size_t live_sidecars;
+        size_t live_files;
+        size_t raw_bytes;
+    };
+
+    ReshardInventory collect_reshard_inventory(const TabletMetadataPB& metadata) {
+        ReshardInventory result{.rowsets = static_cast<size_t>(metadata.rowsets_size()),
+                                .raw_bytes = metadata.ByteSizeLong()};
+        std::set<std::string> files;
+        std::set<std::string> sidecars;
+        for (const auto& rowset : metadata.rowsets()) {
+            result.segments += rowset.segment_metas_size();
+            result.dels += rowset.del_files_size();
+            for (const auto& segment : rowset.segment_metas()) files.insert(segment.filename());
+            for (const auto& del : rowset.del_files()) files.insert(del.name());
+        }
+        for (const auto& [rssid, page] : metadata.delvec_meta().delvecs()) {
+            sidecars.insert(metadata.delvec_meta().version_to_file().at(page.version()).name());
+        }
+        for (const auto& [rssid, dcg] : metadata.dcg_meta().dcgs()) {
+            for (const auto& name : dcg.column_files()) sidecars.insert(name);
+        }
+        for (const auto& [rssid, idg] : metadata.idg_meta().idgs()) {
+            for (const auto& entry : idg.entries()) {
+                if (entry.keys_size() > entry.dropped_keys_size()) sidecars.insert(entry.index_file());
+            }
+        }
+        result.live_sidecars = sidecars.size();
+        files.insert(sidecars.begin(), sidecars.end());
+        for (const auto& sst : metadata.sstable_meta().sstables()) files.insert(sst.filename());
+        result.live_files = files.size();
+        return result;
+    }
+
+    TabletMetadataPtr run_no_write_split_merge_cycle(const TabletMetadataPtr& source, int child_count) {
+        CHECK_OK(put_tablet_metadata(source));
+        SplittingTabletInfoPB split;
+        split.set_old_tablet_id(source->id());
+        for (int i = 0; i < child_count; ++i) {
+            split.add_new_tablet_ids(next_id());
+            auto* range = split.add_new_tablet_ranges();
+            range->mutable_lower_bound()->CopyFrom(generate_sort_key(i * 100 / child_count));
+            range->set_lower_bound_included(true);
+            range->mutable_upper_bound()->CopyFrom(generate_sort_key((i + 1) * 100 / child_count));
+            range->set_upper_bound_included(false);
+        }
+        TxnInfoPB txn;
+        txn.set_txn_id(next_id());
+        txn.set_commit_time(1);
+        ASSIGN_OR_ABORT(auto children,
+                        lake::split_tablet(_tablet_manager.get(), source, split, source->version() + 1, txn));
+        EXPECT_EQ(child_count, children.size());
+        std::vector<TabletMetadataPtr> sources;
+        for (auto id : split.new_tablet_ids()) sources.push_back(children.at(id));
+        std::unordered_map<int64_t, TabletMetadataPtr> published;
+        const int64_t target = next_id();
+        CHECK_OK(publish_resharding_merge(sources, target, source->version() + 1, source->version() + 2, next_id(),
+                                          published));
+        return published.at(target);
+    }
+
+    TabletMetadataPtr fixed_point_source(bool primary_key) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(next_id());
+        metadata->set_version(1);
+        metadata->set_next_rowset_id(10);
+        set_two_column_pk_schema(metadata.get(), 4001);
+        metadata->mutable_schema()->set_keys_type(primary_key ? PRIMARY_KEYS : UNIQUE_KEYS);
+        metadata->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+        metadata->set_enable_persistent_index(primary_key);
+        if (primary_key) metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+        metadata->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+        metadata->mutable_range()->set_lower_bound_included(true);
+        metadata->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+        metadata->mutable_range()->set_upper_bound_included(false);
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(100);
+        rowset->set_overlapped(false);
+        lake::tablet_reshard_helper::set_rowset_uid(rowset);
+        for (int i = 0; i < 2; ++i) {
+            const auto name = fmt::format("fixed_{}_{}.dat", metadata->id(), i);
+            const auto size =
+                    write_two_column_segment(metadata->id(), name, 50, [](int key) { return key * 10; }, i * 50);
+            auto* segment = rowset->add_segment_metas();
+            segment->set_filename(name);
+            segment->set_size(size);
+            segment->set_num_rows(50);
+            segment->set_segment_idx(i == 0 ? 0 : 7);
+            segment->mutable_sort_key_min()->CopyFrom(generate_sort_key(i * 50));
+            segment->mutable_sort_key_max()->CopyFrom(generate_sort_key(i * 50 + 49));
+            rowset->set_data_size(rowset->data_size() + size);
+        }
+        if (primary_key) {
+            const std::string stem = fmt::format("fixed_{}", metadata->id());
+            DelVector delvec;
+            const uint32_t deleted = 1;
+            delvec.init(1, &deleted, 1);
+            add_delvec(metadata.get(), metadata->id(), 1, 1, stem + ".delvec", delvec.save());
+            rowset->set_num_dels(1);
+            const auto size = write_c1_only_cols_file(metadata->id(), stem + ".cols", 50,
+                                                      [](int row) { return row * 10 + 1000; });
+            add_dcg_with_columns(metadata.get(), 1, stem + ".cols", {1002}, 1);
+            metadata->mutable_dcg_meta()->mutable_dcgs()->at(1).add_column_file_sizes(size);
+            auto file = write_sidecar_payload(_tablet_manager->segment_location(metadata->id(), stem + ".idx"),
+                                              "fixed-point-index-payload", false);
+            add_idg_with_key(metadata.get(), 1, stem + ".idx", 1002, BITMAP, 1);
+            add_idg_key(metadata.get(), 1, 1003, BITMAP);
+            add_idg_dropped_key(metadata.get(), 1, 1003, BITMAP);
+            metadata->mutable_idg_meta()->mutable_idgs()->at(1).mutable_entries(0)->set_file_size(file.filesize);
+            auto* del = rowset->add_del_files();
+            del->set_name(stem + ".del");
+            del->set_origin_rowset_id(1);
+            del->set_op_offset(7);
+            del->set_version(1);
+            del->set_num_rows(0);
+            write_binary_del_file(metadata->id(), del->name(), {});
+        } else {
+            metadata->set_version(2);
+            auto* predicate = add_rowset_with_predicate(metadata.get(), 9, 2, true);
+            predicate->mutable_delete_predicate()->mutable_binary_predicates(0)->set_value("98");
+        }
+        CHECK_OK(put_tablet_metadata(metadata));
+        return metadata;
+    }
+
+    void expect_ten_fixed_point_cycles(TabletMetadataPtr current) {
+        ASSIGN_OR_ABORT(auto baseline_signature, semantic_reshard_signature(current));
+        const auto baseline = collect_reshard_inventory(*current);
+        // Conservative field census: tablet scalars plus per-rowset/segment/del,
+        // sidecar and SST integer slots. Each varint can grow by at most 10 bytes.
+        const size_t live_volatile_integer_fields =
+                16 + 8 * baseline.rowsets + 8 * baseline.segments + 8 * baseline.dels + 8 * baseline.live_sidecars;
+        const size_t live_generated_filenames = baseline.live_files;
+        const size_t raw_byte_limit =
+                baseline.raw_bytes + 10 * live_volatile_integer_fields + 64 * live_generated_filenames + 4096;
+        LOG(INFO) << "fixed-point baseline: rowsets=" << baseline.rowsets << " segments=" << baseline.segments
+                  << " dels=" << baseline.dels << " sidecars=" << baseline.live_sidecars
+                  << " files=" << baseline.live_files << " raw_bytes=" << baseline.raw_bytes
+                  << " raw_byte_limit=" << raw_byte_limit;
+        for (int cycle = 0; cycle < 10; ++cycle) {
+            SCOPED_TRACE(fmt::format("fixed-point cycle {} keys_type {}", cycle, int(current->schema().keys_type())));
+            current = run_no_write_split_merge_cycle(current, cycle % 2 == 0 ? 2 : 3);
+            ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(current));
+            const auto inventory = collect_reshard_inventory(*current);
+            EXPECT_EQ(baseline_signature, signature);
+            EXPECT_EQ(baseline.rowsets, inventory.rowsets);
+            EXPECT_EQ(baseline.segments, inventory.segments);
+            EXPECT_EQ(baseline.dels, inventory.dels);
+            EXPECT_EQ(baseline.live_sidecars, inventory.live_sidecars);
+            EXPECT_EQ(baseline.live_files, inventory.live_files);
+            EXPECT_LE(inventory.raw_bytes,
+                      baseline.raw_bytes + 10 * live_volatile_integer_fields + 64 * live_generated_filenames + 4096);
+            LOG(INFO) << "fixed-point cycle=" << cycle << " raw_bytes=" << inventory.raw_bytes;
+            if (HasFailure()) return;
+        }
+    }
+
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
     std::string _test_dir;
     std::shared_ptr<lake::LocationProvider> _location_provider;
     std::unique_ptr<MemTracker> _mem_tracker;
     std::unique_ptr<lake::UpdateManager> _update_manager;
 };
+
+TEST_F(LakeTabletReshardTest, test_range_reshard_no_write_cycles_are_fixed_point) {
+    for (bool primary_key : {true, false}) {
+        expect_ten_fixed_point_cycles(fixed_point_source(primary_key));
+        if (HasFailure()) return;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_range_reshard_post_dml_cycles_are_fixed_point) {
+    const bool old_parallel_compaction = config::enable_pk_index_parallel_compaction;
+    config::enable_pk_index_parallel_compaction = false;
+    DeferOp restore_parallel([&] { config::enable_pk_index_parallel_compaction = old_parallel_compaction; });
+    auto source = fixed_point_source(true);
+    ASSIGN_OR_ABORT(auto written, publish_followup_upsert_delete(source->id(), source->version(), 10, 7777, 60));
+    const int32_t old_min_segments = config::lake_pk_compaction_min_input_segments;
+    config::lake_pk_compaction_min_input_segments = 1;
+    DeferOp restore([&] { config::lake_pk_compaction_min_input_segments = old_min_segments; });
+    ASSIGN_OR_ABORT(auto compacted, compact_tablet(written->id(), written->version(), true));
+    ASSIGN_OR_ABORT(auto rows, read_two_column_rows(compacted));
+    EXPECT_NE(rows.end(), std::find(rows.begin(), rows.end(), std::pair<int32_t, int32_t>{10, 7777}));
+    EXPECT_TRUE(std::none_of(rows.begin(), rows.end(), [](const auto& row) { return row.first == 60; }));
+    // DML and normal compaction are over: establish a fresh baseline here.
+    expect_ten_fixed_point_cycles(compacted);
+}
+
+TEST_F(LakeTabletReshardTest, test_range_reshard_sidecar_and_sst_cold_read_smoke) {
+    auto source = fixed_point_source(true);
+    ASSIGN_OR_ABORT(auto baseline, semantic_reshard_signature(source));
+    ASSIGN_OR_ABORT(auto expected_rows, read_two_column_rows(source));
+    auto current = run_no_write_split_merge_cycle(source, 3);
+    ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(current));
+    EXPECT_EQ(baseline, signature);
+    set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+    DeferOp restore([&] { set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::ENABLE); });
+    ASSIGN_OR_ABORT(auto flushed, _update_manager->flush_pk_memtable(current, current->version()));
+    ASSERT_GT(flushed->sstable_meta().sstables_size(), 0);
+    ASSERT_OK(put_tablet_metadata(flushed));
+    _update_manager->unload_and_remove_primary_index(flushed->id());
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto cold, _tablet_manager->get_tablet_metadata(flushed->id(), flushed->version()));
+    assert_published_sstables_reopen(cold);
+    expect_lifecycle_oracle(cold, expected_rows, {1});
+    ASSIGN_OR_ABORT(auto cold_signature, semantic_reshard_signature(cold));
+    EXPECT_EQ(baseline, cold_signature);
+    // Carry persisted SST state through another SPLIT/MERGE. The merged index may
+    // retain SSTs or use the supported native rebuild representation; both must
+    // honor the same delvec/DCG/IDG and point-lookup oracle after a cold reopen.
+    auto resharded_sst = run_no_write_split_merge_cycle(cold, 2);
+    _update_manager->unload_and_remove_primary_index(resharded_sst->id());
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto reopened, _tablet_manager->get_tablet_metadata(resharded_sst->id(), resharded_sst->version()));
+    assert_published_sstables_reopen(reopened);
+    expect_lifecycle_oracle(reopened, expected_rows, {1});
+    ASSIGN_OR_ABORT(auto final_signature, semantic_reshard_signature(reopened));
+    EXPECT_EQ(baseline, final_signature);
+}
+
+TEST_F(LakeTabletReshardTest, test_range_reshard_vacuum_eligible_attempt_objects_converge) {
+    auto source = fixed_point_source(true);
+    auto current = run_no_write_split_merge_cycle(source, 3);
+    ASSIGN_OR_ABORT(auto baseline, semantic_reshard_signature(current));
+    const auto live_inventory = collect_reshard_inventory(*current);
+    // Leave actual objects from two failed MERGE writer attempts. Transaction
+    // retention protects the second until min_active_txn_id explicitly advances.
+    auto failed_attempt = [&](int64_t txn_id) {
+        ASSIGN_OR_ABORT(auto before, delvec_inventory(current->id()));
+        set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::ENABLE);
+        DeferOp restore(
+                [&] { set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::DISABLE); });
+        std::unordered_map<int64_t, TabletMetadataPtr> unpublished;
+        const int64_t failed_target = next_id();
+        auto status = publish_resharding_merge({current}, failed_target, current->version(), current->version() + 1,
+                                               txn_id, unpublished);
+        EXPECT_FALSE(status.ok());
+        // The error path may return prepared source entries, but none is persisted
+        // and no completed target references the abandoned writer output.
+        EXPECT_FALSE(unpublished.contains(failed_target));
+        EXPECT_TRUE(
+                FileSystem::Default()
+                        ->path_exists(_tablet_manager->tablet_metadata_location(failed_target, current->version() + 1))
+                        .is_not_found());
+        EXPECT_TRUE(
+                FileSystem::Default()
+                        ->path_exists(_tablet_manager->tablet_metadata_location(current->id(), current->version() + 1))
+                        .is_not_found());
+        ASSIGN_OR_ABORT(auto after, delvec_inventory(current->id()));
+        std::set<std::string> attempts;
+        std::set_difference(after.begin(), after.end(), before.begin(), before.end(),
+                            std::inserter(attempts, attempts.end()));
+        EXPECT_EQ(1, attempts.size());
+        return attempts;
+    };
+    const auto eligible = failed_attempt(1);
+    const auto protected_attempt = failed_attempt(3);
+    ASSERT_EQ(1, eligible.size());
+    ASSERT_EQ(1, protected_attempt.size());
+    auto run_vacuum = [&](int64_t min_active_txn_id) {
+        VacuumFullRequest request;
+        request.set_partition_id(1);
+        request.set_tablet_id(current->id());
+        request.set_min_active_txn_id(min_active_txn_id);
+        request.set_grace_timestamp(time(nullptr) + 1);
+        request.set_min_check_version(0);
+        request.set_max_check_version(1);
+        VacuumFullResponse response;
+        lake::vacuum_full(_tablet_manager.get(), request, &response);
+        ASSERT_TRUE(response.has_status());
+        ASSERT_EQ(0, response.status().status_code());
+    };
+    run_vacuum(2);
+    ASSIGN_OR_ABORT(auto retained, delvec_inventory(current->id()));
+    EXPECT_FALSE(retained.contains(*eligible.begin()));
+    EXPECT_TRUE(retained.contains(*protected_attempt.begin()));
+    run_vacuum(4);
+    ASSIGN_OR_ABORT(auto converged, delvec_inventory(current->id()));
+    EXPECT_FALSE(converged.contains(*eligible.begin()));
+    EXPECT_FALSE(converged.contains(*protected_attempt.begin()));
+    run_vacuum(4);
+    EXPECT_EQ(converged, delvec_inventory(current->id()).value());
+    ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(current));
+    EXPECT_EQ(baseline, signature);
+    EXPECT_EQ(live_inventory.live_files, collect_reshard_inventory(*current).live_files);
+}
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_repeated_four_cycle_lifecycle) {
     ASSIGN_OR_ABORT(auto result, run_repeated_four_cycle_lifecycle(/*enable_tde=*/false));

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -13515,6 +13515,52 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_same_range_exact_duplicate_cou
     EXPECT_EQ(7, merged->rowsets(0).segment_metas(0).segment_idx());
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_equivalent_range_encodings_count_once) {
+    for (auto keys_type : {PRIMARY_KEYS, DUP_KEYS}) {
+        for (int encoding = 0; encoding < 3; ++encoding) {
+            SCOPED_TRACE(fmt::format("keys_type={}, encoding={}", static_cast<int>(keys_type), encoding));
+            auto first = make_allocator_source(next_id(), 20);
+            first->mutable_schema()->set_keys_type(keys_type);
+            auto* rowset = add_allocator_rowset(first.get(), 10, 1, "equivalent-range.dat", 7);
+            rowset->set_num_rows(10);
+            rowset->set_data_size(100);
+            rowset->set_num_dels(3);
+            auto* range = first->mutable_range();
+            if (encoding == 2) {
+                *range->mutable_lower_bound() = generate_sort_key(0);
+                range->set_lower_bound_included(true);
+                *range->mutable_upper_bound() = generate_sort_key(20);
+                range->set_upper_bound_included(false);
+            }
+            auto second = std::make_shared<TabletMetadataPB>(*first);
+            second->set_id(next_id());
+            if (encoding < 2) {
+                // Flags on absent endpoints do not change an unbounded range.
+                second->mutable_range()->set_upper_bound_included(encoding == 1);
+            } else {
+                // NORMAL_VALUE is the default, whether explicit or absent.
+                second->mutable_range()->mutable_lower_bound()->mutable_values(0)->clear_variant_type();
+                second->mutable_range()->mutable_upper_bound()->mutable_values(0)->clear_variant_type();
+            }
+            ASSERT_NE(first->range().SerializeAsString(), second->range().SerializeAsString());
+            auto forward = publish_allocator_merge({first, second});
+            auto reverse = publish_allocator_merge({second, first});
+            EXPECT_OK(forward.status());
+            EXPECT_OK(reverse.status());
+            if (!forward.ok() || !reverse.ok()) continue;
+            ASSERT_EQ(1, forward.value()->rowsets_size());
+            ASSERT_EQ(1, reverse.value()->rowsets_size());
+            const auto& output = forward.value()->rowsets(0);
+            EXPECT_EQ(10, output.num_rows());
+            EXPECT_EQ(100, output.data_size());
+            EXPECT_EQ(3, output.num_dels());
+            EXPECT_EQ(7, output.segment_metas(0).segment_idx());
+            EXPECT_EQ(rowset->uid().SerializeAsString(), output.uid().SerializeAsString());
+            EXPECT_EQ(output.SerializeAsString(), reverse.value()->rowsets(0).SerializeAsString());
+        }
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_distinct_ranges_contribute_once) {
     auto first = make_allocator_source(next_id(), 20);
     auto* r = add_allocator_rowset(first.get(), 10, 1, "contributor.dat", 7);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -792,6 +792,9 @@ protected:
         ASSIGN_OR_ABORT(metadata_inventories[target_tablet_id],
                         directory_inventory(_location_provider->metadata_root_location(target_tablet_id)));
 
+        set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::ENABLE);
+        DeferOp restore_delvec_failpoint(
+                [&] { set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::DISABLE); });
         auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts);
 
         EXPECT_TRUE(merged.status().is_corruption()) << merged.status();
@@ -2595,6 +2598,7 @@ protected:
         owner_segment->set_filename(segment_name);
         owner_segment->set_size(segment_size);
         owner_segment->set_num_rows(2);
+        owner_segment->set_segment_idx(0);
         stamp_physical_identity_uid(owner_rowset, segment_name);
 
         DelVector owner_delvec;
@@ -3447,12 +3451,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_metadata_only_source_range_par
         }
     };
     const std::vector<Case> cases = {
-            {"well-formed gap", Outcome::kFallback,
+            {"source gap", Outcome::kCorruption,
              [&](auto& sources) {
                  set_range(sources[0].get(), 0, 40);
                  set_range(sources[1].get(), 50, 100);
              }},
-            {"well-formed overlap", Outcome::kFallback,
+            {"source overlap", Outcome::kCorruption,
              [&](auto& sources) {
                  set_range(sources[0].get(), 0, 60);
                  set_range(sources[1].get(), 50, 100);
@@ -3586,23 +3590,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_metadata_only_source_range_par
     }
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_segmentless_rowset_preservation_controls) {
-    struct Case {
-        const char* name;
-        bool primary_key;
-        bool skip_sstable_merge;
-    };
-    const std::vector<Case> cases = {
-            {"non-PK real merge", false, false},
-            {"read-only PK alias", true, true},
-    };
-    for (const auto& test_case : cases) {
-        SCOPED_TRACE(test_case.name);
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_empty_ordinary_rowsets_before_io) {
+    for (bool primary_key : {false, true}) {
+        SCOPED_TRACE(primary_key);
         auto source = std::make_shared<TabletMetadataPB>();
         source->set_id(next_id());
         source->set_version(1);
         source->set_next_rowset_id(2);
-        if (test_case.primary_key) {
+        if (primary_key) {
             set_primary_key_schema(source.get(), 1001);
         } else {
             source->mutable_schema()->set_id(1001);
@@ -3615,27 +3610,21 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_segmentless_rowset_preservatio
         rowset->set_data_size(0);
         lake::tablet_reshard_helper::set_rowset_uid(rowset);
 
-        MergingTabletInfoPB merging_info;
-        merging_info.set_new_tablet_id(next_id());
-        TxnInfoPB txn_info;
-        txn_info.set_txn_id(next_id());
-        std::vector<TabletMetadataPtr> sources = {source};
-        ASSIGN_OR_ABORT(auto merged, lake::merge_tablet(_tablet_manager.get(), sources, merging_info, /*new_version=*/2,
-                                                        txn_info, test_case.skip_sstable_merge));
-        EXPECT_EQ(1, merged->rowsets_size());
-        if (merged->rowsets_size() != 1) continue;
-        EXPECT_EQ(1, merged->rowsets(0).id());
-        EXPECT_EQ(0, merged->rowsets(0).segment_metas_size());
-        EXPECT_EQ(0, merged->rowsets(0).del_files_size());
+        MergePhaseCounts counts;
+        expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
     }
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_allocation_covers_pruned_delete_history) {
-    constexpr uint32_t kContainingRowset = 1;
+    constexpr uint32_t kContainingRowset = 10;
     constexpr uint32_t kOriginRowset = 1;
     constexpr uint32_t kOpOffset = 7;
     auto add_pruned_delete_history = [=](std::vector<std::shared_ptr<TabletMetadataPB>>& sources) {
         auto* rowset = sources[0]->mutable_rowsets(0);
+        // Compaction transferred this del from rowset 1; its offset remains in
+        // the old origin's coordinate space after all current segments vanish.
+        rowset->set_id(kContainingRowset);
+        sources[0]->set_next_rowset_id(kContainingRowset + 1);
         rowset->clear_segment_metas();
         rowset->set_num_rows(0);
         rowset->set_data_size(0);
@@ -3651,9 +3640,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_allocation_covers_pr
     ASSERT_OK(result_or);
     auto result = std::move(result_or).value();
     const auto& target = result.published.at(result.target_tablet_id);
-    const uint64_t replay_ceiling = uint64_t{kContainingRowset} + kOpOffset;
     const uint64_t origin_ceiling = uint64_t{kOriginRowset} + kOpOffset;
-    EXPECT_GT(target.next_rowset_id(), replay_ceiling);
     EXPECT_GT(target.next_rowset_id(), origin_ceiling);
     EXPECT_EQ(0, target.sstable_meta().sstables_size());
 
@@ -3670,7 +3657,6 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_allocation_covers_pr
     ASSERT_NE(nullptr, write_rowset);
     const auto& write_segment = write_rowset->segment_metas(0);
     const uint64_t allocated_rssid = uint64_t{write_rowset->id()} + write_segment.segment_idx();
-    EXPECT_GT(allocated_rssid, replay_ceiling);
     EXPECT_GT(allocated_rssid, origin_ceiling);
     ASSIGN_OR_ABORT(auto rows, read_two_column_rows(after_dml));
     EXPECT_EQ((std::vector<std::pair<int32_t, int32_t>>{{10, 1010}}), rows);
@@ -3721,14 +3707,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_allocation_covers_pr
         sources[1]->clear_sstable_meta();
         sources[1]->set_next_rowset_id(1);
     };
-    ASSIGN_OR_ABORT(auto zero_control,
-                    publish_metadata_only_merge_fixture(MetadataOnlyMergeShape::kPrivate, /*enable_tde=*/false,
-                                                        /*with_del_file=*/false, /*skip_source_flush=*/true,
-                                                        zero_segment_no_del));
-    const auto& zero_target = zero_control.published.at(zero_control.target_tablet_id);
-    EXPECT_EQ(0, zero_target.rowsets_size());
-    EXPECT_EQ(0, zero_target.sstable_meta().sstables_size());
-    EXPECT_EQ(1, zero_target.next_rowset_id());
+    auto zero_control = publish_metadata_only_merge_fixture(MetadataOnlyMergeShape::kPrivate, /*enable_tde=*/false,
+                                                            /*with_del_file=*/false, /*skip_source_flush=*/true,
+                                                            zero_segment_no_del);
+    EXPECT_TRUE(zero_control.status().is_corruption()) << zero_control.status();
 
     auto one_sst_boundary = [](std::vector<std::shared_ptr<TabletMetadataPB>>& sources) {
         sources[0]->clear_rowsets();
@@ -3749,7 +3731,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_allocation_covers_pr
         rowset->clear_segment_metas();
         auto* del = rowset->add_del_files();
         del->set_name("metadata_only_exhausted_history.del");
-        del->set_origin_rowset_id(1);
+        del->set_origin_rowset_id(2);
         del->set_op_offset(std::numeric_limits<int32_t>::max());
         write_binary_del_file(sources[0]->id(), del->name(), {});
     };
@@ -5818,89 +5800,17 @@ TEST_F(LakeTabletReshardTest, test_tablet_split_pruned_sst_full_merge_uses_live_
     EXPECT_NE(NullIndexValue, high_value.get_value());
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_filters_prechange_protected_rssid_delvecs) {
-    constexpr int64_t kBaseVersion = 1;
-    constexpr int64_t kMergeVersion = 2;
-
-    for (bool stale_first : {false, true}) {
-        SCOPED_TRACE(stale_first ? "partial stale-first" : "partial stale-last");
-        ASSIGN_OR_ABORT(auto fixture, make_prechange_protected_rssid_fixture());
-        const int64_t merged_tablet = next_id();
-        prepare_tablet_dirs(merged_tablet);
-        std::vector<TabletMetadataPtr> sources = {fixture.stale_child, fixture.empty_child};
-        if (!stale_first) std::reverse(sources.begin(), sources.end());
-        ASSIGN_OR_ABORT(auto files_before_merge, delvec_inventory(merged_tablet));
-        std::unordered_map<int64_t, TabletMetadataPtr> published;
-        ASSERT_OK(publish_resharding_merge(sources, merged_tablet, kBaseVersion, kMergeVersion, next_id(), published));
-        const auto& merged = published.at(merged_tablet);
-
-        // No source in this partial merge owns a segment at the protected rssid. The
-        // old zero-segment rowset is discarded, so neither its page nor its file may
-        // survive, independent of which child seeds the merge namespace.
-        EXPECT_EQ(0, merged->rowsets_size());
-        EXPECT_EQ(0, merged->delvec_meta().delvecs_size());
-        EXPECT_EQ(0, merged->delvec_meta().version_to_file_size());
-        ASSIGN_OR_ABORT(auto files_after_merge, delvec_inventory(merged_tablet));
-        EXPECT_EQ(files_before_merge, files_after_merge);
-
-        // Discarding the protected rowset makes rssid 1 the next real allocation.
-        // A stale page at rssid 1 masks this first writer's row even though the PK
-        // index points to it, which is the user-visible corruption this regression
-        // must prevent.
-        ASSERT_EQ(fixture.protected_rssid, merged->next_rowset_id());
-        _update_manager->unload_and_remove_primary_index(merged_tablet);
-        ASSIGN_OR_ABORT(auto after_write,
-                        publish_followup_upsert_delete(merged_tablet, merged->version(), /*upsert_key=*/60,
-                                                       /*upsert_value=*/600, /*delete_key=*/0,
-                                                       /*include_delete=*/false));
-        ASSERT_EQ(1, after_write->rowsets_size());
-        ASSERT_EQ(1, after_write->rowsets(0).segment_metas_size());
-        EXPECT_EQ(fixture.protected_rssid, lake::get_rssid(after_write->rowsets(0), 0));
-
-        _update_manager->unload_and_remove_primary_index(merged_tablet);
-        _tablet_manager->prune_metacache();
-        ASSIGN_OR_ABORT(auto reopened, _tablet_manager->get_tablet_metadata(merged_tablet, after_write->version()));
-        expect_lifecycle_oracle(reopened, {{60, 600}}, /*deleted_keys=*/{});
-    }
-
-    for (bool stale_first : {false, true}) {
-        SCOPED_TRACE(stale_first ? "full stale-first" : "full stale-last");
-        ASSIGN_OR_ABORT(auto fixture, make_prechange_protected_rssid_fixture());
-        const int64_t merged_tablet = next_id();
-        prepare_tablet_dirs(merged_tablet);
-        std::vector<TabletMetadataPtr> sources = {fixture.owner, fixture.stale_child};
-        if (stale_first) std::reverse(sources.begin(), sources.end());
-        ASSIGN_OR_ABORT(auto files_before_merge, delvec_inventory(merged_tablet));
-        std::unordered_map<int64_t, TabletMetadataPtr> published;
-        ASSERT_OK(publish_resharding_merge(sources, merged_tablet, kBaseVersion, kMergeVersion, next_id(), published));
-        const auto& merged = published.at(merged_tablet);
-
-        uint32_t owner_rssid = 0;
-        for (const auto& rowset : merged->rowsets()) {
-            for (int segment_pos = 0; segment_pos < rowset.segment_metas_size(); ++segment_pos) {
-                if (rowset.segment_metas(segment_pos).filename() == "prechange_protected_owner.dat") {
-                    owner_rssid = lake::get_rssid(rowset, segment_pos);
-                }
-            }
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_prechange_empty_protected_rowsets_before_io) {
+    for (bool include_owner : {false, true}) {
+        for (bool stale_first : {false, true}) {
+            SCOPED_TRACE(fmt::format("include_owner={}, stale_first={}", include_owner, stale_first));
+            ASSIGN_OR_ABORT(auto fixture, make_prechange_protected_rssid_fixture());
+            std::vector<TabletMetadataPtr> sources = {include_owner ? fixture.owner : fixture.empty_child,
+                                                      fixture.stale_child};
+            if (stale_first) std::reverse(sources.begin(), sources.end());
+            MergePhaseCounts counts;
+            expect_physical_preflight_rejection(sources, next_id(), 2, &counts);
         }
-        ASSERT_NE(0, owner_rssid);
-        EXPECT_EQ(1, merged->delvec_meta().delvecs_size());
-        EXPECT_TRUE(merged->delvec_meta().delvecs().contains(owner_rssid));
-        EXPECT_EQ(1, merged->delvec_meta().version_to_file_size());
-        ASSIGN_OR_ABORT(auto files_after_merge, delvec_inventory(merged_tablet));
-        EXPECT_EQ(files_before_merge.size() + 1, files_after_merge.size());
-
-        DelVector owner_delvec;
-        LakeIOOptions io_options;
-        ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *merged, owner_rssid, false, io_options, &owner_delvec));
-        ASSERT_NE(nullptr, owner_delvec.roaring());
-        EXPECT_FALSE(owner_delvec.roaring()->contains(0));
-        EXPECT_TRUE(owner_delvec.roaring()->contains(1));
-
-        _update_manager->unload_and_remove_primary_index(merged_tablet);
-        _tablet_manager->prune_metacache();
-        ASSIGN_OR_ABORT(auto reopened, _tablet_manager->get_tablet_metadata(merged_tablet, merged->version()));
-        expect_lifecycle_oracle(reopened, {{0, 0}}, /*deleted_keys=*/{1});
     }
 }
 
@@ -11408,7 +11318,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_duplicate_segment_inde
 
         MergePhaseCounts counts;
         auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
-        EXPECT_TRUE(status.message().contains("duplicate effective segment index")) << status;
+        EXPECT_TRUE(status.message().contains("not strictly increasing")) << status;
     }
 }
 
@@ -11425,8 +11335,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_duplicate_physical_sli
 
         MergePhaseCounts counts;
         auto status = expect_physical_preflight_rejection({source}, next_id(), /*target_version=*/2, &counts);
-        EXPECT_TRUE(status.message().contains(filename)) << status;
-        EXPECT_TRUE(status.message().contains("multiple segment indices")) << status;
+        if (reverse_segments) {
+            EXPECT_TRUE(status.message().contains("not strictly increasing")) << status;
+        } else {
+            EXPECT_TRUE(status.message().contains(filename)) << status;
+            EXPECT_TRUE(status.message().contains("multiple segment indices")) << status;
+        }
     }
 }
 
@@ -11782,7 +11696,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_sst_fil
 
         MergePhaseCounts counts;
         auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
-        EXPECT_TRUE(status.message().contains("SST")) << status;
+        if (std::string_view(conflict.name) != "invalid range arity") {
+            EXPECT_TRUE(status.message().contains("SST")) << status;
+        }
     }
 }
 
@@ -13493,12 +13409,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_same_range_exact_duplicate_cou
     rowset->set_num_rows(10);
     rowset->set_data_size(100);
     rowset->set_num_dels(3);
-    auto second = std::make_shared<TabletMetadataPB>(*first);
-    second->set_id(next_id());
-    // Explicit identical unbounded ranges are deliberate duplicate occurrences.
-    first->mutable_range();
-    second->mutable_range();
-    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({second, first}));
+    // Exact duplicates live inside one source; distinct source tablets must
+    // still form a nonoverlapping partition.
+    first->add_rowsets()->CopyFrom(*rowset);
+    first->mutable_rowsets(1)->set_id(20);
+    first->set_next_rowset_id(30);
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first}));
     ASSERT_EQ(1, merged->rowsets_size());
     EXPECT_EQ(10, merged->rowsets(0).num_rows());
     EXPECT_EQ(100, merged->rowsets(0).data_size());
@@ -13516,15 +13432,18 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_equivalent_range_encodings_cou
             rowset->set_num_rows(10);
             rowset->set_data_size(100);
             rowset->set_num_dels(3);
-            auto* range = first->mutable_range();
+            first->mutable_range();
+            auto* range = rowset->mutable_range();
             if (encoding == 2) {
                 *range->mutable_lower_bound() = generate_sort_key(0);
                 range->set_lower_bound_included(true);
                 *range->mutable_upper_bound() = generate_sort_key(20);
                 range->set_upper_bound_included(false);
             }
-            auto second = std::make_shared<TabletMetadataPB>(*first);
-            second->set_id(next_id());
+            auto* second = first->add_rowsets();
+            second->CopyFrom(*rowset);
+            second->set_id(20);
+            first->set_next_rowset_id(30);
             if (encoding < 2) {
                 // Flags on absent endpoints do not change an unbounded range.
                 second->mutable_range()->set_upper_bound_included(encoding == 1);
@@ -13533,9 +13452,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_equivalent_range_encodings_cou
                 second->mutable_range()->mutable_lower_bound()->mutable_values(0)->clear_variant_type();
                 second->mutable_range()->mutable_upper_bound()->mutable_values(0)->clear_variant_type();
             }
-            ASSERT_NE(first->range().SerializeAsString(), second->range().SerializeAsString());
-            auto forward = publish_allocator_merge({first, second});
-            auto reverse = publish_allocator_merge({second, first});
+            ASSERT_NE(rowset->range().SerializeAsString(), second->range().SerializeAsString());
+            auto forward = publish_allocator_merge({first});
+            first->mutable_rowsets()->SwapElements(0, 1);
+            auto reverse = publish_allocator_merge({first});
             EXPECT_OK(forward.status());
             EXPECT_OK(reverse.status());
             if (!forward.ok() || !reverse.ok()) continue;
@@ -13579,9 +13499,10 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_same_range_requires_complete_s
     add_allocator_segment(second->mutable_rowsets(0), "complete-7.dat", 7);
     second->mutable_rowsets(0)->set_num_rows(r->num_rows());
     second->mutable_rowsets(0)->set_data_size(r->data_size());
-    first->mutable_range();
-    second->mutable_range();
-    auto result = publish_allocator_merge({first, second});
+    first->add_rowsets()->CopyFrom(second->rowsets(0));
+    first->mutable_rowsets(1)->set_id(20);
+    first->set_next_rowset_id(30);
+    auto result = publish_allocator_merge({first});
     EXPECT_TRUE(result.status().is_corruption()) << result.status();
 }
 
@@ -13594,7 +13515,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_strictly_overlapping_u
     first->mutable_range()->set_upper_bound_included(false);
     *second->mutable_range()->mutable_lower_bound() = generate_sort_key(10);
     second->mutable_range()->set_lower_bound_included(true);
-    auto result = publish_allocator_merge({first, second});
+    first->mutable_rowsets(0)->mutable_range()->CopyFrom(first->range());
+    auto* duplicate = first->add_rowsets();
+    duplicate->CopyFrom(second->rowsets(0));
+    duplicate->set_id(20);
+    duplicate->mutable_range()->CopyFrom(second->range());
+    first->clear_range();
+    first->set_next_rowset_id(30);
+    auto result = publish_allocator_merge({first});
     EXPECT_TRUE(result.status().is_corruption()) << result.status();
 }
 
@@ -13626,6 +13554,9 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_non_pk_true_gap_remains_distin
     first->mutable_range()->set_upper_bound_included(false);
     *second->mutable_range()->mutable_lower_bound() = generate_sort_key(20);
     second->mutable_range()->set_lower_bound_included(true);
+    // The rowset has a true gap, but source ownership is still contiguous.
+    second->mutable_rowsets(0)->mutable_range()->CopyFrom(second->range());
+    *second->mutable_range()->mutable_lower_bound() = generate_sort_key(10);
     ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({second, first}));
     ASSERT_EQ(2, merged->rowsets_size());
     for (const auto& r : merged->rowsets()) {
@@ -13883,6 +13814,191 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped
     expect_lifecycle_oracle(reopened_compacted, {{10, 1010}}, {60});
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_sparse_explicit_segment_indices) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(source.get(), 10, 1, "canonical_sparse_2.dat", 2);
+    add_allocator_segment(rowset, "canonical_sparse_7.dat", 7);
+    const auto uid = rowset->uid().SerializeAsString();
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({source}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(uid, merged->rowsets(0).uid().SerializeAsString());
+    ASSERT_EQ(2, merged->rowsets(0).segment_metas_size());
+    EXPECT_EQ(2, merged->rowsets(0).segment_metas(0).segment_idx());
+    EXPECT_EQ(7, merged->rowsets(0).segment_metas(1).segment_idx());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_nonzero_compaction_cursor) {
+    auto a = make_allocator_source(next_id(), 20);
+    auto* first = add_allocator_rowset(a.get(), 10, 1, "canonical_cursor.dat", 7);
+    first->set_overlapped(true);
+    first->set_next_compaction_offset(3);
+    auto b = make_allocator_source(next_id(), 30);
+    auto* second = b->add_rowsets();
+    second->CopyFrom(*first);
+    second->set_id(20);
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({a, b}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(3, merged->rowsets(0).next_compaction_offset());
+    EXPECT_EQ(7, merged->rowsets(0).segment_metas(0).segment_idx());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_invalid_predicate_shape_before_io) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(source.get(), 10, 1, "predicate_payload.dat");
+    rowset->mutable_delete_predicate()->set_version(-1);
+    MergePhaseCounts counts;
+    expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_duplicate_segment_index_before_io) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(source.get(), 10, 1, "canonical_duplicate_a.dat", 2);
+    add_allocator_segment(rowset, "canonical_duplicate_b.dat", 2);
+    MergePhaseCounts counts;
+    expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_self_del_offset_outside_current_segments) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(source.get(), 10, 1, "canonical_self.dat", 7);
+    auto* del = rowset->add_del_files();
+    del->set_name("canonical_self.del");
+    del->set_origin_rowset_id(10);
+    del->set_op_offset(2);
+    MergePhaseCounts counts;
+    expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_segmentless_self_del_offset_zero) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(10);
+    rowset->set_version(1);
+    lake::tablet_reshard_helper::set_rowset_uid(rowset);
+    auto* del = rowset->add_del_files();
+    del->set_name("canonical_segmentless.del");
+    del->set_origin_rowset_id(10);
+    del->set_op_offset(0);
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({source}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(0, merged->rowsets(0).segment_metas_size());
+    ASSERT_EQ(1, merged->rowsets(0).del_files_size());
+    EXPECT_EQ(merged->rowsets(0).id(), merged->rowsets(0).del_files(0).origin_rowset_id());
+    EXPECT_EQ(0, merged->rowsets(0).del_files(0).op_offset());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_inherited_del_offset_outside_current_segments) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(source.get(), 10, 1, "canonical_inherited.dat", 0);
+    auto* del = rowset->add_del_files();
+    del->set_name("canonical_inherited.del");
+    del->set_origin_rowset_id(2);
+    del->set_op_offset(5);
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({source}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(7, merged->rowsets(0).id());
+    EXPECT_EQ(1, merged->rowsets(0).del_files(0).origin_rowset_id());
+    EXPECT_EQ(5, merged->rowsets(0).del_files(0).op_offset());
+    EXPECT_EQ(8, merged->next_rowset_id());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_transferred_inherited_del_survives_cold_load) {
+    const int32_t old_min_segments = config::lake_pk_compaction_min_input_segments;
+    const bool old_parallel = config::enable_pk_index_parallel_compaction;
+    config::lake_pk_compaction_min_input_segments = 1;
+    config::enable_pk_index_parallel_compaction = false;
+    DeferOp restore([&] {
+        config::lake_pk_compaction_min_input_segments = old_min_segments;
+        config::enable_pk_index_parallel_compaction = old_parallel;
+    });
+    ASSIGN_OR_ABORT(auto initial, create_lifecycle_source(next_id(), 0, 300, 10, 100, false));
+    ASSIGN_OR_ABORT(auto deleted, publish_followup_upsert_delete(initial->id(), initial->version(), 110, 1100, 10));
+    ASSERT_EQ(1, deleted->rowsets(deleted->rowsets_size() - 1).del_files_size());
+    const auto original_del = deleted->rowsets(deleted->rowsets_size() - 1).del_files(0);
+    ASSIGN_OR_ABORT(auto compacted, compact_tablet(deleted->id(), deleted->version(), true));
+    ASSERT_EQ(1, compacted->rowsets_size());
+    ASSERT_EQ(1, compacted->rowsets(0).del_files_size());
+    EXPECT_EQ(original_del.origin_rowset_id(), compacted->rowsets(0).del_files(0).origin_rowset_id());
+    ASSERT_NE(compacted->rowsets(0).id(), original_del.origin_rowset_id());
+    ASSIGN_OR_ABORT(auto children, repeated_split_three_way(compacted));
+    ASSERT_EQ(3, children.size());
+    const int64_t target = next_id();
+    prepare_tablet_dirs(target);
+    std::unordered_map<int64_t, TabletMetadataPtr> published;
+    ASSERT_OK(publish_resharding_merge(children, target, children.front()->version(), children.front()->version() + 1,
+                                       next_id(), published));
+    auto merged = published.at(target);
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_EQ(1, merged->rowsets(0).del_files_size());
+    EXPECT_EQ(original_del.name(), merged->rowsets(0).del_files(0).name());
+    EXPECT_NE(merged->rowsets(0).id(), merged->rowsets(0).del_files(0).origin_rowset_id());
+    _update_manager->unload_and_remove_primary_index(target);
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto reopened, _tablet_manager->get_tablet_metadata(target, merged->version()));
+    expect_lifecycle_oracle(reopened, {{110, 1100}}, {10});
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_same_uid_canonical_conflicts_before_io) {
+    enum Mutation { VERSION, SCHEMA_MAPPING, DEL_BEARING_MODE, NEXT_COMPACTION_OFFSET, STABLE_RESIDUAL_FIELD };
+    for (auto mutation : {VERSION, SCHEMA_MAPPING, DEL_BEARING_MODE, NEXT_COMPACTION_OFFSET, STABLE_RESIDUAL_FIELD}) {
+        SCOPED_TRACE(mutation);
+        auto a = make_allocator_source(next_id(), 20);
+        auto* first = add_allocator_rowset(a.get(), 10, 1, "canonical_conflict.dat", 7);
+        first->set_overlapped(true);
+        auto b = make_allocator_source(next_id(), 30);
+        auto* second = b->add_rowsets();
+        second->CopyFrom(*first);
+        second->set_id(20);
+        switch (mutation) {
+        case VERSION:
+            second->set_version(2);
+            break;
+        case SCHEMA_MAPPING:
+            (*b->mutable_rowset_to_schema())[20] = 4001;
+            break;
+        case DEL_BEARING_MODE: {
+            auto* del = second->add_del_files();
+            del->set_name("canonical_conflict.del");
+            del->set_origin_rowset_id(20);
+            del->set_op_offset(7);
+            break;
+        }
+        case NEXT_COMPACTION_OFFSET:
+            second->set_next_compaction_offset(3);
+            break;
+        case STABLE_RESIDUAL_FIELD:
+            first->set_max_compact_input_rowset_id(4);
+            second->set_max_compact_input_rowset_id(5);
+            break;
+        }
+        MergePhaseCounts counts;
+        expect_physical_preflight_rejection({a, b}, next_id(), 2, &counts);
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_empty_effective_rowset_range_before_io) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(source.get(), 10, 1, "canonical_empty_range.dat");
+    source->mutable_range();
+    *rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(1);
+    *rowset->mutable_range()->mutable_upper_bound() = generate_sort_key(1);
+    rowset->mutable_range()->set_lower_bound_included(true);
+    rowset->mutable_range()->set_upper_bound_included(false);
+    MergePhaseCounts counts;
+    expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_rowset_range_outside_source_before_io) {
+    auto source = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(source.get(), 10, 1, "canonical_outside.dat");
+    *source->mutable_range()->mutable_upper_bound() = generate_sort_key(10);
+    source->mutable_range()->set_upper_bound_included(false);
+    *rowset->mutable_range()->mutable_upper_bound() = generate_sort_key(20);
+    rowset->mutable_range()->set_upper_bound_included(false);
+    MergePhaseCounts counts;
+    expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_mixed_self_inherited_del_class) {
     auto selected_source = make_allocator_source(next_id(), 11);
     auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "mixed_del.dat", 0);
@@ -14127,6 +14243,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_unions_matching_predicate_rang
     right->mutable_range()->set_lower_bound_included(true);
     right->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
     right->mutable_range()->set_upper_bound_included(false);
+    first->mutable_range()->CopyFrom(left->range());
+    second->mutable_range()->CopyFrom(right->range());
 
     ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second}));
     ASSERT_EQ(1, merged->rowsets_size());

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -3070,8 +3070,8 @@ protected:
         lake::tablet_reshard_helper::set_rowset_uid(rowset);
         for (int i = 0; i < 2; ++i) {
             const auto name = fmt::format("fixed_{}_{}.dat", metadata->id(), i);
-            const auto size =
-                    write_two_column_segment(metadata->id(), name, 50, [](int key) { return key * 10; }, i * 50);
+            const auto size = write_two_column_segment(
+                    metadata->id(), name, 50, [](int key) { return key * 10; }, i * 50);
             auto* segment = rowset->add_segment_metas();
             segment->set_filename(name);
             segment->set_size(size);
@@ -8955,8 +8955,10 @@ TEST_F(LakeTabletReshardTest, test_batch_virtual_self_del_offset_survives_split_
 
     const std::string first_name = fmt::format("virtual_first_{}.dat", tablet_id);
     const std::string second_name = fmt::format("virtual_second_{}.dat", tablet_id);
-    const uint64_t first_size = write_two_column_segment(tablet_id, first_name, 1, [](int) { return 100; }, 10);
-    const uint64_t second_size = write_two_column_segment(tablet_id, second_name, 1, [](int) { return 300; }, 10);
+    const uint64_t first_size = write_two_column_segment(
+            tablet_id, first_name, 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(
+            tablet_id, second_name, 1, [](int) { return 300; }, 10);
 
     lake::Tablet tablet(_tablet_manager.get(), tablet_id);
     lake::MetaFileBuilder builder(tablet, source);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -3000,8 +3000,8 @@ protected:
         lake::tablet_reshard_helper::set_rowset_uid(rowset);
         for (int i = 0; i < 2; ++i) {
             const auto name = fmt::format("fixed_{}_{}.dat", metadata->id(), i);
-            const auto size =
-                    write_two_column_segment(metadata->id(), name, 50, [](int key) { return key * 10; }, i * 50);
+            const auto size = write_two_column_segment(
+                    metadata->id(), name, 50, [](int key) { return key * 10; }, i * 50);
             auto* segment = rowset->add_segment_metas();
             segment->set_filename(name);
             segment->set_size(size);
@@ -8743,8 +8743,10 @@ TEST_F(LakeTabletReshardTest, test_batch_virtual_self_del_offset_survives_split_
 
     const std::string first_name = fmt::format("virtual_first_{}.dat", tablet_id);
     const std::string second_name = fmt::format("virtual_second_{}.dat", tablet_id);
-    const uint64_t first_size = write_two_column_segment(tablet_id, first_name, 1, [](int) { return 100; }, 10);
-    const uint64_t second_size = write_two_column_segment(tablet_id, second_name, 1, [](int) { return 300; }, 10);
+    const uint64_t first_size = write_two_column_segment(
+            tablet_id, first_name, 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(
+            tablet_id, second_name, 1, [](int) { return 300; }, 10);
 
     lake::Tablet tablet(_tablet_manager.get(), tablet_id);
     lake::MetaFileBuilder builder(tablet, source);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -6274,11 +6274,9 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_scales_num_dels) {
     EXPECT_EQ(6, total_child_num_dels);
 }
 
-// Verify the fallback path: when the parent rowset predates num_dels (has_num_dels() ==
-// false), split derives D from the persisted delvec. A child rowset that cannot retrieve
-// D through either path must still carry an explicit num_dels (0) so that the Step 2
-// router in lake_service sees has_range() but has_num_dels() -> defaults to zero dels.
-TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_fallback_reads_delvec_for_num_dels) {
+// Current producers record the rowset delete anchor explicitly. SPLIT conserves
+// that anchor without deriving historical missing statistics from the delvec.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_explicit_num_dels_conservation) {
     const int64_t base_version = 2;
     const int64_t new_version = 3;
     const int64_t tablet_id = next_id();
@@ -6296,7 +6294,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_fallback_reads_delvec_for
     rowset->set_overlapped(true);
     rowset->set_num_rows(8);
     rowset->set_data_size(800);
-    // num_dels intentionally not set -> exercises get_rowset_num_deletes fallback.
+    rowset->set_num_dels(4);
 
     {
         auto* sm = rowset->add_segment_metas();
@@ -6349,7 +6347,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_fallback_reads_delvec_for
         EXPECT_TRUE(child_rowset.has_num_dels());
         total_child_num_dels += child_rowset.num_dels();
     }
-    // Σ child.num_dels should equal the delvec cardinality recovered via fallback (4).
+    // Σ child.num_dels equals the explicit current-producer anchor.
     EXPECT_EQ(4, total_child_num_dels);
 }
 
@@ -6473,11 +6471,9 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_per_rowset_conserv
     EXPECT_EQ(11, totals[4].num_dels);
 }
 
-// Pathological metadata: parent rowset has num_dels > num_rows. The anchor
-// builder clamps num_dels up front (with WARNING) so cap-and-redistribute
-// has a feasible input. After split, Σ children.num_dels equals the clamped
-// parent.num_rows, and per-child num_dels stays within rows.
-TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_clamps_invalid_parent_dels) {
+// Contradictory parent statistics are Corruption, not a clamped estimate or an
+// identical fallback. Rejection must occur before the required PK flush.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_rejects_invalid_parent_dels_before_flush) {
     const int64_t base_version = 2;
     const int64_t new_version = 3;
     const int64_t tablet_id = next_id();
@@ -6518,7 +6514,9 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_clamps_invalid_par
         sm->set_num_rows(5);
     }
 
-    EXPECT_OK(put_tablet_metadata(metadata));
+    lake::tablet_reshard_helper::set_rowset_uid(rowset);
+    for (int i = 0; i < rowset->segment_metas_size(); ++i) rowset->mutable_segment_metas(i)->set_segment_idx(i);
+    ASSERT_OK(_tablet_manager->put_tablet_metadata(metadata));
 
     ReshardingTabletInfoPB resharding;
     auto& splitting = *resharding.mutable_splitting_tablet_info();
@@ -6534,25 +6532,18 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_clamps_invalid_par
 
     std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
     std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
-    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
-                                              false, tablet_metadatas, tablet_ranges));
-
-    int64_t total_child_num_rows = 0;
-    int64_t total_child_num_dels = 0;
-    for (int64_t cid : {child_id_1, child_id_2}) {
-        auto it = tablet_metadatas.find(cid);
-        ASSERT_TRUE(it != tablet_metadatas.end());
-        ASSERT_EQ(1, it->second->rowsets_size());
-        const auto& child_rs = it->second->rowsets(0);
-        EXPECT_TRUE(child_rs.has_num_dels());
-        EXPECT_LE(child_rs.num_dels(), child_rs.num_rows());
-        total_child_num_rows += child_rs.num_rows();
-        total_child_num_dels += child_rs.num_dels();
-    }
-    // num_rows still conserves at parent.num_rows; num_dels conserves at the
-    // *clamped* parent value (= parent.num_rows = 10), not the bogus 15.
-    EXPECT_EQ(10, total_child_num_rows);
-    EXPECT_EQ(10, total_child_num_dels);
+    auto* sync = SyncPoint::GetInstance();
+    int flushes = 0;
+    sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version,
+                                                  txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_TRUE(status.is_corruption()) << status;
+    EXPECT_EQ(0, flushes);
 }
 
 // Anchor input fallback: legacy / incomplete metadata may omit
@@ -17094,6 +17085,48 @@ TEST_F(LakeTabletReshardTest, test_split_publish_stamps_fresh_sstable_with_new_v
         }
     }
     EXPECT_TRUE(saw_sstable) << "split should have produced a flushed PK sstable from the rebuilt index";
+}
+
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_full_sort_key_sampling_deduplicates_and_budgets_opens) {
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+    const bool old_enable = config::enable_full_sort_key_index;
+    config::enable_full_sort_key_index = true;
+    DeferOp restore_config([&] { config::enable_full_sort_key_index = old_enable; });
+    const std::string filename = "unique-full-key.dat";
+    const auto size = write_two_column_segment(tablet_id, filename, 300, [](int i) { return i; });
+    auto metadata = make_single_segment_pk_tablet(tablet_id, 2, filename, size, 300);
+    auto* rowset = metadata->mutable_rowsets(0);
+    rowset->set_num_dels(0);
+    rowset->mutable_segment_metas(0)->set_segment_idx(0);
+    *rowset->mutable_segment_metas(0)->mutable_sort_key_min() = generate_sort_key(0);
+    *rowset->mutable_segment_metas(0)->mutable_sort_key_max() = generate_sort_key(299);
+    auto* duplicate = metadata->add_rowsets();
+    *duplicate = *rowset;
+    duplicate->set_id(2);
+    duplicate->mutable_segment_metas(0)->set_segment_idx(7);
+    duplicate->mutable_segment_metas(0)->set_shared(true);
+
+    auto* sync = SyncPoint::GetInstance();
+    int opens = 0;
+    sync->SetCallBack("tablet_splitter:segment_open", [&](void*) { ++opens; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    std::vector<lake::TabletRangeInfo> ranges;
+    auto status = lake::get_tablet_split_ranges(_tablet_manager.get(), metadata, 3, &ranges);
+    EXPECT_OK(status);
+    EXPECT_EQ(3, ranges.size());
+    EXPECT_EQ(1, opens) << "one physical full-key index must be opened only once";
+
+    opens = 0;
+    ranges.clear();
+    sync->SetCallBack("tablet_splitter:set_metadata_visit_limit", [](void* p) { *static_cast<size_t*>(p) = 2; });
+    status = lake::get_tablet_split_ranges(_tablet_manager.get(), metadata, 3, &ranges);
+    EXPECT_TRUE(status.is_capacity_limit_exceeded()) << status;
+    EXPECT_EQ(0, opens) << "the shared budget must be charged before opening the first physical slice";
 }
 
 TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_full_sort_key_index_conservation) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -5484,7 +5484,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_self_del_offset_falls_back_a
     auto* del = m->mutable_rowsets(0)->add_del_files();
     del->set_name("self.del");
     del->set_origin_rowset_id(2);
-    del->set_op_offset(1);
+    del->set_op_offset(8);
     expect_split_fallback_after_flush(m);
 }
 
@@ -8562,6 +8562,237 @@ TEST_F(LakeTabletReshardTest, test_split_cross_publish_multi_stmt_batch_keeps_sc
     EXPECT_EQ(child1_rowset.uid().SerializeAsString(), child0_rowset.uid().SerializeAsString());
     EXPECT_EQ(1, child0_rowset.uid().hi());
     EXPECT_EQ(7777, child0_rowset.uid().lo());
+}
+
+// CORE-001: split cross-publish deliberately retains every shared physical segment and apportions
+// rowset stats. A child can therefore have positive approximate stats even when the shared segment
+// is wholly outside its range. A later SPLIT must take the typed identical fallback after its flush,
+// rather than treating current-producer metadata as corruption.
+TEST_F(LakeTabletReshardTest, test_cross_published_off_range_stats_split_falls_back_identical) {
+    constexpr int64_t kBaseVersion = 1;
+    constexpr int64_t kCrossVersion = 2;
+    constexpr int64_t kSplitVersion = 3;
+    const int64_t old_tablet = next_id();
+    const int64_t right_child = next_id();
+    const int64_t fallback_child = next_id();
+    const int64_t unused_child = next_id();
+    for (int64_t id : {old_tablet, right_child, fallback_child, unused_child}) prepare_tablet_dirs(id);
+
+    auto set_range = [&](TabletRangePB* range, int lower, int upper) {
+        *range->mutable_lower_bound() = generate_sort_key(lower);
+        range->set_lower_bound_included(true);
+        *range->mutable_upper_bound() = generate_sort_key(upper);
+        range->set_upper_bound_included(false);
+    };
+
+    auto right = std::make_shared<TabletMetadataPB>();
+    right->set_id(right_child);
+    right->set_version(kBaseVersion);
+    right->set_next_rowset_id(1);
+    set_two_column_pk_schema(right.get(), /*schema_id=*/4001);
+    right->mutable_schema()->set_keys_type(DUP_KEYS);
+    set_range(right->mutable_range(), 50, 100);
+    ASSERT_OK(put_tablet_metadata(right));
+
+    const std::string segment_name = fmt::format("cross_off_range_{}.dat", old_tablet);
+    const uint64_t segment_size =
+            write_two_column_segment(old_tablet, segment_name, 50, [](int key) { return key * 10; });
+    const int64_t cross_txn = next_id();
+    TxnLogPB cross_log;
+    cross_log.set_tablet_id(old_tablet);
+    cross_log.set_txn_id(cross_txn);
+    auto* cross_rowset = cross_log.mutable_op_write()->mutable_rowset();
+    cross_rowset->set_num_rows(50);
+    cross_rowset->set_data_size(segment_size);
+    lake::tablet_reshard_helper::set_rowset_uid(cross_rowset);
+    auto* segment = cross_rowset->add_segment_metas();
+    segment->set_filename(segment_name);
+    segment->set_size(segment_size);
+    segment->set_num_rows(50);
+    segment->set_segment_idx(0);
+    *segment->mutable_sort_key_min() = generate_sort_key(0);
+    *segment->mutable_sort_key_max() = generate_sort_key(49);
+    ASSERT_OK(_tablet_manager->put_txn_log(cross_log));
+
+    lake::PublishTabletInfo cross_info(lake::PublishTabletInfo::SPLITTING_TABLET, old_tablet, right_child,
+                                       /*split_count=*/2, /*split_index=*/1);
+    TxnInfoPB cross_txn_info;
+    cross_txn_info.set_txn_id(cross_txn);
+    cross_txn_info.set_txn_type(TXN_NORMAL);
+    cross_txn_info.set_commit_time(1);
+    ASSIGN_OR_ABORT(auto cross_published,
+                    lake::publish_version(_tablet_manager.get(), cross_info, kBaseVersion, kCrossVersion,
+                                          std::span<const TxnInfoPB>(&cross_txn_info, 1), false));
+    ASSERT_EQ(1, cross_published->rowsets_size());
+    const auto& published_rowset = cross_published->rowsets(0);
+    EXPECT_EQ(25, published_rowset.num_rows());
+    EXPECT_EQ(cross_published->range().SerializeAsString(), published_rowset.range().SerializeAsString());
+    ASSERT_EQ(1, published_rowset.segment_metas_size());
+    EXPECT_TRUE(published_rowset.segment_metas(0).shared());
+    ASSIGN_OR_ABORT(auto before_rows, read_two_column_rows(cross_published));
+    EXPECT_TRUE(before_rows.empty());
+
+    ReshardingTabletInfoPB request;
+    auto* split = request.mutable_splitting_tablet_info();
+    split->set_old_tablet_id(right_child);
+    split->add_new_tablet_ids(fallback_child);
+    split->add_new_tablet_ids(unused_child);
+    set_range(split->add_new_tablet_ranges(), 50, 75);
+    set_range(split->add_new_tablet_ranges(), 75, 100);
+    TxnInfoPB split_txn;
+    split_txn.set_txn_id(next_id());
+    split_txn.set_commit_time(1);
+    split_txn.set_gtid(1);
+
+    int flushes = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+    std::unordered_map<int64_t, TabletMetadataPtr> published;
+    std::unordered_map<int64_t, TabletRangePB> ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, kCrossVersion, kSplitVersion, split_txn,
+                                              false, published, ranges));
+    EXPECT_EQ(1, flushes);
+    ASSERT_TRUE(published.contains(right_child));
+    ASSERT_TRUE(published.contains(fallback_child));
+    EXPECT_FALSE(published.contains(unused_child));
+    EXPECT_EQ(cross_published->range().SerializeAsString(), published.at(fallback_child)->range().SerializeAsString());
+    EXPECT_EQ(cross_published->rowsets(0).SerializeAsString(),
+              published.at(fallback_child)->rowsets(0).SerializeAsString());
+    ASSIGN_OR_ABORT(auto after_rows, read_two_column_rows(published.at(fallback_child)));
+    EXPECT_EQ(before_rows, after_rows);
+}
+
+// CORE-002: MetaFileBuilder reserves a virtual operation slot for a pure DELETE statement in a
+// multi-statement batch. INSERT / DELETE / INSERT therefore produces physical segment indices
+// {0,2} with self-origin delete offset 1. Reshard must preserve that replay ordering even though
+// offset 1 does not name a physical segment.
+TEST_F(LakeTabletReshardTest, test_batch_virtual_self_del_offset_survives_split_merge_cold_load) {
+    constexpr int64_t kWriteVersion = 2;
+    constexpr int64_t kSplitVersion = 3;
+    constexpr int64_t kMergeVersion = 4;
+    const int64_t tablet_id = next_id();
+    const int64_t left_child = next_id();
+    const int64_t right_child = next_id();
+    const int64_t merged_tablet = next_id();
+    for (int64_t id : {tablet_id, left_child, right_child, merged_tablet}) prepare_tablet_dirs(id);
+
+    auto set_range = [&](TabletRangePB* range, int lower, int upper) {
+        *range->mutable_lower_bound() = generate_sort_key(lower);
+        range->set_lower_bound_included(true);
+        *range->mutable_upper_bound() = generate_sort_key(upper);
+        range->set_upper_bound_included(false);
+    };
+
+    auto source = std::make_shared<TabletMetadataPB>();
+    source->set_id(tablet_id);
+    source->set_version(kWriteVersion);
+    source->set_next_rowset_id(1);
+    set_two_column_pk_schema(source.get(), /*schema_id=*/4001);
+    source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    source->set_enable_persistent_index(true);
+    source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+    set_range(source->mutable_range(), 0, 100);
+
+    const std::string first_name = fmt::format("virtual_first_{}.dat", tablet_id);
+    const std::string second_name = fmt::format("virtual_second_{}.dat", tablet_id);
+    const uint64_t first_size = write_two_column_segment(tablet_id, first_name, 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(tablet_id, second_name, 1, [](int) { return 300; }, 10);
+
+    lake::Tablet tablet(_tablet_manager.get(), tablet_id);
+    lake::MetaFileBuilder builder(tablet, source);
+    auto make_upsert = [&](const std::string& name, uint64_t size) {
+        RowsetMetadataPB rowset;
+        rowset.set_num_rows(1);
+        rowset.set_data_size(size);
+        rowset.set_num_dels(0);
+        lake::tablet_reshard_helper::set_rowset_uid(&rowset);
+        auto* segment = rowset.add_segment_metas();
+        segment->set_filename(name);
+        segment->set_size(size);
+        segment->set_num_rows(1);
+        segment->set_segment_idx(0);
+        *segment->mutable_sort_key_min() = generate_sort_key(10);
+        *segment->mutable_sort_key_max() = generate_sort_key(10);
+        return rowset;
+    };
+    builder.add_rowset(make_upsert(first_name, first_size), {}, {}, {}, {}, {});
+
+    const std::string del_name = fmt::format("virtual_middle_{}.del", tablet_id);
+    write_binary_del_file(tablet_id, del_name, {encode_int_primary_key(10)});
+    RowsetMetadataPB pure_delete;
+    pure_delete.set_num_rows(0);
+    pure_delete.set_data_size(0);
+    pure_delete.set_num_dels(1);
+    FileMetaPB del_file;
+    del_file.set_name(del_name);
+    builder.add_rowset(pure_delete, {}, {}, std::vector<FileMetaPB>{del_file},
+                       /*del_op_offsets=*/{-1}, /*del_num_rows=*/{1});
+    builder.add_rowset(make_upsert(second_name, second_size), {}, {}, {}, {}, {});
+    ASSERT_OK(builder.set_final_rowset());
+    ASSERT_EQ(1, source->rowsets_size());
+
+    const auto& built_batch = source->rowsets(0);
+    DelVector first_segment_delvec;
+    const uint32_t deleted_row = 0;
+    first_segment_delvec.init(kWriteVersion, &deleted_row, 1);
+    add_delvec(source.get(), tablet_id, kWriteVersion, built_batch.id(),
+               fmt::format("virtual_middle_{}.delvec", tablet_id), first_segment_delvec.save());
+    ASSERT_OK(put_tablet_metadata(source));
+    TabletMetadataPtr written = source;
+    ASSERT_EQ(1, written->rowsets_size());
+    const auto& batch = written->rowsets(0);
+    ASSERT_EQ(2, batch.segment_metas_size());
+    EXPECT_EQ(0, batch.segment_metas(0).segment_idx());
+    EXPECT_EQ(2, batch.segment_metas(1).segment_idx());
+    ASSERT_EQ(1, batch.del_files_size());
+    EXPECT_EQ(batch.id(), batch.del_files(0).origin_rowset_id());
+    EXPECT_EQ(1, batch.del_files(0).op_offset());
+    expect_lifecycle_oracle(written, {{10, 300}}, {});
+
+    ReshardingTabletInfoPB split_request;
+    auto* split = split_request.mutable_splitting_tablet_info();
+    split->set_old_tablet_id(tablet_id);
+    split->add_new_tablet_ids(left_child);
+    split->add_new_tablet_ids(right_child);
+    set_range(split->add_new_tablet_ranges(), 0, 50);
+    set_range(split->add_new_tablet_ranges(), 50, 100);
+    TxnInfoPB split_info;
+    split_info.set_txn_id(next_id());
+    split_info.set_commit_time(1);
+    split_info.set_gtid(1);
+    std::unordered_map<int64_t, TabletMetadataPtr> split_published;
+    std::unordered_map<int64_t, TabletRangePB> split_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), split_request, kWriteVersion, kSplitVersion,
+                                              split_info, false, split_published, split_ranges));
+    ASSERT_TRUE(split_published.contains(left_child));
+    ASSERT_TRUE(split_published.contains(right_child));
+    for (int64_t child : {left_child, right_child}) {
+        ASSERT_EQ(1, split_published.at(child)->rowsets_size());
+        const auto& child_rowset = split_published.at(child)->rowsets(0);
+        ASSERT_EQ(2, child_rowset.segment_metas_size());
+        EXPECT_EQ(0, child_rowset.segment_metas(0).segment_idx());
+        EXPECT_EQ(2, child_rowset.segment_metas(1).segment_idx());
+        ASSERT_EQ(1, child_rowset.del_files_size());
+        EXPECT_EQ(1, child_rowset.del_files(0).op_offset());
+    }
+
+    std::unordered_map<int64_t, TabletMetadataPtr> merge_published;
+    ASSERT_OK(publish_resharding_merge({split_published.at(left_child), split_published.at(right_child)}, merged_tablet,
+                                       kSplitVersion, kMergeVersion, next_id(), merge_published));
+    auto merged = merge_published.at(merged_tablet);
+    ASSERT_EQ(1, merged->rowsets_size());
+    ASSERT_EQ(1, merged->rowsets(0).del_files_size());
+    EXPECT_EQ(1, merged->rowsets(0).del_files(0).op_offset());
+    expect_lifecycle_oracle(merged, {{10, 300}}, {});
+    _update_manager->unload_and_remove_primary_index(merged_tablet);
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto cold, _tablet_manager->get_tablet_metadata(merged_tablet, kMergeVersion));
+    expect_lifecycle_oracle(cold, {{10, 300}}, {});
 }
 
 TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for_splitting) {
@@ -14642,13 +14873,13 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_duplicate_segment_inde
     expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_self_del_offset_outside_current_segments) {
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_self_del_offset_outside_replay_span) {
     auto source = make_allocator_source(next_id(), 20);
     auto* rowset = add_allocator_rowset(source.get(), 10, 1, "canonical_self.dat", 7);
     auto* del = rowset->add_del_files();
     del->set_name("canonical_self.del");
     del->set_origin_rowset_id(10);
-    del->set_op_offset(2);
+    del->set_op_offset(8);
     MergePhaseCounts counts;
     expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
 }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -17570,7 +17570,8 @@ inline void set_pk_int_key_schema(TabletMetadataPB* metadata, int64_t schema_id)
 inline std::shared_ptr<TabletMetadataPB> make_pk_shared_child_with_real_segment(int64_t tablet_id, int64_t base_version,
                                                                                 uint32_t shared_id, int tablet_lower,
                                                                                 int tablet_upper,
-                                                                                uint64_t segment_size) {
+                                                                                uint64_t segment_size,
+                                                                                int physical_num_rows) {
     auto meta = std::make_shared<TabletMetadataPB>();
     meta->set_id(tablet_id);
     meta->set_version(base_version);
@@ -17587,7 +17588,7 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_shared_child_with_real_segment(
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(segment_size);
-        sm->set_num_rows(tablet_upper - tablet_lower);
+        sm->set_num_rows(physical_num_rows);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across shared siblings => dedup
@@ -17657,7 +17658,7 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_compacted_child(int64_t tablet_
                                                    fmt::format("compacted_{}.dat", i));                                \
             } else {                                                                                                   \
                 metas[i] = make_pk_shared_child_with_real_segment(child_ids[i], base_version, /*shared_id=*/10, lower, \
-                                                                  upper, segment_size);                                \
+                                                                  upper, segment_size, /*physical_num_rows=*/kNumRows); \
             }                                                                                                          \
             EXPECT_OK(put_tablet_metadata(metas[i]));                                                                  \
         }                                                                                                              \
@@ -17719,11 +17720,13 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_encrypted_delvec_gap_promotion
         }
         const uint64_t segment_size =
                 write_two_column_segment(merged_tablet, "shared_seg.dat", 30, [](int value) { return value * 10; });
-        auto left = make_pk_shared_child_with_real_segment(child_left, kBaseVersion, kSharedRssid, 0, 10, segment_size);
+        auto left = make_pk_shared_child_with_real_segment(child_left, kBaseVersion, kSharedRssid, 0, 10, segment_size,
+                                                           /*physical_num_rows=*/30);
         auto compacted =
                 make_pk_compacted_child(child_gap, kBaseVersion, /*compacted_id=*/11, 10, 20, "compacted_gap.dat");
         auto right =
-                make_pk_shared_child_with_real_segment(child_right, kBaseVersion, kSharedRssid, 20, 30, segment_size);
+                make_pk_shared_child_with_real_segment(child_right, kBaseVersion, kSharedRssid, 20, 30, segment_size,
+                                                       /*physical_num_rows=*/30);
         DelVector source_delvec;
         const uint32_t deleted = 0;
         source_delvec.init(/*version=*/10, &deleted, 1);
@@ -17812,7 +17815,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_synthesized_delvec_survives_la
     // sstable_meta carries a shared sstable with shared_rssid=10 (A's R0
     // namespace) and NO has_delvec on source — exercising the §5.2.4 path.
     auto meta_a = make_pk_shared_child_with_real_segment(child_a, base_version, /*shared_id=*/10, /*lower=*/0,
-                                                         /*upper=*/10, segment_size);
+                                                         /*upper=*/10, segment_size, /*physical_num_rows=*/20);
     meta_a->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
     auto* sst_a = meta_a->mutable_sstable_meta()->add_sstables();
     sst_a->set_filename("shared.sst");

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -394,6 +394,7 @@ protected:
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(fmt::format("segment-{}-{}.dat", metadata->id(), rowset_id));
             sm->set_size(128);
+            sm->set_num_rows(1);
         }
         auto* del_file = rowset->add_del_files();
         del_file->set_name("del.dat");
@@ -415,6 +416,7 @@ protected:
                 auto* sm = rowset->add_segment_metas();
                 sm->set_filename(fmt::format("segment_{}.dat", rowset_id));
                 sm->set_size(128);
+                sm->set_num_rows(1);
             }
             rowset->set_num_rows(1);
             rowset->set_data_size(128);
@@ -440,7 +442,8 @@ protected:
         return rowset;
     }
 
-    std::vector<TabletMetadataPtr> merge_fixture_sources(const std::vector<TabletMetadataPtr>& sources) {
+    std::vector<TabletMetadataPtr> merge_fixture_sources(const std::vector<TabletMetadataPtr>& sources,
+                                                         bool normalize_missing_segment_num_rows = true) {
         const bool assign_ranges =
                 std::all_of(sources.begin(), sources.end(), [](const auto& source) { return !source->has_range(); });
         std::vector<int64_t> ids;
@@ -449,6 +452,16 @@ protected:
         std::vector<TabletMetadataPtr> result;
         for (const auto& source : sources) {
             auto copy = std::make_shared<TabletMetadataPB>(*source);
+            if (normalize_missing_segment_num_rows) {
+                for (auto& rowset : *copy->mutable_rowsets()) {
+                    for (auto& segment : *rowset.mutable_segment_metas()) {
+                        // Existing synthetic fixtures predate MERGE's strict segment-count
+                        // contract. Keep their old default-zero behavior; malformed-input
+                        // tests opt out of this fixture-only normalization.
+                        if (!segment.has_num_rows()) segment.set_num_rows(0);
+                    }
+                }
+            }
             if (assign_ranges) {
                 if (copy->has_schema() && copy->schema().column_size() == 0) {
                     auto* column = copy->mutable_schema()->add_column();
@@ -492,8 +505,11 @@ protected:
     Status publish_resharding_merge(const std::vector<TabletMetadataPtr>& sources, int64_t merged_tablet,
                                     int64_t base_version, int64_t new_version, int64_t txn_id,
                                     std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
-                                    const std::function<void()>& before_merge = {}) {
-        for (const auto& source : merge_fixture_sources(sources)) RETURN_IF_ERROR(put_tablet_metadata(source));
+                                    const std::function<void()>& before_merge = {},
+                                    bool normalize_missing_segment_num_rows = true) {
+        for (const auto& source : merge_fixture_sources(sources, normalize_missing_segment_num_rows)) {
+            RETURN_IF_ERROR(put_tablet_metadata(source));
+        }
         if (before_merge) before_merge();
         ReshardingTabletInfoPB resharding_tablet;
         auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -560,7 +576,8 @@ protected:
     }
 
     StatusOr<TabletMetadataPtr> publish_allocator_merge(
-            const std::vector<std::shared_ptr<TabletMetadataPB>>& mutable_sources) {
+            const std::vector<std::shared_ptr<TabletMetadataPB>>& mutable_sources,
+            bool normalize_missing_segment_num_rows = true) {
         if (mutable_sources.empty()) return Status::InvalidArgument("allocator merge fixture has no source");
         const int64_t target_id = next_id();
         prepare_tablet_dirs(target_id);
@@ -572,7 +589,8 @@ protected:
         }
         std::unordered_map<int64_t, TabletMetadataPtr> published;
         RETURN_IF_ERROR(publish_resharding_merge(sources, target_id, /*base_version=*/1, /*new_version=*/2,
-                                                 /*txn_id=*/next_id(), published));
+                                                 /*txn_id=*/next_id(), published, {},
+                                                 normalize_missing_segment_num_rows));
         auto target = published.find(target_id);
         if (target == published.end()) return Status::InternalError("allocator merge target was not published");
         return target->second;
@@ -770,7 +788,8 @@ protected:
 
     StatusOr<MutableTabletMetadataPtr> merge_with_phase_counts(const std::vector<TabletMetadataPtr>& sources,
                                                                int64_t target_tablet_id, int64_t target_version,
-                                                               MergePhaseCounts* counts) {
+                                                               MergePhaseCounts* counts,
+                                                               bool normalize_missing_segment_num_rows = true) {
         auto* sync = SyncPoint::GetInstance();
         sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++counts->materialize; });
         sync->SetCallBack("merge_dcg_meta:after_write_cols", [&](void*) { ++counts->dcg_writes; });
@@ -790,7 +809,7 @@ protected:
 
         ReshardingTabletInfoPB resharding;
         auto* merging = resharding.mutable_merging_tablet_info();
-        for (const auto& source : merge_fixture_sources(sources)) {
+        for (const auto& source : merge_fixture_sources(sources, normalize_missing_segment_num_rows)) {
             RETURN_IF_ERROR(_tablet_manager->put_tablet_metadata(source));
             merging->add_old_tablet_ids(source->id());
         }
@@ -807,11 +826,12 @@ protected:
     }
 
     Status expect_physical_preflight_rejection(const std::vector<TabletMetadataPtr>& sources, int64_t target_tablet_id,
-                                               int64_t target_version, MergePhaseCounts* counts) {
+                                               int64_t target_version, MergePhaseCounts* counts,
+                                               bool normalize_missing_segment_num_rows = true) {
         std::vector<std::string> source_pbs;
         std::map<int64_t, std::set<std::string>> segment_inventories;
         std::map<int64_t, std::set<std::string>> metadata_inventories;
-        for (const auto& source : merge_fixture_sources(sources)) {
+        for (const auto& source : merge_fixture_sources(sources, normalize_missing_segment_num_rows)) {
             CHECK_OK(_tablet_manager->put_tablet_metadata(source));
         }
         for (const auto& source : sources) {
@@ -831,7 +851,8 @@ protected:
         set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::ENABLE);
         DeferOp restore_delvec_failpoint(
                 [&] { set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::DISABLE); });
-        auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts);
+        auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts,
+                                              normalize_missing_segment_num_rows);
 
         EXPECT_TRUE(merged.status().is_corruption()) << merged.status();
         EXPECT_EQ(0, counts->materialize);
@@ -1670,6 +1691,7 @@ protected:
                 auto* segment_meta = rowset->add_segment_metas();
                 segment_meta->set_filename(fmt::format("compacted_{}.dat", i));
                 segment_meta->set_size(100);
+                segment_meta->set_num_rows(upper - lower);
                 set_key_range(rowset->mutable_range(), lower, upper);
                 (*meta->mutable_rowset_to_schema())[2] = kSchemaId;
             } else {
@@ -1690,6 +1712,7 @@ protected:
                 auto* segment_meta = rowset->add_segment_metas();
                 segment_meta->set_filename(shared_segment_name);
                 segment_meta->set_size(base_segment_size);
+                segment_meta->set_num_rows(kNumRows);
                 segment_meta->set_shared(true);
                 stamp_physical_identity_uid(rowset, shared_segment_name); // same uid across siblings => dedup
                 set_key_range(rowset->mutable_range(), lower, upper);
@@ -4436,6 +4459,32 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_empty_ordinary_rowsets
 
         MergePhaseCounts counts;
         expect_physical_preflight_rejection({source}, next_id(), 2, &counts);
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_invalid_segment_num_rows_rejected_before_io) {
+    struct Mutation {
+        const char* name;
+        std::function<void(SegmentMetadataPB*)> apply;
+    };
+    const std::vector<Mutation> mutations = {
+            {"missing", [](SegmentMetadataPB* segment) { segment->clear_num_rows(); }},
+            {"negative", [](SegmentMetadataPB* segment) { segment->set_num_rows(-1); }},
+    };
+
+    for (const auto& mutation : mutations) {
+        for (const bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("mutation={} reverse_sources={}", mutation.name, reverse_sources));
+            auto source_a = make_preflight_sidecar_source(next_id(), fmt::format("invalid_{}_a.dat", next_id()));
+            auto source_b = make_preflight_sidecar_source(next_id(), fmt::format("invalid_{}_b.dat", next_id()));
+            mutation.apply(source_a->mutable_rowsets(0)->mutable_segment_metas(0));
+            std::vector<TabletMetadataPtr> sources = {source_a, source_b};
+            if (reverse_sources) std::reverse(sources.begin(), sources.end());
+
+            MergePhaseCounts counts;
+            expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts,
+                                                /*normalize_missing_segment_num_rows=*/false);
+        }
     }
 }
 
@@ -9598,6 +9647,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_vector_index_built_version_min) 
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
         stamp_physical_identity_uid(rowset, "shared_seg.dat");
         return meta;
@@ -12690,7 +12740,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_invalid_physical_segme
                  left->set_size(128);
                  right->set_bundle_file_offset(-1);
              }},
-            {"negative size", true, "size",
+            {"negative size", true, "negative statistics",
              [](SegmentMetadataPB* left, SegmentMetadataPB* right) {
                  left->set_size(-1);
                  right->set_size(-1);
@@ -14368,6 +14418,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_skip_sstable_merge_accepts_sig
     rowset->set_num_rows(1);
     rowset->set_data_size(1);
     rowset->add_segment_metas()->set_filename("skip_source_segment.dat");
+    rowset->mutable_segment_metas(0)->set_num_rows(1);
     rowset->mutable_segment_metas(0)->set_segment_idx(0);
     lake::tablet_reshard_helper::set_rowset_uid(rowset);
     auto* sst = source->mutable_sstable_meta()->add_sstables();
@@ -14548,6 +14599,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_packs_upper_half_live_rowset_w
     rowset->set_num_rows(1);
     rowset->set_data_size(1);
     rowset->add_segment_metas()->set_filename("last_live_segment.dat");
+    rowset->mutable_segment_metas(0)->set_num_rows(1);
     const std::string source_before = source->SerializeAsString();
     ASSERT_OK(put_tablet_metadata(source));
 
@@ -15775,7 +15827,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_segment_declaration_co
             break;
         }
         }
-        auto result = publish_allocator_merge({selected_source, duplicate_source});
+        auto result = publish_allocator_merge({selected_source, duplicate_source},
+                                               /*normalize_missing_segment_num_rows=*/false);
         EXPECT_TRUE(result.status().is_corruption()) << result.status();
     }
 }
@@ -17455,6 +17508,7 @@ inline std::shared_ptr<TabletMetadataPB> make_compacted_child(int64_t tablet_id,
         auto* sm = rowset->add_segment_metas();
         sm->set_filename(compacted_seg_name);
         sm->set_size(100);
+        sm->set_num_rows(10);
     }
     // Not shared: this is the local compaction output.
     set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
@@ -17506,6 +17560,7 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_shared_child_with_real_segment(
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(segment_size);
+        sm->set_num_rows(tablet_upper - tablet_lower);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across shared siblings => dedup
@@ -17533,6 +17588,7 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_compacted_child(int64_t tablet_
         auto* sm = rowset->add_segment_metas();
         sm->set_filename(compacted_seg_name);
         sm->set_size(100);
+        sm->set_num_rows(tablet_upper - tablet_lower);
     }
     set_int_range(rowset->mutable_range(), tablet_lower, tablet_upper);
     return meta;

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -21,6 +21,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <cstdlib>
 #include <ctime>
 #include <functional>
@@ -7325,6 +7326,108 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_accepts_dels_above_zero_e
     EXPECT_EQ(0, total_rows);
     EXPECT_EQ(15, total_dels);
     EXPECT_TRUE(saw_dels_above_rows);
+}
+
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_zero_active_weights_omit_child_conserves_deletes) {
+    auto set_range = [&](TabletRangePB* range, int lower, int upper) {
+        range->mutable_lower_bound()->CopyFrom(generate_sort_key(lower));
+        range->set_lower_bound_included(true);
+        range->mutable_upper_bound()->CopyFrom(generate_sort_key(upper));
+        range->set_upper_bound_included(false);
+    };
+
+    auto source = std::make_shared<TabletMetadataPB>();
+    source->set_id(next_id());
+    source->set_version(1);
+    source->set_next_rowset_id(3);
+    set_two_column_pk_schema(source.get(), 4001);
+    set_range(source->mutable_range(), 0, 200);
+    prepare_tablet_dirs(source->id());
+
+    const std::string segment_name = "zero-active-delete-weight.dat";
+    write_two_column_segment(
+            source->id(), segment_name, /*num_rows=*/2, [](int key) { return key * 10; },
+            /*key_start=*/0, [](int index) { return index * 100; });
+
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(2);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(0);
+    rowset->set_data_size(1000);
+    rowset->set_num_dels(1);
+    set_range(rowset->mutable_range(), 90, 200);
+    lake::tablet_reshard_helper::set_rowset_uid(rowset);
+    auto* segment = rowset->add_segment_metas();
+    segment->set_filename(segment_name);
+    segment->set_size(1000);
+    segment->set_num_rows(2);
+    segment->set_segment_idx(0);
+    segment->set_shared(true);
+    segment->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    segment->mutable_sort_key_max()->CopyFrom(generate_sort_key(100));
+
+    auto split_once = [&](const TabletMetadataPtr& input) {
+        SplittingTabletInfoPB splitting;
+        splitting.set_old_tablet_id(input->id());
+        const std::array<std::pair<int, int>, 3> bounds = {{{0, 50}, {50, 95}, {95, 200}}};
+        std::vector<int64_t> child_ids;
+        for (const auto& [lower, upper] : bounds) {
+            const int64_t child_id = next_id();
+            child_ids.push_back(child_id);
+            prepare_tablet_dirs(child_id);
+            splitting.add_new_tablet_ids(child_id);
+            set_range(splitting.add_new_tablet_ranges(), lower, upper);
+        }
+        TxnInfoPB txn;
+        txn.set_txn_id(next_id());
+        txn.set_commit_time(1);
+        txn.set_gtid(1);
+        ASSIGN_OR_ABORT(auto mutable_children,
+                        lake::split_tablet(_tablet_manager.get(), input, splitting, input->version() + 1, txn));
+        std::vector<TabletMetadataPtr> children;
+        for (const int64_t child_id : child_ids) children.push_back(mutable_children.at(child_id));
+        return children;
+    };
+
+    auto expect_conserved_split = [&](const std::vector<TabletMetadataPtr>& children) {
+        ASSERT_EQ(3, children.size());
+        EXPECT_EQ(0, children[0]->rowsets_size());
+        ASSERT_EQ(1, children[1]->rowsets_size());
+        ASSERT_EQ(1, children[2]->rowsets_size());
+        const auto& middle = children[1]->rowsets(0);
+        const auto& right = children[2]->rowsets(0);
+        EXPECT_EQ(0, middle.num_rows() + right.num_rows());
+        EXPECT_EQ(1000, middle.data_size() + right.data_size());
+        EXPECT_EQ(1, middle.num_dels() + right.num_dels());
+        EXPECT_EQ(1, middle.num_dels());
+        EXPECT_EQ(0, right.num_dels());
+        EXPECT_EQ(rowset->uid().SerializeAsString(), middle.uid().SerializeAsString());
+        EXPECT_EQ(rowset->uid().SerializeAsString(), right.uid().SerializeAsString());
+    };
+
+    auto first = split_once(source);
+    expect_conserved_split(first);
+    const RowsetMetadataPB first_middle(first[1]->rowsets(0));
+    const RowsetMetadataPB first_right(first[2]->rowsets(0));
+    auto stable_rowset = [](RowsetMetadataPB rowset) {
+        rowset.clear_id();
+        return rowset.SerializeAsString();
+    };
+
+    const int64_t merged_id = next_id();
+    prepare_tablet_dirs(merged_id);
+    std::unordered_map<int64_t, TabletMetadataPtr> published;
+    ASSERT_OK(publish_resharding_merge(first, merged_id, first[0]->version(), first[0]->version() + 1, next_id(),
+                                       published));
+    const auto& merged = published.at(merged_id);
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(1, merged->rowsets(0).num_dels());
+    EXPECT_EQ(rowset->uid().SerializeAsString(), merged->rowsets(0).uid().SerializeAsString());
+
+    auto second = split_once(merged);
+    expect_conserved_split(second);
+    EXPECT_EQ(stable_rowset(first_middle), stable_rowset(second[1]->rowsets(0)));
+    EXPECT_EQ(stable_rowset(first_right), stable_rowset(second[2]->rowsets(0)));
 }
 
 // Anchor input fallback: legacy / incomplete metadata may omit

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1740,6 +1740,7 @@ protected:
         }
         std::vector<IndexValue> values(keys.size());
         RETURN_IF_ERROR(index->get(keys.size(), key_slices.data(), values.data()));
+        ++_cold_pk_lookup_batches;
         return values;
     }
 
@@ -2662,6 +2663,82 @@ protected:
         return fixture;
     }
 
+    StatusOr<std::string> cold_fixed_point_pk_signature(const TabletMetadataPtr& metadata,
+                                                        const std::vector<std::pair<int32_t, int32_t>>& expected_rows) {
+        // Every fixed-point fixture covers keys [0, 100). Query the whole domain,
+        // including key 1 (delvec-deleted) and key 60 after the DML delete/compaction.
+        std::map<int32_t, int32_t> expected(expected_rows.begin(), expected_rows.end());
+        if (expected.empty() || expected.size() != expected_rows.size()) {
+            return Status::Corruption("fixed-point PK scan must contain distinct live keys");
+        }
+        std::vector<std::string> keys;
+        for (int32_t key = 0; key < 100; ++key) keys.push_back(encode_int_primary_key(key));
+        ASSIGN_OR_RETURN(auto values, load_index_values(metadata, metadata->id(), keys));
+        std::map<uint32_t, std::vector<uint32_t>> rowids_by_rssid;
+        std::map<uint32_t, std::vector<std::pair<int32_t, int32_t>>> expected_by_rssid;
+        std::map<uint32_t, uint64_t> segment_rows;
+        for (const auto& rowset : metadata->rowsets()) {
+            for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+                const auto& segment = rowset.segment_metas(i);
+                segment_rows.emplace(rowset.id() + (segment.has_segment_idx() ? segment.segment_idx() : i),
+                                     segment.num_rows());
+            }
+        }
+        std::string signature;
+        size_t deleted_keys = 0;
+        for (int32_t key = 0; key < 100; ++key) {
+            auto found = expected.find(key);
+            if (found == expected.end()) {
+                if (values[key] != IndexValue(NullIndexValue)) {
+                    return Status::Corruption(fmt::format("cold PK lookup resurrected deleted key {}", key));
+                }
+                ++deleted_keys;
+                signature += fmt::format("pk-deleted={};", key);
+                continue;
+            }
+            const auto& value = values[key];
+            if (value == IndexValue(NullIndexValue) || !segment_rows.contains(value.get_rssid()) ||
+                value.get_rowid() >= segment_rows.at(value.get_rssid())) {
+                return Status::Corruption(fmt::format("cold PK lookup has no valid physical row for key {}", key));
+            }
+            rowids_by_rssid[value.get_rssid()].push_back(value.get_rowid());
+            expected_by_rssid[value.get_rssid()].push_back(*found);
+            signature += fmt::format("pk-row={}:{};", key, found->second);
+        }
+        if (deleted_keys == 0) return Status::Corruption("fixed-point PK lookup must exercise deleted keys");
+
+        // Resolve each returned (RSSID,rowid) to physical column values through the
+        // fixture manager, including active DCG overrides. Compare logical rows,
+        // never the projected RSSID numbers across reshard cycles.
+        lake::RssidFileInfoContainer files;
+        files.add_rssid_to_file(*metadata);
+        auto schema = TabletSchema::create(metadata->schema());
+        lake::Tablet tablet(_tablet_manager.get(), metadata->id());
+        TxnLogPB_OpWrite read_context;
+        read_context.mutable_txn_meta(); // enable DCG-aware physical column reads
+        lake::RowsetUpdateStateParams params{read_context, schema, metadata, &tablet, files};
+        MutableColumns columns;
+        columns.push_back(Int32Column::create());
+        columns.push_back(Int32Column::create());
+        RETURN_IF_ERROR(_update_manager->get_column_values(params, {0, 1}, false, rowids_by_rssid, &columns));
+        if (columns[0]->size() != expected.size() || columns[1]->size() != expected.size()) {
+            return Status::Corruption("cold PK physical row resolution has the wrong cardinality");
+        }
+        size_t offset = 0;
+        for (const auto& [rssid, rows] : expected_by_rssid) {
+            for (const auto& [key, value] : rows) {
+                if (columns[0]->get(offset).get_int32() != key || columns[1]->get(offset).get_int32() != value) {
+                    return Status::Corruption(
+                            fmt::format("cold PK lookup resolves to the wrong logical row for key {}", key));
+                }
+                ++offset;
+            }
+        }
+        _cold_pk_deleted_keys_checked += deleted_keys;
+        LOG(INFO) << "fixed-point cold PK lookup: live=" << expected.size() << " deleted=" << deleted_keys;
+        return signature;
+    }
+
     // Canonicalize logical state, not the protobuf's allocation/serialization choices.
     // Segment filenames and bundle offsets remain physical identity; generated sidecar
     // names, projected RSSIDs and the SST representation deliberately do not.
@@ -2752,6 +2829,10 @@ protected:
         for (const auto& record : records) append(&result, record);
         ASSIGN_OR_RETURN(auto rows, read_two_column_rows(cold));
         for (const auto& [key, value] : rows) result += fmt::format("row={}:{};", key, value);
+        if (cold->schema().keys_type() == PRIMARY_KEYS) {
+            ASSIGN_OR_RETURN(auto pk_signature, cold_fixed_point_pk_signature(cold, rows));
+            append(&result, pk_signature);
+        }
         return result;
     }
 
@@ -2887,7 +2968,13 @@ protected:
     }
 
     void expect_ten_fixed_point_cycles(TabletMetadataPtr current) {
+        const bool primary_key = current->schema().keys_type() == PRIMARY_KEYS;
+        size_t prior_lookup_batches = _cold_pk_lookup_batches;
+        size_t prior_deleted_keys = _cold_pk_deleted_keys_checked;
         ASSIGN_OR_ABORT(auto baseline_signature, semantic_reshard_signature(current));
+        ASSERT_EQ(prior_lookup_batches + static_cast<size_t>(primary_key), _cold_pk_lookup_batches)
+                << "every PK baseline must exercise a cold PK lookup batch";
+        if (primary_key) ASSERT_GT(_cold_pk_deleted_keys_checked, prior_deleted_keys);
         const auto baseline = collect_reshard_inventory(*current);
         // Conservative field census: tablet scalars plus per-rowset/segment/del,
         // sidecar and SST integer slots. Each varint can grow by at most 10 bytes.
@@ -2903,7 +2990,12 @@ protected:
         for (int cycle = 0; cycle < 10; ++cycle) {
             SCOPED_TRACE(fmt::format("fixed-point cycle {} keys_type {}", cycle, int(current->schema().keys_type())));
             current = run_no_write_split_merge_cycle(current, cycle % 2 == 0 ? 2 : 3);
+            prior_lookup_batches = _cold_pk_lookup_batches;
+            prior_deleted_keys = _cold_pk_deleted_keys_checked;
             ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(current));
+            EXPECT_EQ(prior_lookup_batches + static_cast<size_t>(primary_key), _cold_pk_lookup_batches)
+                    << "every PK cycle must exercise a cold PK lookup batch";
+            if (primary_key) EXPECT_GT(_cold_pk_deleted_keys_checked, prior_deleted_keys);
             const auto inventory = collect_reshard_inventory(*current);
             EXPECT_EQ(baseline_signature, signature);
             EXPECT_EQ(baseline.rowsets, inventory.rowsets);
@@ -2918,6 +3010,8 @@ protected:
         }
     }
 
+    size_t _cold_pk_lookup_batches = 0;
+    size_t _cold_pk_deleted_keys_checked = 0;
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
     std::string _test_dir;
     std::shared_ptr<lake::LocationProvider> _location_provider;
@@ -2986,6 +3080,38 @@ TEST_F(LakeTabletReshardTest, test_range_reshard_vacuum_eligible_attempt_objects
     auto current = run_no_write_split_merge_cycle(source, 3);
     ASSIGN_OR_ABORT(auto baseline, semantic_reshard_signature(current));
     const auto live_inventory = collect_reshard_inventory(*current);
+    ASSERT_FALSE(current->delvec_meta().delvecs().empty());
+    const auto& live_page = current->delvec_meta().delvecs().begin()->second;
+    const auto& live_delvec = current->delvec_meta().version_to_file().at(live_page.version()).name();
+    const auto live_txn_id = lake::extract_txn_id_prefix(live_delvec).value_or(0);
+    ASSERT_GT(live_txn_id, 0) << "the live delvec must be transaction-aged, not txnless";
+    std::set<std::string> expected_live_files;
+    for (const auto& rowset : current->rowsets()) {
+        for (const auto& segment : rowset.segment_metas()) expected_live_files.insert(segment.filename());
+        for (const auto& del : rowset.del_files()) expected_live_files.insert(del.name());
+    }
+    for (const auto& [rssid, page] : current->delvec_meta().delvecs()) {
+        expected_live_files.insert(current->delvec_meta().version_to_file().at(page.version()).name());
+    }
+    for (const auto& [rssid, dcg] : current->dcg_meta().dcgs()) {
+        expected_live_files.insert(dcg.column_files().begin(), dcg.column_files().end());
+    }
+    lake::LakeIndexDeltaGroupLoader idg_loader(current);
+    for (const auto& [rssid, idg] : current->idg_meta().idgs()) {
+        lake::IndexDeltaGroupList active;
+        ASSERT_OK(idg_loader.load(TabletSegmentId(current->id(), rssid), current->version(), &active));
+        for (const auto& entry : active) expected_live_files.insert(entry.index_file);
+    }
+    for (const auto& sst : current->sstable_meta().sstables()) expected_live_files.insert(sst.filename());
+    ASSERT_EQ(live_inventory.live_files, expected_live_files.size());
+    auto expect_live_files_present = [&] {
+        for (const auto& name : expected_live_files) {
+            ASSERT_OK(FileSystem::Default()->path_exists(
+                    lake::join_path(_location_provider->segment_root_location(current->id()), name)));
+        }
+        ASSERT_OK(FileSystem::Default()->path_exists(_tablet_manager->delvec_location(current->id(), live_delvec)));
+    };
+    expect_live_files_present();
     // Leave actual objects from two failed MERGE writer attempts. Transaction
     // retention protects the second until min_active_txn_id explicitly advances.
     auto failed_attempt = [&](int64_t txn_id) {
@@ -3016,11 +3142,13 @@ TEST_F(LakeTabletReshardTest, test_range_reshard_vacuum_eligible_attempt_objects
         EXPECT_EQ(1, attempts.size());
         return attempts;
     };
-    const auto eligible = failed_attempt(1);
-    const auto protected_attempt = failed_attempt(3);
+    const auto eligible = failed_attempt(live_txn_id - 1);
+    const auto protected_attempt = failed_attempt(live_txn_id + 2);
     ASSERT_EQ(1, eligible.size());
     ASSERT_EQ(1, protected_attempt.size());
     auto run_vacuum = [&](int64_t min_active_txn_id) {
+        EXPECT_LT(live_txn_id, min_active_txn_id)
+                << "live delvec protection must come from metadata references, not transaction retention";
         VacuumFullRequest request;
         request.set_partition_id(1);
         request.set_tablet_id(current->id());
@@ -3032,16 +3160,19 @@ TEST_F(LakeTabletReshardTest, test_range_reshard_vacuum_eligible_attempt_objects
         lake::vacuum_full(_tablet_manager.get(), request, &response);
         ASSERT_TRUE(response.has_status());
         ASSERT_EQ(0, response.status().status_code());
+        expect_live_files_present();
+        LOG(INFO) << "fixed-point vacuum: min_active_txn_id=" << min_active_txn_id
+                  << " live_delvec_txn_id=" << live_txn_id << " live_files_present=" << expected_live_files.size();
     };
-    run_vacuum(2);
+    run_vacuum(live_txn_id + 1);
     ASSIGN_OR_ABORT(auto retained, delvec_inventory(current->id()));
     EXPECT_FALSE(retained.contains(*eligible.begin()));
     EXPECT_TRUE(retained.contains(*protected_attempt.begin()));
-    run_vacuum(4);
+    run_vacuum(live_txn_id + 3);
     ASSIGN_OR_ABORT(auto converged, delvec_inventory(current->id()));
     EXPECT_FALSE(converged.contains(*eligible.begin()));
     EXPECT_FALSE(converged.contains(*protected_attempt.begin()));
-    run_vacuum(4);
+    run_vacuum(live_txn_id + 3);
     EXPECT_EQ(converged, delvec_inventory(current->id()).value());
     ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(current));
     EXPECT_EQ(baseline, signature);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -442,8 +442,7 @@ protected:
         return rowset;
     }
 
-    std::vector<TabletMetadataPtr> merge_fixture_sources(const std::vector<TabletMetadataPtr>& sources,
-                                                         bool normalize_missing_segment_num_rows = true) {
+    std::vector<TabletMetadataPtr> merge_fixture_sources(const std::vector<TabletMetadataPtr>& sources) {
         const bool assign_ranges =
                 std::all_of(sources.begin(), sources.end(), [](const auto& source) { return !source->has_range(); });
         std::vector<int64_t> ids;
@@ -452,16 +451,6 @@ protected:
         std::vector<TabletMetadataPtr> result;
         for (const auto& source : sources) {
             auto copy = std::make_shared<TabletMetadataPB>(*source);
-            if (normalize_missing_segment_num_rows) {
-                for (auto& rowset : *copy->mutable_rowsets()) {
-                    for (auto& segment : *rowset.mutable_segment_metas()) {
-                        // Existing synthetic fixtures predate MERGE's strict segment-count
-                        // contract. Keep their old default-zero behavior; malformed-input
-                        // tests opt out of this fixture-only normalization.
-                        if (!segment.has_num_rows()) segment.set_num_rows(0);
-                    }
-                }
-            }
             if (assign_ranges) {
                 if (copy->has_schema() && copy->schema().column_size() == 0) {
                     auto* column = copy->mutable_schema()->add_column();
@@ -505,11 +494,8 @@ protected:
     Status publish_resharding_merge(const std::vector<TabletMetadataPtr>& sources, int64_t merged_tablet,
                                     int64_t base_version, int64_t new_version, int64_t txn_id,
                                     std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
-                                    const std::function<void()>& before_merge = {},
-                                    bool normalize_missing_segment_num_rows = true) {
-        for (const auto& source : merge_fixture_sources(sources, normalize_missing_segment_num_rows)) {
-            RETURN_IF_ERROR(put_tablet_metadata(source));
-        }
+                                    const std::function<void()>& before_merge = {}) {
+        for (const auto& source : merge_fixture_sources(sources)) RETURN_IF_ERROR(put_tablet_metadata(source));
         if (before_merge) before_merge();
         ReshardingTabletInfoPB resharding_tablet;
         auto& merging_info = *resharding_tablet.mutable_merging_tablet_info();
@@ -576,8 +562,7 @@ protected:
     }
 
     StatusOr<TabletMetadataPtr> publish_allocator_merge(
-            const std::vector<std::shared_ptr<TabletMetadataPB>>& mutable_sources,
-            bool normalize_missing_segment_num_rows = true) {
+            const std::vector<std::shared_ptr<TabletMetadataPB>>& mutable_sources) {
         if (mutable_sources.empty()) return Status::InvalidArgument("allocator merge fixture has no source");
         const int64_t target_id = next_id();
         prepare_tablet_dirs(target_id);
@@ -589,8 +574,7 @@ protected:
         }
         std::unordered_map<int64_t, TabletMetadataPtr> published;
         RETURN_IF_ERROR(publish_resharding_merge(sources, target_id, /*base_version=*/1, /*new_version=*/2,
-                                                 /*txn_id=*/next_id(), published, {},
-                                                 normalize_missing_segment_num_rows));
+                                                 /*txn_id=*/next_id(), published));
         auto target = published.find(target_id);
         if (target == published.end()) return Status::InternalError("allocator merge target was not published");
         return target->second;
@@ -788,8 +772,7 @@ protected:
 
     StatusOr<MutableTabletMetadataPtr> merge_with_phase_counts(const std::vector<TabletMetadataPtr>& sources,
                                                                int64_t target_tablet_id, int64_t target_version,
-                                                               MergePhaseCounts* counts,
-                                                               bool normalize_missing_segment_num_rows = true) {
+                                                               MergePhaseCounts* counts) {
         auto* sync = SyncPoint::GetInstance();
         sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++counts->materialize; });
         sync->SetCallBack("merge_dcg_meta:after_write_cols", [&](void*) { ++counts->dcg_writes; });
@@ -809,7 +792,7 @@ protected:
 
         ReshardingTabletInfoPB resharding;
         auto* merging = resharding.mutable_merging_tablet_info();
-        for (const auto& source : merge_fixture_sources(sources, normalize_missing_segment_num_rows)) {
+        for (const auto& source : merge_fixture_sources(sources)) {
             RETURN_IF_ERROR(_tablet_manager->put_tablet_metadata(source));
             merging->add_old_tablet_ids(source->id());
         }
@@ -826,12 +809,11 @@ protected:
     }
 
     Status expect_physical_preflight_rejection(const std::vector<TabletMetadataPtr>& sources, int64_t target_tablet_id,
-                                               int64_t target_version, MergePhaseCounts* counts,
-                                               bool normalize_missing_segment_num_rows = true) {
+                                               int64_t target_version, MergePhaseCounts* counts) {
         std::vector<std::string> source_pbs;
         std::map<int64_t, std::set<std::string>> segment_inventories;
         std::map<int64_t, std::set<std::string>> metadata_inventories;
-        for (const auto& source : merge_fixture_sources(sources, normalize_missing_segment_num_rows)) {
+        for (const auto& source : merge_fixture_sources(sources)) {
             CHECK_OK(_tablet_manager->put_tablet_metadata(source));
         }
         for (const auto& source : sources) {
@@ -851,8 +833,7 @@ protected:
         set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::ENABLE);
         DeferOp restore_delvec_failpoint(
                 [&] { set_failpoint_mode("tablet_merge_after_write_delvec", FailPointTriggerModeType::DISABLE); });
-        auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts,
-                                              normalize_missing_segment_num_rows);
+        auto merged = merge_with_phase_counts(sources, target_tablet_id, target_version, counts);
 
         EXPECT_TRUE(merged.status().is_corruption()) << merged.status();
         EXPECT_EQ(0, counts->materialize);
@@ -991,6 +972,7 @@ protected:
             auto* segment = rowset->add_segment_metas();
             segment->set_filename(segment_filename);
             segment->set_size(100);
+            segment->set_num_rows(10);
             segment->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, segment_filenames.front());
@@ -4482,8 +4464,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_invalid_segment_num_rows_rejec
             if (reverse_sources) std::reverse(sources.begin(), sources.end());
 
             MergePhaseCounts counts;
-            expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts,
-                                                /*normalize_missing_segment_num_rows=*/false);
+            expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
         }
     }
 }
@@ -9480,6 +9461,7 @@ TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(segment_name);
             sm->set_size(1);
+            sm->set_num_rows(1);
         }
         set_range(rowset->mutable_range(), lower, upper);
     };
@@ -9563,6 +9545,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_then_merge) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -9713,6 +9696,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_vector_index_built_version_mixed
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
         stamp_physical_identity_uid(rowset, "shared_seg.dat");
         return meta;
@@ -9772,6 +9756,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_vector_index_built_version_none)
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
         stamp_physical_identity_uid(rowset, "shared_seg.dat");
         return meta;
@@ -9837,6 +9822,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_segment_union_preserves_ownershi
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
             sm->set_segment_idx(0);
             sm->set_encryption_meta("enc_shared");
@@ -9845,6 +9831,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_segment_union_preserves_ownershi
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(private_seg);
             sm->set_size(50);
+            sm->set_num_rows(10);
             sm->set_shared(false);
             sm->set_segment_idx(private_idx);
             sm->set_encryption_meta("enc_" + private_seg);
@@ -9943,6 +9930,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_multi_level_disjoint_all_shared_
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(segment_name);
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
             sm->set_segment_idx(segment_idx);
         }
@@ -9999,6 +9987,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_bundled_segments_union_offsets) 
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("bundle.dat"); // same physical file for every slice
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_bundle_file_offset(off);
         sm->set_shared(true);
         sm->set_segment_idx(idx);
@@ -10090,6 +10079,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merge_multi_level_unequal_count_all_sh
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(segment_names[i]);
             sm->set_size(50);
+            sm->set_num_rows(10);
             sm->set_shared(true);
             sm->set_segment_idx(segment_indexes[i]);
         }
@@ -10155,6 +10145,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_accumulates_num_dels) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -10218,6 +10209,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         auto* sm = shared_a->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(shared_a, "shared_seg.dat"); // same uid across siblings => dedup
@@ -10231,6 +10223,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         auto* sm = local_a->add_segment_metas();
         sm->set_filename("local_a_seg.dat");
         sm->set_size(50);
+        sm->set_num_rows(10);
     }
 
     auto meta_b = std::make_shared<TabletMetadataPB>();
@@ -10248,6 +10241,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         auto* sm = shared_b->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(shared_b, "shared_seg.dat"); // same uid across siblings => dedup
@@ -10261,6 +10255,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_upsert_delete) {
         auto* sm = local_b->add_segment_metas();
         sm->set_filename("local_b_seg.dat");
         sm->set_size(30);
+        sm->set_num_rows(10);
     }
 
     ASSERT_OK(put_merge_sources(meta_a, meta_b));
@@ -10325,6 +10320,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_compaction) {
         auto* sm = compacted_a->add_segment_metas();
         sm->set_filename("compacted_a.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
     }
     // not shared - this is the compaction output
 
@@ -10343,6 +10339,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_split_with_compaction) {
         auto* sm = shared_b->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
 
@@ -10400,6 +10397,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_rowset_on_non_first_chi
         auto* sm = rowset_a->add_segment_metas();
         sm->set_filename("local_a.dat");
         sm->set_size(50);
+        sm->set_num_rows(5);
     }
 
     auto meta_b = std::make_shared<TabletMetadataPB>();
@@ -10415,6 +10413,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_rowset_on_non_first_chi
         auto* sm = rowset_b->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
 
@@ -10526,6 +10525,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_different_split_families) {
         auto* sm = rowset_c->add_segment_metas();
         sm->set_filename("family_a_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
 
@@ -10542,6 +10542,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_different_split_families) {
         auto* sm = rowset_d->add_segment_metas();
         sm->set_filename("family_e_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
 
@@ -10595,6 +10596,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_publish_different_id) {
         auto* sm = rowset_a->add_segment_metas();
         sm->set_filename("cross_pub.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     // Cross-publish: the same write txn log is applied to both children, so both
@@ -10614,6 +10616,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_cross_publish_different_id) {
         auto* sm = rowset_b->add_segment_metas(); // Same segment
         sm->set_filename("cross_pub.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_b, "cross_pub.dat"); // same uid as A (cross-publish)
@@ -10668,6 +10671,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_fail_fast) {
         auto* sm = rowset_a->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_a, "shared_seg.dat"); // same uid across siblings => dedup
@@ -10687,6 +10691,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_fail_fast) {
         auto* sm = rowset_b->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_b, "shared_seg.dat"); // same uid across siblings => dedup
@@ -10797,6 +10802,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_dcg_dedup) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -11776,6 +11782,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_independent_delete) {
         auto* sm = rowset_a->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_a, "shared_seg.dat"); // same uid across siblings => dedup
@@ -11796,6 +11803,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_independent_delete) {
         auto* sm = rowset_b->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_b, "shared_seg.dat"); // same uid across siblings => dedup
@@ -11895,12 +11903,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_multi_target_union) {
         auto* sm = rowset_a->add_segment_metas();
         sm->set_filename("shared_seg1.dat");
         sm->set_size(100);
+        sm->set_num_rows(5);
         sm->set_shared(true);
     }
     {
         auto* sm = rowset_a->add_segment_metas();
         sm->set_filename("shared_seg2.dat");
         sm->set_size(100);
+        sm->set_num_rows(5);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_a, "shared_seg1.dat"); // same uid across siblings => dedup
@@ -11942,12 +11952,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_multi_target_union) {
         auto* sm = rowset_b->add_segment_metas();
         sm->set_filename("shared_seg1.dat");
         sm->set_size(100);
+        sm->set_num_rows(5);
         sm->set_shared(true);
     }
     {
         auto* sm = rowset_b->add_segment_metas();
         sm->set_filename("shared_seg2.dat");
         sm->set_size(100);
+        sm->set_num_rows(5);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_b, "shared_seg1.dat"); // same uid across siblings => dedup
@@ -12075,6 +12087,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_three_way_union) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -12160,6 +12173,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_no_independent_delete) 
         auto* sm = rowset_a->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_a, "shared_seg.dat"); // same uid across siblings => dedup
@@ -12180,6 +12194,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_delvec_no_independent_delete) 
         auto* sm = rowset_b->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset_b, "shared_seg.dat"); // same uid across siblings => dedup
@@ -13377,6 +13392,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_disjoint_columns) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -13454,6 +13470,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         // Matching uid across siblings so the rowsets dedup at merge — without this
@@ -13522,6 +13539,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_same_column_conflict) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -13581,6 +13599,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_partial_overlap) {
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -13637,6 +13656,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_missing_shape) {
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
     }
     // Use legacy add_dcg (no unique_column_ids/versions)
     add_dcg(meta_a.get(), 1, "malformed.cols");
@@ -13684,6 +13704,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_duplicate_column_uid) {
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
     }
     // Build a malformed DCG with overlapping column UIDs across entries
     add_dcg_with_columns(meta_a.get(), 1, "first.cols", {1, 2}, 1);
@@ -14092,6 +14113,7 @@ RowsetMetadataPB* add_shared_rowset(TabletMetadataPB* metadata, uint32_t rowset_
         auto* sm = rowset->add_segment_metas();
         sm->set_filename(segment_filename);
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset, segment_filename);
@@ -15827,8 +15849,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_segment_declaration_co
             break;
         }
         }
-        auto result = publish_allocator_merge({selected_source, duplicate_source},
-                                               /*normalize_missing_segment_num_rows=*/false);
+        auto result = publish_allocator_merge({selected_source, duplicate_source});
         EXPECT_TRUE(result.status().is_corruption()) << result.status();
     }
 }
@@ -17083,6 +17104,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_two_children_same_
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(shared_segment_name);
             sm->set_size(base_segment_size);
+            sm->set_num_rows(kNumRows);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset,
@@ -17197,6 +17219,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_exact_dedup_consistency_fa
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same UID across siblings => one canonical rowset
@@ -17260,6 +17283,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_missing_uid_falls_
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same UID across siblings => one canonical rowset
@@ -17354,6 +17378,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_cleanup_on_failure
             auto* sm = rowset->add_segment_metas();
             sm->set_filename(good_segment);
             sm->set_size(good_seg_size);
+            sm->set_num_rows(kNumRows);
             sm->set_shared(true);
         }
         *rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(lower_key);
@@ -17371,6 +17396,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_rebuild_cleanup_on_failure
             auto* sm = bad_rowset->add_segment_metas();
             sm->set_filename(bad_segment);
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         *bad_rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(lower_key);
@@ -17477,6 +17503,7 @@ inline std::shared_ptr<TabletMetadataPB> make_shared_child(int64_t tablet_id, in
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
     }
     stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across shared siblings => dedup
@@ -18227,6 +18254,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_canonical_range_extends_for_du
             auto* sm = rowset->add_segment_metas();
             sm->set_filename("shared_seg.dat");
             sm->set_size(100);
+            sm->set_num_rows(10);
             sm->set_shared(true);
         }
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
@@ -18457,6 +18485,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_shared_idg_dedup) {
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
         stamp_physical_identity_uid(rowset, "shared_seg.dat"); // same uid across siblings => dedup
         add_idg_with_key(meta.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1);
@@ -18513,6 +18542,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_unions_divergent_tombstone
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
         stamp_physical_identity_uid(rowset, "shared_seg.dat");
         add_idg_with_key(meta.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1);
@@ -18568,6 +18598,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_drops_fully_tombstoned) {
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("shared_seg.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true);
         stamp_physical_identity_uid(rowset, "shared_seg.dat");
         add_idg_with_key(meta.get(), 1, "shared.idx", /*col_uid=*/5, BITMAP, 1);
@@ -18625,6 +18656,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_global_tombstone_orphans_w
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("same_base.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         lake::tablet_reshard_helper::set_rowset_uid(rowset); // distinct uid per child => both kept
         add_idg_with_key(meta.get(), 1, "same.idx", /*col_uid=*/5, BITMAP, 1);
         if (tombstone) add_idg_dropped_key(meta.get(), 1, /*col_uid=*/5, BITMAP);
@@ -18686,6 +18718,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_derives_shared_from_segmen
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("seg_shared.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         sm->set_shared(true); // shared segment
         stamp_physical_identity_uid(rowset, "seg_shared.dat");
     }
@@ -18705,6 +18738,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_derives_shared_from_segmen
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("seg_b.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         stamp_physical_identity_uid(rowset, "seg_b.dat");
     }
 
@@ -18763,6 +18797,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_skips_stale_source_entry) 
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("seg_a.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         stamp_physical_identity_uid(rowset, "seg_a.dat");
     }
     // Stale idg keyed at rssid 2 -- child_a has NO segment there.
@@ -18781,6 +18816,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_skips_stale_source_entry) 
         auto* sm = rowset->add_segment_metas();
         sm->set_filename("seg_b.dat");
         sm->set_size(100);
+        sm->set_num_rows(10);
         stamp_physical_identity_uid(rowset, "seg_b.dat"); // distinct uid => not deduped
     }
 
@@ -18832,6 +18868,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_idg_remaps_private_segments) {
         auto* sm = rowset->add_segment_metas();
         sm->set_filename(seg);
         sm->set_size(100);
+        sm->set_num_rows(10);
         stamp_physical_identity_uid(rowset, seg); // distinct seed per child => distinct uid
         // Exclusive (private) segment => its .idx is shared_file=false, as split's
         // propagate_pruned would have marked it. merge must PRESERVE this (not force true).
@@ -19731,6 +19768,7 @@ TEST_F(LakeTabletReshardTest, test_merge_failpoint_after_write_dcg_cols) {
                 auto* sm = rowset->add_segment_metas();
                 sm->set_filename(shared_segment_name);
                 sm->set_size(base_segment_size);
+                sm->set_num_rows(kNumRows);
                 sm->set_shared(true);
             }
             stamp_physical_identity_uid(rowset, shared_segment_name);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -764,6 +764,7 @@ protected:
         int dcg_writes = 0;
         int delvec_writes = 0;
         int source_flushes = 0;
+        int sstable_opens = 0;
     };
 
     StatusOr<MutableTabletMetadataPtr> merge_with_phase_counts(const std::vector<TabletMetadataPtr>& sources,
@@ -775,12 +776,14 @@ protected:
         sync->SetCallBack("merge_delvecs:writer_invocations",
                           [&](void* arg) { counts->delvec_writes += *static_cast<int*>(arg); });
         sync->SetCallBack("merge_sstables:source_pk_flush", [&](void*) { ++counts->source_flushes; });
+        sync->SetCallBack("PersistentIndexSstable::init:table_open_error", [&](void*) { ++counts->sstable_opens; });
         sync->EnableProcessing();
         DeferOp cleanup_sync_points([&] {
             sync->ClearCallBack("materialize_planned_rowsets:entry");
             sync->ClearCallBack("merge_dcg_meta:after_write_cols");
             sync->ClearCallBack("merge_delvecs:writer_invocations");
             sync->ClearCallBack("merge_sstables:source_pk_flush");
+            sync->ClearCallBack("PersistentIndexSstable::init:table_open_error");
             sync->DisableProcessing();
         });
 
@@ -834,6 +837,7 @@ protected:
         EXPECT_EQ(0, counts->dcg_writes);
         EXPECT_EQ(0, counts->delvec_writes);
         EXPECT_EQ(0, counts->source_flushes);
+        EXPECT_EQ(0, counts->sstable_opens);
         for (size_t i = 0; i < sources.size(); ++i) {
             EXPECT_EQ(source_pbs[i], sources[i]->SerializeAsString());
         }
@@ -12707,6 +12711,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_same_physical_sst_allows_logic
     struct LogicalAttachment {
         const char* name;
         std::function<void(PersistentIndexSstablePB*)> apply;
+        bool reuse_when_ranges_ordered = false;
     };
     const std::vector<LogicalAttachment> attachments = {
             {"deprecated version", [](PersistentIndexSstablePB* sst) { sst->set_version(2); }},
@@ -12723,7 +12728,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_same_physical_sst_allows_logic
              [](PersistentIndexSstablePB* sst) {
                  sst->mutable_fileset_id()->set_hi(2);
                  sst->mutable_fileset_id()->set_lo(2);
-             }},
+             },
+             true},
             {"rssid offset", [](PersistentIndexSstablePB* sst) { sst->set_rssid_offset(1); }},
             {"generation version", [](PersistentIndexSstablePB* sst) { sst->set_generation_version(2); }},
     };
@@ -12739,10 +12745,21 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_same_physical_sst_allows_logic
             if (reverse_sources) std::swap(immutable_sources[0], immutable_sources[1]);
             const int64_t target = next_id();
             prepare_tablet_dirs(target);
+            int classifier_entries = 0;
+            auto* sync = SyncPoint::GetInstance();
+            sync->SetCallBack("merge_sstables:metadata_classifier_entry", [&](void*) { ++classifier_entries; });
+            sync->EnableProcessing();
+            DeferOp clear_classifier_callback([&] {
+                sync->ClearCallBack("merge_sstables:metadata_classifier_entry");
+                sync->DisableProcessing();
+            });
             std::unordered_map<int64_t, TabletMetadataPtr> published;
             ASSERT_OK(publish_resharding_merge(immutable_sources, target, /*base_version=*/1, /*new_version=*/2,
                                                next_id(), published));
             auto merged = published.at(target);
+            EXPECT_EQ(1, classifier_entries);
+            EXPECT_EQ(attachment.reuse_when_ranges_ordered && !reverse_sources ? 1 : 0,
+                      merged->sstable_meta().sstables_size());
             _update_manager->unload_and_remove_primary_index(target);
             expect_lifecycle_oracle(merged, expected_rows, {});
         }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -41,6 +41,7 @@
 #include "column/datum_tuple.h"
 #include "column/serde/column_array_serde.h"
 #include "common/config_compaction_fwd.h"
+#include "common/config_ingest_fwd.h"
 #include "common/config_lake_fwd.h"
 #include "common/config_primary_key_fwd.h"
 #include "common/config_rowset_fwd.h"
@@ -2996,8 +2997,9 @@ protected:
         return result;
     }
 
-    std::vector<TabletMetadataPtr> split_fixed_point_source(const TabletMetadataPtr& source, int child_count) {
-        CHECK_OK(put_tablet_metadata(source));
+    StatusOr<std::vector<TabletMetadataPtr>> try_split_fixed_point_source(const TabletMetadataPtr& source,
+                                                                          int child_count) {
+        RETURN_IF_ERROR(put_tablet_metadata(source));
         SplittingTabletInfoPB split;
         split.set_old_tablet_id(source->id());
         for (int i = 0; i < child_count; ++i) {
@@ -3011,21 +3013,33 @@ protected:
         TxnInfoPB txn;
         txn.set_txn_id(next_id());
         txn.set_commit_time(1);
-        ASSIGN_OR_ABORT(auto children,
-                        lake::split_tablet(_tablet_manager.get(), source, split, source->version() + 1, txn));
-        EXPECT_EQ(child_count, children.size());
+        ASSIGN_OR_RETURN(auto children,
+                         lake::split_tablet(_tablet_manager.get(), source, split, source->version() + 1, txn));
+        if (children.size() != child_count) {
+            return Status::InternalError("fixed-point split returned the wrong number of children");
+        }
         std::vector<TabletMetadataPtr> sources;
         for (auto id : split.new_tablet_ids()) sources.push_back(children.at(id));
         return sources;
     }
 
-    TabletMetadataPtr run_no_write_split_merge_cycle(const TabletMetadataPtr& source, int child_count) {
-        auto sources = split_fixed_point_source(source, child_count);
+    std::vector<TabletMetadataPtr> split_fixed_point_source(const TabletMetadataPtr& source, int child_count) {
+        ASSIGN_OR_ABORT(auto sources, try_split_fixed_point_source(source, child_count));
+        return sources;
+    }
+
+    StatusOr<TabletMetadataPtr> try_run_no_write_split_merge_cycle(const TabletMetadataPtr& source, int child_count) {
+        ASSIGN_OR_RETURN(auto sources, try_split_fixed_point_source(source, child_count));
         std::unordered_map<int64_t, TabletMetadataPtr> published;
         const int64_t target = next_id();
-        CHECK_OK(publish_resharding_merge(sources, target, source->version() + 1, source->version() + 2, next_id(),
-                                          published));
+        RETURN_IF_ERROR(publish_resharding_merge(sources, target, source->version() + 1, source->version() + 2,
+                                                 next_id(), published));
         return published.at(target);
+    }
+
+    TabletMetadataPtr run_no_write_split_merge_cycle(const TabletMetadataPtr& source, int child_count) {
+        ASSIGN_OR_ABORT(auto result, try_run_no_write_split_merge_cycle(source, child_count));
+        return result;
     }
 
     TabletMetadataPtr fixed_point_source(bool primary_key) {
@@ -5512,6 +5526,12 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_missing_uid_is_corruption) {
 TEST_F(LakeTabletReshardTest, test_tablet_splitting_absent_segment_idx_falls_back_after_pk_flush) {
     auto m = split_source();
     m->mutable_rowsets(0)->mutable_segment_metas(0)->clear_segment_idx();
+    expect_split_fallback_after_flush(m);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_missing_segment_num_rows_falls_back_after_pk_flush) {
+    auto m = split_source();
+    m->mutable_rowsets(0)->mutable_segment_metas(0)->clear_num_rows();
     expect_split_fallback_after_flush(m);
 }
 
@@ -8999,6 +9019,242 @@ TEST_F(LakeTabletReshardTest, test_delete_only_zero_row_segment_survives_split_m
     expect_canonical_delete(second_cold);
     expect_lifecycle_oracle(second_cold, {}, {10});
     EXPECT_EQ(2, flushes);
+}
+
+TEST_F(LakeTabletReshardTest, test_mixed_zero_row_delete_slot_survives_split_merge_cold_load) {
+    const int64_t tablet_id = next_id();
+    ASSIGN_OR_ABORT(auto seeded,
+                    create_lifecycle_source(tablet_id, /*lower=*/0, /*upper=*/100, /*key=*/10, /*value=*/100,
+                                            /*include_delete=*/false));
+
+    const int64_t old_write_buffer_size = config::write_buffer_size;
+    const bool old_enable_load_spill = config::enable_load_spill;
+    const bool old_preserve_delete_order = config::lake_enable_pk_preserve_txn_delete_order;
+    config::write_buffer_size = 1;
+    config::enable_load_spill = false;
+    config::lake_enable_pk_preserve_txn_delete_order = true;
+    DeferOp restore_config([&] {
+        config::write_buffer_size = old_write_buffer_size;
+        config::enable_load_spill = old_enable_load_spill;
+        config::lake_enable_pk_preserve_txn_delete_order = old_preserve_delete_order;
+    });
+
+    std::vector<SlotDescriptor> slots;
+    slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+    slots.emplace_back(2, "__op", TypeDescriptor{LogicalType::TYPE_INT});
+    std::vector<SlotDescriptor*> slot_pointers = {&slots[0], &slots[1], &slots[2]};
+    Chunk::SlotHashMap slot_cid_map = {{0, 0}, {1, 1}, {2, 2}};
+    auto make_chunk = [&](bool upsert) {
+        const int32_t key = 10;
+        const int32_t value = upsert ? 300 : 0;
+        const uint8_t operation = upsert ? TOpType::UPSERT : TOpType::DELETE;
+        auto key_column = Int32Column::create();
+        auto value_column = Int32Column::create();
+        auto operation_column = Int8Column::create();
+        key_column->append_numbers(&key, sizeof(key));
+        value_column->append_numbers(&value, sizeof(value));
+        operation_column->append_numbers(&operation, sizeof(operation));
+        return Chunk(Columns{std::move(key_column), std::move(value_column), std::move(operation_column)},
+                     slot_cid_map);
+    };
+    auto delete_chunk = make_chunk(false);
+    auto upsert_chunk = make_chunk(true);
+    const uint32_t index = 0;
+    const int64_t txn_id = next_id();
+    auto tablet_schema = TabletSchema::create(seeded->schema());
+    RuntimeProfile profile("mixed-zero-row-delete-slot");
+    ASSIGN_OR_ABORT(auto delta_writer, lake::DeltaWriterBuilder()
+                                               .set_tablet_manager(_tablet_manager.get())
+                                               .set_tablet_id(tablet_id)
+                                               .set_txn_id(txn_id)
+                                               .set_partition_id(next_id())
+                                               .set_mem_tracker(_mem_tracker.get())
+                                               .set_schema_id(seeded->schema().id())
+                                               .set_tablet_schema(std::move(tablet_schema))
+                                               .set_slot_descriptors(&slot_pointers)
+                                               .set_profile(&profile)
+                                               .build());
+    ASSERT_OK(delta_writer->open());
+    ASSERT_OK(delta_writer->write(delete_chunk, &index, 1));
+    ASSERT_OK(delta_writer->write(upsert_chunk, &index, 1));
+    ASSERT_OK(delta_writer->finish_with_txnlog());
+    delta_writer->close();
+    TxnInfoPB txn;
+    txn.set_txn_id(txn_id);
+    txn.set_txn_type(TXN_NORMAL);
+    txn.set_commit_time(1);
+    ASSIGN_OR_ABORT(auto written,
+                    lake::publish_version(_tablet_manager.get(), lake::PublishTabletInfo(tablet_id), seeded->version(),
+                                          seeded->version() + 1, std::span<const TxnInfoPB>(&txn, 1), false));
+
+    const RowsetMetadataPB* mixed = nullptr;
+    for (const auto& rowset : written->rowsets()) {
+        if (rowset.version() == written->version()) mixed = &rowset;
+    }
+    ASSERT_NE(nullptr, mixed);
+    ASSERT_EQ(2, mixed->segment_metas_size());
+    EXPECT_EQ((std::vector<int64_t>{0, 1}),
+              (std::vector<int64_t>{mixed->segment_metas(0).num_rows(), mixed->segment_metas(1).num_rows()}));
+    EXPECT_EQ((std::vector<uint32_t>{0, 1}),
+              (std::vector<uint32_t>{mixed->segment_metas(0).segment_idx(), mixed->segment_metas(1).segment_idx()}));
+    ASSERT_EQ(1, mixed->del_files_size());
+    EXPECT_EQ(mixed->id(), mixed->del_files(0).origin_rowset_id());
+    EXPECT_EQ(0, mixed->del_files(0).op_offset());
+    const auto mixed_uid = mixed->uid().SerializeAsString();
+    const int64_t mixed_rows = mixed->num_rows();
+    const int64_t mixed_bytes = mixed->data_size();
+    const int64_t mixed_dels = mixed->num_dels();
+    auto canonical_mixed_signature = [&](const TabletMetadataPtr& metadata) {
+        for (const auto& rowset : metadata->rowsets()) {
+            if (rowset.uid().SerializeAsString() != mixed_uid) continue;
+            RowsetMetadataPB stable(rowset);
+            stable.clear_id();
+            stable.clear_range();
+            for (auto& segment : *stable.mutable_segment_metas()) segment.clear_shared();
+            for (auto& del : *stable.mutable_del_files()) {
+                del.clear_origin_rowset_id();
+                del.clear_shared();
+            }
+            return stable.SerializeAsString();
+        }
+        return std::string();
+    };
+    const auto baseline_signature = canonical_mixed_signature(written);
+    ASSERT_FALSE(baseline_signature.empty());
+
+    set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+    DeferOp restore_pk_flush([&] { set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::ENABLE); });
+    auto children_or = try_split_fixed_point_source(written, /*child_count=*/2);
+    ASSERT_OK(children_or.status());
+    auto children = std::move(children_or).value();
+    for (const auto& child : children) {
+        auto it = std::find_if(child->rowsets().begin(), child->rowsets().end(),
+                               [&](const auto& rowset) { return rowset.uid().SerializeAsString() == mixed_uid; });
+        ASSERT_NE(child->rowsets().end(), it);
+        ASSERT_EQ(2, it->segment_metas_size());
+        EXPECT_EQ(0, it->segment_metas(0).segment_idx());
+        EXPECT_EQ(1, it->segment_metas(1).segment_idx());
+        ASSERT_EQ(1, it->del_files_size());
+        EXPECT_EQ(0, it->del_files(0).op_offset());
+    }
+
+    const int64_t merged_tablet = next_id();
+    std::unordered_map<int64_t, TabletMetadataPtr> published;
+    ASSERT_OK(publish_resharding_merge(children, merged_tablet, written->version() + 1, written->version() + 2,
+                                       next_id(), published));
+    auto merged = published.at(merged_tablet);
+    auto merged_it = std::find_if(merged->rowsets().begin(), merged->rowsets().end(),
+                                  [&](const auto& rowset) { return rowset.uid().SerializeAsString() == mixed_uid; });
+    ASSERT_NE(merged->rowsets().end(), merged_it);
+    ASSERT_EQ(2, merged_it->segment_metas_size());
+    EXPECT_EQ(0, merged_it->segment_metas(0).segment_idx());
+    EXPECT_EQ(1, merged_it->segment_metas(1).segment_idx());
+    ASSERT_EQ(1, merged_it->del_files_size());
+    EXPECT_EQ(0, merged_it->del_files(0).op_offset());
+    EXPECT_EQ(mixed_rows, merged_it->num_rows());
+    EXPECT_EQ(mixed_bytes, merged_it->data_size());
+    EXPECT_EQ(mixed_dels, merged_it->num_dels());
+    expect_lifecycle_oracle(merged, {{10, 300}}, {});
+    _update_manager->unload_and_remove_primary_index(merged_tablet);
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto cold, _tablet_manager->get_tablet_metadata(merged_tablet, written->version() + 2));
+    expect_lifecycle_oracle(cold, {{10, 300}}, {});
+    EXPECT_EQ(baseline_signature, canonical_mixed_signature(cold));
+
+    auto three_way_or = try_run_no_write_split_merge_cycle(cold, /*child_count=*/3);
+    ASSERT_OK(three_way_or.status());
+    auto three_way = std::move(three_way_or).value();
+    expect_lifecycle_oracle(three_way, {{10, 300}}, {});
+    EXPECT_EQ(baseline_signature, canonical_mixed_signature(three_way));
+}
+
+TEST_F(LakeTabletReshardTest, test_all_zero_rowset_without_delete_survives_split_merge_fixed_point) {
+    for (const bool positive_anchor : {true, false}) {
+        SCOPED_TRACE(fmt::format("positive aggregate byte anchor: {}", positive_anchor));
+        const int64_t tablet_id = next_id();
+        prepare_tablet_dirs(tablet_id);
+        const std::string segment_name = fmt::format("all-zero-{}.dat", positive_anchor);
+        const uint64_t footer_size = write_two_column_segment(tablet_id, segment_name, 0, [](int key) { return key; });
+        ASSERT_GT(footer_size, 0);
+
+        auto source = std::make_shared<TabletMetadataPB>();
+        source->set_id(tablet_id);
+        source->set_version(1);
+        source->set_next_rowset_id(2);
+        set_two_column_pk_schema(source.get(), 4001);
+        source->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+        source->mutable_range()->set_lower_bound_included(true);
+        source->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+        source->mutable_range()->set_upper_bound_included(false);
+        auto* rowset = source->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(0);
+        rowset->set_data_size(positive_anchor ? footer_size : 0);
+        rowset->set_num_dels(0);
+        lake::tablet_reshard_helper::set_rowset_uid(rowset);
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(segment_name);
+        segment->set_segment_idx(0);
+        segment->set_num_rows(0);
+        segment->set_size(footer_size);
+        const auto original_uid = rowset->uid().SerializeAsString();
+        const SegmentMetadataPB original_segment(*segment);
+        const int64_t expected_bytes = rowset->data_size();
+        auto canonical_signature = [](const TabletMetadataPtr& metadata) {
+            RowsetMetadataPB stable(metadata->rowsets(0));
+            stable.clear_id();
+            stable.clear_range();
+            for (auto& stable_segment : *stable.mutable_segment_metas()) stable_segment.clear_shared();
+            return stable.SerializeAsString();
+        };
+        const auto baseline_signature = canonical_signature(source);
+        ASSERT_OK(put_tablet_metadata(source));
+
+        TabletMetadataPtr current = source;
+        for (const int child_count : {2, 3}) {
+            auto children_or = try_split_fixed_point_source(current, child_count);
+            ASSERT_OK(children_or.status());
+            auto children = std::move(children_or).value();
+            int64_t total_rows = 0;
+            int64_t total_bytes = 0;
+            int64_t total_dels = 0;
+            for (const auto& child : children) {
+                ASSERT_EQ(1, child->rowsets_size());
+                const auto& child_rowset = child->rowsets(0);
+                EXPECT_EQ(original_uid, child_rowset.uid().SerializeAsString());
+                ASSERT_EQ(1, child_rowset.segment_metas_size());
+                SegmentMetadataPB child_segment(child_rowset.segment_metas(0));
+                child_segment.clear_shared();
+                EXPECT_EQ(original_segment.SerializeAsString(), child_segment.SerializeAsString());
+                total_rows += child_rowset.num_rows();
+                total_bytes += child_rowset.data_size();
+                total_dels += child_rowset.num_dels();
+            }
+            EXPECT_EQ(0, total_rows);
+            EXPECT_EQ(expected_bytes, total_bytes);
+            EXPECT_EQ(0, total_dels);
+
+            const int64_t target = next_id();
+            std::unordered_map<int64_t, TabletMetadataPtr> published;
+            ASSERT_OK(publish_resharding_merge(children, target, current->version() + 1, current->version() + 2,
+                                               next_id(), published));
+            current = published.at(target);
+            ASSERT_EQ(1, current->rowsets_size());
+            const auto& merged_rowset = current->rowsets(0);
+            EXPECT_EQ(original_uid, merged_rowset.uid().SerializeAsString());
+            EXPECT_EQ(0, merged_rowset.num_rows());
+            EXPECT_EQ(expected_bytes, merged_rowset.data_size());
+            EXPECT_EQ(0, merged_rowset.num_dels());
+            ASSERT_EQ(1, merged_rowset.segment_metas_size());
+            EXPECT_EQ(0, merged_rowset.segment_metas(0).segment_idx());
+            SegmentMetadataPB merged_segment(merged_rowset.segment_metas(0));
+            merged_segment.clear_shared();
+            EXPECT_EQ(original_segment.SerializeAsString(), merged_segment.SerializeAsString());
+            EXPECT_EQ(baseline_signature, canonical_signature(current));
+        }
+    }
 }
 
 // CORE-005: split row counts are estimates, but later PK deletes are exact. A skewed shared segment
@@ -18711,6 +18967,60 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_full_sort_key_sampling_de
     status = lake::get_tablet_split_ranges(_tablet_manager.get(), metadata, 3, &ranges);
     EXPECT_TRUE(status.is_capacity_limit_exceeded()) << status;
     EXPECT_EQ(0, opens) << "the shared budget must be charged before opening the first physical slice";
+}
+
+TEST_F(LakeTabletReshardTest, test_split_boundary_planner_skips_zero_row_segment_without_open) {
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+    const std::string empty_name = "sampleless-empty.dat";
+    const std::string live_name = "sampled-live.dat";
+    const auto empty_size = write_two_column_segment(tablet_id, empty_name, 0, [](int key) { return key; });
+    const auto live_size = write_two_column_segment(tablet_id, live_name, 100, [](int key) { return key; });
+
+    auto metadata = std::make_shared<TabletMetadataPB>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(1);
+    metadata->set_next_rowset_id(3);
+    set_two_column_pk_schema(metadata.get(), 4001);
+    metadata->mutable_range()->mutable_lower_bound()->CopyFrom(generate_sort_key(0));
+    metadata->mutable_range()->set_lower_bound_included(true);
+    metadata->mutable_range()->mutable_upper_bound()->CopyFrom(generate_sort_key(100));
+    metadata->mutable_range()->set_upper_bound_included(false);
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(empty_size + live_size);
+    rowset->set_num_dels(0);
+    lake::tablet_reshard_helper::set_rowset_uid(rowset);
+    auto* empty = rowset->add_segment_metas();
+    empty->set_filename(empty_name);
+    empty->set_segment_idx(0);
+    empty->set_num_rows(0);
+    empty->set_size(empty_size);
+    auto* live = rowset->add_segment_metas();
+    live->set_filename(live_name);
+    live->set_segment_idx(1);
+    live->set_num_rows(100);
+    live->set_size(live_size);
+    live->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
+    live->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
+    live->set_deprecated_sort_key_sample_row_interval(50);
+    live->add_deprecated_sort_key_samples()->CopyFrom(generate_sort_key(50));
+
+    auto* sync = SyncPoint::GetInstance();
+    int opens = 0;
+    sync->SetCallBack("tablet_splitter:segment_open", [&](void*) { ++opens; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    std::vector<lake::TabletRangeInfo> ranges;
+    ASSERT_OK(lake::get_tablet_split_ranges(_tablet_manager.get(), metadata, 2, &ranges));
+    EXPECT_EQ(0, opens);
+    ASSERT_EQ(2, ranges.size());
+    ASSERT_TRUE(ranges[0].range.has_upper_bound());
+    EXPECT_EQ(1, ranges[0].range.upper_bound().values_size());
 }
 
 TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_full_sort_key_index_conservation) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1418,7 +1418,8 @@ protected:
     // Returns the segment file size on disk. The file is placed under
     // tablet_id's segment directory as |segment_name|.
     uint64_t write_two_column_segment(int64_t tablet_id, const std::string& segment_name, int num_rows,
-                                      const std::function<int(int)>& source_value_of, int key_start = 0) {
+                                      const std::function<int(int)>& source_value_of, int key_start = 0,
+                                      const std::function<int(int)>& key_of = {}) {
         TabletSchemaPB schema_pb;
         schema_pb.set_keys_type(PRIMARY_KEYS);
         schema_pb.set_id(2001);
@@ -1453,7 +1454,7 @@ protected:
         auto col1 = Int32Column::create();
         std::vector<int> v0(num_rows), v1(num_rows);
         for (int i = 0; i < num_rows; ++i) {
-            v0[i] = key_start + i;
+            v0[i] = key_of ? key_of(i) : key_start + i;
             v1[i] = source_value_of(v0[i]);
         }
         col0->append_numbers(v0.data(), v0.size() * sizeof(int));
@@ -1844,6 +1845,55 @@ protected:
     StatusOr<TabletMetadataPtr> publish_followup_delete(int64_t tablet_id, int64_t base_version, int32_t delete_key) {
         return publish_followup_upsert_delete(tablet_id, base_version, /*upsert_key=*/0, /*upsert_value=*/0, delete_key,
                                               /*include_delete=*/true, /*include_upsert=*/false);
+    }
+
+    StatusOr<TabletMetadataPtr> publish_followup_deletes(int64_t tablet_id, int64_t base_version,
+                                                         const std::vector<int32_t>& delete_keys) {
+        std::vector<SlotDescriptor> slots;
+        slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
+        slots.emplace_back(1, "c1", TypeDescriptor{LogicalType::TYPE_INT});
+        slots.emplace_back(2, "__op", TypeDescriptor{LogicalType::TYPE_INT});
+        std::vector<SlotDescriptor*> slot_pointers = {&slots[0], &slots[1], &slots[2]};
+        Chunk::SlotHashMap slot_cid_map = {{0, 0}, {1, 1}, {2, 2}};
+
+        std::vector<int32_t> values(delete_keys.size(), 0);
+        std::vector<uint8_t> operations(delete_keys.size(), TOpType::DELETE);
+        std::vector<uint32_t> indexes(delete_keys.size());
+        std::iota(indexes.begin(), indexes.end(), 0);
+        auto key_column = Int32Column::create();
+        auto value_column = Int32Column::create();
+        auto operation_column = Int8Column::create();
+        key_column->append_numbers(delete_keys.data(), sizeof(delete_keys[0]) * delete_keys.size());
+        value_column->append_numbers(values.data(), sizeof(values[0]) * values.size());
+        operation_column->append_numbers(operations.data(), sizeof(operations[0]) * operations.size());
+        Chunk chunk(Columns{std::move(key_column), std::move(value_column), std::move(operation_column)}, slot_cid_map);
+
+        ASSIGN_OR_RETURN(auto metadata, _tablet_manager->get_tablet_metadata(tablet_id, base_version));
+        auto tablet_schema = TabletSchema::create(metadata->schema());
+        RuntimeProfile profile("tablet-merge-lifecycle-delete-batch");
+        const int64_t txn_id = next_id();
+        ASSIGN_OR_RETURN(auto delta_writer, lake::DeltaWriterBuilder()
+                                                    .set_tablet_manager(_tablet_manager.get())
+                                                    .set_tablet_id(tablet_id)
+                                                    .set_txn_id(txn_id)
+                                                    .set_partition_id(next_id())
+                                                    .set_mem_tracker(_mem_tracker.get())
+                                                    .set_schema_id(metadata->schema().id())
+                                                    .set_tablet_schema(std::move(tablet_schema))
+                                                    .set_slot_descriptors(&slot_pointers)
+                                                    .set_profile(&profile)
+                                                    .build());
+        RETURN_IF_ERROR(delta_writer->open());
+        RETURN_IF_ERROR(delta_writer->write(chunk, indexes.data(), indexes.size()));
+        RETURN_IF_ERROR(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+
+        TxnInfoPB txn_info;
+        txn_info.set_txn_id(txn_id);
+        txn_info.set_txn_type(TXN_NORMAL);
+        txn_info.set_commit_time(1);
+        return lake::publish_version(_tablet_manager.get(), lake::PublishTabletInfo(tablet_id), base_version,
+                                     base_version + 1, std::span<const TxnInfoPB>(&txn_info, 1), false);
     }
 
     StatusOr<TabletMetadataPtr> compact_tablet(int64_t tablet_id, int64_t base_version, bool force_base) {
@@ -5409,7 +5459,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_corruption_does_not_use_iden
         auto* rowset = m->mutable_rowsets(0);
         switch (malformed) {
         case 0:
-            rowset->set_num_dels(101);
+            rowset->mutable_segment_metas(0)->set_num_rows(-1);
             break;
         case 1:
             rowset->set_num_rows(-1);
@@ -5439,7 +5489,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_corruption_does_not_use_iden
 
 TEST_F(LakeTabletReshardTest, test_tablet_splitting_corrupt_source_fails_before_pk_flush) {
     auto m = split_source();
-    m->mutable_rowsets(0)->set_num_dels(101);
+    m->mutable_rowsets(0)->mutable_segment_metas(0)->set_num_rows(-1);
     auto* sync = SyncPoint::GetInstance();
     int flushes = 0;
     sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
@@ -6934,7 +6984,6 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_scales_num_dels) {
         ASSERT_EQ(1, it->second->rowsets_size());
         const auto& child_rowset = it->second->rowsets(0);
         EXPECT_TRUE(child_rowset.has_num_dels()) << "split must always write num_dels on PK children";
-        EXPECT_LE(child_rowset.num_dels(), child_rowset.num_rows()) << "num_dels must not exceed child num_rows";
         total_child_num_rows += child_rowset.num_rows();
         total_child_num_dels += child_rowset.num_dels();
     }
@@ -7124,7 +7173,6 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_per_rowset_conserv
             t.num_rows += rs.num_rows();
             t.data_size += rs.data_size();
             t.num_dels += rs.num_dels();
-            EXPECT_LE(rs.num_dels(), rs.num_rows()) << "child cid=" << cid << " rs=" << rs.id();
         }
     }
 
@@ -7141,9 +7189,9 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_per_rowset_conserv
     EXPECT_EQ(11, totals[4].num_dels);
 }
 
-// Contradictory parent statistics are Corruption, not a clamped estimate or an
-// identical fallback. Rejection must occur before the required PK flush.
-TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_rejects_invalid_parent_dels_before_flush) {
+// A previously split child can have an approximate row count below its exact delete count while
+// retaining many more shared physical rows. The next split must conserve both estimates independently.
+TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_accepts_dels_above_zero_estimated_rows) {
     const int64_t base_version = 2;
     const int64_t new_version = 3;
     const int64_t tablet_id = next_id();
@@ -7159,9 +7207,9 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_rejects_invalid_parent_de
     auto* rowset = metadata.add_rowsets();
     rowset->set_id(2);
     rowset->set_overlapped(true);
-    rowset->set_num_rows(10);
+    rowset->set_num_rows(0);
     rowset->set_data_size(1000);
-    rowset->set_num_dels(15); // pathological: > num_rows
+    rowset->set_num_dels(15);
 
     // Two segments so calculate_range_split_boundaries has enough key-space
     // boundaries to produce a 2-way split (single segment falls back to
@@ -7172,7 +7220,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_rejects_invalid_parent_de
         sm->set_size(500);
         sm->mutable_sort_key_min()->CopyFrom(generate_sort_key(0));
         sm->mutable_sort_key_max()->CopyFrom(generate_sort_key(49));
-        sm->set_num_rows(5);
+        sm->set_num_rows(50);
     }
 
     {
@@ -7181,7 +7229,7 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_rejects_invalid_parent_de
         sm->set_size(500);
         sm->mutable_sort_key_min()->CopyFrom(generate_sort_key(50));
         sm->mutable_sort_key_max()->CopyFrom(generate_sort_key(99));
-        sm->set_num_rows(5);
+        sm->set_num_rows(50);
     }
 
     lake::tablet_reshard_helper::set_rowset_uid(rowset);
@@ -7210,10 +7258,23 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_rejects_invalid_parent_de
         sync->DisableProcessing();
         sync->ClearAllCallBacks();
     });
-    auto status = lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version,
-                                                  txn_info, false, tablet_metadatas, tablet_ranges);
-    EXPECT_TRUE(status.is_corruption()) << status;
-    EXPECT_EQ(0, flushes);
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), resharding, base_version, new_version, txn_info,
+                                              false, tablet_metadatas, tablet_ranges));
+    EXPECT_EQ(1, flushes);
+    int64_t total_rows = 0;
+    int64_t total_dels = 0;
+    bool saw_dels_above_rows = false;
+    for (int64_t child_id : {child_id_1, child_id_2}) {
+        ASSERT_TRUE(tablet_metadatas.contains(child_id));
+        ASSERT_EQ(1, tablet_metadatas.at(child_id)->rowsets_size());
+        const auto& child = tablet_metadatas.at(child_id)->rowsets(0);
+        total_rows += child.num_rows();
+        total_dels += child.num_dels();
+        saw_dels_above_rows |= child.num_dels() > child.num_rows();
+    }
+    EXPECT_EQ(0, total_rows);
+    EXPECT_EQ(15, total_dels);
+    EXPECT_TRUE(saw_dels_above_rows);
 }
 
 // Anchor input fallback: legacy / incomplete metadata may omit
@@ -7342,8 +7403,6 @@ TEST_F(LakeTabletReshardTest, test_pk_tablet_splitting_anchor_three_level_chain_
                 t.num_rows += rs.num_rows();
                 t.data_size += rs.data_size();
                 t.num_dels += rs.num_dels();
-                EXPECT_LE(rs.num_dels(), rs.num_rows())
-                        << level << ": child " << cid << " rs " << rs.id() << " num_dels exceeds num_rows";
             }
         }
         for (const auto& rs : parent_md.rowsets()) {
@@ -8940,6 +8999,152 @@ TEST_F(LakeTabletReshardTest, test_delete_only_zero_row_segment_survives_split_m
     expect_canonical_delete(second_cold);
     expect_lifecycle_oracle(second_cold, {}, {10});
     EXPECT_EQ(2, flushes);
+}
+
+// CORE-005: split row counts are estimates, but later PK deletes are exact. A skewed shared segment
+// can therefore produce a valid child whose num_dels exceeds its estimated num_rows. Both re-split
+// and sibling merge must preserve that delete anchor instead of treating the estimate as a hard cap.
+TEST_F(LakeTabletReshardTest, test_skewed_child_exact_deletes_survive_resplit_merge_cold_load) {
+    constexpr int64_t kSourceVersion = 1;
+    constexpr int64_t kSplitVersion = 2;
+    constexpr int64_t kDmlVersion = 3;
+    constexpr int64_t kMergeVersion = 4;
+    const int64_t source_id = next_id();
+    const int64_t left_id = next_id();
+    const int64_t right_id = next_id();
+    const int64_t target_id = next_id();
+    for (int64_t id : {source_id, left_id, right_id, target_id}) prepare_tablet_dirs(id);
+
+    auto set_range = [&](TabletRangePB* range, int lower, int upper) {
+        *range->mutable_lower_bound() = generate_sort_key(lower);
+        range->set_lower_bound_included(true);
+        *range->mutable_upper_bound() = generate_sort_key(upper);
+        range->set_upper_bound_included(false);
+    };
+    const std::string segment_name = fmt::format("skewed_delete_{}.dat", source_id);
+    const uint64_t segment_size = write_two_column_segment(
+            source_id, segment_name, /*num_rows=*/100, [](int key) { return key * 10; }, /*key_start=*/0,
+            [](int ordinal) { return ordinal < 90 ? ordinal : 1000 + ordinal - 90; });
+
+    auto source = std::make_shared<TabletMetadataPB>();
+    source->set_id(source_id);
+    source->set_version(kSourceVersion);
+    source->set_next_rowset_id(2);
+    set_two_column_pk_schema(source.get(), /*schema_id=*/4001);
+    source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+    source->set_enable_persistent_index(true);
+    source->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+    set_range(source->mutable_range(), 0, 1010);
+    auto* rowset = source->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_version(kSourceVersion);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(segment_size);
+    rowset->set_num_dels(0);
+    lake::tablet_reshard_helper::set_rowset_uid(rowset);
+    const auto source_uid = rowset->uid().SerializeAsString();
+    auto* segment = rowset->add_segment_metas();
+    segment->set_filename(segment_name);
+    segment->set_size(segment_size);
+    segment->set_num_rows(100);
+    segment->set_segment_idx(0);
+    *segment->mutable_sort_key_min() = generate_sort_key(0);
+    *segment->mutable_sort_key_max() = generate_sort_key(1009);
+    ASSERT_EQ(0, segment->deprecated_sort_key_samples_size());
+    ASSERT_OK(put_tablet_metadata(source));
+
+    ReshardingTabletInfoPB split_request;
+    auto* split = split_request.mutable_splitting_tablet_info();
+    split->set_old_tablet_id(source_id);
+    split->add_new_tablet_ids(left_id);
+    split->add_new_tablet_ids(right_id);
+    set_range(split->add_new_tablet_ranges(), 0, 500);
+    set_range(split->add_new_tablet_ranges(), 500, 1010);
+    TxnInfoPB split_info;
+    split_info.set_txn_id(next_id());
+    split_info.set_commit_time(1);
+    split_info.set_gtid(1);
+    std::unordered_map<int64_t, TabletMetadataPtr> split_published;
+    std::unordered_map<int64_t, TabletRangePB> split_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), split_request, kSourceVersion, kSplitVersion,
+                                              split_info, false, split_published, split_ranges));
+    auto left = split_published.at(left_id);
+    auto right = split_published.at(right_id);
+    auto find_source_rowset = [&](const TabletMetadataPtr& metadata) -> const RowsetMetadataPB* {
+        for (const auto& candidate : metadata->rowsets()) {
+            if (candidate.uid().SerializeAsString() == source_uid) return &candidate;
+        }
+        return nullptr;
+    };
+    const auto* estimated_left = find_source_rowset(left);
+    ASSERT_NE(nullptr, estimated_left);
+    EXPECT_LT(estimated_left->num_rows(), 60);
+
+    std::vector<int32_t> deleted_keys(60);
+    std::iota(deleted_keys.begin(), deleted_keys.end(), 0);
+    ASSIGN_OR_ABORT(auto left_deleted, publish_followup_deletes(left_id, kSplitVersion, deleted_keys));
+    ASSIGN_OR_ABORT(auto right_aligned,
+                    publish_followup_upsert_delete(right_id, kSplitVersion, /*upsert_key=*/1000,
+                                                   /*upsert_value=*/10000, /*delete_key=*/0,
+                                                   /*include_delete=*/false, /*include_upsert=*/true));
+    ASSERT_EQ(kDmlVersion, left_deleted->version());
+    ASSERT_EQ(kDmlVersion, right_aligned->version());
+    const auto* deleted_source = find_source_rowset(left_deleted);
+    ASSERT_NE(nullptr, deleted_source);
+    EXPECT_EQ(60, deleted_source->num_dels());
+    EXPECT_GT(deleted_source->num_dels(), deleted_source->num_rows());
+
+    SplittingTabletInfoPB nested_split;
+    nested_split.set_old_tablet_id(left_id);
+    const int64_t nested_left = next_id();
+    const int64_t nested_right = next_id();
+    nested_split.add_new_tablet_ids(nested_left);
+    nested_split.add_new_tablet_ids(nested_right);
+    set_range(nested_split.add_new_tablet_ranges(), 0, 250);
+    set_range(nested_split.add_new_tablet_ranges(), 250, 500);
+    TxnInfoPB nested_info;
+    nested_info.set_txn_id(next_id());
+    nested_info.set_commit_time(1);
+    nested_info.set_gtid(2);
+    ASSIGN_OR_ABORT(auto nested_children,
+                    lake::split_tablet(_tablet_manager.get(), left_deleted, nested_split, kMergeVersion, nested_info));
+    int64_t nested_rows = 0;
+    int64_t nested_dels = 0;
+    bool saw_dels_above_rows = false;
+    for (int64_t child_id : {nested_left, nested_right}) {
+        const auto* child_rowset = find_source_rowset(nested_children.at(child_id));
+        ASSERT_NE(nullptr, child_rowset);
+        nested_rows += child_rowset->num_rows();
+        nested_dels += child_rowset->num_dels();
+        saw_dels_above_rows |= child_rowset->num_dels() > child_rowset->num_rows();
+    }
+    EXPECT_EQ(deleted_source->num_rows(), nested_rows);
+    EXPECT_EQ(60, nested_dels);
+    EXPECT_TRUE(saw_dels_above_rows);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> merged_published;
+    const auto* right_source = find_source_rowset(right_aligned);
+    ASSERT_NE(nullptr, right_source);
+    const int64_t expected_merged_rows = deleted_source->num_rows() + right_source->num_rows();
+    const int64_t expected_merged_bytes = deleted_source->data_size() + right_source->data_size();
+    const int64_t expected_merged_dels = deleted_source->num_dels() + right_source->num_dels();
+    ASSERT_OK(publish_resharding_merge({left_deleted, right_aligned}, target_id, kDmlVersion, kMergeVersion, next_id(),
+                                       merged_published));
+    auto merged = merged_published.at(target_id);
+    const auto* merged_source = find_source_rowset(merged);
+    ASSERT_NE(nullptr, merged_source);
+    EXPECT_EQ(expected_merged_rows, merged_source->num_rows());
+    EXPECT_EQ(expected_merged_bytes, merged_source->data_size());
+    EXPECT_EQ(expected_merged_dels, merged_source->num_dels());
+    std::vector<std::pair<int32_t, int32_t>> expected_rows;
+    for (int key = 60; key < 90; ++key) expected_rows.emplace_back(key, key * 10);
+    for (int key = 1000; key < 1010; ++key) expected_rows.emplace_back(key, key * 10);
+    expect_lifecycle_oracle(merged, expected_rows, deleted_keys);
+    _update_manager->unload_and_remove_primary_index(target_id);
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto cold, _tablet_manager->get_tablet_metadata(target_id, kMergeVersion));
+    expect_lifecycle_oracle(cold, expected_rows, deleted_keys);
 }
 
 TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for_splitting) {
@@ -14624,6 +14829,52 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_distinct_ranges_contribute_onc
     EXPECT_EQ(20, merged->rowsets(0).num_rows());
     EXPECT_EQ(200, merged->rowsets(0).data_size());
     EXPECT_EQ(6, merged->rowsets(0).num_dels());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_accepts_dels_above_zero_estimated_rows) {
+    auto first = make_allocator_source(next_id(), 20);
+    auto* rowset = add_allocator_rowset(first.get(), 10, 1, "zero-estimate.dat", 0);
+    rowset->set_num_rows(0);
+    rowset->set_num_dels(3);
+    rowset->mutable_segment_metas(0)->set_num_rows(10);
+    auto second = std::make_shared<TabletMetadataPB>(*first);
+    second->set_id(next_id());
+    *first->mutable_range()->mutable_upper_bound() = generate_sort_key(10);
+    first->mutable_range()->set_upper_bound_included(false);
+    *second->mutable_range()->mutable_lower_bound() = generate_sort_key(10);
+    second->mutable_range()->set_lower_bound_included(true);
+
+    ASSIGN_OR_ABORT(auto merged, publish_allocator_merge({first, second}));
+    ASSERT_EQ(1, merged->rowsets_size());
+    EXPECT_EQ(0, merged->rowsets(0).num_rows());
+    EXPECT_EQ(2, merged->rowsets(0).data_size());
+    EXPECT_EQ(6, merged->rowsets(0).num_dels());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_contributor_statistics_overflow_before_io) {
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(reverse_sources);
+        auto first = make_allocator_source(next_id(), 20);
+        auto* rowset = add_allocator_rowset(first.get(), 10, 1, "stats-overflow.dat", 0);
+        rowset->set_num_rows(std::numeric_limits<int64_t>::max());
+        rowset->set_data_size(std::numeric_limits<int64_t>::max());
+        rowset->set_num_dels(std::numeric_limits<int64_t>::max());
+        auto second = std::make_shared<TabletMetadataPB>(*first);
+        second->set_id(next_id());
+        second->mutable_rowsets(0)->set_num_rows(1);
+        second->mutable_rowsets(0)->set_data_size(1);
+        second->mutable_rowsets(0)->set_num_dels(1);
+        *first->mutable_range()->mutable_upper_bound() = generate_sort_key(10);
+        first->mutable_range()->set_upper_bound_included(false);
+        *second->mutable_range()->mutable_lower_bound() = generate_sort_key(10);
+        second->mutable_range()->set_lower_bound_included(true);
+        std::vector<TabletMetadataPtr> sources = {first, second};
+        if (reverse_sources) std::swap(sources[0], sources[1]);
+
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection(sources, next_id(), /*target_version=*/2, &counts);
+        EXPECT_TRUE(status.message().contains("statistics overflow")) << status;
+    }
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_same_range_requires_complete_segment_set) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -3070,8 +3070,8 @@ protected:
         lake::tablet_reshard_helper::set_rowset_uid(rowset);
         for (int i = 0; i < 2; ++i) {
             const auto name = fmt::format("fixed_{}_{}.dat", metadata->id(), i);
-            const auto size = write_two_column_segment(
-                    metadata->id(), name, 50, [](int key) { return key * 10; }, i * 50);
+            const auto size =
+                    write_two_column_segment(metadata->id(), name, 50, [](int key) { return key * 10; }, i * 50);
             auto* segment = rowset->add_segment_metas();
             segment->set_filename(name);
             segment->set_size(size);
@@ -8955,10 +8955,8 @@ TEST_F(LakeTabletReshardTest, test_batch_virtual_self_del_offset_survives_split_
 
     const std::string first_name = fmt::format("virtual_first_{}.dat", tablet_id);
     const std::string second_name = fmt::format("virtual_second_{}.dat", tablet_id);
-    const uint64_t first_size = write_two_column_segment(
-            tablet_id, first_name, 1, [](int) { return 100; }, 10);
-    const uint64_t second_size = write_two_column_segment(
-            tablet_id, second_name, 1, [](int) { return 300; }, 10);
+    const uint64_t first_size = write_two_column_segment(tablet_id, first_name, 1, [](int) { return 100; }, 10);
+    const uint64_t second_size = write_two_column_segment(tablet_id, second_name, 1, [](int) { return 300; }, 10);
 
     lake::Tablet tablet(_tablet_manager.get(), tablet_id);
     lake::MetaFileBuilder builder(tablet, source);
@@ -17672,8 +17670,7 @@ inline void set_pk_int_key_schema(TabletMetadataPB* metadata, int64_t schema_id)
 
 inline std::shared_ptr<TabletMetadataPB> make_pk_shared_child_with_real_segment(int64_t tablet_id, int64_t base_version,
                                                                                 uint32_t shared_id, int tablet_lower,
-                                                                                int tablet_upper,
-                                                                                uint64_t segment_size,
+                                                                                int tablet_upper, uint64_t segment_size,
                                                                                 int physical_num_rows) {
     auto meta = std::make_shared<TabletMetadataPB>();
     meta->set_id(tablet_id);
@@ -17760,8 +17757,9 @@ inline std::shared_ptr<TabletMetadataPB> make_pk_compacted_child(int64_t tablet_
                 metas[i] = make_pk_compacted_child(child_ids[i], base_version, /*compacted_id=*/11, lower, upper,      \
                                                    fmt::format("compacted_{}.dat", i));                                \
             } else {                                                                                                   \
-                metas[i] = make_pk_shared_child_with_real_segment(child_ids[i], base_version, /*shared_id=*/10, lower, \
-                                                                  upper, segment_size, /*physical_num_rows=*/kNumRows); \
+                metas[i] =                                                                                             \
+                        make_pk_shared_child_with_real_segment(child_ids[i], base_version, /*shared_id=*/10, lower,    \
+                                                               upper, segment_size, /*physical_num_rows=*/kNumRows);   \
             }                                                                                                          \
             EXPECT_OK(put_tablet_metadata(metas[i]));                                                                  \
         }                                                                                                              \

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -893,6 +893,45 @@ protected:
         return {std::move(source_a), std::move(source_b)};
     }
 
+    std::vector<std::shared_ptr<TabletMetadataPB>> make_readable_preflight_sst_sources(const std::string& stem) {
+        auto sources = make_preflight_sst_sources(stem);
+        const std::string segment_name = stem + ".dat";
+        const uint64_t segment_size =
+                write_two_column_segment(sources[0]->id(), segment_name, 100, [](int key) { return key * 10; });
+        std::vector<std::pair<std::string, std::string>> entries;
+        entries.reserve(100);
+        for (uint32_t key = 0; key < 100; ++key) {
+            entries.emplace_back(encode_int_primary_key(key), serialize_index_values({{1, 1, key}}));
+        }
+        const auto sst_file = write_raw_pk_sstable(_tablet_manager->sst_location(sources[0]->id(), stem + ".sst"),
+                                                   std::move(entries), /*encrypted=*/false);
+        for (auto& source : sources) {
+            source->clear_schema();
+            set_two_column_pk_schema(source.get(), /*schema_id=*/4001);
+            source->mutable_schema()->set_primary_key_encoding_type(PrimaryKeyEncodingTypePB::PK_ENCODING_TYPE_V2);
+            auto* rowset = source->mutable_rowsets(0);
+            rowset->set_num_rows(50);
+            rowset->set_data_size(segment_size / 2);
+            rowset->set_num_dels(0);
+            auto* segment = rowset->mutable_segment_metas(0);
+            segment->set_size(segment_size);
+            segment->set_num_rows(100);
+            segment->set_segment_idx(0);
+            segment->set_shared(true);
+            *segment->mutable_sort_key_min() = generate_sort_key(0);
+            *segment->mutable_sort_key_max() = generate_sort_key(99);
+            auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
+            sst->set_version(1);
+            sst->set_filesize(sst_file.filesize);
+            sst->set_max_rss_rowid((uint64_t{1} << 32) | 99);
+            *sst->mutable_range() = sst_file.range;
+            sst->mutable_fileset_id()->set_hi(1);
+            sst->mutable_fileset_id()->set_lo(1);
+        }
+        sources[1]->mutable_rowsets(0)->set_data_size(segment_size - segment_size / 2);
+        return sources;
+    }
+
     void add_delvec(TabletMetadataPB* metadata, int64_t tablet_id, int64_t version, uint32_t segment_id,
                     const std::string& file_name, const std::string& content) {
         FileMetaPB file_meta;
@@ -8795,6 +8834,108 @@ TEST_F(LakeTabletReshardTest, test_batch_virtual_self_del_offset_survives_split_
     expect_lifecycle_oracle(cold, {{10, 300}}, {});
 }
 
+// CORE-003: a normal serial PK DELETE writes a zero-row physical segment whose footer has positive
+// size and whose sort-key bounds are empty. Split must conserve its physical bytes and replay order;
+// cold PK-index rebuild must skip the empty segment while still applying its del file.
+TEST_F(LakeTabletReshardTest, test_delete_only_zero_row_segment_survives_split_merge_cold_load) {
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+
+    ASSIGN_OR_ABORT(auto seeded,
+                    create_lifecycle_source(tablet_id, /*lower=*/0, /*upper=*/100, /*key=*/10, /*value=*/100,
+                                            /*include_delete=*/false));
+    ASSIGN_OR_ABORT(auto deleted, publish_followup_delete(tablet_id, seeded->version(), /*delete_key=*/10));
+    set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::DISABLE);
+    DeferOp restore_pk_flush([&] { set_failpoint_mode("skip_lake_pk_index_flush", FailPointTriggerModeType::ENABLE); });
+    const RowsetMetadataPB* delete_rowset = nullptr;
+    for (const auto& rowset : deleted->rowsets()) {
+        if (rowset.del_files_size() > 0) delete_rowset = &rowset;
+    }
+    ASSERT_NE(nullptr, delete_rowset);
+    EXPECT_EQ(0, delete_rowset->num_rows());
+    EXPECT_GT(delete_rowset->data_size(), 0);
+    ASSERT_EQ(1, delete_rowset->segment_metas_size());
+    EXPECT_EQ(0, delete_rowset->segment_metas(0).num_rows());
+    EXPECT_EQ(0, delete_rowset->segment_metas(0).sort_key_min().values_size());
+    EXPECT_EQ(0, delete_rowset->segment_metas(0).sort_key_max().values_size());
+    ASSERT_EQ(1, delete_rowset->del_files_size());
+    EXPECT_GT(delete_rowset->del_files(0).num_rows(), 0);
+    const RowsetMetadataPB original_delete(*delete_rowset);
+    auto find_delete_rowset = [&](const TabletMetadataPtr& metadata) -> const RowsetMetadataPB* {
+        for (const auto& rowset : metadata->rowsets()) {
+            if (rowset.uid().SerializeAsString() == original_delete.uid().SerializeAsString()) return &rowset;
+        }
+        return nullptr;
+    };
+    auto expect_canonical_delete = [&](const TabletMetadataPtr& metadata) {
+        const auto* rowset = find_delete_rowset(metadata);
+        ASSERT_NE(nullptr, rowset);
+        EXPECT_EQ(0, rowset->num_rows());
+        EXPECT_EQ(0, rowset->num_dels());
+        EXPECT_EQ(original_delete.data_size(), rowset->data_size());
+        ASSERT_EQ(1, rowset->segment_metas_size());
+        SegmentMetadataPB expected_segment(original_delete.segment_metas(0));
+        SegmentMetadataPB actual_segment(rowset->segment_metas(0));
+        expected_segment.clear_shared();
+        actual_segment.clear_shared();
+        EXPECT_EQ(expected_segment.SerializeAsString(), actual_segment.SerializeAsString());
+        ASSERT_EQ(1, rowset->del_files_size());
+        DelfileWithRowsetId expected_del(original_delete.del_files(0));
+        DelfileWithRowsetId actual_del(rowset->del_files(0));
+        expected_del.clear_shared();
+        actual_del.clear_shared();
+        EXPECT_EQ(expected_del.SerializeAsString(), actual_del.SerializeAsString());
+    };
+
+    int flushes = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+    sync->EnableProcessing();
+    DeferOp clear_sync([&] {
+        sync->ClearAllCallBacks();
+        sync->DisableProcessing();
+    });
+
+    auto children = split_fixed_point_source(deleted, /*child_count=*/2);
+    int64_t projected_bytes = 0;
+    for (const auto& child : children) {
+        const auto* rowset = find_delete_rowset(child);
+        ASSERT_NE(nullptr, rowset);
+        ASSERT_EQ(1, rowset->segment_metas_size());
+        ASSERT_EQ(1, rowset->del_files_size());
+        EXPECT_EQ(0, rowset->num_rows());
+        EXPECT_EQ(0, rowset->num_dels());
+        EXPECT_GT(rowset->data_size(), 0);
+        projected_bytes += rowset->data_size();
+    }
+    EXPECT_EQ(original_delete.data_size(), projected_bytes);
+    EXPECT_EQ(1, flushes);
+
+    const int64_t merged_tablet = next_id();
+    std::unordered_map<int64_t, TabletMetadataPtr> published;
+    ASSERT_OK(publish_resharding_merge(children, merged_tablet, deleted->version() + 1, deleted->version() + 2,
+                                       next_id(), published));
+    auto merged = published.at(merged_tablet);
+    expect_canonical_delete(merged);
+    expect_lifecycle_oracle(merged, {}, {10});
+    _update_manager->unload_and_remove_primary_index(merged_tablet);
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto cold, _tablet_manager->get_tablet_metadata(merged_tablet, deleted->version() + 2));
+    expect_canonical_delete(cold);
+    expect_lifecycle_oracle(cold, {}, {10});
+
+    auto second_cycle = run_no_write_split_merge_cycle(cold, /*child_count=*/3);
+    expect_canonical_delete(second_cycle);
+    expect_lifecycle_oracle(second_cycle, {}, {10});
+    _update_manager->unload_and_remove_primary_index(second_cycle->id());
+    _tablet_manager->prune_metacache();
+    ASSIGN_OR_ABORT(auto second_cold,
+                    _tablet_manager->get_tablet_metadata(second_cycle->id(), second_cycle->version()));
+    expect_canonical_delete(second_cold);
+    expect_lifecycle_oracle(second_cold, {}, {10});
+    EXPECT_EQ(2, flushes);
+}
+
 TEST_F(LakeTabletReshardTest, test_convert_txn_log_updates_all_rowset_ranges_for_splitting) {
     auto base_metadata = std::make_shared<TabletMetadataPB>();
     base_metadata->set_id(next_id());
@@ -12562,38 +12703,49 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_modern_sst_i
     }
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_sst_same_file_form_or_range_conflict_before_io) {
-    struct DeclarationConflict {
+TEST_F(LakeTabletReshardTest, test_tablet_merging_same_physical_sst_allows_logical_attachment_differences) {
+    struct LogicalAttachment {
         const char* name;
         std::function<void(PersistentIndexSstablePB*)> apply;
     };
-    const std::vector<DeclarationConflict> conflicts = {
-            {"max rss rowid", [](PersistentIndexSstablePB* sst) { sst->set_max_rss_rowid(uint64_t{2} << 32); }},
+    const std::vector<LogicalAttachment> attachments = {
+            {"deprecated version", [](PersistentIndexSstablePB* sst) { sst->set_version(2); }},
+            {"max rss rowid", [](PersistentIndexSstablePB* sst) { sst->set_max_rss_rowid((uint64_t{2} << 32) | 99); }},
+            {"shared", [](PersistentIndexSstablePB* sst) { sst->set_shared(false); }},
             {"shared rssid", [](PersistentIndexSstablePB* sst) { sst->set_shared_rssid(2); }},
             {"shared version", [](PersistentIndexSstablePB* sst) { sst->set_shared_version(2); }},
-            {"shared version presence", [](PersistentIndexSstablePB* sst) { sst->clear_shared_version(); }},
-            {"rssid offset", [](PersistentIndexSstablePB* sst) { sst->set_rssid_offset(1); }},
             {"embedded delvec",
              [](PersistentIndexSstablePB* sst) {
                  sst->mutable_delvec()->set_version(1);
                  sst->mutable_delvec()->set_size(1);
              }},
-            {"range start",
-             [&](PersistentIndexSstablePB* sst) { sst->mutable_range()->set_start_key(encode_int_primary_key(11)); }},
-            {"range end",
-             [&](PersistentIndexSstablePB* sst) { sst->mutable_range()->set_end_key(encode_int_primary_key(89)); }},
-            {"range presence", [](PersistentIndexSstablePB* sst) { sst->clear_range(); }},
+            {"fileset",
+             [](PersistentIndexSstablePB* sst) {
+                 sst->mutable_fileset_id()->set_hi(2);
+                 sst->mutable_fileset_id()->set_lo(2);
+             }},
+            {"rssid offset", [](PersistentIndexSstablePB* sst) { sst->set_rssid_offset(1); }},
+            {"generation version", [](PersistentIndexSstablePB* sst) { sst->set_generation_version(2); }},
     };
 
-    for (const auto& conflict : conflicts) {
-        SCOPED_TRACE(conflict.name);
-        auto sources = make_preflight_sst_sources(fmt::format("sst_form_conflict_{}", next_id()));
-        conflict.apply(sources[1]->mutable_sstable_meta()->mutable_sstables(0));
-        std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
-        MergePhaseCounts counts;
-        auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
-        EXPECT_TRUE(status.message().contains("SST")) << status;
-        EXPECT_TRUE(status.message().contains("conflict")) << status;
+    std::vector<std::pair<int32_t, int32_t>> expected_rows;
+    for (int key = 0; key < 100; ++key) expected_rows.emplace_back(key, key * 10);
+    for (const auto& attachment : attachments) {
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("{}; reverse={}", attachment.name, reverse_sources));
+            auto sources = make_readable_preflight_sst_sources(fmt::format("sst_attachment_{}", next_id()));
+            attachment.apply(sources[1]->mutable_sstable_meta()->mutable_sstables(0));
+            std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
+            if (reverse_sources) std::swap(immutable_sources[0], immutable_sources[1]);
+            const int64_t target = next_id();
+            prepare_tablet_dirs(target);
+            std::unordered_map<int64_t, TabletMetadataPtr> published;
+            ASSERT_OK(publish_resharding_merge(immutable_sources, target, /*base_version=*/1, /*new_version=*/2,
+                                               next_id(), published));
+            auto merged = published.at(target);
+            _update_manager->unload_and_remove_primary_index(target);
+            expect_lifecycle_oracle(merged, expected_rows, {});
+        }
     }
 }
 
@@ -12620,6 +12772,18 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_sst_fil
              }},
             {"encryption presence",
              [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->clear_encryption_meta(); }},
+            {"range presence",
+             [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->clear_range(); }},
+            {"range value",
+             [&](auto& sources) {
+                 sources[1]->mutable_sstable_meta()->mutable_sstables(0)->mutable_range()->set_start_key(
+                         encode_int_primary_key(11));
+             }},
+            {"unknown field",
+             [](auto& sources) {
+                 auto* sst = sources[1]->mutable_sstable_meta()->mutable_sstables(0);
+                 sst->GetReflection()->MutableUnknownFields(sst)->AddVarint(1000, 1);
+             }},
             {"empty filename",
              [](auto& sources) { sources[1]->mutable_sstable_meta()->mutable_sstables(0)->set_filename(""); }},
             {"negative size",
@@ -12632,20 +12796,24 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_preflight_rejects_late_sst_fil
     };
 
     for (const auto& conflict : conflicts) {
-        SCOPED_TRACE(conflict.name);
-        auto sources = make_preflight_sst_sources(fmt::format("sst_preflight_{}", next_id()));
-        for (auto& source : sources) {
-            auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
-            sst->set_filename("repeated_physical.sst");
-            sst->set_encryption_meta(encryption_a.encryption_meta);
-        }
-        conflict.apply(sources);
-        std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
+        for (bool reverse_sources : {false, true}) {
+            SCOPED_TRACE(fmt::format("{}; reverse={}", conflict.name, reverse_sources));
+            auto sources = make_preflight_sst_sources(fmt::format("sst_preflight_{}", next_id()));
+            for (auto& source : sources) {
+                auto* sst = source->mutable_sstable_meta()->mutable_sstables(0);
+                sst->set_filename("repeated_physical.sst");
+                sst->set_encryption_meta(encryption_a.encryption_meta);
+            }
+            conflict.apply(sources);
+            std::vector<TabletMetadataPtr> immutable_sources(sources.begin(), sources.end());
+            if (reverse_sources) std::swap(immutable_sources[0], immutable_sources[1]);
 
-        MergePhaseCounts counts;
-        auto status = expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
-        if (std::string_view(conflict.name) != "invalid range arity") {
-            EXPECT_TRUE(status.message().contains("SST")) << status;
+            MergePhaseCounts counts;
+            auto status =
+                    expect_physical_preflight_rejection(immutable_sources, next_id(), /*target_version=*/2, &counts);
+            if (std::string_view(conflict.name) != "invalid range arity") {
+                EXPECT_TRUE(status.message().contains("SST")) << status;
+            }
         }
     }
 }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -212,6 +212,38 @@ protected:
         return lake::split_tablet(_tablet_manager.get(), m, splitting, 2, TxnInfoPB());
     }
 
+    TabletMetadataPtr cache_reshard_metadata(int64_t key_id, int64_t metadata_id, int64_t version, int64_t gtid,
+                                             const TabletRangePB* range = nullptr) {
+        _tablet_manager->metacache()->update_capacity(1024 * 1024);
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(metadata_id);
+        metadata->set_version(version);
+        metadata->set_gtid(gtid);
+        if (range != nullptr) *metadata->mutable_range() = *range;
+        _tablet_manager->metacache()->cache_tablet_metadata(_tablet_manager->tablet_metadata_location(key_id, version),
+                                                            metadata);
+        return metadata;
+    }
+
+    ReshardingTabletInfoPB make_split_retry_request(const TabletMetadataPtr& source,
+                                                    const std::vector<int64_t>& children, bool external) {
+        CHECK_OK(put_tablet_metadata(source));
+        ReshardingTabletInfoPB request;
+        auto* split = request.mutable_splitting_tablet_info();
+        split->set_old_tablet_id(source->id());
+        for (auto child : children) {
+            prepare_tablet_dirs(child);
+            split->add_new_tablet_ids(child);
+        }
+        if (external) {
+            *split->add_new_tablet_ranges()->mutable_upper_bound() = generate_sort_key(50);
+            split->mutable_new_tablet_ranges(0)->set_upper_bound_included(false);
+            *split->add_new_tablet_ranges()->mutable_lower_bound() = generate_sort_key(50);
+            split->mutable_new_tablet_ranges(1)->set_lower_bound_included(true);
+        }
+        return request;
+    }
+
     void expect_split_fallback_after_flush(const std::shared_ptr<TabletMetadataPB>& m) {
         auto* sync = SyncPoint::GetInstance();
         int flushes = 0;
@@ -17996,6 +18028,262 @@ TEST_F(LakeTabletReshardTest, publish_resharding_tablet_shared_first_skips_per_t
     // The old tablet's own version-1 key was never probed; the shared object was read exactly once.
     EXPECT_EQ(0, count_ending_with(lake::tablet_metadata_filename(old_tablet_id, 1)));
     EXPECT_EQ(1, count_ending_with(lake::tablet_initial_metadata_filename()));
+}
+
+TEST_F(LakeTabletReshardTest, test_split_retry_cache_complete_returns_without_recompute) {
+    constexpr int64_t kVersion = 2;
+    constexpr int64_t kGtid = 77;
+    auto source = split_source();
+    std::vector<int64_t> children{next_id(), next_id()};
+    auto request = make_split_retry_request(source, children, true);
+    const auto& ranges = request.splitting_tablet_info().new_tablet_ranges();
+
+    std::unordered_map<int64_t, TabletMetadataPtr> expected;
+    expected.emplace(source->id(), cache_reshard_metadata(source->id(), source->id(), kVersion, kGtid));
+    for (size_t i = 0; i < children.size(); ++i) {
+        expected.emplace(children[i], cache_reshard_metadata(children[i], children[i], kVersion, kGtid, &ranges[i]));
+    }
+
+    int flushes = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    TxnInfoPB txn;
+    txn.set_gtid(kGtid);
+    std::unordered_map<int64_t, TabletMetadataPtr> actual;
+    std::unordered_map<int64_t, TabletRangePB> actual_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, source->version(), kVersion, txn, false,
+                                              actual, actual_ranges));
+    EXPECT_EQ(0, flushes);
+    ASSERT_EQ(expected.size(), actual.size());
+    for (const auto& [id, metadata] : expected) {
+        EXPECT_EQ(metadata->SerializeAsString(), actual.at(id)->SerializeAsString());
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_split_identical_retry_cache_requires_absent_extra_children) {
+    constexpr int64_t kVersion = 2;
+    constexpr int64_t kGtid = 78;
+    auto source = split_source();
+    std::vector<int64_t> children{next_id(), next_id(), next_id()};
+    auto request = make_split_retry_request(source, children, false);
+    TabletRangePB identical_range;
+    *identical_range.mutable_lower_bound() = generate_sort_key(0);
+    *identical_range.mutable_upper_bound() = generate_sort_key(100);
+    auto cached_source = cache_reshard_metadata(source->id(), source->id(), kVersion, kGtid, &identical_range);
+    auto cached_child = cache_reshard_metadata(children[0], children[0], kVersion, kGtid, &identical_range);
+    for (size_t i = 1; i < children.size(); ++i) {
+        ASSERT_EQ(nullptr, _tablet_manager->metacache()->lookup_tablet_metadata(
+                                   _tablet_manager->tablet_metadata_location(children[i], kVersion)));
+    }
+
+    int planner_calls = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_splitter:set_metadata_visit_limit", [&](void* arg) {
+        ++planner_calls;
+        *static_cast<size_t*>(arg) = 0;
+    });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    TxnInfoPB txn;
+    txn.set_gtid(kGtid);
+    std::unordered_map<int64_t, TabletMetadataPtr> actual;
+    std::unordered_map<int64_t, TabletRangePB> actual_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, source->version(), kVersion, txn, false,
+                                              actual, actual_ranges));
+    EXPECT_EQ(0, planner_calls);
+    ASSERT_EQ(2, actual.size());
+    EXPECT_EQ(cached_source->SerializeAsString(), actual.at(source->id())->SerializeAsString());
+    EXPECT_EQ(cached_child->SerializeAsString(), actual.at(children[0])->SerializeAsString());
+}
+
+TEST_F(LakeTabletReshardTest, test_split_identical_retry_cache_rejects_mismatched_extra_child) {
+    constexpr int64_t kVersion = 2;
+    constexpr int64_t kGtid = 79;
+    auto source = split_source();
+    std::vector<int64_t> children{next_id(), next_id()};
+    auto request = make_split_retry_request(source, children, false);
+    cache_reshard_metadata(source->id(), source->id(), kVersion, kGtid);
+    cache_reshard_metadata(children[0], children[0], kVersion, kGtid);
+    cache_reshard_metadata(children[1], children[1], kVersion, kGtid + 1);
+
+    int planner_calls = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("tablet_splitter:set_metadata_visit_limit", [&](void* arg) {
+        ++planner_calls;
+        *static_cast<size_t*>(arg) = 0;
+    });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    TxnInfoPB txn;
+    txn.set_gtid(kGtid);
+    std::unordered_map<int64_t, TabletMetadataPtr> actual;
+    std::unordered_map<int64_t, TabletRangePB> actual_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, source->version(), kVersion, txn, false,
+                                              actual, actual_ranges));
+    EXPECT_EQ(1, planner_calls);
+    EXPECT_EQ(2, actual.size());
+    EXPECT_EQ(0, actual.count(children[1]));
+}
+
+TEST_F(LakeTabletReshardTest, test_reshard_retry_cache_rejects_wrong_id_version_or_gtid) {
+    constexpr int64_t kVersion = 2;
+    constexpr int64_t kGtid = 80;
+    for (int malformed_field = 0; malformed_field < 3; ++malformed_field) {
+        auto source = split_source();
+        std::vector<int64_t> children{next_id(), next_id()};
+        auto request = make_split_retry_request(source, children, true);
+        cache_reshard_metadata(source->id(), source->id(), kVersion, kGtid);
+        cache_reshard_metadata(children[1], children[1], kVersion, kGtid);
+        auto malformed = std::make_shared<TabletMetadataPB>();
+        malformed->set_id(malformed_field == 0 ? next_id() : children[0]);
+        malformed->set_version(malformed_field == 1 ? kVersion + 1 : kVersion);
+        malformed->set_gtid(malformed_field == 2 ? kGtid + 1 : kGtid);
+        _tablet_manager->metacache()->cache_tablet_metadata(
+                _tablet_manager->tablet_metadata_location(children[0], kVersion), malformed);
+
+        int flushes = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->DisableProcessing();
+            sync->ClearAllCallBacks();
+        });
+        TxnInfoPB txn;
+        txn.set_gtid(kGtid);
+        std::unordered_map<int64_t, TabletMetadataPtr> actual;
+        std::unordered_map<int64_t, TabletRangePB> actual_ranges;
+        ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, source->version(), kVersion, txn,
+                                                  false, actual, actual_ranges));
+        EXPECT_EQ(1, flushes) << "malformed field " << malformed_field;
+        ASSERT_EQ(3, actual.size());
+        for (const auto& [id, metadata] : actual) {
+            EXPECT_EQ(id, metadata->id());
+            EXPECT_EQ(kVersion, metadata->version());
+            EXPECT_EQ(kGtid, metadata->gtid());
+        }
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_reshard_retry_cache_skips_nonpositive_gtid) {
+    constexpr int64_t kVersion = 2;
+    for (int64_t gtid : {0, -1}) {
+        auto source = split_source();
+        std::vector<int64_t> children{next_id(), next_id()};
+        auto request = make_split_retry_request(source, children, true);
+        cache_reshard_metadata(source->id(), source->id(), kVersion, gtid);
+        for (auto child : children) cache_reshard_metadata(child, child, kVersion, gtid);
+
+        int flushes = 0;
+        auto* sync = SyncPoint::GetInstance();
+        sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->DisableProcessing();
+            sync->ClearAllCallBacks();
+        });
+        TxnInfoPB txn;
+        txn.set_gtid(gtid);
+        std::unordered_map<int64_t, TabletMetadataPtr> actual;
+        std::unordered_map<int64_t, TabletRangePB> actual_ranges;
+        ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, source->version(), kVersion, txn,
+                                                  false, actual, actual_ranges));
+        EXPECT_EQ(1, flushes) << "gtid " << gtid;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_merge_retry_cache_complete_returns_without_recompute) {
+    constexpr int64_t kVersion = 2;
+    constexpr int64_t kGtid = 81;
+    const int64_t source0 = next_id();
+    const int64_t source1 = next_id();
+    const int64_t target = next_id();
+    for (auto id : {source0, source1, target}) prepare_tablet_dirs(id);
+    auto base0 = std::make_shared<TabletMetadataPB>();
+    base0->set_id(source0);
+    base0->set_version(1);
+    auto base1 = std::make_shared<TabletMetadataPB>();
+    base1->set_id(source1);
+    base1->set_version(1);
+    ASSERT_OK(put_merge_sources(base0, base1));
+    ReshardingTabletInfoPB request;
+    auto* merge = request.mutable_merging_tablet_info();
+    merge->add_old_tablet_ids(source0);
+    merge->add_old_tablet_ids(source1);
+    merge->set_new_tablet_id(target);
+    std::unordered_map<int64_t, TabletMetadataPtr> expected;
+    for (auto id : {source0, source1, target}) {
+        expected.emplace(id, cache_reshard_metadata(id, id, kVersion, kGtid));
+    }
+
+    int planner_calls = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("materialize_planned_rowsets:entry", [&](void*) { ++planner_calls; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    TxnInfoPB txn;
+    txn.set_gtid(kGtid);
+    std::unordered_map<int64_t, TabletMetadataPtr> actual;
+    std::unordered_map<int64_t, TabletRangePB> actual_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, 1, kVersion, txn, false, actual,
+                                              actual_ranges));
+    EXPECT_EQ(0, planner_calls);
+    ASSERT_EQ(expected.size(), actual.size());
+    for (const auto& [id, metadata] : expected) {
+        EXPECT_EQ(metadata->SerializeAsString(), actual.at(id)->SerializeAsString());
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_identical_retry_cache_complete_returns_without_recompute) {
+    constexpr int64_t kVersion = 2;
+    constexpr int64_t kGtid = 82;
+    const int64_t source = next_id();
+    const int64_t target = next_id();
+    prepare_tablet_dirs(source);
+    prepare_tablet_dirs(target);
+    TabletMetadataPB base;
+    base.set_id(source);
+    base.set_version(1);
+    ASSERT_OK(put_tablet_metadata(base));
+    ReshardingTabletInfoPB request;
+    request.mutable_identical_tablet_info()->set_old_tablet_id(source);
+    request.mutable_identical_tablet_info()->set_new_tablet_id(target);
+    auto cached_source = cache_reshard_metadata(source, source, kVersion, kGtid);
+    auto cached_target = cache_reshard_metadata(target, target, kVersion, kGtid);
+    _tablet_manager->metacache()->erase(_tablet_manager->tablet_metadata_location(source, 1));
+
+    int metadata_reads = 0;
+    auto* sync = SyncPoint::GetInstance();
+    sync->SetCallBack("TabletManager::load_tablet_metadata:path", [&](void*) { ++metadata_reads; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    TxnInfoPB txn;
+    txn.set_gtid(kGtid);
+    std::unordered_map<int64_t, TabletMetadataPtr> actual;
+    std::unordered_map<int64_t, TabletRangePB> actual_ranges;
+    ASSERT_OK(lake::publish_resharding_tablet(_tablet_manager.get(), request, 1, kVersion, txn, false, actual,
+                                              actual_ranges));
+    EXPECT_EQ(0, metadata_reads);
+    ASSERT_EQ(2, actual.size());
+    EXPECT_EQ(cached_source->SerializeAsString(), actual.at(source)->SerializeAsString());
+    EXPECT_EQ(cached_target->SerializeAsString(), actual.at(target)->SerializeAsString());
 }
 
 } // namespace starrocks

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -73,6 +73,7 @@
 #include "storage/lake/tablet_range_helper.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_reshard_helper.h"
+#include "storage/lake/tablet_splitter.h"
 #include "storage/lake/test_util.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
@@ -161,6 +162,71 @@ public:
     }
 
 protected:
+    std::shared_ptr<TabletMetadataPB> split_source(bool separate_sort = false) {
+        auto m = std::make_shared<TabletMetadataPB>();
+        m->set_id(next_id());
+        m->set_version(1);
+        m->set_next_rowset_id(30);
+        set_int_primary_key_schema(m.get(), next_id());
+        if (separate_sort) {
+            auto* c = m->mutable_schema()->add_column();
+            c->set_unique_id(1);
+            c->set_name("v");
+            c->set_type("INT");
+            c->set_is_key(false);
+            c->set_is_nullable(false);
+            m->mutable_schema()->add_sort_key_idxes(1);
+        }
+        auto* r = m->add_rowsets();
+        r->set_id(2);
+        lake::tablet_reshard_helper::set_rowset_uid(r);
+        r->set_num_rows(100);
+        r->set_data_size(1000);
+        r->set_num_dels(10);
+        for (int i = 0; i < 2; ++i) {
+            auto* sm = r->add_segment_metas();
+            sm->set_filename(fmt::format("split-{}.dat", i));
+            sm->set_segment_idx(i == 0 ? 0 : 7);
+            sm->set_num_rows(50);
+            sm->set_size(500);
+            *sm->mutable_sort_key_min() = generate_sort_key(i * 50);
+            *sm->mutable_sort_key_max() = generate_sort_key(i * 50 + 49);
+        }
+        return m;
+    }
+
+    auto split_source_into_children(const TabletMetadataPtr& m, bool external = true) {
+        // Deliberately bypass the current-producer stamping wrapper: malformed
+        // rejection fixtures must reach SPLIT exactly as declared by each test.
+        CHECK_OK(_tablet_manager->put_tablet_metadata(m));
+        SplittingTabletInfoPB splitting;
+        splitting.set_old_tablet_id(m->id());
+        splitting.add_new_tablet_ids(m->id() + 100000);
+        splitting.add_new_tablet_ids(m->id() + 200000);
+        if (external) {
+            *splitting.add_new_tablet_ranges()->mutable_upper_bound() = generate_sort_key(50);
+            splitting.mutable_new_tablet_ranges(0)->set_upper_bound_included(false);
+            *splitting.add_new_tablet_ranges()->mutable_lower_bound() = generate_sort_key(50);
+            splitting.mutable_new_tablet_ranges(1)->set_lower_bound_included(true);
+        }
+        return lake::split_tablet(_tablet_manager.get(), m, splitting, 2, TxnInfoPB());
+    }
+
+    void expect_split_fallback_after_flush(const std::shared_ptr<TabletMetadataPB>& m) {
+        auto* sync = SyncPoint::GetInstance();
+        int flushes = 0;
+        sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+        sync->EnableProcessing();
+        DeferOp cleanup([&] {
+            sync->DisableProcessing();
+            sync->ClearAllCallBacks();
+        });
+        ASSIGN_OR_ABORT(auto children, split_source_into_children(m));
+        ASSERT_EQ(1, children.size());
+        EXPECT_EQ(1, flushes);
+        EXPECT_EQ(m->rowsets(0).SerializeAsString(), children.begin()->second->rowsets(0).SerializeAsString());
+    }
+
     void prepare_tablet_dirs(int64_t tablet_id) {
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(tablet_id)));
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(tablet_id)));
@@ -268,6 +334,9 @@ protected:
     Status put_tablet_metadata(TabletMetadataPB metadata) {
         for (auto& rowset : *metadata.mutable_rowsets()) {
             lake::tablet_reshard_helper::ensure_rowset_uid(&rowset);
+            for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+                if (!rowset.segment_metas(i).has_segment_idx()) rowset.mutable_segment_metas(i)->set_segment_idx(i);
+            }
         }
         return _tablet_manager->put_tablet_metadata(metadata);
     }
@@ -276,6 +345,9 @@ protected:
         auto mutable_meta = std::make_shared<TabletMetadataPB>(*metadata);
         for (auto& rowset : *mutable_meta->mutable_rowsets()) {
             lake::tablet_reshard_helper::ensure_rowset_uid(&rowset);
+            for (int i = 0; i < rowset.segment_metas_size(); ++i) {
+                if (!rowset.segment_metas(i).has_segment_idx()) rowset.mutable_segment_metas(i)->set_segment_idx(i);
+            }
         }
         return _tablet_manager->put_tablet_metadata(mutable_meta);
     }
@@ -4464,6 +4536,242 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_indexless_tde_failure_retry_ma
     }
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_preserves_sparse_segment_indices) {
+    auto m = split_source();
+    ASSIGN_OR_ABORT(auto children, split_source_into_children(m));
+    ASSERT_EQ(2, children.size());
+    EXPECT_EQ(0, children.at(m->id() + 100000)->rowsets(0).segment_metas(0).segment_idx());
+    EXPECT_EQ(7, children.at(m->id() + 200000)->rowsets(0).segment_metas(0).segment_idx());
+    for (const auto& [id, child] : children) {
+        ASSERT_EQ(1, child->rowsets(0).segment_metas_size());
+        EXPECT_EQ(m->rowsets(0).uid().SerializeAsString(), child->rowsets(0).uid().SerializeAsString());
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_omits_nonintersecting_rowset_and_sidecars) {
+    auto m = split_source();
+    for (uint32_t rssid : {2, 9}) {
+        auto& page = (*m->mutable_delvec_meta()->mutable_delvecs())[rssid];
+        page.set_version(rssid);
+        (*m->mutable_delvec_meta()->mutable_version_to_file())[rssid].set_name(fmt::format("{}.dv", rssid));
+        (*m->mutable_dcg_meta()->mutable_dcgs())[rssid].add_column_files(fmt::format("{}.dcg", rssid));
+        (*m->mutable_idg_meta()->mutable_idgs())[rssid];
+    }
+    auto* outside = m->add_rowsets();
+    *outside = m->rowsets(0);
+    outside->set_id(20);
+    lake::tablet_reshard_helper::set_rowset_uid(outside);
+    outside->clear_segment_metas();
+    *outside->add_segment_metas() = m->rowsets(0).segment_metas(1);
+    outside->mutable_segment_metas(0)->set_segment_idx(0);
+    *outside->mutable_range()->mutable_lower_bound() = generate_sort_key(50);
+    outside->mutable_range()->set_lower_bound_included(true);
+    outside->set_next_compaction_offset(1); // opaque rowset still must be omitted by effective range
+    (*m->mutable_rowset_to_schema())[20] = 123;
+    ASSIGN_OR_ABORT(auto children, split_source_into_children(m));
+    ASSERT_EQ(2, children.size());
+    auto left = children.at(m->id() + 100000);
+    auto right = children.at(m->id() + 200000);
+    EXPECT_EQ(1, left->rowsets_size());
+    EXPECT_EQ(0, left->rowset_to_schema().count(20));
+    for (auto [child, live, dead] : {std::tuple{left, 2, 9}, std::tuple{right, 9, 2}}) {
+        EXPECT_EQ(1, child->delvec_meta().delvecs().count(live));
+        EXPECT_EQ(1, child->dcg_meta().dcgs().count(live));
+        EXPECT_EQ(1, child->idg_meta().idgs().count(live));
+        EXPECT_EQ(0, child->delvec_meta().delvecs().count(dead));
+        EXPECT_EQ(0, child->delvec_meta().version_to_file().count(dead));
+        EXPECT_EQ(0, child->dcg_meta().dcgs().count(dead));
+        EXPECT_EQ(0, child->idg_meta().idgs().count(dead));
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_preserves_nonzero_compaction_cursor) {
+    auto m = split_source();
+    m->mutable_rowsets(0)->set_next_compaction_offset(1);
+    ASSIGN_OR_ABORT(auto children, split_source_into_children(m));
+    ASSERT_EQ(2, children.size());
+    for (const auto& [id, child] : children) {
+        EXPECT_EQ(1, child->rowsets(0).next_compaction_offset());
+        EXPECT_EQ(2, child->rowsets(0).segment_metas_size());
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_capacity_limit_uses_identical_fallback) {
+    auto m = split_source();
+    SyncPoint::GetInstance()->SetCallBack("tablet_splitter:set_metadata_visit_limit",
+                                          [](void* p) { *static_cast<size_t*>(p) = 0; });
+    expect_split_fallback_after_flush(m);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_corruption_does_not_use_identical_fallback) {
+    for (int malformed = 0; malformed < 7; ++malformed) {
+        auto m = split_source();
+        auto* rowset = m->mutable_rowsets(0);
+        switch (malformed) {
+        case 0:
+            rowset->set_num_dels(101);
+            break;
+        case 1:
+            rowset->set_num_rows(-1);
+            break;
+        case 2:
+            rowset->set_data_size(-1);
+            break;
+        case 3:
+            rowset->set_num_dels(-1);
+            break;
+        case 4:
+            rowset->mutable_delete_predicate()->set_version(1);
+            break;
+        case 5:
+            rowset->mutable_segment_metas(1)->set_segment_idx(UINT32_MAX);
+            break;
+        case 6:
+            auto* del = rowset->add_del_files();
+            del->set_name("overflow.del");
+            del->set_origin_rowset_id(UINT32_MAX);
+            del->set_op_offset(1);
+            break;
+        }
+        EXPECT_TRUE(split_source_into_children(m).status().is_corruption()) << malformed;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_corrupt_source_fails_before_pk_flush) {
+    auto m = split_source();
+    m->mutable_rowsets(0)->set_num_dels(101);
+    auto* sync = SyncPoint::GetInstance();
+    int flushes = 0;
+    sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    EXPECT_TRUE(split_source_into_children(m).status().is_corruption());
+    EXPECT_EQ(0, flushes);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_missing_uid_is_corruption) {
+    auto m = split_source();
+    m->mutable_rowsets(0)->clear_uid();
+    ASSERT_OK(_tablet_manager->put_tablet_metadata(m));
+    EXPECT_TRUE(split_source_into_children(m).status().is_corruption());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_absent_segment_idx_falls_back_after_pk_flush) {
+    auto m = split_source();
+    m->mutable_rowsets(0)->mutable_segment_metas(0)->clear_segment_idx();
+    expect_split_fallback_after_flush(m);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_duplicate_segment_idx_is_corruption) {
+    auto m = split_source();
+    m->mutable_rowsets(0)->mutable_segment_metas(1)->set_segment_idx(0);
+    EXPECT_TRUE(split_source_into_children(m).status().is_corruption());
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_logically_empty_range_falls_back_after_pk_flush) {
+    auto m = split_source();
+    auto* range = m->mutable_rowsets(0)->mutable_range();
+    *range->mutable_lower_bound() = generate_sort_key(50);
+    *range->mutable_upper_bound() = generate_sort_key(50);
+    range->set_lower_bound_included(true);
+    range->set_upper_bound_included(false);
+    expect_split_fallback_after_flush(m);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_self_del_offset_falls_back_after_pk_flush) {
+    auto m = split_source();
+    auto* del = m->mutable_rowsets(0)->add_del_files();
+    del->set_name("self.del");
+    del->set_origin_rowset_id(2);
+    del->set_op_offset(1);
+    expect_split_fallback_after_flush(m);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_inherited_del_offset_uses_origin_space) {
+    auto m = split_source();
+    auto* del = m->mutable_rowsets(0)->add_del_files();
+    del->set_name("inherited.del");
+    del->set_origin_rowset_id(1);
+    del->set_op_offset(19);
+    ASSIGN_OR_ABORT(auto children, split_source_into_children(m));
+    ASSERT_EQ(2, children.size());
+    for (const auto& [id, child] : children) {
+        EXPECT_EQ(2, child->rowsets(0).segment_metas_size());
+        EXPECT_EQ(19, child->rowsets(0).del_files(0).op_offset());
+        EXPECT_EQ(1, child->rowsets(0).del_files(0).origin_rowset_id());
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_opaque_del_rowset_is_full_copy_or_omitted) {
+    auto m = split_source();
+    auto* rowset = m->mutable_rowsets(0);
+    *rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(50);
+    rowset->mutable_range()->set_lower_bound_included(true);
+    auto* del = rowset->add_del_files();
+    del->set_name("self.del");
+    del->set_origin_rowset_id(2);
+    del->set_op_offset(7);
+    ASSIGN_OR_ABORT(auto children, split_source_into_children(m));
+    ASSERT_EQ(2, children.size());
+    EXPECT_EQ(0, children.at(m->id() + 100000)->rowsets_size());
+    auto right = children.at(m->id() + 200000);
+    ASSERT_EQ(1, right->rowsets_size());
+    EXPECT_EQ(2, right->rowsets(0).segment_metas_size());
+    EXPECT_EQ(1, right->rowsets(0).del_files_size());
+    EXPECT_EQ(100, right->rowsets(0).num_rows());
+}
+
+TEST_F(LakeTabletReshardTest, test_separate_sort_pk_split_flushes_before_budgeted_sst_sampling) {
+    auto m = split_source(true);
+    const std::string name = "split-sampling.sst";
+    std::vector<std::tuple<std::string, uint32_t, uint32_t>> entries;
+    for (int i = 0; i < 100; ++i) entries.emplace_back(encode_int_primary_key(i), 2, i);
+    auto* sst = m->mutable_sstable_meta()->add_sstables();
+    sst->set_filename(name);
+    sst->set_filesize(write_legacy_pk_sstable(_tablet_manager->sst_location(m->id(), name), entries));
+    sst->mutable_range()->set_start_key(encode_int_primary_key(0));
+    sst->mutable_range()->set_end_key(encode_int_primary_key(99));
+    auto* sync = SyncPoint::GetInstance();
+    std::vector<std::string> order;
+    for (const auto& phase : {"pk_flush", "pk_sampler", "sst_open"}) {
+        sync->SetCallBack(std::string("tablet_splitter:") + phase, [&, phase](void*) { order.emplace_back(phase); });
+    }
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    ASSIGN_OR_ABORT(auto children, split_source_into_children(m, false));
+    EXPECT_EQ(2, children.size());
+    EXPECT_EQ((std::vector<std::string>{"pk_flush", "pk_sampler", "sst_open"}), order);
+}
+
+TEST_F(LakeTabletReshardTest, test_separate_sort_pk_budget_stops_before_sst_open_then_falls_back) {
+    auto m = split_source(true);
+    auto* sst = m->mutable_sstable_meta()->add_sstables();
+    sst->set_filename("must-not-open.sst");
+    sst->mutable_range()->set_start_key(encode_int_primary_key(0));
+    sst->mutable_range()->set_end_key(encode_int_primary_key(99));
+    auto* sync = SyncPoint::GetInstance();
+    std::vector<std::string> order;
+    // Enough for source preflight and the SST declaration, not its requested 64 samples.
+    sync->SetCallBack("tablet_splitter:set_metadata_visit_limit", [](void* p) { *static_cast<size_t*>(p) = 10; });
+    for (const auto& phase : {"pk_flush", "pk_sampler", "sst_open"}) {
+        sync->SetCallBack(std::string("tablet_splitter:") + phase, [&, phase](void*) { order.emplace_back(phase); });
+    }
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    ASSIGN_OR_ABORT(auto children, split_source_into_children(m, false));
+    EXPECT_EQ(1, children.size());
+    EXPECT_EQ((std::vector<std::string>{"pk_flush"}), order);
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_splitting) {
     starrocks::TabletMetadata metadata;
     auto tablet_id = next_id();
@@ -5222,7 +5530,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_split_keeps_del_files_rowset) {
                                               metadata.version() + 1, txn_info, false, tablet_metadatas,
                                               tablet_ranges));
 
-    int rs_a_fully_pruned_but_kept = 0;
+    int rs_a_full_copies = 0;
     int rs_b_present = 0;
     for (int64_t child : {child0, child1}) {
         auto c = tablet_metadatas.at(child);
@@ -5231,12 +5539,14 @@ TEST_F(LakeTabletReshardTest, test_tablet_split_keeps_del_files_rowset) {
             if (r.id() == 2) rs_a_out = &r;
             if (r.id() == 10) ++rs_b_present;
         }
-        ASSERT_NE(rs_a_out, nullptr) << "rs_a must survive on every child (overlap or del_files guard)";
+        ASSERT_NE(rs_a_out, nullptr) << "the opaque rowset's unbounded effective range overlaps every child";
         EXPECT_GT(rs_a_out->del_files_size(), 0) << "rs_a keeps its del_files";
-        if (rs_a_out->segment_metas_size() == 0) ++rs_a_fully_pruned_but_kept; // kept purely by the del_files guard
+        ASSERT_EQ(1, rs_a_out->segment_metas_size());
+        EXPECT_EQ("a_seg.dat", rs_a_out->segment_metas(0).filename());
+        EXPECT_TRUE(rs_a_out->segment_metas(0).shared());
+        ++rs_a_full_copies;
     }
-    EXPECT_EQ(1, rs_a_fully_pruned_but_kept)
-            << "exactly one child fully prunes rs_a's segment yet keeps it for del_files";
+    EXPECT_EQ(2, rs_a_full_copies) << "opaque del-bearing rowsets retain the complete ordered file set";
     EXPECT_EQ(1, rs_b_present) << "rs_b (no del_files) is removed from the non-overlapping child";
 }
 

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -4665,6 +4665,47 @@ TEST_F(LakeTabletReshardTest, test_tablet_splitting_absent_segment_idx_falls_bac
     expect_split_fallback_after_flush(m);
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_splitting_source_fallback_does_not_mask_invalid_external_ranges) {
+    auto* sync = SyncPoint::GetInstance();
+    int flushes = 0;
+    sync->SetCallBack("tablet_splitter:pk_flush", [&](void*) { ++flushes; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    for (int malformed = 0; malformed < 3; ++malformed) {
+        auto metadata = split_source();
+        metadata->mutable_rowsets(0)->mutable_segment_metas(0)->clear_segment_idx();
+        ASSERT_OK(_tablet_manager->put_tablet_metadata(metadata));
+        SplittingTabletInfoPB splitting;
+        splitting.set_old_tablet_id(metadata->id());
+        splitting.add_new_tablet_ids(next_id());
+        splitting.add_new_tablet_ids(next_id());
+        auto* left = splitting.add_new_tablet_ranges();
+        *left->mutable_upper_bound() = generate_sort_key(50);
+        left->set_upper_bound_included(false);
+        auto* right = splitting.add_new_tablet_ranges();
+        right->set_lower_bound_included(true);
+        if (malformed == 0) {
+            *right->mutable_lower_bound() = generate_sort_key(60); // gap
+        } else {
+            VariantTuple boundary;
+            if (malformed == 1) {
+                boundary.append(DatumVariant(get_type_info(TYPE_BIGINT), Datum(int64_t{50})));
+            } else {
+                boundary.append(DatumVariant(get_type_info(TYPE_INT), Datum(50)));
+                boundary.append(DatumVariant(get_type_info(TYPE_INT), Datum(50)));
+            }
+            boundary.to_proto(left->mutable_upper_bound());
+            *right->mutable_lower_bound() = left->upper_bound();
+        }
+        auto result = lake::split_tablet(_tablet_manager.get(), metadata, splitting, 2, TxnInfoPB());
+        EXPECT_TRUE(result.status().is_invalid_argument()) << "malformed range case " << malformed;
+        EXPECT_EQ(0, flushes) << "malformed range case " << malformed;
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_splitting_duplicate_segment_idx_is_corruption) {
     auto m = split_source();
     m->mutable_rowsets(0)->mutable_segment_metas(1)->set_segment_idx(0);

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -2750,22 +2750,53 @@ protected:
         auto append = [](std::string* out, const std::string& value) {
             *out += fmt::format("{}:", value.size()) + value;
         };
+        // Rank effective recovery keys, preserving equality classes and strict order
+        // without comparing tablet-local projected integers across cycles.
+        std::map<uint32_t, size_t> recovery_order;
+        for (const auto& rowset : cold->rowsets()) {
+            recovery_order.emplace(
+                    rowset.has_max_compact_input_rowset_id() ? rowset.max_compact_input_rowset_id() : rowset.id(), 0);
+        }
+        size_t rank = 0;
+        for (auto& [key, ordinal] : recovery_order) ordinal = rank++;
         for (const auto& rowset : cold->rowsets()) {
             std::string record =
                     fmt::format("uid={}:{};version={};", rowset.uid().hi(), rowset.uid().lo(), rowset.version());
-            const auto& range = rowset.has_range() ? rowset.range() : cold->range();
-            append(&record, range.SerializeAsString());
+            RowsetMetadataPB stable(rowset);
+            stable.clear_id();
+            stable.clear_overlapped();
+            stable.clear_deprecated_segments();
+            stable.clear_deprecated_segment_size();
+            stable.clear_deprecated_segment_encryption_metas();
+            stable.clear_deprecated_bundle_file_offsets();
+            stable.clear_deprecated_shared_segments();
+            stable.clear_range();
+            stable.clear_max_compact_input_rowset_id();
+            // Stats are semantic values, including an absent zero on a predicate.
+            stable.set_num_rows(rowset.num_rows());
+            stable.set_data_size(rowset.data_size());
+            stable.set_num_dels(rowset.num_dels());
+            for (auto& segment : *stable.mutable_segment_metas()) segment.clear_shared();
+            for (auto& del : *stable.mutable_del_files()) {
+                del.clear_origin_rowset_id();
+                del.clear_shared();
+            }
             if (rowset.has_delete_predicate()) {
                 record = fmt::format("predicate-version={};", rowset.version());
-                append(&record, rowset.delete_predicate().SerializeAsString());
+                stable.clear_uid(); // Predicate identity is its version and payload, not its independently minted UID.
             }
+            const auto& range = rowset.has_range() ? rowset.range() : cold->range();
+            append(&record, range.SerializeAsString());
+            append(&record, stable.SerializeAsString());
+            const uint32_t recovery_key =
+                    rowset.has_max_compact_input_rowset_id() ? rowset.max_compact_input_rowset_id() : rowset.id();
+            record += fmt::format("recovery-present={};recovery-order={};", rowset.has_max_compact_input_rowset_id(),
+                                  recovery_order.at(recovery_key));
             for (int i = 0; i < rowset.segment_metas_size(); ++i) {
                 const auto& segment = rowset.segment_metas(i);
                 const uint32_t original_idx = segment.has_segment_idx() ? segment.segment_idx() : i;
                 const uint32_t rssid = rowset.id() + original_idx;
-                record += fmt::format("segment={};slice={}:{};rows={};", original_idx, segment.bundle_file_offset(),
-                                      segment.size(), segment.num_rows());
-                append(&record, segment.filename());
+                record += fmt::format("segment={};", original_idx);
                 if (cold->delvec_meta().delvecs().contains(rssid)) {
                     DelVector delvec;
                     RETURN_IF_ERROR(_update_manager->get_del_vec_in_meta(TabletSegmentId(cold->id(), rssid),
@@ -2818,9 +2849,7 @@ protected:
                 }
             }
             for (const auto& del : rowset.del_files()) {
-                // op_offset is a stable operation ordinal; origin_rowset_id is projected.
-                record += fmt::format("del-version={};op={};", del.version(), del.op_offset());
-                append(&record, del.name());
+                record += del.origin_rowset_id() == rowset.id() ? "del-origin=self;" : "del-origin=inherited;";
             }
             records.emplace_back(std::move(record));
         }
@@ -2874,7 +2903,7 @@ protected:
         return result;
     }
 
-    TabletMetadataPtr run_no_write_split_merge_cycle(const TabletMetadataPtr& source, int child_count) {
+    std::vector<TabletMetadataPtr> split_fixed_point_source(const TabletMetadataPtr& source, int child_count) {
         CHECK_OK(put_tablet_metadata(source));
         SplittingTabletInfoPB split;
         split.set_old_tablet_id(source->id());
@@ -2894,6 +2923,11 @@ protected:
         EXPECT_EQ(child_count, children.size());
         std::vector<TabletMetadataPtr> sources;
         for (auto id : split.new_tablet_ids()) sources.push_back(children.at(id));
+        return sources;
+    }
+
+    TabletMetadataPtr run_no_write_split_merge_cycle(const TabletMetadataPtr& source, int child_count) {
+        auto sources = split_fixed_point_source(source, child_count);
         std::unordered_map<int64_t, TabletMetadataPtr> published;
         const int64_t target = next_id();
         CHECK_OK(publish_resharding_merge(sources, target, source->version() + 1, source->version() + 2, next_id(),
@@ -2953,7 +2987,7 @@ protected:
             metadata->mutable_idg_meta()->mutable_idgs()->at(1).mutable_entries(0)->set_file_size(file.filesize);
             auto* del = rowset->add_del_files();
             del->set_name(stem + ".del");
-            del->set_origin_rowset_id(1);
+            del->set_origin_rowset_id(0);
             del->set_op_offset(7);
             del->set_version(1);
             del->set_num_rows(0);
@@ -2969,6 +3003,15 @@ protected:
 
     void expect_ten_fixed_point_cycles(TabletMetadataPtr current) {
         const bool primary_key = current->schema().keys_type() == PRIMARY_KEYS;
+        auto inherited_dels = [](const TabletMetadataPB& metadata) {
+            size_t count = 0;
+            for (const auto& rowset : metadata.rowsets()) {
+                for (const auto& del : rowset.del_files()) count += del.origin_rowset_id() != rowset.id();
+            }
+            return count;
+        };
+        const size_t baseline_inherited_dels = inherited_dels(*current);
+        if (primary_key) ASSERT_GT(baseline_inherited_dels, 0);
         size_t prior_lookup_batches = _cold_pk_lookup_batches;
         size_t prior_deleted_keys = _cold_pk_deleted_keys_checked;
         ASSIGN_OR_ABORT(auto baseline_signature, semantic_reshard_signature(current));
@@ -2997,6 +3040,7 @@ protected:
                     << "every PK cycle must exercise a cold PK lookup batch";
             if (primary_key) EXPECT_GT(_cold_pk_deleted_keys_checked, prior_deleted_keys);
             const auto inventory = collect_reshard_inventory(*current);
+            EXPECT_EQ(baseline_inherited_dels, inherited_dels(*current));
             EXPECT_EQ(baseline_signature, signature);
             EXPECT_EQ(baseline.rowsets, inventory.rowsets);
             EXPECT_EQ(baseline.segments, inventory.segments);
@@ -3023,6 +3067,137 @@ TEST_F(LakeTabletReshardTest, test_range_reshard_no_write_cycles_are_fixed_point
     for (bool primary_key : {true, false}) {
         expect_ten_fixed_point_cycles(fixed_point_source(primary_key));
         if (HasFailure()) return;
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_range_reshard_signature_detects_declaration_changes) {
+    auto source = fixed_point_source(true);
+    ASSIGN_OR_ABORT(auto baseline, semantic_reshard_signature(source));
+    enum Mutation {
+        ROWS,
+        BYTES,
+        DELETES,
+        CURSOR,
+        RECOVERY_PRESENCE,
+        ROWSET_RESIDUAL,
+        SEGMENT_RESIDUAL,
+        DEL_ORIGIN,
+        DEL_RESIDUAL
+    };
+    for (auto mutation : {ROWS, BYTES, DELETES, CURSOR, RECOVERY_PRESENCE, ROWSET_RESIDUAL, SEGMENT_RESIDUAL,
+                          DEL_ORIGIN, DEL_RESIDUAL}) {
+        SCOPED_TRACE(mutation);
+        auto changed = std::make_shared<TabletMetadataPB>(*source);
+        auto* rowset = changed->mutable_rowsets(0);
+        auto add_unknown = [](auto* pb) {
+            std::string serialized = pb->SerializeAsString();
+            serialized.append("\xF8\x07\x01", 3);
+            CHECK(pb->ParseFromString(serialized));
+        };
+        switch (mutation) {
+        case ROWS:
+            rowset->set_num_rows(rowset->num_rows() + 1);
+            break;
+        case BYTES:
+            rowset->set_data_size(rowset->data_size() + 1);
+            break;
+        case DELETES:
+            rowset->set_num_dels(rowset->num_dels() + 1);
+            break;
+        case CURSOR:
+            rowset->set_next_compaction_offset(1);
+            break;
+        case RECOVERY_PRESENCE:
+            rowset->set_max_compact_input_rowset_id(0);
+            break;
+        case ROWSET_RESIDUAL:
+            add_unknown(rowset);
+            break;
+        case SEGMENT_RESIDUAL:
+            add_unknown(rowset->mutable_segment_metas(0));
+            break;
+        case DEL_ORIGIN:
+            rowset->mutable_del_files(0)->set_origin_rowset_id(rowset->id());
+            break;
+        case DEL_RESIDUAL:
+            add_unknown(rowset->mutable_del_files(0));
+            break;
+        }
+        ASSERT_OK(put_tablet_metadata(changed));
+        ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(changed));
+        EXPECT_NE(baseline, signature);
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_range_reshard_compaction_partial_merge_rejoin) {
+    const int32_t old_min_segments = config::lake_pk_compaction_min_input_segments;
+    const bool old_parallel = config::enable_pk_index_parallel_compaction;
+    config::lake_pk_compaction_min_input_segments = 1;
+    config::enable_pk_index_parallel_compaction = false;
+    DeferOp restore([&] {
+        config::lake_pk_compaction_min_input_segments = old_min_segments;
+        config::enable_pk_index_parallel_compaction = old_parallel;
+    });
+    auto source = fixed_point_source(true);
+    ASSIGN_OR_ABORT(auto written, publish_followup_upsert_delete(source->id(), source->version(), 10, 7777, 60));
+    ASSIGN_OR_ABORT(auto compacted, compact_tablet(written->id(), written->version(), true));
+    ASSERT_EQ(1, compacted->rowsets_size());
+    ASSERT_TRUE(compacted->rowsets(0).has_max_compact_input_rowset_id());
+    ASSIGN_OR_ABORT(auto baseline, semantic_reshard_signature(compacted));
+    auto children = split_fixed_point_source(compacted, 3);
+    ASSERT_EQ(3, children.size());
+    for (bool reverse_sources : {false, true}) {
+        SCOPED_TRACE(reverse_sources);
+        std::vector<TabletMetadataPtr> pair{children[0], children[1]};
+        if (reverse_sources) std::reverse(pair.begin(), pair.end());
+        const int64_t partial_id = next_id();
+        std::unordered_map<int64_t, TabletMetadataPtr> published;
+        ASSERT_OK(publish_resharding_merge(pair, partial_id, children[0]->version(), children[0]->version() + 1,
+                                           next_id(), published));
+        auto partial = published.at(partial_id);
+        // Advance the untouched third child with an empty transaction: no rowset or recovery-coordinate rewrite.
+        ASSERT_OK(put_tablet_metadata(children[2]));
+        TxnLogPB empty_log;
+        empty_log.set_tablet_id(children[2]->id());
+        empty_log.set_txn_id(next_id());
+        ASSERT_OK(_tablet_manager->put_txn_log(empty_log));
+        TxnInfoPB empty_txn;
+        empty_txn.set_txn_id(empty_log.txn_id());
+        empty_txn.set_txn_type(TXN_NORMAL);
+        empty_txn.set_commit_time(1);
+        ASSIGN_OR_ABORT(auto untouched,
+                        lake::publish_version(_tablet_manager.get(), lake::PublishTabletInfo(children[2]->id()),
+                                              children[2]->version(), partial->version(),
+                                              std::span<const TxnInfoPB>(&empty_txn, 1), false));
+        ASSERT_NE(partial->rowsets(0).max_compact_input_rowset_id(),
+                  untouched->rowsets(0).max_compact_input_rowset_id());
+        std::vector<TabletMetadataPtr> rejoin{partial, untouched};
+        if (reverse_sources) std::reverse(rejoin.begin(), rejoin.end());
+        const int64_t target = next_id();
+        published.clear();
+        ASSERT_OK(publish_resharding_merge(rejoin, target, partial->version(), partial->version() + 1, next_id(),
+                                           published));
+        ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(published.at(target)));
+        EXPECT_EQ(baseline, signature);
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_range_reshard_signature_normalizes_recovery_equivalence_and_order) {
+    auto source = std::make_shared<TabletMetadataPB>(*fixed_point_source(false));
+    // The ordinary rowset's recovery key precedes the predicate's key (9).
+    source->mutable_rowsets(0)->set_max_compact_input_rowset_id(0);
+    ASSERT_OK(put_tablet_metadata(source));
+    ASSIGN_OR_ABORT(auto baseline, semantic_reshard_signature(source));
+    for (uint32_t key : {4, 9, 10}) {
+        auto changed = std::make_shared<TabletMetadataPB>(*source);
+        changed->mutable_rowsets(0)->set_max_compact_input_rowset_id(key);
+        ASSERT_OK(put_tablet_metadata(changed));
+        ASSIGN_OR_ABORT(auto signature, semantic_reshard_signature(changed));
+        if (key == 4) {
+            EXPECT_EQ(baseline, signature) << "raw coordinate changed, but equivalence and order did not";
+        } else {
+            EXPECT_NE(baseline, signature) << "key 9 joins an equivalence class; key 10 reverses the order";
+        }
     }
 }
 
@@ -14219,13 +14394,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_interval_projection_missing_pr
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_selected_delete_uses_final_canonical_max) {
-    auto selected_source = make_allocator_source(next_id(), 101);
+    auto selected_source = make_allocator_source(next_id(), 201);
     auto* selected = add_allocator_rowset(selected_source.get(), 100, 1, "selected_del_low.dat", 0);
+    add_allocator_segment(selected, "selected_del_high.dat", 100);
     auto* selected_del = selected->add_del_files();
     selected_del->set_name("selected_final.del");
     selected_del->set_origin_rowset_id(80);
     auto duplicate_source = make_allocator_source(next_id(), 301);
-    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 200, 1, "selected_del_high.dat", 100);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 200, 1, "selected_del_low.dat", 0);
+    add_allocator_segment(duplicate, "selected_del_high.dat", 100);
     duplicate->mutable_uid()->CopyFrom(selected->uid());
     auto* duplicate_del = duplicate->add_del_files();
     duplicate_del->set_name(selected_del->name());
@@ -14245,14 +14422,80 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_selected_delete_uses_final_can
     EXPECT_EQ(122, merged->next_rowset_id());
 }
 
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_del_bearing_complementary_segment_sets_before_io) {
+    auto first = make_allocator_source(next_id(), 101);
+    auto* selected = add_allocator_rowset(first.get(), 100, 1, "opaque_low.dat", 0);
+    auto* del = selected->add_del_files();
+    del->set_name("opaque.del");
+    del->set_origin_rowset_id(80);
+    auto second = make_allocator_source(next_id(), 301);
+    auto* other = add_allocator_rowset(second.get(), 200, 1, "opaque_high.dat", 100);
+    other->mutable_uid()->CopyFrom(selected->uid());
+    other->add_del_files()->CopyFrom(*del);
+    other->mutable_del_files(0)->set_origin_rowset_id(180);
+    // Public MERGE fixture assigns distinct adjacent ranges, so this is not the equal-range duplicate check.
+    MergePhaseCounts counts;
+    expect_physical_preflight_rejection({first, second}, next_id(), 2, &counts);
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_different_uid_recovery_histories_remain_distinct) {
+    auto first = make_allocator_source(next_id(), 11);
+    auto* a = add_allocator_rowset(first.get(), 10, 1, "independent_compaction_a.dat", 0);
+    a->set_max_compact_input_rowset_id(9);
+    auto second = make_allocator_source(next_id(), 101);
+    auto* b = add_allocator_rowset(second.get(), 100, 1, "independent_compaction_b.dat", 0);
+    b->set_max_compact_input_rowset_id(99);
+    ASSERT_NE(a->uid().SerializeAsString(), b->uid().SerializeAsString());
+    for (bool reverse_sources : {false, true}) {
+        std::vector<std::shared_ptr<TabletMetadataPB>> sources{first, second};
+        if (reverse_sources) std::reverse(sources.begin(), sources.end());
+        ASSIGN_OR_ABORT(auto merged, publish_allocator_merge(sources));
+        ASSERT_EQ(2, merged->rowsets_size());
+        std::map<std::string, uint32_t> recovery_by_uid;
+        for (const auto& rowset : merged->rowsets()) {
+            recovery_by_uid.emplace(rowset.uid().SerializeAsString(), rowset.max_compact_input_rowset_id());
+        }
+        EXPECT_LT(recovery_by_uid.at(a->uid().SerializeAsString()), recovery_by_uid.at(b->uid().SerializeAsString()));
+    }
+}
+
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_conflicting_or_divergent_recovery_aliases_before_io) {
+    for (bool divergent_primary : {false, true}) {
+        SCOPED_TRACE(divergent_primary);
+        auto first = make_allocator_source(next_id(), 101);
+        auto* a = add_allocator_rowset(first.get(), 100, 1, "recovery_alias_a.dat", 0);
+        a->set_max_compact_input_rowset_id(90);
+        auto second = make_allocator_source(next_id(), 201);
+        auto* b = add_allocator_rowset(second.get(), 200, 2, "recovery_alias_b.dat", 0);
+        b->set_max_compact_input_rowset_id(190);
+        auto third = make_allocator_source(next_id(), 601);
+        auto* copy_a = third->add_rowsets();
+        copy_a->CopyFrom(*a);
+        copy_a->set_id(300);
+        copy_a->set_max_compact_input_rowset_id(500);
+        if (divergent_primary) {
+            auto* independent = add_allocator_rowset(third.get(), 600, 3, "recovery_alias_independent.dat", 0);
+            independent->set_max_compact_input_rowset_id(500);
+        } else {
+            auto* copy_b = third->add_rowsets();
+            copy_b->CopyFrom(*b);
+            copy_b->set_id(400);
+            copy_b->set_max_compact_input_rowset_id(500);
+        }
+        MergePhaseCounts counts;
+        auto status = expect_physical_preflight_rejection({first, second, third}, next_id(), 2, &counts);
+        EXPECT_TRUE(status.message().contains(divergent_primary ? "recovery keys" : "conflicting aliases")) << status;
+    }
+}
+
 TEST_F(LakeTabletReshardTest, test_tablet_merging_validation_only_delete_origin_allocates_no_slots) {
     auto selected_source = make_allocator_source(next_id(), 111);
     auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "validation_high.dat", 100);
     auto* selected_del = selected->add_del_files();
     selected_del->set_name("validation_only.del");
     selected_del->set_origin_rowset_id(5);
-    auto duplicate_source = make_allocator_source(next_id(), 21);
-    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "validation_low.dat", 0);
+    auto duplicate_source = make_allocator_source(next_id(), 121);
+    auto* duplicate = add_allocator_rowset(duplicate_source.get(), 20, 1, "validation_high.dat", 100);
     duplicate->mutable_uid()->CopyFrom(selected->uid());
     auto* duplicate_del = duplicate->add_del_files();
     duplicate_del->set_name(selected_del->name());
@@ -14267,7 +14510,7 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_validation_only_delete_origin_
     EXPECT_EQ(107, merged->next_rowset_id());
 }
 
-TEST_F(LakeTabletReshardTest, test_tablet_merging_validation_only_delete_uses_local_max) {
+TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_del_bearing_local_max_complementarity) {
     auto selected_source = make_allocator_source(next_id(), 111);
     auto* selected = add_allocator_rowset(selected_source.get(), 10, 1, "validation_local_high.dat", 100);
     auto* selected_del = selected->add_del_files();
@@ -14280,9 +14523,8 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_validation_only_delete_uses_lo
     duplicate_del->set_name(selected_del->name());
     duplicate_del->set_origin_rowset_id(std::numeric_limits<int32_t>::max() - 50);
 
-    auto merged = publish_allocator_merge({selected_source, duplicate_source});
-    ASSERT_OK(merged.status());
-    EXPECT_EQ(107, merged.value()->next_rowset_id());
+    MergePhaseCounts counts;
+    expect_physical_preflight_rejection({selected_source, duplicate_source}, next_id(), 2, &counts);
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejoins_independently_remapped_delete_origins) {
@@ -14481,8 +14723,16 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_transferred_inherited_del_surv
 }
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_same_uid_canonical_conflicts_before_io) {
-    enum Mutation { VERSION, SCHEMA_MAPPING, DEL_BEARING_MODE, NEXT_COMPACTION_OFFSET, STABLE_RESIDUAL_FIELD };
-    for (auto mutation : {VERSION, SCHEMA_MAPPING, DEL_BEARING_MODE, NEXT_COMPACTION_OFFSET, STABLE_RESIDUAL_FIELD}) {
+    enum Mutation {
+        VERSION,
+        SCHEMA_MAPPING,
+        DEL_BEARING_MODE,
+        NEXT_COMPACTION_OFFSET,
+        RECOVERY_PRESENCE,
+        STABLE_RESIDUAL_FIELD
+    };
+    for (auto mutation : {VERSION, SCHEMA_MAPPING, DEL_BEARING_MODE, NEXT_COMPACTION_OFFSET, RECOVERY_PRESENCE,
+                          STABLE_RESIDUAL_FIELD}) {
         SCOPED_TRACE(mutation);
         auto a = make_allocator_source(next_id(), 20);
         auto* first = add_allocator_rowset(a.get(), 10, 1, "canonical_conflict.dat", 7);
@@ -14508,10 +14758,15 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_rejects_same_uid_canonical_con
         case NEXT_COMPACTION_OFFSET:
             second->set_next_compaction_offset(3);
             break;
-        case STABLE_RESIDUAL_FIELD:
+        case RECOVERY_PRESENCE:
             first->set_max_compact_input_rowset_id(4);
-            second->set_max_compact_input_rowset_id(5);
             break;
+        case STABLE_RESIDUAL_FIELD: {
+            std::string serialized = second->SerializeAsString();
+            serialized.append("\xF8\x07\x01", 3);
+            ASSERT_TRUE(second->ParseFromString(serialized));
+            break;
+        }
         }
         MergePhaseCounts counts;
         expect_physical_preflight_rejection({a, b}, next_id(), 2, &counts);

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -21,6 +21,7 @@
 
 #include "base/testutil/assert.h"
 #include "base/testutil/id_generator.h"
+#include "base/testutil/sync_point.h"
 #include "base/utility/defer_op.h"
 #include "column/binary_column.h"
 #include "column/chunk_factory.h"
@@ -258,7 +259,7 @@ TEST(TabletSplitterTest, pk_index_samples_reject_insufficient_distinct_keys) {
     std::vector<TabletRangeInfo> ranges;
     auto status = get_tablet_split_ranges_from_pk_index_samples(/*tablet_manager=*/nullptr, metadata,
                                                                 /*split_count=*/3, std::move(samples), &ranges);
-    EXPECT_TRUE(status.is_invalid_argument());
+    EXPECT_TRUE(status.is_not_supported());
     EXPECT_TRUE(ranges.empty());
 }
 
@@ -1225,6 +1226,144 @@ static TabletMetadataPtr make_dup_keys_metadata_with_rowsets(
 }
 
 } // namespace
+
+TEST(TabletSplitterTest, DataDrivenSplit_UsesUniquePhysicalSegmentsForBoundaries) {
+    auto unique = std::make_shared<TabletMetadataPB>(
+            *make_dup_keys_metadata_with_rowsets({{1, 0, 90, 100, 1000}, {2, 100, 190, 100, 1000}}));
+    for (int i = 0; i < 2; ++i) {
+        auto* sm = unique->mutable_rowsets(i)->mutable_segment_metas(0);
+        sm->set_bundle_file_offset(64);
+        sm->set_deprecated_sort_key_sample_row_interval(10);
+        for (int k = 1; k < 9; ++k) *sm->add_deprecated_sort_key_samples() = make_bigint_tuple_pb(i * 100 + k * 10);
+    }
+    auto repeated = std::make_shared<TabletMetadataPB>(*unique);
+    auto* duplicate = repeated->add_rowsets();
+    *duplicate = repeated->rowsets(0);
+    duplicate->set_id(3);
+    duplicate->mutable_segment_metas(0)->set_segment_idx(7);
+    duplicate->mutable_segment_metas(0)->set_shared(true);
+    std::vector<TabletRangeInfo> expected, actual;
+    ASSERT_OK(get_tablet_split_ranges(nullptr, unique, 2, &expected));
+    ASSERT_OK(get_tablet_split_ranges(nullptr, repeated, 2, &actual));
+    ASSERT_EQ(expected.size(), actual.size());
+    for (size_t i = 0; i < actual.size(); ++i) {
+        EXPECT_TRUE(MessageDifferencer::Equals(expected[i].range, actual[i].range));
+    }
+}
+
+TEST(TabletSplitterTest, DataDrivenSplit_RejectsConflictingPhysicalSlice) {
+    auto source = make_dup_keys_metadata_with_rowsets({{1, 0, 40, 100, 1000}, {2, 50, 99, 100, 1000}});
+    auto m = std::make_shared<TabletMetadataPB>(*source);
+    auto* duplicate = m->add_rowsets();
+    *duplicate = m->rowsets(0);
+    duplicate->set_id(3);
+    duplicate->mutable_segment_metas(0)->set_size(1001);
+    std::vector<TabletRangeInfo> ranges;
+    EXPECT_TRUE(get_tablet_split_ranges(nullptr, m, 2, &ranges).is_corruption());
+}
+
+TEST(TabletSplitterTest, DataDrivenSplit_StopsAtMetadataVisitBudget) {
+    auto m = make_dup_keys_metadata_with_rowsets({{1, 0, 40, 100, 1000}, {2, 50, 99, 100, 1000}});
+    auto* sync = SyncPoint::GetInstance();
+    int opens = 0;
+    sync->SetCallBack("tablet_splitter:set_metadata_visit_limit", [](void* p) { *static_cast<size_t*>(p) = 1; });
+    sync->SetCallBack("tablet_splitter:segment_open", [&](void*) { ++opens; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    std::vector<TabletRangeInfo> ranges;
+    EXPECT_TRUE(get_tablet_split_ranges(nullptr, m, 2, &ranges).is_capacity_limit_exceeded());
+    EXPECT_EQ(0, opens);
+    // Parallel-compaction callers keep the unlimited public calculator even while
+    // a focused SPLIT helper has an exhausted test budget.
+    EXPECT_OK(calculate_range_split_boundaries({make_seg(0, 40, 100, 1000), make_seg(50, 99, 100, 1000)}, 2, 100, true)
+                      .status());
+}
+
+TEST(TabletSplitterExternalBoundariesTest, ExternalRanges_SkipBoundaryPlannerAndConserveStats) {
+    auto m = make_dup_keys_metadata_with_rowsets({{1, 0, 40, 101, 1001}, {2, 50, 99, 103, 1003}},
+                                                 make_bigint_range_pb(0, 100));
+    RepeatedPtrField<TabletRangePB> external;
+    *external.Add() = make_bigint_range_pb(0, 50);
+    *external.Add() = make_bigint_range_pb(50, 100);
+    auto* sync = SyncPoint::GetInstance();
+    int planners = 0;
+    sync->SetCallBack("tablet_splitter:boundary_planner", [&](void*) { ++planners; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    std::vector<TabletRangeInfo> ranges;
+    ASSERT_OK(compute_split_ranges_from_external_boundaries(nullptr, m, external, &ranges));
+    ASSERT_EQ(2, ranges.size());
+    EXPECT_EQ(0, planners);
+    EXPECT_EQ(101, ranges[0].rowset_stats.at(1).num_rows);
+    EXPECT_EQ(1003, ranges[1].rowset_stats.at(2).data_size);
+    EXPECT_EQ(0, ranges[0].rowset_stats.count(2));
+    EXPECT_EQ(0, ranges[1].rowset_stats.count(1));
+}
+
+TEST(TabletSplitterExternalBoundariesTest, ExternalRanges_AssignsPointAtPhysicalEnvelopeEndToRightChild) {
+    auto m = std::make_shared<TabletMetadataPB>(*make_dup_keys_metadata_with_rowsets({{1, 0, 40, 50, 500}}));
+    auto* rowset = m->mutable_rowsets(0);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(1000);
+    auto* point = rowset->add_segment_metas();
+    *point = rowset->segment_metas(0);
+    point->set_filename("point");
+    point->set_segment_idx(7);
+    *point->mutable_sort_key_min() = make_bigint_tuple_pb(50);
+    *point->mutable_sort_key_max() = make_bigint_tuple_pb(50);
+    RepeatedPtrField<TabletRangePB> external;
+    *external.Add() = make_bigint_range_pb(std::nullopt, 50);
+    *external.Add() = make_bigint_range_pb(50, std::nullopt);
+    std::vector<TabletRangeInfo> ranges;
+    ASSERT_OK(compute_split_ranges_from_external_boundaries(nullptr, m, external, &ranges));
+    ASSERT_EQ(2, ranges.size());
+    EXPECT_EQ(50, ranges[0].rowset_stats.at(1).num_rows);
+    EXPECT_EQ(50, ranges[1].rowset_stats.at(1).num_rows);
+}
+
+TEST(TabletSplitterExternalBoundariesTest, ExternalRanges_SeparateSortPkUsesEligibleUniformWeights) {
+    auto m = make_pk_order_by_metadata();
+    auto* r = m->add_rowsets();
+    r->set_id(1);
+    r->set_num_rows(101);
+    r->set_data_size(1001);
+    r->set_num_dels(3);
+    *r->mutable_range()->mutable_lower_bound() = [] {
+        VariantTuple t;
+        t.append(DatumVariant(get_type_info(TYPE_INT), Datum(50)));
+        TuplePB p;
+        t.to_proto(&p);
+        return p;
+    }();
+    r->mutable_range()->set_lower_bound_included(true);
+    RepeatedPtrField<TabletRangePB> external;
+    *external.Add()->mutable_upper_bound() = r->range().lower_bound();
+    external.Mutable(0)->set_upper_bound_included(false);
+    *external.Add()->mutable_lower_bound() = r->range().lower_bound();
+    external.Mutable(1)->set_lower_bound_included(true);
+    auto* sync = SyncPoint::GetInstance();
+    int planners = 0;
+    sync->SetCallBack("tablet_splitter:boundary_planner", [&](void*) { ++planners; });
+    sync->EnableProcessing();
+    DeferOp cleanup([&] {
+        sync->DisableProcessing();
+        sync->ClearAllCallBacks();
+    });
+    std::vector<TabletRangeInfo> ranges;
+    ASSERT_OK(compute_split_ranges_from_external_boundaries(nullptr, m, external, &ranges));
+    ASSERT_EQ(2, ranges.size());
+    EXPECT_EQ(0, planners);
+    EXPECT_EQ(0, ranges[0].rowset_stats.count(1));
+    EXPECT_EQ(101, ranges[1].rowset_stats.at(1).num_rows);
+    EXPECT_EQ(1001, ranges[1].rowset_stats.at(1).data_size);
+    EXPECT_EQ(3, ranges[1].rowset_stats.at(1).num_dels);
+}
 
 TEST(TabletSplitterExternalBoundariesTest, parent_envelope_clips_effective_lo_hi) {
     // Parent [0, 100). Two rowsets fully within parent at [10, 40] and [60, 90].

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -1365,6 +1365,68 @@ TEST(TabletSplitterExternalBoundariesTest, ExternalRanges_SeparateSortPkUsesElig
     EXPECT_EQ(3, ranges[1].rowset_stats.at(1).num_dels);
 }
 
+TEST(TabletSplitterExternalBoundariesTest, zero_row_segment_is_not_geometry_and_all_stats_are_conserved) {
+    auto m = std::make_shared<TabletMetadataPB>(
+            *make_dup_keys_metadata_with_rowsets({{1, 0, 100, 101, 1201}}, make_bigint_range_pb(0, 101)));
+    auto* rowset = m->mutable_rowsets(0);
+    rowset->set_num_dels(7);
+    SegmentMetadataPB live(rowset->segment_metas(0));
+    live.set_segment_idx(1);
+    live.set_size(1001);
+    rowset->clear_segment_metas();
+    auto* empty = rowset->add_segment_metas();
+    empty->set_filename("empty");
+    empty->set_segment_idx(0);
+    empty->set_num_rows(0);
+    empty->set_size(200);
+    *rowset->add_segment_metas() = live;
+
+    auto external = make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 101)});
+    std::vector<TabletRangeInfo> ranges;
+    ASSERT_OK(compute_split_ranges_from_external_boundaries(nullptr, m, external, &ranges));
+    ASSERT_EQ(2, ranges.size());
+    ASSERT_TRUE(ranges[0].rowset_stats.contains(1));
+    ASSERT_TRUE(ranges[1].rowset_stats.contains(1));
+    const auto& left = ranges[0].rowset_stats.at(1);
+    const auto& right = ranges[1].rowset_stats.at(1);
+    EXPECT_EQ(51, left.num_rows);
+    EXPECT_EQ(50, right.num_rows);
+    EXPECT_EQ(601, left.data_size);
+    EXPECT_EQ(600, right.data_size);
+    EXPECT_EQ(4, left.num_dels);
+    EXPECT_EQ(3, right.num_dels);
+    EXPECT_EQ(101, left.num_rows + right.num_rows);
+    EXPECT_EQ(1201, left.data_size + right.data_size);
+    EXPECT_EQ(7, left.num_dels + right.num_dels);
+}
+
+TEST(TabletSplitterExternalBoundariesTest, all_zero_segments_use_emitted_child_weights_without_shape_requirements) {
+    auto m = std::make_shared<TabletMetadataPB>(*make_dup_keys_metadata_with_rowsets({}, make_bigint_range_pb(0, 100)));
+    auto* rowset = m->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_num_rows(0);
+    rowset->set_data_size(1);
+    rowset->set_num_dels(0);
+    for (int i = 0; i < 2; ++i) {
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename("empty" + std::to_string(i));
+        segment->set_segment_idx(i);
+        segment->set_num_rows(0);
+        segment->set_size(1);
+    }
+
+    auto external = make_ranges({make_bigint_range_pb(0, 50), make_bigint_range_pb(50, 100)});
+    std::vector<TabletRangeInfo> ranges;
+    ASSERT_OK(compute_split_ranges_from_external_boundaries(nullptr, m, external, &ranges));
+    ASSERT_EQ(2, ranges.size());
+    ASSERT_TRUE(ranges[0].rowset_stats.contains(1));
+    ASSERT_TRUE(ranges[1].rowset_stats.contains(1));
+    EXPECT_EQ(0, ranges[0].rowset_stats.at(1).num_rows + ranges[1].rowset_stats.at(1).num_rows);
+    EXPECT_EQ(0, ranges[0].rowset_stats.at(1).num_dels + ranges[1].rowset_stats.at(1).num_dels);
+    EXPECT_EQ(1, ranges[0].rowset_stats.at(1).data_size);
+    EXPECT_EQ(0, ranges[1].rowset_stats.at(1).data_size);
+}
+
 TEST(TabletSplitterExternalBoundariesTest, parent_envelope_clips_effective_lo_hi) {
     // Parent [0, 100). Two rowsets fully within parent at [10, 40] and [60, 90].
     // external boundaries K=2 split at 50. Exercises the effective-envelope branches that read
@@ -1488,6 +1550,7 @@ namespace {
 static void add_bigint_seg(RowsetMetadataPB* rs, int64_t mn, int64_t mx, const std::string& name) {
     auto* m = rs->add_segment_metas();
     m->set_filename(name);
+    m->set_num_rows(1);
     *m->mutable_sort_key_min() = make_bigint_tuple_pb(mn);
     *m->mutable_sort_key_max() = make_bigint_tuple_pb(mx);
 }
@@ -1526,6 +1589,13 @@ TEST(TabletSplitterTest, CanPruneRowsetSegments_predicates) {
         rs.mutable_segment_metas(0)->set_shared(true);
         EXPECT_TRUE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
     } // (d) ok
+    {
+        auto rs = make_pruneable();
+        rs.mutable_segment_metas(0)->clear_num_rows();
+        EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
+        rs.mutable_segment_metas(0)->set_num_rows(0);
+        EXPECT_FALSE(can_prune_rowset_segments(rs, /*sort_key_arity=*/1));
+    } // zero or missing count has no pruneable geometry
     {
         // (e) bounds narrower than the current sort key (a rowset written before a metadata-only
         // trailing sort-key ADD): not comparable with the new tablets' ranges, so not pruneable.
@@ -2411,6 +2481,31 @@ TEST(TabletSplitterTest, BuildSegmentsFromRowsets_NullTabletManagerSkipsLoader) 
     ASSERT_EQ(1u, segments.size());
     EXPECT_TRUE(segments[0].sort_key_samples.empty());
     EXPECT_EQ(0, segments[0].sort_key_sample_row_interval);
+}
+
+TEST(TabletSplitterTest, build_segments_from_rowsets_skips_explicit_zero_rows) {
+    auto metadata = std::make_shared<TabletMetadataPB>(*make_dup_keys_metadata_with_rowsets({{1, 10, 19, 10, 100}}));
+    auto* rowset = metadata->mutable_rowsets(0);
+    SegmentMetadataPB live(rowset->segment_metas(0));
+    live.set_segment_idx(1);
+    rowset->clear_segment_metas();
+    auto* empty = rowset->add_segment_metas();
+    empty->set_filename("empty");
+    empty->set_segment_idx(0);
+    empty->set_num_rows(0);
+    empty->set_size(37);
+    *rowset->add_segment_metas() = live;
+
+    std::vector<SegmentSplitInfo> segments;
+    ASSERT_OK(build_segments_from_rowsets(/*tablet_manager=*/nullptr, metadata, &segments));
+    ASSERT_EQ(1, segments.size());
+    EXPECT_EQ(1, segments[0].source_id);
+    EXPECT_EQ(10, segments[0].num_rows);
+    EXPECT_EQ(100, segments[0].data_size);
+    ASSERT_EQ(1, segments[0].min_key.size());
+    ASSERT_EQ(1, segments[0].max_key.size());
+    EXPECT_EQ(10, segments[0].min_key[0].value().get_int64());
+    EXPECT_EQ(19, segments[0].max_key[0].value().get_int64());
 }
 
 // =============================================================================

--- a/be/test/storage/lake/tablet_splitter_test.cpp
+++ b/be/test/storage/lake/tablet_splitter_test.cpp
@@ -2186,6 +2186,65 @@ TEST_F(BuildSegmentsFromRowsetsLoaderTest, RealFullKeySegmentPopulatesSamplesVia
     EXPECT_EQ(100, segments[0].sort_key_sample_row_interval);
 }
 
+TEST_F(BuildSegmentsFromRowsetsLoaderTest, MissingZeroRowFileDoesNotDiscardLiveFullKeySamples) {
+    const bool old_enable = config::enable_full_sort_key_index;
+    config::enable_full_sort_key_index = true;
+    DeferOp restore([&] { config::enable_full_sort_key_index = old_enable; });
+
+    const int64_t tablet_id = next_id();
+    prepare_tablet_dirs(tablet_id);
+    const int64_t num_rows = 250;
+    const std::string live_name = "live-full-key.dat";
+    const uint64_t live_size = write_int_key_segment(tablet_id, live_name, num_rows);
+
+    auto make_metadata = [&] {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(1);
+        set_int_key_schema(metadata.get());
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_num_rows(num_rows);
+        rowset->set_data_size(live_size);
+        auto* live = rowset->add_segment_metas();
+        live->set_filename(live_name);
+        live->set_size(live_size);
+        live->set_num_rows(num_rows);
+        make_int32_tuple(0).to_proto(live->mutable_sort_key_min());
+        make_int32_tuple(static_cast<int32_t>(num_rows - 1)).to_proto(live->mutable_sort_key_max());
+        return metadata;
+    };
+
+    auto control = make_metadata();
+    std::vector<SegmentSplitInfo> control_segments;
+    ASSERT_OK(build_segments_from_rowsets(_tablet_manager.get(), control, &control_segments));
+    ASSERT_EQ(1, control_segments.size());
+    ASSERT_EQ(2, control_segments[0].sort_key_samples.size()) << "the live full-key fixture must be usable";
+    EXPECT_EQ(100, control_segments[0].sort_key_samples[0][0].value().get_int32());
+    EXPECT_EQ(200, control_segments[0].sort_key_samples[1][0].value().get_int32());
+
+    auto mixed = make_metadata();
+    auto* rowset = mixed->mutable_rowsets(0);
+    SegmentMetadataPB live(rowset->segment_metas(0));
+    live.set_segment_idx(1);
+    rowset->clear_segment_metas();
+    auto* empty = rowset->add_segment_metas();
+    empty->set_filename("intentionally-absent-empty.dat");
+    empty->set_segment_idx(0);
+    empty->set_size(37);
+    empty->set_num_rows(0);
+    *rowset->add_segment_metas() = live;
+
+    std::vector<SegmentSplitInfo> segments;
+    ASSERT_OK(build_segments_from_rowsets(_tablet_manager.get(), mixed, &segments));
+    ASSERT_EQ(1, segments.size());
+    ASSERT_EQ(2, segments[0].sort_key_samples.size())
+            << "the absent zero-row file must not downgrade the live segment to coarse geometry";
+    EXPECT_EQ(100, segments[0].sort_key_samples[0][0].value().get_int32());
+    EXPECT_EQ(200, segments[0].sort_key_samples[1][0].value().get_int32());
+    EXPECT_EQ(100, segments[0].sort_key_sample_row_interval);
+}
+
 // Tablet split is NOT read-config-gated: with config::enable_full_sort_key_index_read = false,
 // build_segments_from_rowsets must STILL populate samples from a present + usable full page (the
 // read config gates only query seek paths, never split-boundary precision).


### PR DESCRIPTION
## Why I'm doing:

Repeated no-write range-tablet split/merge cycles could keep expanding rowset/RSSID metadata instead of returning to a stable canonical form. The split side emitted logically empty occurrences and projected metadata per candidate, while the merge side grouped rowsets only inside version windows. Retries could also recompute already completed reshard publications.

The same lifecycle exposed two current-producer cases that must remain valid: a PK DELETE can intentionally create a zero-row segment that reserves an operation-order RSSID, and one physical shared SST can carry different tablet-local logical attachments after different split/merge branches.

## What I'm doing:

- Preserve rowset UID and original sparse `segment_idx`, and emit a rowset only to children with a non-empty semantic intersection.
- Group merge inputs globally by UID/predicate identity, distinguish contributors from exact duplicates, and canonicalize output order and tablet-local recovery coordinates.
- Bound split planning/projection metadata work and avoid per-candidate source-stat maps.
- Remove sidecar metadata belonging only to omitted rowsets and keep repeated no-write split/merge cycles at a fixed point.
- Reuse only complete, exact reshard results from the existing metadata cache on retries.
- Preserve intentional zero-row segment declarations, RSSIDs, and operation order while excluding them from split geometry and real segment iteration; positional rowset APIs return the established empty/null iterator forms.
- Compare same-filename SST declarations by physical identity only; tablet-local logical attachments continue to the existing reuse/lazy-rebuild classifier.
- Keep existing delvec write-failure atomicity tests on valid current-producer merge metadata so they reach their intended injection points.

Validation:

- Combined affected ASAN suite: 511/511 passed.
- Combined affected Release suite: 512/512 passed (`-O3 -DNDEBUG`; one additional existing Release-only assertion-safety case is registered).
- Full `MetaFileTest.*`: 77/77 passed in both ASAN and Release; the two prior CI failures pass 2/2 in each build.
- ASAN and Release `LakeServiceTest.*`: 99/99 passed in each build.
- Includes real-writer split/merge/cold-rebuild cycles, retry-cache cases, sparse/virtual segment indices, zero-row segment iterator and geometry cases, exact delete conservation, logical-vs-physical SST matrices, sidecar/vacuum oracles, and fixed-point loops.
- Full BE module-boundary, generated AGENTS, diff-check, and changed-line clang-format checks passed.

Fixes StarRocks/StarRocksTest#12091

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
