### PR TITLE
[BugFix] Stop the lake PK index compactor from silently giving up

### DIFF
--- a/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
+++ b/be/src/storage/lake/lake_persistent_index_size_tiered_compaction_strategy.cpp
@@ -173,8 +173,21 @@ StatusOr<CompactionCandidateResult> LakePersistentIndexSizeTieredCompactionStrat
         return result;
     }
 
-    SizeTieredLevel* selected_level = *priority_levels.begin();
-    if (selected_level->fileset_indexes.size() < min_compaction_filesets) {
+    // Walk the levels in score order and take the first one that actually has enough filesets to
+    // compact. Stopping at the highest-scoring level alone starves the index whenever a level of
+    // one fileset sorts ahead of a level that holds two or more: the round then produces no index
+    // compaction while the flush side keeps adding sstables. The level bonus rewards small levels,
+    // so at the shipped config a fileset below pk_index_size_tiered_min_level_size ties a
+    // two-fileset level on score, and LevelComparator's tie-break on `fileset_indexes[0] >` puts
+    // the newer, single-fileset level first.
+    SizeTieredLevel* selected_level = nullptr;
+    for (auto* level : priority_levels) {
+        if (level->fileset_indexes.size() >= min_compaction_filesets) {
+            selected_level = level;
+            break;
+        }
+    }
+    if (selected_level == nullptr) {
         return result;
     }
 

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1641,11 +1641,14 @@ Status TabletParallelCompactionManager::execute_sst_compaction_for_parallel(
     TxnLogPB temp_log;
     auto st = update_mgr->execute_index_major_compaction(metadata, &temp_log);
     if (!st.ok()) {
-        LOG(WARNING) << "SST compaction failed for tablet " << tablet_id << ": " << st
-                     << ". This will not fail the parallel compaction.";
-        // Don't fail the entire parallel compaction for SST compaction failure
-        // SST compaction can be retried in the next compaction cycle
-        return Status::OK();
+        // Propagate, like horizontal_compaction_task.cpp, vertical_compaction_task.cpp and
+        // cloud_native_index_compaction_task.cpp do for the same call. Swallowing it here let the
+        // index compactor stop for good while the flush side kept producing sstables, and it
+        // downgraded every consistency guard inside major compaction ("sstables are not ordered",
+        // "inconsistent fileset_id in sstables", "no matching sstable fileset found") to a single
+        // WARNING on this path only.
+        LOG(WARNING) << "SST compaction failed for tablet " << tablet_id << ": " << st;
+        return st;
     }
 
     // Copy SST compaction results from temp_log.op_compaction() to op_parallel

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -2407,7 +2407,13 @@ void UpdateManager::preload_compaction_state(const TxnLog& txnlog, const Tablet&
     TEST_SYNC_POINT("UpdateManager::preload_compaction_state:return");
 }
 
+DEFINE_FAIL_POINT(fail_execute_index_major_compaction);
+
 Status UpdateManager::execute_index_major_compaction(const TabletMetadataPtr& metadata, TxnLogPB* txn_log) {
+    // Test-only: inject an index major compaction failure so callers can exercise their
+    // error-propagation paths.
+    FAIL_POINT_TRIGGER_EXECUTE(fail_execute_index_major_compaction,
+                               { return Status::InternalError("injected index major compaction failure"); });
     if (config::enable_pk_index_parallel_compaction) {
         if (_parallel_compact_mgr == nullptr) {
             return Status::InternalError("parallel compact manager is not initialized");

--- a/be/test/storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
@@ -497,4 +497,123 @@ TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_level_multiple_
     EXPECT_EQ(result.candidate_filesets.size(), 2);
 }
 
+// Test 21: The highest-scoring level holds a single fileset, a lower-scoring level holds two.
+//
+// Regression test for the index compactor declining to compact anything at all in this layout.
+// The level bonus rewards small levels by up to pk_index_size_tiered_max_level, so a single small
+// fileset can outscore an older level of two large filesets and, because only the top level was
+// considered, that round produced no index compaction at all while the flush side kept adding
+// sstables.
+//
+// NOTE: the scores below are computed with THIS FIXTURE's config (SetUp overrides
+// pk_index_size_tiered_level_multiplier to 5 and pk_index_size_tiered_max_level to 7), not with the
+// shipped defaults of 10 and 5. At the shipped defaults the 200KB level scores 6, below the
+// two-fileset level's 7, so this exact layout is not starved on a real cluster.
+// test_falls_back_at_product_default_config below covers a layout that is.
+TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_falls_back_when_top_level_has_one_fileset) {
+    std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
+            {1, 104857600, 100}, // fileset 1: 100MB  -- base, level {1,2}, score 3*2-2+3 = 7
+            {2, 104857600, 200}, // fileset 2: 100MB
+            {3, 204800, 300},    // fileset 3: 200KB  -- own level, alone, score 3*1-2+7 = 8
+            {4, 500000, 400},    // active, never a candidate
+    };
+
+    auto metadata = create_tablet_metadata_with_sstables(sstables_info);
+
+    ASSIGN_OR_ABORT(
+            CompactionCandidateResult result,
+            LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(metadata->sstable_meta()));
+
+    // The single-fileset level cannot be compacted, so the two-fileset level must be taken instead.
+    ASSERT_EQ(2, result.candidate_filesets.size());
+    EXPECT_EQ(1, result.candidate_filesets[0][0].fileset_id().hi());
+    EXPECT_EQ(2, result.candidate_filesets[1][0].fileset_id().hi());
+    EXPECT_TRUE(result.merge_base_level);
+    EXPECT_EQ(200, result.max_max_rss_rowid);
+}
+
+// Test 22: Every level holds exactly one fileset -- the fallback must still decline.
+// Guards the other direction of test 21: falling back may not lower the two-fileset minimum.
+TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_no_fallback_when_every_level_has_one_fileset) {
+    std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
+            {1, 104857600, 100}, // 100MB
+            {2, 4194304, 200},   // 4MB   -- 25x smaller, own level
+            {3, 204800, 300},    // 200KB -- 20x smaller, own level
+            {4, 500000, 400},    // active
+    };
+
+    auto metadata = create_tablet_metadata_with_sstables(sstables_info);
+
+    ASSIGN_OR_ABORT(
+            CompactionCandidateResult result,
+            LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(metadata->sstable_meta()));
+
+    EXPECT_EQ(0, result.candidate_filesets.size());
+    EXPECT_FALSE(result.merge_base_level);
+}
+
+// Test 23: the same starvation, reached at the SHIPPED config rather than this fixture's.
+//
+// The defaults are pk_index_size_tiered_min_level_size = 131072, _level_multiplier = 10 and
+// _max_level = 5, so max_level_size = 131072 * 10^5. There the level bonus tops out at 6 and a
+// single small fileset can only *tie* a two-fileset level, never outscore it:
+//
+//   two 100MB filesets   -> level_bonus 3, score 3*2-2+3 = 7
+//   one 200KB fileset    -> level_bonus 5, score 3*1-2+5 = 6   (not starved)
+//   one fileset < 131072 -> level_bonus 6, score 3*1-2+6 = 7   (ties)
+//
+// A tie is enough, because LevelComparator breaks it on `fileset_indexes[0] >` and filesets are
+// ordered oldest-first, so the newest single-fileset level sorts ahead of the compactable one and
+// *priority_levels.begin() lands on the level that cannot be compacted. The boundary is exact:
+// 131071 bytes reproduces it, 131072 does not.
+TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_falls_back_at_product_default_config) {
+    config::pk_index_size_tiered_level_multiplier = 10;
+    config::pk_index_size_tiered_max_level = 5;
+    // min_level_size is already the shipped 131072; TearDown restores all three.
+
+    std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
+            {1, 104857600, 100}, // fileset 1: 100MB   -- base, level {1,2}, score 7
+            {2, 104857600, 200}, // fileset 2: 100MB
+            {3, 131071, 300},    // fileset 3: one byte under min_level_size -- own level, score 7
+            {4, 500000, 400},    // active, never a candidate
+    };
+
+    auto metadata = create_tablet_metadata_with_sstables(sstables_info);
+
+    ASSIGN_OR_ABORT(
+            CompactionCandidateResult result,
+            LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(metadata->sstable_meta()));
+
+    ASSERT_EQ(2, result.candidate_filesets.size());
+    EXPECT_EQ(1, result.candidate_filesets[0][0].fileset_id().hi());
+    EXPECT_EQ(2, result.candidate_filesets[1][0].fileset_id().hi());
+    EXPECT_TRUE(result.merge_base_level);
+    EXPECT_EQ(200, result.max_max_rss_rowid);
+}
+
+// Test 24: the other side of test 23's boundary. At the shipped config a fileset of exactly
+// min_level_size scores 6, strictly below the two-fileset level's 7, so the pre-existing code
+// already selected the compactable level and the fallback changes nothing here.
+TEST_F(LakePersistentIndexSizeTieredCompactionStrategyTest, test_no_starvation_at_min_level_size_boundary) {
+    config::pk_index_size_tiered_level_multiplier = 10;
+    config::pk_index_size_tiered_max_level = 5;
+
+    std::vector<std::tuple<int64_t, int64_t, uint64_t>> sstables_info = {
+            {1, 104857600, 100}, // 100MB -- level {1,2}, score 7
+            {2, 104857600, 200}, // 100MB
+            {3, 131072, 300},    // exactly min_level_size -- own level, score 6
+            {4, 500000, 400},    // active
+    };
+
+    auto metadata = create_tablet_metadata_with_sstables(sstables_info);
+
+    ASSIGN_OR_ABORT(
+            CompactionCandidateResult result,
+            LakePersistentIndexSizeTieredCompactionStrategy::pick_compaction_candidates(metadata->sstable_meta()));
+
+    ASSERT_EQ(2, result.candidate_filesets.size());
+    EXPECT_EQ(1, result.candidate_filesets[0][0].fileset_id().hi());
+    EXPECT_EQ(2, result.candidate_filesets[1][0].fileset_id().hi());
+}
+
 } // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -7637,4 +7637,79 @@ TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_range_spl
     }
 }
 
