### PR TITLE
[BugFix] Report invalid JSON from velocypack without throwing per row

### DIFF
--- a/be/src/column/variant_encoder.cpp
+++ b/be/src/column/variant_encoder.cpp
@@ -814,15 +814,15 @@ StatusOr<VariantRowValue> VariantEncoder::encode_json_text_to_variant(std::strin
     if (json_text.empty()) {
         return encode_json_to_variant(JsonValue::from_string(Slice("", 0)));
     }
-    try {
-        auto builder = vpack::Parser::fromJson(json_text.data(), json_text.size());
-        JsonValue parsed;
-        parsed.assign(*builder);
-        return encode_json_to_variant(parsed);
-    } catch (const vpack::Exception&) {
-        // Keep backward compatibility for plain scalar text input (for example "abc").
+    // Plain scalar text (for example "abc") is accepted as a string value. Detect it through the parser's
+    // error-code API: a throw per non-JSON row would be far too expensive.
+    auto builder = vpack::Parser::tryFromJson(json_text.data(), json_text.size(), nullptr);
+    if (builder == nullptr) {
         return encode_json_to_variant(JsonValue::from_string(Slice(json_text.data(), json_text.size())));
     }
+    JsonValue parsed;
+    parsed.assign(*builder);
+    return encode_json_to_variant(parsed);
 }
 
 Status VariantEncoder::encode_column(const ColumnPtr& column, const TypeDescriptor& type,

--- a/be/src/column/variant_encoder.cpp
+++ b/be/src/column/variant_encoder.cpp
@@ -815,14 +815,20 @@ StatusOr<VariantRowValue> VariantEncoder::encode_json_text_to_variant(std::strin
         return encode_json_to_variant(JsonValue::from_string(Slice("", 0)));
     }
     // Plain scalar text (for example "abc") is accepted as a string value. Detect it through the parser's
-    // error-code API: a throw per non-JSON row would be far too expensive.
-    auto builder = vpack::Parser::tryFromJson(json_text.data(), json_text.size(), nullptr);
-    if (builder == nullptr) {
+    // error-code API: a throw per non-JSON row would be far too expensive. The catch only remains as a safety
+    // net for exceptions that are not caused by the input, so it costs nothing on the hot path.
+    try {
+        auto builder = vpack::Parser::tryFromJson(json_text.data(), json_text.size(), nullptr);
+        if (builder == nullptr) {
+            return encode_json_to_variant(JsonValue::from_string(Slice(json_text.data(), json_text.size())));
+        }
+        JsonValue parsed;
+        parsed.assign(*builder);
+        return encode_json_to_variant(parsed);
+    } catch (const vpack::Exception&) {
+        // Keep backward compatibility for plain scalar text input (for example "abc").
         return encode_json_to_variant(JsonValue::from_string(Slice(json_text.data(), json_text.size())));
     }
-    JsonValue parsed;
-    parsed.assign(*builder);
-    return encode_json_to_variant(parsed);
 }
 
 Status VariantEncoder::encode_column(const ColumnPtr& column, const TypeDescriptor& type,

--- a/be/src/types/json_value.cpp
+++ b/be/src/types/json_value.cpp
@@ -100,8 +100,14 @@ StatusOr<JsonValue> JsonValue::parse_json_or_string(const Slice& src) {
         auto end = src.get_data() + src.get_size();
         auto iter = std::find_if_not(src.get_data(), end, std::iswspace);
         if (iter != end && is_json_start_char(*iter)) {
-            // Parse it as an object or array
-            auto b = vpack::Parser::fromJson(src.get_data(), src.get_size());
+            // Parse it as an object or array. Invalid JSON is common in dirty data, so use the parser's
+            // error-code API: reporting it by throwing costs a full C++ unwind per row and serializes all
+            // threads on the unwinder lock.
+            vpack::Exception error(vpack::Exception::InternalError);
+            auto b = vpack::Parser::tryFromJson(src.get_data(), src.get_size(), &error);
+            if (b == nullptr) {
+                return fromVPackException(error);
+            }
             JsonValue res;
             res.assign(*b);
             return res;

--- a/be/test/types/json_value_test.cpp
+++ b/be/test/types/json_value_test.cpp
@@ -49,6 +49,39 @@ TEST(JsonValueTest, Parse) {
     ASSERT_FALSE(oversized_json.ok());
 }
 
+TEST(JsonValueTest, ParseInvalidJsonReportsVelocypackError) {
+    // Invalid JSON must come back as a status (never an exception escaping parse()) and keep the
+    // velocypack error message, whichever parser API is in use.
+    struct Case {
+        std::string input;
+        std::string expected_message;
+    };
+    std::vector<Case> cases = {
+            {R"({"a":1)", "Expecting ',' or '}'"},
+            {R"({"a":1,)", "Expecting '\"' or '}'"},
+            {R"([1,2)", "Expecting ',' or ']'"},
+            {R"({"a" 1})", "Expecting ':'"},
+            {R"("abc)", "Unfinished string"},
+            {R"({"a":tru})", "Expecting 'true'"},
+            {R"({"a":1} x)", "Expecting EOF"},
+            {R"([1e999])", "Number out of range"},
+            {std::string("[\"ctrl\x01char\"]"), "Unexpected control character"},
+    };
+    for (const auto& c : cases) {
+        auto res = JsonValue::parse(c.input);
+        ASSERT_FALSE(res.ok()) << c.input;
+        ASSERT_EQ(TStatusCode::DATA_QUALITY_ERROR, res.status().code()) << res.status();
+        ASSERT_NE(res.status().message().find(c.expected_message), std::string::npos)
+                << c.input << " -> " << res.status();
+    }
+    // A prefix of a document is not accepted either, and valid documents still parse.
+    std::string doc = R"({"id":42,"name":"x","tags":["a","b"],"nums":[1,2.5,-3e2],"obj":{"t":true,"n":null}})";
+    for (size_t len = 1; len < doc.size(); ++len) {
+        ASSERT_FALSE(JsonValue::parse(doc.substr(0, len)).ok()) << doc.substr(0, len);
+    }
+    ASSERT_TRUE(JsonValue::parse(doc).ok());
+}
+
 TEST(JsonValueTest, ToString) {
     auto maybe_json = JsonValue::parse(R"( {"a": "a"} )");
     ASSERT_TRUE(maybe_json.ok());

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -732,6 +732,8 @@ if [[ -d $TP_SOURCE_DIR/$VPACK_SOURCE ]] ; then
     cd $TP_SOURCE_DIR/$VPACK_SOURCE
     if [ ! -f $PATCHED_MARK ] && [ $VPACK_SOURCE = "velocypack-XYZ1.0" ]; then
         apply_patch -p1 $TP_PATCH_DIR/velocypack-XYZ1.0.patch
+        # non-throwing Parser::tryParse()/tryFromJson() for invalid JSON input
+        apply_patch -p1 $TP_PATCH_DIR/velocypack-XYZ1.0-tryparse.patch
         touch $PATCHED_MARK
     fi
     cd -

--- a/thirdparty/patches/velocypack-XYZ1.0-tryparse.patch
+++ b/thirdparty/patches/velocypack-XYZ1.0-tryparse.patch
@@ -1,0 +1,765 @@
+diff -rupN velocypack-XYZ1.0.orig/include/velocypack/Parser.h velocypack-XYZ1.0/include/velocypack/Parser.h
+--- velocypack-XYZ1.0.orig/include/velocypack/Parser.h	2026-09-08 11:08:55.915341585 +0800
++++ velocypack-XYZ1.0/include/velocypack/Parser.h	2026-09-08 16:05:14.887477778 +0800
+@@ -43,14 +43,15 @@ class Parser {
+   struct ParsedNumber {
+     ParsedNumber() : intValue(0), doubleValue(0.0), isInteger(true) {}
+ 
+-    void addDigit(int i) {
++    // returns false if the number overflows
++    bool addDigit(int i) {
+       if (isInteger) {
+         // check if adding another digit to the int will make it overflow
+         if (intValue < 1844674407370955161ULL ||
+             (intValue == 1844674407370955161ULL && (i - '0') <= 5)) {
+           // int won't overflow
+           intValue = intValue * 10 + (i - '0');
+-          return;
++          return true;
+         }
+         // int would overflow
+         doubleValue = static_cast<double>(intValue);
+@@ -58,9 +59,7 @@ class Parser {
+       }
+ 
+       doubleValue = doubleValue * 10.0 + (i - '0');
+-      if (std::isnan(doubleValue) || !std::isfinite(doubleValue)) {
+-        throw Exception(Exception::NumberOutOfRange);
+-      }
++      return !(std::isnan(doubleValue) || !std::isfinite(doubleValue));
+     }
+ 
+     double asDouble() const {
+@@ -81,6 +80,9 @@ class Parser {
+   std::size_t _size;
+   std::size_t _pos;
+   int _nesting;
++  // error reported by the last failed tryParse()
++  Exception::ExceptionType _errorType;
++  char const* _errorMsg;
+ 
+  public:
+   Options const* options;
+@@ -96,6 +98,8 @@ class Parser {
+         _size(0), 
+         _pos(0), 
+         _nesting(0), 
++        _errorType(Exception::InternalError),
++        _errorMsg(nullptr),
+         options(&Options::Defaults) {
+     _builder.reset(new Builder());
+     _builderPtr = _builder.get();
+@@ -107,6 +111,8 @@ class Parser {
+         _size(0), 
+         _pos(0), 
+         _nesting(0), 
++        _errorType(Exception::InternalError),
++        _errorMsg(nullptr),
+         options(options) {
+     if (VELOCYPACK_UNLIKELY(options == nullptr)) {
+       throw Exception(Exception::InternalError, "Options cannot be a nullptr");
+@@ -124,6 +130,8 @@ class Parser {
+         _size(0), 
+         _pos(0), 
+         _nesting(0),
++        _errorType(Exception::InternalError),
++        _errorMsg(nullptr),
+          options(options) {
+     if (VELOCYPACK_UNLIKELY(options == nullptr)) {
+       throw Exception(Exception::InternalError, "Options cannot be a nullptr");
+@@ -137,6 +145,8 @@ class Parser {
+         _size(0), 
+         _pos(0), 
+         _nesting(0),
++        _errorType(Exception::InternalError),
++        _errorMsg(nullptr),
+          options(options) {
+     if (VELOCYPACK_UNLIKELY(options == nullptr)) {
+       throw Exception(Exception::InternalError, "Options cannot be a nullptr");
+@@ -171,6 +181,55 @@ class Parser {
+     return parser.steal();
+   }
+ 
++  // Non-throwing variant of fromJson(): returns nullptr if the input is not
++  // valid JSON and stores the reason in *error (if given). Errors that are
++  // not caused by the input (e.g. allocation failures) are still thrown.
++  static std::shared_ptr<Builder> tryFromJson(
++      char const* start, std::size_t size, Exception* error,
++      Options const* options = &Options::Defaults) {
++    Parser parser(options);
++    if (!parser.tryParse(start, size)) {
++      if (error != nullptr) {
++        *error = parser.error();
++      }
++      return nullptr;
++    }
++    return parser.steal();
++  }
++
++  static std::shared_ptr<Builder> tryFromJson(
++      uint8_t const* start, std::size_t size, Exception* error,
++      Options const* options = &Options::Defaults) {
++    return tryFromJson(reinterpret_cast<char const*>(start), size, error,
++                       options);
++  }
++
++  // Non-throwing variant of parse(): returns false if the input is not valid
++  // JSON; error() then describes the problem and errorPos() its position,
++  // and the contents of the builder are unspecified. Errors that are not
++  // caused by the input (e.g. allocation failures) are still thrown.
++  bool tryParse(char const* start, std::size_t size, bool multi = false) {
++    return tryParse(reinterpret_cast<uint8_t const*>(start), size, multi);
++  }
++
++  bool tryParse(uint8_t const* start, std::size_t size, bool multi = false) {
++    _start = start;
++    _size = size;
++    _pos = 0;
++    _nesting = 0;
++    _errorMsg = nullptr;
++    if (options->clearBuilderBeforeParse) {
++      _builder->clear();
++    }
++    ValueLength nr = 0;
++    return parseInternal(multi, nr);
++  }
++
++  // the error reported by the last failed tryParse()
++  Exception error() const {
++    return Exception(_errorType, _errorMsg != nullptr ? _errorMsg : "");
++  }
++
+   ValueLength parse(std::string const& json, bool multi = false) {
+     return parse(reinterpret_cast<uint8_t const*>(json.data()), json.size(),
+                  multi);
+@@ -187,7 +246,12 @@ class Parser {
+     if (options->clearBuilderBeforeParse) {
+       _builder->clear();
+     }
+-    return parseInternal(multi);
++    _errorMsg = nullptr;
++    ValueLength nr = 0;
++    if (!parseInternal(multi, nr)) {
++      throw error();
++    }
++    return nr;
+   }
+ 
+   // We probably want a parse from stream at some stage...
+@@ -230,52 +294,69 @@ class Parser {
+ 
+   inline void reset() { _pos = 0; }
+ 
+-  ValueLength parseInternal(bool multi);
++  bool parseInternal(bool multi, ValueLength& nr);
++
++  // records the error for tryParse() and returns false
++  bool fail(Exception::ExceptionType type, char const* msg) {
++    _errorType = type;
++    _errorMsg = msg;
++    return false;
++  }
++
++  bool fail(Exception::ExceptionType type) {
++    return fail(type, Exception::message(type));
++  }
+ 
+   inline bool isWhiteSpace(uint8_t i) const noexcept {
+     return (i == ' ' || i == '\t' || i == '\n' || i == '\r');
+   }
+ 
+   // skips over all following whitespace tokens but does not consume the
+-  // byte following the whitespace
++  // byte following the whitespace. returns the byte, or -1 after recording
++  // a parse error (unexpected end of input)
+   int skipWhiteSpace(char const*);
+ 
+-  void parseTrue() {
++  bool parseTrue() {
+     // Called, when main mode has just seen a 't', need to see "rue" next
+     if (consume() != 'r' || consume() != 'u' || consume() != 'e') {
+-      throw Exception(Exception::ParseError, "Expecting 'true'");
++      return fail(Exception::ParseError, "Expecting 'true'");
+     }
+     _builderPtr->addTrue();
++    return true;
+   }
+ 
+-  void parseFalse() {
++  bool parseFalse() {
+     // Called, when main mode has just seen a 'f', need to see "alse" next
+     if (consume() != 'a' || consume() != 'l' || consume() != 's' ||
+         consume() != 'e') {
+-      throw Exception(Exception::ParseError, "Expecting 'false'");
++      return fail(Exception::ParseError, "Expecting 'false'");
+     }
+     _builderPtr->addFalse();
++    return true;
+   }
+ 
+-  void parseNull() {
++  bool parseNull() {
+     // Called, when main mode has just seen a 'n', need to see "ull" next
+     if (consume() != 'u' || consume() != 'l' || consume() != 'l') {
+-      throw Exception(Exception::ParseError, "Expecting 'null'");
++      return fail(Exception::ParseError, "Expecting 'null'");
+     }
+     _builderPtr->addNull();
++    return true;
+   }
+ 
+-  void scanDigits(ParsedNumber& value) {
++  bool scanDigits(ParsedNumber& value) {
+     while (true) {
+       int i = consume();
+       if (i < 0) {
+-        return;
++        return true;
+       }
+       if (i < '0' || i > '9') {
+         unconsume();
+-        return;
++        return true;
++      }
++      if (!value.addDigit(i)) {
++        return fail(Exception::NumberOutOfRange);
+       }
+-      value.addDigit(i);
+     }
+   }
+ 
+@@ -296,10 +377,12 @@ class Parser {
+     }
+   }
+ 
+-  inline int getOneOrThrow(char const* msg) {
++  // returns the next byte, or -1 after recording a parse error
++  inline int getOneOrFail(char const* msg) {
+     int i = consume();
+     if (i < 0) {
+-      throw Exception(Exception::ParseError, msg);
++      fail(Exception::ParseError, msg);
++      return -1;
+     }
+     return i;
+   }
+@@ -308,15 +391,16 @@ class Parser {
+ 
+   inline void decreaseNesting() { --_nesting; }
+ 
+-  void parseNumber();
++  // the parse* functions return false after recording a parse error
++  bool parseNumber();
+ 
+-  void parseString();
++  bool parseString();
+ 
+-  void parseArray();
++  bool parseArray();
+ 
+-  void parseObject();
++  bool parseObject();
+ 
+-  void parseJson();
++  bool parseJson();
+ };
+ 
+ }  // namespace arangodb::velocypack
+diff -rupN velocypack-XYZ1.0.orig/src/Parser.cpp velocypack-XYZ1.0/src/Parser.cpp
+--- velocypack-XYZ1.0.orig/src/Parser.cpp	2026-09-08 11:08:55.919737589 +0800
++++ velocypack-XYZ1.0/src/Parser.cpp	2026-09-08 11:13:25.646994716 +0800
+@@ -34,12 +34,13 @@ using namespace arangodb::velocypack;
+ 
+ // The following function does the actual parse. It gets bytes
+ // via peek, consume and reset appends the result to the Builder
+-// in *_builderPtr. Errors are reported via an exception.
++// in *_builderPtr. Parse errors are recorded via fail() and reported
++// by returning false; parse() turns them into an exception.
+ // Behind the scenes it runs two parses, one to collect sizes and
+ // check for parse errors (scan phase) and then one to actually
+ // build the result (build phase).
+ 
+-ValueLength Parser::parseInternal(bool multi) {
++bool Parser::parseInternal(bool multi, ValueLength& nr) {
+   // skip over optional BOM
+   if (_size >= 3 && _start[0] == 0xef && _start[1] == 0xbb &&
+       _start[2] == 0xbf) {
+@@ -47,7 +48,7 @@ ValueLength Parser::parseInternal(bool m
+     _pos += 3;
+   }
+ 
+-  ValueLength nr = 0;
++  nr = 0;
+   do {
+     bool haveReported = false;
+     if (!_builderPtr->_stack.empty()) {
+@@ -63,31 +64,39 @@ ValueLength Parser::parseInternal(bool m
+         haveReported = true;
+       }
+     }
++    bool ok;
+     try {
+-      parseJson();
++      ok = parseJson();
+     } catch (...) {
+       if (haveReported) {
+         _builderPtr->cleanupAdd();
+       }
+       throw;
+     }
++    if (!ok) {
++      if (haveReported) {
++        _builderPtr->cleanupAdd();
++      }
++      return false;
++    }
+     nr++;
+     while (_pos < _size && isWhiteSpace(_start[_pos])) {
+       ++_pos;
+     }
+     if (!multi && _pos != _size) {
+       consume();  // to get error reporting right. return value intentionally not checked
+-      throw Exception(Exception::ParseError, "Expecting EOF");
++      return fail(Exception::ParseError, "Expecting EOF");
+     }
+   } while (multi && _pos < _size);
+-  return nr;
++  return true;
+ }
+ 
+ // skips over all following whitespace tokens but does not consume the
+ // byte following the whitespace
+ int Parser::skipWhiteSpace(char const* err) {
+   if (VELOCYPACK_UNLIKELY(_pos >= _size)) {
+-    throw Exception(Exception::ParseError, err);
++    fail(Exception::ParseError, err);
++    return -1;
+   }
+   uint8_t c = _start[_pos];
+   if (!isWhiteSpace(c)) {
+@@ -96,7 +105,8 @@ int Parser::skipWhiteSpace(char const* e
+   if (c == ' ') {
+     if (_pos + 1 >= _size) {
+       _pos++;
+-      throw Exception(Exception::ParseError, err);
++      fail(Exception::ParseError, err);
++      return -1;
+     }
+     c = _start[_pos + 1];
+     if (!isWhiteSpace(c)) {
+@@ -115,11 +125,12 @@ int Parser::skipWhiteSpace(char const* e
+     }
+     _pos++;
+   } while (_pos < _size);
+-  throw Exception(Exception::ParseError, err);
++  fail(Exception::ParseError, err);
++  return -1;
+ }
+ 
+ // parses a number value
+-void Parser::parseNumber() {
++bool Parser::parseNumber() {
+   std::size_t startPos = _pos;
+   ParsedNumber numberValue;
+   bool negative = false;
+@@ -127,16 +138,21 @@ void Parser::parseNumber() {
+   // We know that a character is coming, and it's a number if it
+   // starts with '-' or a digit. otherwise it's invalid
+   if (i == '-') {
+-    i = getOneOrThrow("Incomplete number");
++    i = getOneOrFail("Incomplete number");
++    if (i < 0) {
++      return false;
++    }
+     negative = true;
+   }
+   if (i < '0' || i > '9') {
+-    throw Exception(Exception::ParseError, "Expecting digit");
++    return fail(Exception::ParseError, "Expecting digit");
+   }
+ 
+   if (i != '0') {
+     unconsume();
+-    scanDigits(numberValue);
++    if (!scanDigits(numberValue)) {
++      return false;
++    }
+   }
+   i = consume();
+   if (i < 0 || (i != '.' && i != 'e' && i != 'E')) {
+@@ -160,15 +176,18 @@ void Parser::parseNumber() {
+     } else {
+       _builderPtr->addUInt(numberValue.intValue);
+     }
+-    return;
++    return true;
+   }
+ 
+   double fractionalPart;
+   if (i == '.') {
+     // fraction. skip over '.'
+-    i = getOneOrThrow("Incomplete number");
++    i = getOneOrFail("Incomplete number");
++    if (i < 0) {
++      return false;
++    }
+     if (i < '0' || i > '9') {
+-      throw Exception(Exception::ParseError, "Incomplete number");
++      return fail(Exception::ParseError, "Incomplete number");
+     }
+     unconsume();
+     fractionalPart = scanDigitsFractional();
+@@ -180,7 +199,7 @@ void Parser::parseNumber() {
+     i = consume();
+     if (i < 0) {
+       _builderPtr->addDouble(fractionalPart);
+-      return;
++      return true;
+     }
+   } else {
+     if (negative) {
+@@ -195,35 +214,44 @@ void Parser::parseNumber() {
+     // when interpreting and multiplying the single digits of the input stream
+     // _builderPtr->addDouble(fractionalPart);
+     _builderPtr->addDouble(atof(reinterpret_cast<char const*>(_start) + startPos));
+-    return;
++    return true;
++  }
++  i = getOneOrFail("Incomplete number");
++  if (i < 0) {
++    return false;
+   }
+-  i = getOneOrThrow("Incomplete number");
+   negative = false;
+   if (i == '+' || i == '-') {
+     negative = (i == '-');
+-    i = getOneOrThrow("Incomplete number");
++    i = getOneOrFail("Incomplete number");
++    if (i < 0) {
++      return false;
++    }
+   }
+   if (i < '0' || i > '9') {
+-    throw Exception(Exception::ParseError, "Incomplete number");
++    return fail(Exception::ParseError, "Incomplete number");
+   }
+   unconsume();
+   ParsedNumber exponent;
+-  scanDigits(exponent);
++  if (!scanDigits(exponent)) {
++    return false;
++  }
+   if (negative) {
+     fractionalPart *= pow(10, -exponent.asDouble());
+   } else {
+     fractionalPart *= pow(10, exponent.asDouble());
+   }
+   if (std::isnan(fractionalPart) || !std::isfinite(fractionalPart)) {
+-    throw Exception(Exception::NumberOutOfRange);
++    return fail(Exception::NumberOutOfRange);
+   }
+   // use conventional atof() conversion here, to avoid precision loss
+   // when interpreting and multiplying the single digits of the input stream
+   // _builderPtr->addDouble(fractionalPart);
+   _builderPtr->addDouble(atof(reinterpret_cast<char const*>(_start) + startPos));
++  return true;
+ }
+ 
+-void Parser::parseString() {
++bool Parser::parseString() {
+   // When we get here, we have seen a " character and now want to
+   // find the end of the string and parse the string value to its
+   // VPack representation. We assume that the string is short and
+@@ -254,7 +282,10 @@ void Parser::parseString() {
+       _pos += count;
+       _builderPtr->advance(count);
+     }
+-    int i = getOneOrThrow("Unfinished string");
++    int i = getOneOrFail("Unfinished string");
++    if (i < 0) {
++      return false;
++    }
+     if (!large && _builderPtr->_pos - (base + 1) > 126) {
+       large = true;
+       _builderPtr->reserve(8);
+@@ -277,12 +308,12 @@ void Parser::parseString() {
+             len >>= 8;
+           }
+         }
+-        return;
++        return true;
+       case '\\':
+-        // Handle cases or throw error
++        // Handle cases or fail
+         i = consume();
+         if (VELOCYPACK_UNLIKELY(i < 0)) {
+-          throw Exception(Exception::ParseError, "Invalid escape sequence");
++          return fail(Exception::ParseError, "Invalid escape sequence");
+         }
+         switch (i) {
+           case '"':
+@@ -316,8 +347,8 @@ void Parser::parseString() {
+             for (int j = 0; j < 4; j++) {
+               i = consume();
+               if (i < 0) {
+-                throw Exception(Exception::ParseError,
+-                                "Unfinished \\uXXXX escape sequence");
++                return fail(Exception::ParseError,
++                            "Unfinished \\uXXXX escape sequence");
+               }
+               if (i >= '0' && i <= '9') {
+                 v = (v << 4) + i - '0';
+@@ -326,8 +357,8 @@ void Parser::parseString() {
+               } else if (i >= 'A' && i <= 'F') {
+                 v = (v << 4) + i - 'A' + 10;
+               } else {
+-                throw Exception(Exception::ParseError,
+-                                "Illegal \\uXXXX escape sequence");
++                return fail(Exception::ParseError,
++                            "Illegal \\uXXXX escape sequence");
+               }
+             }
+             if (v < 0x80) {
+@@ -363,7 +394,7 @@ void Parser::parseString() {
+             break;
+           }
+           default:
+-            throw Exception(Exception::ParseError, "Invalid escape sequence");
++            return fail(Exception::ParseError, "Invalid escape sequence");
+         }
+         break;
+       default:
+@@ -371,7 +402,7 @@ void Parser::parseString() {
+           // non-UTF-8 sequence
+           if (VELOCYPACK_UNLIKELY(i < 0x20)) {
+             // control character
+-            throw Exception(Exception::UnexpectedControlCharacter);
++            return fail(Exception::UnexpectedControlCharacter);
+           }
+           highSurrogate = 0;
+           _builderPtr->appendByte(static_cast<uint8_t>(i));
+@@ -383,7 +414,7 @@ void Parser::parseString() {
+             // multi-byte UTF-8 sequence!
+             int follow = 0;
+             if ((i & 0xe0) == 0x80) {
+-              throw Exception(Exception::InvalidUtf8Sequence);
++              return fail(Exception::InvalidUtf8Sequence);
+             } else if ((i & 0xe0) == 0xc0) {
+               // two-byte sequence
+               follow = 1;
+@@ -394,16 +425,19 @@ void Parser::parseString() {
+               // four-byte sequence
+               follow = 3;
+             } else {
+-              throw Exception(Exception::InvalidUtf8Sequence);
++              return fail(Exception::InvalidUtf8Sequence);
+             }
+ 
+             // validate follow up characters
+             _builderPtr->reserve(1 + follow);
+             _builderPtr->appendByteUnchecked(static_cast<uint8_t>(i));
+             for (int j = 0; j < follow; ++j) {
+-              i = getOneOrThrow("scanString: truncated UTF-8 sequence");
++              i = getOneOrFail("scanString: truncated UTF-8 sequence");
++              if (i < 0) {
++                return false;
++              }
+               if ((i & 0xc0) != 0x80) {
+-                throw Exception(Exception::InvalidUtf8Sequence);
++                return fail(Exception::InvalidUtf8Sequence);
+               }
+               _builderPtr->appendByteUnchecked(static_cast<uint8_t>(i));
+             }
+@@ -415,15 +449,18 @@ void Parser::parseString() {
+   }
+ }
+ 
+-void Parser::parseArray() {
++bool Parser::parseArray() {
+   _builderPtr->addArray();
+ 
+   int i = skipWhiteSpace("Expecting item or ']'");
++  if (i < 0) {
++    return false;
++  }
+   if (i == ']') {
+     // empty array
+     ++_pos;  // the closing ']'
+     _builderPtr->close();
+-    return;
++    return true;
+   }
+ 
+   increaseNesting();
+@@ -431,30 +468,39 @@ void Parser::parseArray() {
+   while (true) {
+     // parse array element itself
+     _builderPtr->reportAdd();
+-    parseJson();
++    if (!parseJson()) {
++      return false;
++    }
+     i = skipWhiteSpace("Expecting ',' or ']'");
++    if (i < 0) {
++      return false;
++    }
+     if (i == ']') {
+       // end of array
+       ++_pos;  // the closing ']'
+       _builderPtr->close();
+       decreaseNesting();
+-      return;
++      return true;
+     }
+     // skip over ','
+     if (VELOCYPACK_UNLIKELY(i != ',')) {
+-      throw Exception(Exception::ParseError, "Expecting ',' or ']'");
++      return fail(Exception::ParseError, "Expecting ',' or ']'");
+     }
+     ++_pos;  // the ','
+   }
+ 
+   // should never get here
+   VELOCYPACK_ASSERT(false);
++  return false;
+ }
+ 
+-void Parser::parseObject() {
++bool Parser::parseObject() {
+   _builderPtr->addObject();
+ 
+   int i = skipWhiteSpace("Expecting item or '}'");
++  if (i < 0) {
++    return false;
++  }
+   if (i == '}') {
+     // empty object
+     consume();  // the closing '}'. return value intentionally not checked
+@@ -463,7 +509,7 @@ void Parser::parseObject() {
+       // only close if we've not been asked to keep top level open
+       _builderPtr->close();
+     }
+-    return;
++    return true;
+   }
+ 
+   increaseNesting();
+@@ -471,14 +517,16 @@ void Parser::parseObject() {
+   while (true) {
+     // always expecting a string attribute name here
+     if (VELOCYPACK_UNLIKELY(i != '"')) {
+-      throw Exception(Exception::ParseError, "Expecting '\"' or '}'");
++      return fail(Exception::ParseError, "Expecting '\"' or '}'");
+     }
+     // get past the initial '"'
+     ++_pos;
+ 
+     _builderPtr->reportAdd();
+     auto const lastPos = _builderPtr->_pos;
+-    parseString();
++    if (!parseString()) {
++      return false;
++    }
+ 
+     if (options->attributeTranslator != nullptr) {
+       // check if a translation for the attribute name exists
+@@ -501,15 +549,23 @@ void Parser::parseObject() {
+     }
+ 
+     i = skipWhiteSpace("Expecting ':'");
++    if (i < 0) {
++      return false;
++    }
+     // always expecting the ':' here
+     if (VELOCYPACK_UNLIKELY(i != ':')) {
+-      throw Exception(Exception::ParseError, "Expecting ':'");
++      return fail(Exception::ParseError, "Expecting ':'");
+     }
+     ++_pos;  // skip over the colon
+ 
+-    parseJson();
++    if (!parseJson()) {
++      return false;
++    }
+ 
+     i = skipWhiteSpace("Expecting ',' or '}'");
++    if (i < 0) {
++      return false;
++    }
+     if (i == '}') {
+       // end of object
+       ++_pos;  // the closing '}'
+@@ -518,53 +574,52 @@ void Parser::parseObject() {
+         _builderPtr->close();
+       }
+       decreaseNesting();
+-      return;
++      return true;
+     }
+     if (VELOCYPACK_UNLIKELY(i != ',')) {
+-      throw Exception(Exception::ParseError, "Expecting ',' or '}'");
++      return fail(Exception::ParseError, "Expecting ',' or '}'");
+     }
+     // skip over ','
+     ++_pos;  // the ','
+     i = skipWhiteSpace("Expecting '\"' or '}'");
++    if (i < 0) {
++      return false;
++    }
+   }
+ 
+   // should never get here
+   VELOCYPACK_ASSERT(false);
++  return false;
+ }
+ 
+-void Parser::parseJson() {
+-  skipWhiteSpace("Expecting item"); // return value intentionally not checked
++bool Parser::parseJson() {
++  if (skipWhiteSpace("Expecting item") < 0) {
++    return false;
++  }
+ 
+   int i = consume();
+   if (i < 0) {
+-    return;
++    return true;
+   }
+   switch (i) {
+     case '{':
+-      parseObject();  // this consumes the closing '}' or throws
+-      break;
++      return parseObject();  // this consumes the closing '}' or fails
+     case '[':
+-      parseArray();  // this consumes the closing ']' or throws
+-      break;
++      return parseArray();  // this consumes the closing ']' or fails
+     case 't':
+-      parseTrue();  // this consumes "rue" or throws
+-      break;
++      return parseTrue();  // this consumes "rue" or fails
+     case 'f':
+-      parseFalse();  // this consumes "alse" or throws
+-      break;
++      return parseFalse();  // this consumes "alse" or fails
+     case 'n':
+-      parseNull();  // this consumes "ull" or throws
+-      break;
++      return parseNull();  // this consumes "ull" or fails
+     case '"':
+-      parseString();
+-      break;
++      return parseString();
+     default: {
+       // everything else must be a number or is invalid...
+-      // this includes '-' and '0' to '9'. scanNumber() will
+-      // throw if the input is non-numeric
++      // this includes '-' and '0' to '9'. parseNumber() will
++      // fail if the input is non-numeric
+       unconsume();
+-      parseNumber();  // this consumes the number or throws
+-      break;
++      return parseNumber();  // this consumes the number or fails
+     }
+   }
+ }


### PR DESCRIPTION
## Why I'm doing:

`JsonValue::parse` hands text to `vpack::Parser::fromJson`, whose only way to report invalid input is a C++ exception. Every VARCHAR row that looks like JSON but is truncated or otherwise malformed therefore costs a full throw and unwind, and the unwinder serializes all threads on a process-wide lock (`_Unwind_Find_FDE` -> `dl_iterate_phdr`). Dirty data with many such rows turns `parse_json`, `get_json_string`, `json_query` and friends into a lock convoy: on a 20M-row table of truncated `{"a":1` strings, `get_json_string(s, '$.a')` took 263s with 3474s of system CPU and 83M context switches on a branch-3.5 build, while the same query over valid rows takes under a second.

Patch the vendored velocypack parser (thirdparty/patches, applied after the existing XYZ1.0 patch) to record parse errors and return false instead of throwing: `Parser::tryParse()` / `Parser::tryFromJson()` report failures through `Parser::error()`, while the existing `parse()` and `fromJson()` keep their throwing behaviour by rethrowing the same exception, so no other caller changes. The header defines `VELOCYPACK_HAS_TRY_PARSE`; `JsonValue::parse` and the variant text encoder use the non-throwing API when it is present and fall back to the current code on a toolchain image whose thirdparty predates the patch. Error codes, messages and `errorPos()` are unchanged: a harness parsing 203 inputs (valid documents, every prefix of a document, random byte mutations, bad escapes, control characters, invalid UTF-8, huge numbers, BOM, trailing garbage) against the original and patched library produced identical results for `parse()`, and `tryParse()` agreed with `parse()` on every input, with and without UTF-8 validation.

Measured on the branch-3.5 BE rebuilt against the patched library: valid rows parse at the same speed (parser micro-benchmark 159ns vs 157ns per small document, 1671ns vs 1690ns per 680-byte document), the truncated-row query drops from 263s to 0.8s, and rejecting one invalid document costs 124ns instead of 4.8us plus the global lock.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
