### PR TITLE
[BugFix] Read prof.active into a bool in has_enable_heap_profile

### DIFF
--- a/be/src/runtime/prof/heap_prof.cpp
+++ b/be/src/runtime/prof/heap_prof.cpp
@@ -41,12 +41,16 @@ static int set_jemalloc_profiling(bool enable) {
     return je_mallctl("prof.active", nullptr, nullptr, &enable, sizeof(enable));
 }
 
-static int has_enable_heap_profile() {
-    int value = 0;
+static bool has_enable_heap_profile() {
+    // `prof.active` is a bool node, and je_mallctl() rejects a read whose length does not match
+    // the node's type: the ctl layer copies min(sizeof(bool), *oldlenp) bytes and returns EINVAL
+    // rather than filling the buffer. Reading it into an int with sizeof(int) therefore only
+    // happened to work because the int was zero initialized and the caller never looked at the
+    // return code -- checking the code without fixing the type would have made this always
+    // report false.
+    bool value = false;
     size_t size = sizeof(value);
-
-    je_mallctl("prof.active", &value, &size, nullptr, 0);
-    return value;
+    return je_mallctl("prof.active", &value, &size, nullptr, 0) == 0 && value;
 }
 #endif
 

--- a/be/test/runtime/prof/heap_prof_test.cpp
+++ b/be/test/runtime/prof/heap_prof_test.cpp
@@ -89,4 +89,18 @@ TEST(HeapProfTest, toggling_the_profile_keeps_thread_active_init) {
 #endif
 }
 
+// has_enable() reads `prof.active` through je_mallctl, which returns EINVAL when the length does
+// not match the node's bool type -- after copying as many bytes as fit, so a failed read leaves
+// the buffer partly written rather than intact. A process not started with `prof:true` must
+// report false, and so must one whose read failed, which is why the helper checks the return
+// code before looking at the value.
+TEST(HeapProfTest, has_enable_is_false_without_startup_prof) {
+#ifndef __APPLE__
+    if (prof_enabled_at_startup()) {
+        GTEST_SKIP() << "the process was started with prof:true, so prof.active may legitimately be on";
+    }
+#endif
+    EXPECT_FALSE(HeapProf::getInstance().has_enable());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`has_enable_heap_profile()` in `be/src/runtime/prof/heap_prof.cpp` read a **bool** mallctl node into an **int**:

```cpp
static int has_enable_heap_profile() {
    int value = 0;
    size_t size = sizeof(value);          // 4, but prof.active is a bool
    je_mallctl("prof.active", &value, &size, nullptr, 0);
    return value;                          // return code discarded
}
```

je_mallctl() does not fill a mismatched buffer. The ctl layer's `READ` macro (`src/ctl.c`) takes the mismatch branch, copies `min(sizeof(bool), *oldlenp)` = 1 byte, rewrites `*oldlenp`, sets `ret = EINVAL` and jumps out:

```c
if (*oldlenp != sizeof(t)) {
        size_t copylen = (sizeof(t) <= *oldlenp) ? sizeof(t) : *oldlenp;
        memcpy(oldp, (void *)&(v), copylen);
        *oldlenp = copylen;
        ret = EINVAL;
        goto label_return;
}
```

So the call has always been failing while still writing one byte into a four byte int. It produced the right answer only because three things lined up: the mismatch branch copies the byte anyway, `int value = 0` zeroed the other three, and the caller (`HeapProf::has_enable()`, which returns `bool`) used only the truthiness — never the return code and never the number.

Two ways that turns into a real bug:

- Dropping the `= 0` initializer lets the upper three bytes decide the result, so `has_enable()` starts reporting true at random.
- Adding the missing return-code check *without* fixing the type makes the function report false unconditionally, because the length mismatch fails every time. That is the natural "let's check the error" cleanup, and it would have quietly disabled the check that `/pprof/heap` and the `jemalloc_conf` updater both rely on.

Not a memory-safety issue: the macro's `copylen` is a `min`, so it never writes past the caller's buffer. That is why this sat here without a crash or an ASAN report — just a discarded error code.

## What I'm doing:

Read into a `bool` with `sizeof(bool)` and check the return code, so a failed read reports false rather than whatever the buffer held:

```cpp
static bool has_enable_heap_profile() {
    bool value = false;
    size_t size = sizeof(value);
    return je_mallctl("prof.active", &value, &size, nullptr, 0) == 0 && value;
}
```

The return type changes from `int` to `bool`; the only caller is `HeapProf::has_enable()`, which already returns `bool`.

Added a test asserting that a process not started with `prof:true` reports false. **It would not have caught the original defect** — that version answered correctly too — but it guards the new shape, where dropping `&& value` would make a successful read report true. The discriminating case needs `opt_prof`, which is covered by the existing `toggling_the_profile_keeps_thread_active_init` test; that one skips unless the process was started with `prof:true`.

## Observability

Reviewed the heap-profile path: `HeapProf::has_enable()` feeds the `/pprof/heap` handler and the `jemalloc_conf` update hook's `prof_active` verification. No signal is added or removed — the fix makes the existing one trustworthy, and a read failure is now reported as "not enabled" instead of being inferred from an untouched buffer.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

On every platform StarRocks builds for, the old code returned the same answer as the new one; this removes the accidents it depended on.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
