### PR TITLE
[Enhancement] Consider NULL values in equality cardinality estimation using histograms

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -400,16 +400,17 @@ public class BinaryPredicateStatisticCalculator {
         Optional<Histogram> hist = enableJoinHistogram ?
                 updateHistWithJoin(leftColumnStatistic, leftColumn.getType(), rightColumnStatistic, rightColumn.getType()) :
                 Optional.empty();
+        double nonNullFactor = isEqualForNull ? 1 :
+                (1 - leftColumnStatistic.getNullsFraction()) * (1 - rightColumnStatistic.getNullsFraction());
         if (hist.isEmpty()) {
             double selectivity = 1.0 /
                     max(1, max(leftColumnStatistic.getDistinctValuesCount(), rightColumnStatistic.getDistinctValuesCount()));
-            rowCount = statistics.getOutputRowCount() * selectivity *
-                    (isEqualForNull ? 1 :
-                            (1 - leftColumnStatistic.getNullsFraction()) * (1 - rightColumnStatistic.getNullsFraction()));
+            rowCount = statistics.getOutputRowCount() * selectivity * nonNullFactor;
         } else {
             double selectivity = hist.get().getTotalRows() / (double)
                     (leftColumnStatistic.getHistogram().getTotalRows() * rightColumnStatistic.getHistogram().getTotalRows());
-            rowCount = statistics.getOutputRowCount() * selectivity;
+            // Histograms exclude nulls, so their selectivity is conditional on both operands being non-null.
+            rowCount = statistics.getOutputRowCount() * selectivity * nonNullFactor;
         }
 
         ColumnStatistic.Builder newLeftStatisticBuilder = ColumnStatistic.buildFrom(newEstimateColumnStatistics.build());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/HistogramStatisticsTest.java
@@ -282,6 +282,24 @@ public class HistogramStatisticsTest {
         Assertions.assertNotEquals(estimated.getColumnStatistic(leftColumnRefOperator).getHistogram(), leftHistogram);
         Assertions.assertNotEquals(estimated.getColumnStatistic(rightColumnRefOperator).getHistogram(), rightHistogram);
         Assertions.assertEquals(83576, estimated.getOutputRowCount(), 0.1);
+
+        // Histogram row counts exclude nulls, but the input cardinality still includes them.
+        double leftNullFraction = 0.2;
+        double rightNullFraction = 0.3;
+        Statistics statisticsWithNulls = Statistics.buildFrom(statistics)
+                .addColumnStatistic(leftColumnRefOperator,
+                        ColumnStatistic.buildFrom(statistics.getColumnStatistic(leftColumnRefOperator))
+                                .setNullsFraction(leftNullFraction)
+                                .build())
+                .addColumnStatistic(rightColumnRefOperator,
+                        ColumnStatistic.buildFrom(statistics.getColumnStatistic(rightColumnRefOperator))
+                                .setNullsFraction(rightNullFraction)
+                                .build())
+                .build();
+        Statistics estimatedWithNulls = PredicateStatisticsCalculator.statisticsCalculate(
+                binaryPredicateOperator, statisticsWithNulls);
+        Assertions.assertEquals(83576 * (1 - leftNullFraction) * (1 - rightNullFraction),
+                estimatedWithNulls.getOutputRowCount(), 0.1);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -1350,6 +1350,17 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
     }
 
     @Test
+    public void testWindowSkewMergeSortWithHistogramJoinNulls() throws Exception {
+        String dumpString = getDumpInfoFromFile("query_dump/window_skew_merge_sort");
+        QueryDumpInfo queryDumpInfo = getDumpInfoFromJson(dumpString);
+        Pair<QueryDumpInfo, String> replayPair =
+                getCostPlanFragment(dumpString, queryDumpInfo.getSessionVariable());
+        String plan = replayPair.second;
+
+        PlanTestBase.assertContains(plan, "ANALYTIC", "MERGING-EXCHANGE");
+    }
+
+    @Test
     public void testPushDownDistinctBelowWindowNoEmptyAnalytic() throws Exception {
         String dumpString = getDumpInfoFromFile(
                 "query_dump/push_down_distinct_below_window_empty_analytic");

--- a/fe/fe-core/src/test/resources/sql/query_dump/window_skew_merge_sort.json
+++ b/fe/fe-core/src/test/resources/sql/query_dump/window_skew_merge_sort.json
@@ -1,0 +1,88 @@
+{
+  "statement": "SELECT row_number() OVER (PARTITION BY d.k, d.g ORDER BY f.id) FROM synthetic.fact f LEFT OUTER JOIN synthetic.dim d ON f.fk = d.k",
+  "table_meta": {
+    "synthetic.fact": "CREATE TABLE `synthetic`.`fact` (`id` BIGINT NOT NULL, `fk` BIGINT NULL) ENGINE=OLAP DUPLICATE KEY(`id`) DISTRIBUTED BY HASH(`id`) BUCKETS 3 PROPERTIES (\"replication_num\" = \"1\");",
+    "synthetic.dim": "CREATE TABLE `synthetic`.`dim` (`k` BIGINT NOT NULL, `g` INT NULL) ENGINE=OLAP DUPLICATE KEY(`k`) DISTRIBUTED BY HASH(`k`) BUCKETS 3 PROPERTIES (\"replication_num\" = \"1\");"
+  },
+  "table_row_count": {
+    "synthetic.fact": {
+      "fact": 1000
+    },
+    "synthetic.dim": {
+      "dim": 1000
+    }
+  },
+  "column_statistics": {
+    "synthetic.fact": {
+      "id": {
+        "version": 1,
+        "min": "1.0",
+        "max": "1000.0",
+        "nullsFraction": "0.0",
+        "averageRowSize": "8.0",
+        "distinctValuesCount": "1000.0",
+        "collectionSize": "-1.0",
+        "type": "ESTIMATE"
+      },
+      "fk": {
+        "version": 1,
+        "min": "1.0",
+        "max": "1001.0",
+        "nullsFraction": "0.5",
+        "averageRowSize": "8.0",
+        "distinctValuesCount": "500.0",
+        "collectionSize": "-1.0",
+        "type": "ESTIMATE",
+        "histogram": {
+          "buckets": [
+            {
+              "lower": "1.0",
+              "upper": "1001.0",
+              "count": 500,
+              "upperRepeats": 1
+            }
+          ],
+          "mcv": {}
+        }
+      }
+    },
+    "synthetic.dim": {
+      "k": {
+        "version": 1,
+        "min": "1.0",
+        "max": "1001.0",
+        "nullsFraction": "0.0",
+        "averageRowSize": "8.0",
+        "distinctValuesCount": "1000.0",
+        "collectionSize": "-1.0",
+        "type": "ESTIMATE",
+        "histogram": {
+          "buckets": [
+            {
+              "lower": "1.0",
+              "upper": "1001.0",
+              "count": 1000,
+              "upperRepeats": 1
+            }
+          ],
+          "mcv": {}
+        }
+      },
+      "g": {
+        "version": 1,
+        "min": "0.0",
+        "max": "99.0",
+        "nullsFraction": "0.3",
+        "averageRowSize": "4.0",
+        "distinctValuesCount": "100.0",
+        "collectionSize": "-1.0",
+        "type": "ESTIMATE"
+      }
+    }
+  },
+  "session_variables": "{\"cbo_enable_histogram_join_estimation\":true,\"enable_window_skew_merge_sort\":true,\"enable_split_window_skew_to_union\":true,\"data_skew_row_percentage_threshold\":0.2}",
+  "be_number": 3,
+  "exception": [],
+  "version": "UNKNOWN",
+  "commit_version": "UNKNOWN"
+}


### PR DESCRIPTION
## Why I'm doing:

Currently, `estimateColumnEqualToColumn` when using histograms does not consider the NULL count correctly. Histograms do not include NULL values (they are ignored during collection already), hence`histogram.getTotalRows()` will also yield a row count without NULL values. We use this count for estimating the cardinality of the equality predicate though. If we have a lot of NULLs, the matching rows are overestimated massively. In the non-histogram estimation case, this was already considered and adjusted by multiplying a `nonNullFactor` to the estimate.

## What I'm doing:
Consider the NULL values for the histogram estimation case. 
Also adjusts tests and adds a query dump that replicates the problem where NULLs were significantly underestimated because the equality cardinality was overestimated, and a skew rewrite was not triggered where it should have been.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
