### PR TITLE
[BugFix] Add PlannerMetaLocker.isEmpty() for the CTAS files() pre-lock pass

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PlannerMetaLocker.java
@@ -138,6 +138,10 @@ public class PlannerMetaLocker implements AutoCloseable {
         return true;
     }
 
+    public boolean isEmpty() {
+        return tables.isEmpty();
+    }
+
     public void lock() {
         Locker locker = new Locker(queryId);
         List<Map.Entry<Long, Set<Long>>> lockedEntries = new ArrayList<>(tables.size());


### PR DESCRIPTION
Fixes the build of #78844 (mergify backport of #78772 to branch-4.0).

The cherry-pick applied cleanly but does not compile here:

```
StatementPlanner.java: cannot find symbol
  symbol:   method isEmpty()
  location: variable locker of type com.starrocks.sql.analyzer.PlannerMetaLocker
```

`PlannerMetaLocker` on branch-4.0 has no `isEmpty()`; main already had it, and the
new guard in `StatementPlanner.analyzeStatement` uses it. Added in the same
position as main (right before `lock()`).

Unlike branch-3.5 (see #78853), this branch's `PlannerMetaLocker` is already
`AutoCloseable` with a `heldStack`, so the test needs no adaptation and stays
byte-identical to #78772. `StatementPlanner.java` is untouched.

Verified locally on this branch:

- `mvn test -pl fe-core -am -Dtest=StatementPlannerTest` — 15 tests, 0 failures
- `mvn checkstyle:check -pl fe-core` — BUILD SUCCESS
