### PR TITLE
[Tool] Retire the stale BoundingBox waivers

### DIFF
--- a/build-support/schema_compatibility_waivers.json
+++ b/build-support/schema_compatibility_waivers.json
@@ -9,46 +9,5 @@
     "reason": "Reviewed compatibility exception after a multi-release deprecation window.",
     "owner": "engprod"
   },
-  "waivers": [
-    {
-      "path": "gensrc/thrift/parquet.thrift",
-      "container_or_method": "BoundingBox",
-      "field_number": 1,
-      "field_name": "xmin",
-      "rule": "new_field_must_be_optional",
-      "base_signature": null,
-      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
-      "owner": "ViktorGo86"
-    },
-    {
-      "path": "gensrc/thrift/parquet.thrift",
-      "container_or_method": "BoundingBox",
-      "field_number": 2,
-      "field_name": "xmax",
-      "rule": "new_field_must_be_optional",
-      "base_signature": null,
-      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
-      "owner": "ViktorGo86"
-    },
-    {
-      "path": "gensrc/thrift/parquet.thrift",
-      "container_or_method": "BoundingBox",
-      "field_number": 3,
-      "field_name": "ymin",
-      "rule": "new_field_must_be_optional",
-      "base_signature": null,
-      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
-      "owner": "ViktorGo86"
-    },
-    {
-      "path": "gensrc/thrift/parquet.thrift",
-      "container_or_method": "BoundingBox",
-      "field_number": 4,
-      "field_name": "ymax",
-      "rule": "new_field_must_be_optional",
-      "base_signature": null,
-      "reason": "Apache Parquet defines this XY bound as required. Exception only for introducing this upstream field; existing-field type, deletion and ordinal checks remain active.",
-      "owner": "ViktorGo86"
-    }
-  ]
+  "waivers": []
 }

--- a/build-support/test_check_gensrc_schema_compatibility.py
+++ b/build-support/test_check_gensrc_schema_compatibility.py
@@ -390,21 +390,20 @@ class CheckGensrcSchemaCompatibilityTest(unittest.TestCase):
                 self.assertEqual(["unsupported_syntax"],
                                  [issue.rule for issue in module.check_repo(repo, mode="full", base="HEAD")])
 
-    def test_parquet_required_field_waivers_are_narrow(self) -> None:
+    def test_parquet_required_field_waivers_are_retired(self) -> None:
+        # The BoundingBox X/Y addition waivers were single-PR exceptions. Now that the
+        # comparison base carries the fields they can never match again, so keeping them
+        # would trip the stale-waiver check and leave a standing exception nobody reviewed.
         module = _load_module()
         waivers = module.load_waivers(MODULE_PATH.parent / "schema_compatibility_waivers.json")
         parquet_waivers = [w for w in waivers if w.path == "gensrc/thrift/parquet.thrift"]
-        self.assertEqual(4, len(parquet_waivers))
+        self.assertEqual([], parquet_waivers)
         for number, name in enumerate(("xmin", "xmax", "ymin", "ymax"), 1):
-            issue = module.Violation(path="gensrc/thrift/parquet.thrift", container="BoundingBox",
-                                     field_number=number, field_name=name, rule="new_field_must_be_optional",
-                                     detail="", remediation="")
-            self.assertIsNotNone(module._match_waiver(issue, parquet_waivers))
-            for rule in ("field_deleted", "field_type_changed", "field_renumbered"):
+            for rule in ("new_field_must_be_optional", "field_deleted", "field_type_changed", "field_renumbered"):
                 issue = module.Violation(path="gensrc/thrift/parquet.thrift", container="BoundingBox",
                                          field_number=number, field_name=name, rule=rule,
                                          detail="", remediation="")
-                self.assertIsNone(module._match_waiver(issue, parquet_waivers))
+                self.assertIsNone(module._match_waiver(issue, waivers))
 
     def test_changed_mode_rejects_unsupported_thrift_union_change(self) -> None:
         module = _load_module()

--- a/handbook/architecture/schema-compatibility-harness.md
+++ b/handbook/architecture/schema-compatibility-harness.md
@@ -35,7 +35,8 @@ the pre-existing union body. This is not general Thrift union support: other uni
 edits still fail closed, and parsed structs are checked independently even when
 an unsupported construct changes.
 
-The four upstream-required `BoundingBox` X/Y fields have field-specific
-`new_field_must_be_optional` waivers. These do not waive deletion, renumbering, or
-type changes. Remove these addition waivers once the comparison base contains the
-fields, as required by the stale-waiver check.
+The four upstream-required `BoundingBox` X/Y fields were introduced under
+field-specific `new_field_must_be_optional` waivers. Those addition waivers have
+been retired now that the comparison base contains the fields; keeping them would
+fail the stale-waiver check. The fields keep their upstream `required` cardinality,
+and the existing-field deletion, renumbering, and type checks stay active on them.


### PR DESCRIPTION
The four new_field_must_be_optional waivers went stale once the geospatial fields landed in the comparison base (introduced in #78701) , so the schema gate failed for any PR touching a full-scan trigger path. The fields keep their upstream required cardinality and stay covered by the deletion, renumbering, and type checks.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
