### PR TITLE
[Tool] ci-sync: compute the anti-loop flag per downstream, not once for both

### DIFF
--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -34,7 +34,8 @@ jobs:
           # Collapsing both into one flag is what silently starved mirrorship of every
           # cd-contributed change (the step showed `skipped` while the job stayed green).
           #
-          #   `sync` / `cd-sync` -> legacy CelerData reverse-sync markers. On StarRocks a
+          #   `sync`            -> legacy CelerData reverse-sync marker (`cd-sync`, retired,
+          #                        only ever co-occurred with it). On StarRocks a
           #                        `sync`-labelled PR is cd-origin: every one of them comes
           #                        from the old cd->sr executor (`<branch>-cd-sync-pr-*`
           #                        heads), and mirrorship->sr has never run. So this is a CD
@@ -53,9 +54,10 @@ jobs:
           if [[ "${labels}" =~ sync ]]; then
             skip_cd=true
           fi
-          # Exact whole-line match, like the mergify fallback below and
-          # contributed-backport-label.yml. The `sync` test above stays a substring match on
-          # purpose: it must keep catching the `cd-sync` label as well.
+          # Whole-line match, like the mergify fallback below and
+          # contributed-backport-label.yml. The `sync` test above is a substring match, so it
+          # also trips on any other label containing "sync" (e.g. the retired `cd-sync`);
+          # such a PR skips the CD path.
           echo "${labels}" | grep -qx 'cd-contributed' && skip_cd=true
           echo "${labels}" | grep -qx 'ms-contributed' && skip_ms=true
 
@@ -99,8 +101,12 @@ jobs:
           # sync picks it up again). Assert the contract instead of trusting merge order.
           # Failing loudly beats looping silently -- silence is what cost mirrorship three
           # weeks of changes in the first place.
-          if ! grep -q 'SKIP_CD' ./scripts/run-repo-sync.sh; then
-            echo "::error::ci-tool run-repo-sync.sh predates the SKIP_CD/SKIP_MS contract (stale /var/lib/ci-tool on this runner, or StarRocks/ci-tool#5248 not merged yet). Refusing to run: the CD anti-loop would be unenforced."
+          if [[ ! -f ./scripts/run-repo-sync.sh ]]; then
+            echo "::error::ci-tool checkout failed on this runner (no ./scripts/run-repo-sync.sh); the cp/cd above is swallowed by the || echo."
+            exit 1
+          fi
+          if ! grep -q 'SKIP_CD' ./scripts/run-repo-sync.sh || ! grep -q 'SKIP_MS' ./scripts/run-repo-sync.sh; then
+            echo "::error::ci-tool run-repo-sync.sh predates the SKIP_CD/SKIP_MS contract (stale /var/lib/ci-tool on this runner, or StarRocks/ci-tool#5248 not merged yet). Refusing to run: the anti-loop would be unenforced."
             exit 1
           fi
 

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -34,8 +34,14 @@ jobs:
           # Collapsing both into one flag is what silently starved mirrorship of every
           # cd-contributed change (the step showed `skipped` while the job stayed green).
           #
-          #   `sync`            -> legacy catch-all: the marker every sync-produced PR
-          #                        carries. Kept on BOTH paths as the old-sync fallback.
+          #   `sync` / `cd-sync` -> legacy CelerData reverse-sync markers. On StarRocks a
+          #                        `sync`-labelled PR is cd-origin: every one of them comes
+          #                        from the old cd->sr executor (`<branch>-cd-sync-pr-*`
+          #                        heads), and mirrorship->sr has never run. So this is a CD
+          #                        provenance marker and gates the CD path ONLY -- gating MS
+          #                        on it would repeat the very bug this commit fixes.
+          #                        (`sync` on the mirrorship side means something else: it
+          #                        marks every PR the FORWARD sr->ms sync opens there.)
           #   `cd-contributed`  -> came up from CelerData; skip the CD path only.
           #   `ms-contributed`  -> came up from mirrorship; skip the MS path only.
           #