+// A failing PK index major compaction must fail the parallel compaction, exactly as it does on the
+// three non-parallel paths (horizontal_compaction_task.cpp, vertical_compaction_task.cpp,
+// cloud_native_index_compaction_task.cpp all RETURN_IF_ERROR the same call).
+//
+// Swallowing it here returned Status::OK() after one WARNING, so the data compaction reported
+// success while the index compactor made no progress -- and every consistency guard inside major
+// compaction ("sstables are not ordered", "inconsistent fileset_id in sstables", "no matching
+// sstable fileset found") was silent on this path only. Both directions are asserted: armed, so a
+// typo'd failpoint name cannot make the test vacuous; disarmed, so the path is not failing
+// unconditionally.
+TEST_F(TabletParallelCompactionManagerTest, test_index_major_compaction_failure_fails_parallel_compaction) {
+    int64_t tablet_id = 10023;
+    int64_t txn_id = 20023;
+    int64_t version = 11;
+
+    // A cloud-native persistent-index PK tablet is the only shape that reaches
+    // execute_index_major_compaction from the parallel path.
+    auto metadata = generate_simple_tablet_metadata(PRIMARY_KEYS);
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    metadata->set_enable_persistent_index(true);
+    metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    auto register_completed_state = [&](int64_t id) {
+        auto state = std::make_shared<TabletParallelCompactionState>();
+        state->tablet_id = tablet_id;
+        state->txn_id = id;
+        state->version = version;
+        state->max_parallel = 1;
+
+        auto ctx = std::make_unique<CompactionTaskContext>(id, tablet_id, version, false, true, nullptr);
+        ctx->subtask_id = 0;
+        ctx->txn_log = std::make_unique<TxnLogPB>();
+        ctx->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+        ctx->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+        state->completed_subtasks.push_back(std::move(ctx));
+
+        _manager->register_tablet_state_for_test(tablet_id, id, state);
+    };
+
+    auto set_failpoint_mode = [](const std::string& name, FailPointTriggerModeType mode) {
+        PFailPointTriggerMode trigger_mode;
+        trigger_mode.set_mode(mode);
+        auto* fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(name);
+        ASSERT_NE(nullptr, fp) << "failpoint " << name << " is not registered";
+        fp->setMode(trigger_mode);
+    };
+
+    // Take the serial branch of execute_index_major_compaction so the disarmed leg below returns OK
+    // deterministically: the parallel branch needs a LakePersistentIndexParallelCompactMgr, which
+    // TestBase only wires up when StorageEnv happens to have one. The failpoint sits ahead of this
+    // branch, so the armed leg is unaffected.
+    const bool saved_parallel = config::enable_pk_index_parallel_compaction;
+    config::enable_pk_index_parallel_compaction = false;
+    DeferOp restore_parallel([&] { config::enable_pk_index_parallel_compaction = saved_parallel; });
+
+    // Armed: the injected failure must reach the caller.
+    register_completed_state(txn_id);
+    set_failpoint_mode("fail_execute_index_major_compaction", FailPointTriggerModeType::ENABLE);
+    auto failed = _manager->get_merged_txn_log(tablet_id, txn_id);
+    set_failpoint_mode("fail_execute_index_major_compaction", FailPointTriggerModeType::DISABLE);
+
+    ASSERT_FALSE(failed.ok());
+    EXPECT_NE(std::string::npos, failed.status().to_string().find("injected index major compaction failure"))
+            << failed.status();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+
+    // Disarmed: the same tablet and state must merge cleanly.
+    register_completed_state(txn_id + 1);
+    auto ok = _manager->get_merged_txn_log(tablet_id, txn_id + 1);
+    EXPECT_TRUE(ok.ok()) << ok.status();
+    _manager->cleanup_tablet(tablet_id, txn_id + 1);
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
## Why I'm doing:

Two independent ways the lake primary-key **index** compactor can stop while the flush side keeps
producing sstables. Both are reachable at product defaults, both are silent, and both leave a tablet
whose persistent index grows without bound. That is expensive on its own — `get_from_sstables()`
walks filesets newest-to-oldest until every key is found, so a fresh key costs one lookup per fileset,
and on a measured shared-data tablet at ~3700 filesets one publish spent 0.60-0.71 s in `multi_get_us`
and ingest fell from 4.89 to 1.18 txn/s, with a cache hit ratio of ~22 000 hits to ~10 misses (it is
the walk, not IO). Index-open cost at restart reached `pindex_init_sst_open_us` = 11.9 s for one
tablet's 3834 sstables.

**1. `pick_compaction_candidates` gives up instead of falling back**
(`lake_persistent_index_size_tiered_compaction_strategy.cpp`). It takes
`*priority_levels.begin()` — the single highest-scoring size-tiered level — and returns an empty
candidate set if that level holds fewer than `min_compaction_filesets` (2). Whenever a level of one
fileset sorts ahead of a level that holds two or more, the round does nothing at all while the flush
side keeps adding sstables.

At the shipped config (`pk_index_size_tiered_min_level_size` 131072,
`pk_index_size_tiered_level_multiplier` 10, `pk_index_size_tiered_max_level` 5, so
`max_level_size = 131072 * 10^5`) the level bonus tops out at 6, so a single small fileset **ties** a
two-fileset level rather than outscoring it:

| filesets (oldest first) | level | n | level_bonus | score |
|---|---|---|---|---|
| 100 MiB, 100 MiB | 0 | 2 | 3 | `3*2-2 + 3` = **7** |
| 200 KiB | 1 | 1 | 5 | `3*1-2 + 5` = **6** — not starved |
| < 131072 B | 1 | 1 | 6 | `3*1-2 + 6` = **7** — ties |

A tie is enough, because `LevelComparator` breaks it on `fileset_indexes[0] >` and filesets are
ordered oldest-first, so the newest single-fileset level sorts ahead of the compactable one and
`*priority_levels.begin()` lands on a level it cannot compact. The boundary is exact: 131071 bytes
reproduces it, 131072 does not.

**2. A failing index major compaction is swallowed by the parallel compaction path**
(`tablet_parallel_compaction_manager.cpp`). Four of the five callers of
`UpdateManager::execute_index_major_compaction` propagate the error with `RETURN_IF_ERROR`
(`horizontal_compaction_task.cpp`, `vertical_compaction_task.cpp`,
`cloud_native_index_compaction_task.cpp`, `compaction_task.cpp`); only this one logs a WARNING and
returns `Status::OK()`. Two consequences: the index consumer can stop **permanently** while the data
compaction still reports success, and every consistency guard inside major compaction — `"sstables are
not ordered"`, `"inconsistent fileset_id in sstables"`, `"no matching sstable fileset found"` — is
downgraded to a single WARNING on this path only.

Neither was observed firing in this investigation's clusters (`SST compaction failed for tablet` read
0 across four runs); they are established by reading the code plus the arithmetic above, and pinned
by the tests below.

