### PR TITLE
[BugFix] Do not hsync HDFS files on close

### DIFF
--- a/be/src/fs_ext/hdfs/fs_hdfs.cpp
+++ b/be/src/fs_ext/hdfs/fs_hdfs.cpp
@@ -365,17 +365,15 @@ Status HDFSWritableFile::close() {
     FileSystem::on_file_write_close(this);
     Status st = JavaEnv::GetInstance()->call_function_in_pthread([this]() {
         FAIL_POINT_TRIGGER_RETURN(output_stream_io_error, Status::IOError("injected output_stream_io_error"));
-        int r = hdfsHSync(_fs, _file);
-        TEST_SYNC_POINT_CALLBACK("HDFSWritableFile::close", &r);
+        // No hdfsHSync() here. hdfsCloseFile() already flushes the remaining
+        // packets, waits for the acks of every DataNode in the pipeline and
+        // completes the file on the NameNode, which is what other HDFS writers
+        // rely on. hsync additionally forces an fsync on every DataNode and can
+        // block for a long time on busy disks. Use sync() explicitly if the
+        // data must be on disk before close().
         auto st = Status::OK();
-        if (r == -1) {
-            auto error_msg = fmt::format("Fail to sync file {}: {}", _path, get_hdfs_err_msg());
-            LOG(WARNING) << error_msg;
-            st.update(Status::IOError(error_msg));
-        }
-
-        FAIL_POINT_TRIGGER_RETURN(output_stream_io_error, Status::IOError("injected output_stream_io_error"));
-        r = hdfsCloseFile(_fs, _file);
+        int r = hdfsCloseFile(_fs, _file);
+        TEST_SYNC_POINT_CALLBACK("HDFSWritableFile::close", &r);
         if (r == -1) {
             auto error_msg = fmt::format("Fail to close file {}: {}", _path, get_hdfs_err_msg());
             LOG(WARNING) << error_msg;

--- a/be/test/fs_ext/hdfs_filesystem_test.cpp
+++ b/be/test/fs_ext/hdfs_filesystem_test.cpp
@@ -63,8 +63,14 @@ void HdfsFileSystemTest::create_file_and_destroy() {
     EXPECT_TRUE(fs->new_sequential_file(filepath).ok());
     EXPECT_TRUE(fs->new_random_access_file(filepath).ok());
 
-    // error injection during HDFSWritableFile::close, it is hard to simulate a sync failure with a POSIX filesystem.
-    // HDFS FileSystem sync operation will fail if the file is removed from remote name node.
+    // done the file, check if there is any memory leak
+    (*wfile).reset();
+
+    // error injection during HDFSWritableFile::close, it is hard to simulate a close failure with a POSIX filesystem.
+    // HDFS FileSystem close operation will fail if the file is removed from remote name node.
+    std::string filepath2 = "file://" + _root_path + "/create_file_and_destroy_close_failure_file";
+    auto wfile2 = fs->new_writable_file(filepath2);
+    ASSERT_TRUE(wfile2.ok());
     SyncPoint::GetInstance()->SetCallBack("HDFSWritableFile::close", [](void* arg) { *(int*)arg = -1; });
     SyncPoint::GetInstance()->EnableProcessing();
 
@@ -73,8 +79,11 @@ void HdfsFileSystemTest::create_file_and_destroy() {
         SyncPoint::GetInstance()->DisableProcessing();
     });
 
-    // done the file, check if there is any memory leak
-    (*wfile).reset();
+    auto close_st = (*wfile2)->close();
+    EXPECT_TRUE(close_st.is_io_error()) << close_st;
+    // the file is marked closed even if hdfsCloseFile() failed, so a second close() is a no-op
+    EXPECT_TRUE((*wfile2)->close().ok());
+    (*wfile2).reset();
 }
 
 TEST_F(HdfsFileSystemTest, get_namenode_from_path) {


### PR DESCRIPTION

## Why I'm doing:
`HDFSWritableFile::close()` always calls `hdfsHSync()` before `hdfsCloseFile()`.

The hsync was introduced in #10522 to work around a BE crash on "open a file and close it immediately". That commit also changed `const std::string& _path` to `std::string _path`, which is what actually fixed the crash: the reference dangled after the constructor returned. HDFS creates the file on the NameNode at open time, so hsync is not needed for the file to be found after close.

`hdfsHSync()` forces an `fsync()` of the block file, its meta file and the directory on every DataNode of the write pipeline. On busy spinning disks a single fsync can block for minutes. The client meanwhile times out waiting for the pipeline ack (`dfs.client.socket-timeout + 5000 ms * nodes`), marks the wrong DataNodes as bad one by one, fails to add a replacement DataNode because the stuck one cannot transfer the block either, and the whole `INSERT` into a Hive/Iceberg table or `FILES()` fails with `Fail to sync file ... SocketTimeoutException`.

`hdfsCloseFile()` → `DFSOutputStream.close()` already flushes the remaining packets, waits for the acks of every DataNode in the pipeline and completes the file on the NameNode. That is the durability level Hive, Spark, Impala and the Iceberg Java writers rely on; none of them hsync before close. From the Hadoop `OutputStream`/`Syncable` spec: "HDFS does not immediately sync() the output of a written file to disk on OutputStream.close() unless configured with dfs.datanode.synconclose is true."

## What I'm doing:

- Remove the `hdfsHSync()` call from `HDFSWritableFile::close()`. `close()` now only does `hdfsCloseFile()`, the same as before #10522.
- `WritableFile::sync()` (`hdfsHSync()`) is unchanged and still available for callers that need the data on disk before `close()`.
- Move the `HDFSWritableFile::close` sync point to the `hdfsCloseFile()` result and fix `HdfsFileSystemTest.create_file_and_destroy`: the existing error injection was registered after the file had already been closed, so the callback never ran. The test now closes a second file with the injection active and asserts that `close()` returns an `IOError` and that a second `close()` is a no-op.
- The absence of hsync is not observable with the local-filesystem UT backend (`file://`). On a real HDFS cluster it can be checked with `strace -f -e trace=fsync -p <DataNode pid>` while an `INSERT INTO` a Hive/Iceberg table runs: with this change the DataNode should not fsync the BE's block files, and `Slow flushOrSync ... isSync:true` should not appear in the DataNode log for them. Before the change, a DataNode under heavy read I/O spent ~110 s in `FileChannelImpl.force()` for a single 8 MB block (stack trace in the linked issue).


Fixes #78863 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5