@@ -46,11 +52,10 @@ jobs:
           skip_ms=false
           if [[ "${labels}" =~ sync ]]; then
             skip_cd=true
-            skip_ms=true
           fi
           # Exact whole-line match, like the mergify fallback below and
           # contributed-backport-label.yml. The `sync` test above stays a substring match on
-          # purpose: it is the legacy catch-all and must keep catching `cd-sync` too.
+          # purpose: it must keep catching the `cd-sync` label as well.
           echo "${labels}" | grep -qx 'cd-contributed' && skip_cd=true
           echo "${labels}" | grep -qx 'ms-contributed' && skip_ms=true
 

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -34,15 +34,11 @@ jobs:
           # Collapsing both into one flag is what silently starved mirrorship of every
           # cd-contributed change (the step showed `skipped` while the job stayed green).
           #
-          #   `sync`            -> legacy CelerData reverse-sync marker (`cd-sync`, retired,
-          #                        only ever co-occurred with it). On StarRocks a
-          #                        `sync`-labelled PR is cd-origin: every one of them comes
-          #                        from the old cd->sr executor (`<branch>-cd-sync-pr-*`
-          #                        heads), and mirrorship->sr has never run. So this is a CD
-          #                        provenance marker and gates the CD path ONLY -- gating MS
-          #                        on it would repeat the very bug this commit fixes.
-          #                        (`sync` on the mirrorship side means something else: it
-          #                        marks every PR the FORWARD sr->ms sync opens there.)
+          #   `sync`            -> legacy sync marker, kept as the catch-all: it gates BOTH
+          #                        paths. Substring match, so any other label containing
+          #                        "sync" (e.g. the retired `cd-sync`) trips it too. A
+          #                        `sync`-labelled change that mirrorship needs is
+          #                        backfilled by hand, not by this workflow.
           #   `cd-contributed`  -> came up from CelerData; skip the CD path only.
           #   `ms-contributed`  -> came up from mirrorship; skip the MS path only.
           #
@@ -53,11 +49,11 @@ jobs:
           skip_ms=false
           if [[ "${labels}" =~ sync ]]; then
             skip_cd=true
+            skip_ms=true
           fi
           # Whole-line match, like the mergify fallback below and
-          # contributed-backport-label.yml. The `sync` test above is a substring match, so it
-          # also trips on any other label containing "sync" (e.g. the retired `cd-sync`);
-          # such a PR skips the CD path.
+          # contributed-backport-label.yml. (The `sync` test above is a substring match; see
+          # the marker list.)
           echo "${labels}" | grep -qx 'cd-contributed' && skip_cd=true
           echo "${labels}" | grep -qx 'ms-contributed' && skip_ms=true
 

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -48,8 +48,11 @@ jobs:
             skip_cd=true
             skip_ms=true
           fi
-          [[ "${labels}" =~ cd-contributed ]] && skip_cd=true
-          [[ "${labels}" =~ ms-contributed ]] && skip_ms=true
+          # Exact whole-line match, like the mergify fallback below and
+          # contributed-backport-label.yml. The `sync` test above stays a substring match on
+          # purpose: it is the legacy catch-all and must keep catching `cd-sync` too.
+          echo "${labels}" | grep -qx 'cd-contributed' && skip_cd=true
+          echo "${labels}" | grep -qx 'ms-contributed' && skip_ms=true
 
           if [[ "$skip_cd" != "true" || "$skip_ms" != "true" ]]; then
             src=""