## What I'm doing:

1. Walk `priority_levels` in score order and select the first level that actually has
 `>= min_compaction_filesets`; return empty only when none does. Behaviour is unchanged wherever the
 top level was already compactable — all 20 pre-existing tests in the strategy suite pass unmodified.
2. Propagate the error from `execute_index_major_compaction` in
 `execute_sst_compaction_for_parallel`, matching the other four callers.

**Tests.** Five new cases. Three fail without the fixes; two are boundary guards that pass either way and are there so a later change cannot quietly widen the fallback:

| test | unfixed | with the fixes |
|---|---|---|
| `test_falls_back_when_top_level_has_one_fileset` | **FAIL** — `candidate_filesets.size()` is 0, expected 2 | PASS |
| `test_index_major_compaction_failure_fails_parallel_compaction` | **FAIL** — the injected error was swallowed and `Status::OK()` returned | PASS |
| `test_no_fallback_when_every_level_has_one_fileset` | PASS | PASS |
| `test_falls_back_at_product_default_config` | **FAIL** — same, at the shipped multiplier 10 / max_level 5 | PASS |
| `test_no_starvation_at_min_level_size_boundary` | PASS | PASS |

`test_no_fallback_when_every_level_has_one_fileset` guards the other direction: falling back may not
lower the two-fileset minimum. The failure-propagation test asserts **both** directions — armed, the
injected error reaches the caller; disarmed, the same tablet merges cleanly — so a typo'd failpoint
name cannot make it vacuous. The seam is one new failpoint, `fail_execute_index_major_compaction`,
defined next to the existing `fail_lake_pk_index_flush` in `update_manager.cpp` and following the same
idiom.

Whole suites with the fixes: `120 tests from 2 test suites ran. [ PASSED ] 120 tests.`

**Observability:** the existing `SST compaction failed for tablet` WARNING is preserved (fix 2 keeps
the log line and adds the propagation), and the guards inside major compaction regain their intended
severity on this path — a failing index compaction now fails its compaction task instead of being
reported as success. `pindex_init_fileset_cnt` / `pindex_init_sst_cnt` remain the counters that show a
starved index; no signal was removed and none needed adding.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function
 - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5