### PR TITLE
[BugFix] Adapt the CTAS files() pre-lock pass to branch-3.5

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -103,6 +103,10 @@ public class PlannerMetaLocker {
         return true;
     }
 
+    public boolean isEmpty() {
+        return tables.isEmpty();
+    }
+
     public void lock() {
         Locker locker = new Locker(queryId);
         for (Map.Entry<Long, Set<Long>> entry : tables.entrySet()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
@@ -421,10 +421,10 @@ class StatementPlannerTest extends PlanTestBase {
         // Without an internal table to lock there is no critical section to stay out of.
         assertFalse(locker.isEmpty(), "statement must lock at least one internal table: " + sql);
 
-        // close() drains the whole heldStack; unlock() would pop only one frame and leak a real
-        // read lock into the rest of the surefire fork if the statement ever locked twice.
-        try (PlannerMetaLocker ignored = locker) {
+        try {
             StatementPlanner.analyzeStatement(stmt, connectContext, locker);
+        } finally {
+            locker.unlock();
         }
 
         assertTrue(lockCalls.get() >= 1, "meta lock should be taken at least once");


### PR DESCRIPTION
Fixes the build of #78846 (mergify backport of #78772 to branch-3.5).

The cherry-pick applied cleanly but does not compile here:

```
StatementPlanner.java:[264,62] cannot find symbol
  symbol:   method isEmpty()
  location: variable locker of type com.starrocks.sql.analyzer.PlannerMetaLocker
```

`PlannerMetaLocker` on branch-3.5 has neither `isEmpty()` nor `AutoCloseable`;
main already had both. Two adaptations:

- Add `PlannerMetaLocker.isEmpty()` — used by the new guard in
  `StatementPlanner.analyzeStatement`.
- Release the locker in the test with `unlock()` in a `finally` instead of
  try-with-resources. This branch's locker has no `heldStack`, so `unlock()` is
  the symmetric release.

The fix itself is untouched — `StatementPlanner.java` is byte-identical to #78772.

Verified locally on this branch:

- `mvn test -pl fe-core -am -Dtest=StatementPlannerTest` — 14 tests, 0 failures
- `mvn checkstyle:check -pl fe-core` — BUILD SUCCESS