@@ -82,4 +85,18 @@ jobs:
           SKIP_MS: ${{ steps.commit_sha.outputs.skip_ms }}
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && timeout 60 git pull >/dev/null || echo "git pull timeout, using cached ci-tool"
+
+          # The CD anti-loop is no longer enforced by this step's `if` -- run-repo-sync.sh
+          # owns it via SKIP_CD. That script is fetched at run time and the `git pull` above
+          # deliberately tolerates failure, so a stale /var/lib/ci-tool checkout would run a
+          # pre-contract script that ignores SKIP_CD and pushes cd-contributed changes back
+          # to CelerData (ping-pong: the new CD PR carries no `sr-synced`, so TSP's reverse
+          # sync picks it up again). Assert the contract instead of trusting merge order.
+          # Failing loudly beats looping silently -- silence is what cost mirrorship three
+          # weeks of changes in the first place.
+          if ! grep -q 'SKIP_CD' ./scripts/run-repo-sync.sh; then
+            echo "::error::ci-tool run-repo-sync.sh predates the SKIP_CD/SKIP_MS contract (stale /var/lib/ci-tool on this runner, or StarRocks/ci-tool#5248 not merged yet). Refusing to run: the CD anti-loop would be unenforced."
+            exit 1
+          fi
+
           ./scripts/run-repo-sync.sh

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -89,14 +89,14 @@ jobs:
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && timeout 60 git pull >/dev/null || echo "git pull timeout, using cached ci-tool"
 
-          # The CD anti-loop is no longer enforced by this step's `if` -- run-repo-sync.sh
-          # owns it via SKIP_CD. That script is fetched at run time and the `git pull` above
-          # deliberately tolerates failure, so a stale /var/lib/ci-tool checkout would run a
-          # pre-contract script that ignores SKIP_CD and pushes cd-contributed changes back
-          # to CelerData (ping-pong: the new CD PR carries no `sr-synced`, so TSP's reverse
-          # sync picks it up again). Assert the contract instead of trusting merge order.
-          # Failing loudly beats looping silently -- silence is what cost mirrorship three
-          # weeks of changes in the first place.
+          # The anti-loop is no longer enforced by this step's `if` -- run-repo-sync.sh owns
+          # it via SKIP_CD / SKIP_MS. That script is fetched at run time and the `git pull`
+          # above deliberately tolerates failure, so a stale /var/lib/ci-tool checkout, or
+          # this workflow landing before StarRocks/ci-tool#5248, would run a pre-contract
+          # script that ignores both flags and dispatches back to the downstream the change
+          # came from -- a redundant sync PR there, and no signal that the anti-loop was
+          # bypassed. Assert the contract rather than trust merge order: failing loudly
+          # beats skipping silently, which is what cost mirrorship three weeks of changes.
           if [[ ! -f ./scripts/run-repo-sync.sh ]]; then
             echo "::error::ci-tool checkout failed on this runner (no ./scripts/run-repo-sync.sh); the cp/cd above is swallowed by the || echo."
             exit 1

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -24,41 +24,62 @@ jobs:
           set -x
           pr_info=$(gh pr view ${PR_NUMBER} -R ${{ github.repository }} --json mergeCommit,labels,title,headRefName)
           labels=`echo $pr_info | jq -r '.labels[].name'`
-          # Anti-loop: skip forward SR->CD sync for reverse-synced PRs. `sync` covers the SR
-          # main PR; `cd-contributed` covers its mergify backport PRs (which do NOT inherit
-          # `sync`; contributed-backport-label.yml adds cd-contributed to them).
-          is_sync=false
-          if [[ "${labels}" =~ sync || "${labels}" =~ cd-contributed ]]; then
-            is_sync=true
-          else
-            # Durable fallback (don't rely solely on the opened-time labeling): a mergify
-            # backport whose SOURCE main PR is cd-contributed must be skipped even if this
-            # backport PR itself is missing the label. Recompute from the source at merge time.
-            title=`echo $pr_info | jq -r '.title'`
-            head=`echo $pr_info | jq -r '.headRefName'`
+          title=`echo $pr_info | jq -r '.title'`
+          head=`echo $pr_info | jq -r '.headRefName'`
+
+          # Anti-loop, PER DOWNSTREAM. StarRocks fans out to two independent downstreams
+          # (CelerData and mirrorship, see ci-tool/scripts/run-repo-sync.sh), so a single
+          # `is_sync` gate on this whole step is wrong: a change contributed UP by one
+          # downstream is brand new to the OTHER one and must still be forwarded there.
+          # Collapsing both into one flag is what silently starved mirrorship of every
+          # cd-contributed change (the step showed `skipped` while the job stayed green).
+          #
+          #   `sync`            -> legacy catch-all: the marker every sync-produced PR
+          #                        carries. Kept on BOTH paths as the old-sync fallback.
+          #   `cd-contributed`  -> came up from CelerData; skip the CD path only.
+          #   `ms-contributed`  -> came up from mirrorship; skip the MS path only.
+          #
+          # Mergify backports do NOT inherit these labels, so recompute from the source
+          # main PR ("(backport #N)" / mergify/bp/.../pr-N) at merge time — same durable
+          # fallback as before, now applied to both markers.
+          skip_cd=false
+          skip_ms=false
+          if [[ "${labels}" =~ sync ]]; then
+            skip_cd=true
+            skip_ms=true
+          fi
+          [[ "${labels}" =~ cd-contributed ]] && skip_cd=true
+          [[ "${labels}" =~ ms-contributed ]] && skip_ms=true
+
+          if [[ "$skip_cd" != "true" || "$skip_ms" != "true" ]]; then
             src=""
             if [[ "$head" =~ ^mergify/bp/.*/pr-([0-9]+)$ ]]; then
               src="${BASH_REMATCH[1]}"
             else
               src=$(echo "$title" | grep -oP '\(backport #\K[0-9]+' | tail -n1 || true)
             fi
