### PR TITLE
[UT] Stop test_short_circuit_unique from leaking GLOBAL enable_short_circuit

### DIFF
--- a/test/sql/test_spill/R/test_short_circuit_unique
+++ b/test/sql/test_spill/R/test_short_circuit_unique
@@ -8,10 +8,13 @@ PROPERTIES('replication_num' = '1');
 insert into unique_tbl values(1,'hi'),(2,'hello');
 -- result:
 -- !result
-set global enable_short_circuit = true;
+set enable_short_circuit = true;
 -- result:
 -- !result
 select * from unique_tbl where a=1;
 -- result:
 1	hi
+-- !result
+set enable_short_circuit = false;
+-- result:
 -- !result


### PR DESCRIPTION
## Why I'm doing:

VALIDATE runs the R file. `test_short_circuit_unique` recorded `SET GLOBAL enable_short_circuit = true` and never restored it, so later cases inherit short-circuit (e.g. `lookup_string` inner HTTP result sink fails with `Unknown result sink type`).

T already used session SET + restore. Main archived this case in #77827; branch-3.5/4.0/4.1 still ship it.

## What I'm doing:

Align R with T: session-level `set enable_short_circuit = true`, then `set enable_short_circuit = false`.

## Test plan
- [ ] sql-tester `test_short_circuit_unique` still passes
- [ ] After the case, `SHOW GLOBAL VARIABLES LIKE 'enable_short_circuit'` is `false`


Made with [Cursor](https://cursor.com)