-            if [[ -n "$src" ]] && gh pr view "$src" -R ${{ github.repository }} --json labels -q '.labels[].name' | grep -qx 'cd-contributed'; then
-              is_sync=true
+            if [[ -n "$src" ]]; then
+              src_labels=$(gh pr view "$src" -R ${{ github.repository }} --json labels -q '.labels[].name' || true)
+              echo "${src_labels}" | grep -qx 'cd-contributed' && skip_cd=true
+              echo "${src_labels}" | grep -qx 'ms-contributed' && skip_ms=true
             fi
           fi
-          if [[ "$is_sync" == "true" ]]; then
-            echo "is_sync=true" >> $GITHUB_OUTPUT
-          else
-            commit_sha=`echo $pr_info | jq -r '.mergeCommit.oid'`
-            echo "commit_sha=${commit_sha:0:7}" >> $GITHUB_OUTPUT
-          fi
+
+          commit_sha=`echo $pr_info | jq -r '.mergeCommit.oid'`
+          echo "commit_sha=${commit_sha:0:7}" >> $GITHUB_OUTPUT
+          echo "skip_cd=${skip_cd}" >> $GITHUB_OUTPUT
+          echo "skip_ms=${skip_ms}" >> $GITHUB_OUTPUT
 
       - name: sync
-        if: steps.commit_sha.outputs.is_sync != 'true'
+        # Run unless BOTH downstreams are anti-looped; run-repo-sync.sh gates each
+        # dispatch on its own flag.
+        if: steps.commit_sha.outputs.skip_cd != 'true' || steps.commit_sha.outputs.skip_ms != 'true'
         env:
           PR_ID: ${{ github.event.number }}
           COMMIT_ID: ${{ steps.commit_sha.outputs.commit_sha }}
           BRANCH: ${{ github.base_ref }}
+          SKIP_CD: ${{ steps.commit_sha.outputs.skip_cd }}
+          SKIP_MS: ${{ steps.commit_sha.outputs.skip_ms }}
         run: |
           rm -rf ./ci-tool && cp -rf /var/lib/ci-tool ./ci-tool && cd ci-tool && timeout 60 git pull >/dev/null || echo "git pull timeout, using cached ci-tool"
           ./scripts/run-repo-sync.sh


### PR DESCRIPTION
## Why I'm doing:

`ci-sync.yml`'s `sync` step runs `ci-tool/scripts/run-repo-sync.sh`, which dispatches the same StarRocks change to **two independent downstreams**: `[Sync CD]` to `CelerData/celerdata-enterprise` and `[Sync MS]` to `MirrorshipOrg/mirrorship-enterprise`. Both sat behind one step-level gate, `if: steps.commit_sha.outputs.is_sync != 'true'`.

The `cd-contributed` marker is documented in `cd-repo-sync.yml` as a *forward SR→CD* anti-loop marker only. But because the two dispatches shared a single gate, it cancelled the mirrorship fan-out as well — even though a change contributed up by CelerData is brand new to mirrorship and must still be forwarded there.

The failure was invisible: the unit skipped is a *step*, so the `SYNC PIPELINE` run and its check stay green. Runs [34094007366](https://github.com/StarRocks/starrocks/actions/runs/34094007366) (#78731) and [33351201693](https://github.com/StarRocks/starrocks/actions/runs/33351201693) (#78382) both report `success` with `sync` = `skipped`.

Measured on `sync-check` build #2852 (2026-09-07): of the 41 commits reported missing from mirrorship, **32 are `cd-contributed`** (main 16 / branch-4.1 12 / branch-4.0 4), continuous over three weeks. Mergify-generated release-branch backports are affected identically (verified on #78402).

## What I'm doing:

Computing two flags instead of one and letting each downstream honour only its own marker:

| marker | `[Sync CD]` | `[Sync MS]` |
|---|---|---|
| `sync` | skip | skip |
| `cd-contributed` | skip | **forward** |
| `ms-contributed` | **forward** | skip |

- `sync` stays the catch-all and gates **both** paths; it is a substring match, so any other label containing "sync" (e.g. the retired `cd-sync`) trips it too. The three merged `sync`-labelled SR PRs that mirrorship is missing (#78301, #78039, #78038) are backfilled by hand — a separate operation from this gate.
- Only the `*-contributed` provenance markers are per-downstream.
- The step-level gate becomes `skip_cd != 'true' || skip_ms != 'true'`; the step now exports `SKIP_CD` / `SKIP_MS` and `run-repo-sync.sh` gates each dispatch.
- The durable mergify-backport fallback (recompute from the `(backport #N)` / `mergify/bp/.../pr-N` source main PR) is kept, now resolving both markers in a single lookup.
- `ms-contributed` does not exist on this repo yet, so `skip_ms` is currently always false — that is the intended unblocking, and it reserves the correct semantics for when the mirrorship→SR reverse sync is turned on. That reverse executor must apply `ms-contributed` to the SR PRs it opens before it goes live, or ms→sr→ms will loop.

- The step no longer enforces the anti-loop, so it asserts the contract before running: it checks that `./scripts/run-repo-sync.sh` exists and greps it for both `SKIP_CD` and `SKIP_MS`, failing with `::error::` otherwise. That `git pull` deliberately tolerates failure, so a stale `/var/lib/ci-tool` checkout — or this PR landing before StarRocks/ci-tool#5248 — would otherwise run a pre-contract script that ignores both flags and dispatches back to the downstream the change came from: a redundant sync PR there, and no signal that the anti-loop was bypassed. Merge order alone does not cover the stale-checkout path. Failing loudly beats skipping silently.
- The two new provenance markers are matched with `grep -qx` (whole line), like the mergify fallback in the same step and `contributed-backport-label.yml`. The `sync` test remains a substring match, so it also trips on any other label containing "sync" (e.g. the retired `cd-sync`, applied to 4 PRs in total, all closed and never merged, and never without `sync` beside it); such a PR skips both paths.

Companion PR: StarRocks/ci-tool#5248. **Merge that one first** — it is a no-op until this PR exports the flags. The reverse order would leave the old script ignoring `SKIP_CD` with the step-level gate already gone, sending `cd-contributed` changes straight back to CelerData.

Validated: the workflow parses (`yaml.safe_load`), and the decision logic was exercised against the real label sets:

```
skip_cd=true  skip_ms=false   #78731  cd-contributed         -> MS forwarded
skip_cd=true  skip_ms=true    #78301  sync (catch-all)       -> both skipped
skip_cd=false skip_ms=false   #78219  native SR PR           -> both forwarded
skip_cd=false skip_ms=true    (future ms-contributed)        -> CD forwarded
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

CI-only. Forward sync to mirrorship is no longer cancelled by the CelerData anti-loop marker. No product code is touched.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
