### PR TITLE
[BugFix] Register the script toString bindings as Wren getters

### DIFF
--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -117,10 +117,17 @@ static uint64_t get_minor_number(EditVersion& self) {
     return self.minor_number();
 }
 
+// Status::to_string() takes a defaulted argument, so its member pointer does not fit the
+// zero-argument getter form propReadonly() binds. Wrap it.
+static std::string status_to_string(Status& self) {
+    return self.to_string();
+}
+
 static void bind_common(ForeignModule& m) {
     {
         auto& cls = m.klass<Status>("Status");
         cls.func<&Status::to_string>("toString");
+        cls.propReadonlyExt<&status_to_string>("toString");
         REG_METHOD(Status, ok);
     }
 }
@@ -229,6 +236,7 @@ void bind_exec_env(ForeignModule& m) {
         REG_METHOD(MemTracker, peak_consumption);
         REG_METHOD(MemTracker, parent);
         cls.funcExt<&memtracker_debug_string>("toString");
+        cls.propReadonlyExt<&memtracker_debug_string>("toString");
     }
     {
         auto& cls = m.klass<FileWriteStat>("FileWriteStat");
@@ -484,6 +492,7 @@ public:
             REG_METHOD(TabletSchema, keys_type);
             REG_METHOD(TabletSchema, mem_usage);
             cls.func<&TabletSchema::debug_string>("toString");
+            cls.propReadonly<&TabletSchema::debug_string>("toString");
         }
         {
             auto& cls = m.klass<Tablet>("Tablet");
@@ -510,12 +519,14 @@ public:
         {
             auto& cls = m.klass<EditVersionPB>("EditVersionPB");
             cls.funcExt<&proto_to_json<EditVersionPB>>("toString");
+            cls.propReadonlyExt<&proto_to_json<EditVersionPB>>("toString");
         }
         {
             auto& cls = m.klass<EditVersionMetaPB>("EditVersionMetaPB");
             REG_METHOD(EditVersionMetaPB, version);
             REG_METHOD(EditVersionMetaPB, creation_time);
             cls.funcExt<&proto_to_json<EditVersionMetaPB>>("toString");
+            cls.propReadonlyExt<&proto_to_json<EditVersionMetaPB>>("toString");
         }
         {
             auto& cls = m.klass<TabletUpdatesPB>("TabletUpdatesPB");
@@ -525,12 +536,14 @@ public:
             REG_METHOD(TabletUpdatesPB, next_rowset_id);
             REG_METHOD(TabletUpdatesPB, next_log_id);
             cls.funcExt<&proto_to_json<TabletUpdatesPB>>("toString");
+            cls.propReadonlyExt<&proto_to_json<TabletUpdatesPB>>("toString");
         }
         {
             auto& cls = m.klass<EditVersion>("EditVersion");
             cls.funcExt<&get_major_number>("major_number");
             cls.funcExt<&get_minor_number>("minor_number");
             cls.func<&EditVersion::to_string>("toString");
+            cls.propReadonly<&EditVersion::to_string>("toString");
         }
         {
             auto& cls = m.klass<CompactionInfo>("CompactionInfo");

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3248,11 +3248,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         numeric id through getBackendOrComputeNode(), so either kind serves. Which node is
         picked does not matter for anything per-process and identical everywhere.
         """
-        node_ids = self.get_all_backend_ids()
-        if not node_ids:
-            res = self.execute_sql("show compute nodes;", ori=True)
-            tools.assert_true(res["status"], res["msg"])
-            node_ids = [str(row[0]) for row in res["result"]]
+        node_ids = self.get_all_backend_ids() or self.get_all_compute_node_ids()
 
         tools.assert_true(len(node_ids) > 0, "no backend or compute node to run ADMIN EXECUTE on")
         return node_ids[0]
@@ -3276,9 +3272,13 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         )
         return "OK"
 
-    def get_all_backend_ids(self) -> List[str]:
-        """Return ids of all alive backends (fallback to all rows if Alive not found)."""
-        res = self.execute_sql("show backends;", ori=True)
+    def _alive_node_ids(self, sql, id_column_names) -> List[str]:
+        """Ids of the alive rows of a `show backends`/`show compute nodes` style result.
+
+        Both listings include dead nodes, so the Alive column decides. It is only ignored when
+        the column is absent, in which case every row is returned rather than none.
+        """
+        res = self.execute_sql(sql, ori=True)
         tools.assert_true(res["status"], res["msg"])
 
         alive_idx = None
@@ -3286,24 +3286,32 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         for i, col_info in enumerate(res["desc"]):
             if col_info[0] == "Alive":
                 alive_idx = i
-            if col_info[0] in ("BackendId", "BackendID", "BackendId "):
+            if col_info[0] in id_column_names:
                 id_idx = i
         if id_idx is None:
             id_idx = 0
 
-        be_ids: List[str] = []
+        node_ids: List[str] = []
         if alive_idx is not None:
             for row in res["result"]:
                 try:
                     if str(row[alive_idx]).lower() == "true":
-                        be_ids.append(str(row[id_idx]))
+                        node_ids.append(str(row[id_idx]))
                 except Exception:
                     continue
         else:
             for row in res["result"]:
-                be_ids.append(str(row[id_idx]))
+                node_ids.append(str(row[id_idx]))
 
-        return be_ids
+        return node_ids
+
+    def get_all_backend_ids(self) -> List[str]:
+        """Return ids of all alive backends (fallback to all rows if Alive not found)."""
+        return self._alive_node_ids("show backends;", ("BackendId", "BackendID", "BackendId "))
+
+    def get_all_compute_node_ids(self) -> List[str]:
+        """Return ids of all alive compute nodes (empty on a shared-nothing cluster)."""
+        return self._alive_node_ids("show compute nodes;", ("ComputeNodeId", "ComputeNodeID"))
 
     def set_vlog_level_for_all_be(self, prefixes, level: int):
         """Set VLOG level for one or more file-prefix patterns on all alive backends.

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3240,6 +3240,29 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
 
         tools.assert_true(False, f"failed to get backend cpu cores [res={res}]")
 
+    def assert_admin_execute_prints(self, script, pattern):
+        """Run a Wren script on one backend and check the printed result against a regex.
+
+        ADMIN EXECUTE needs a concrete backend id, and `ALL BACKENDS` only exists on newer
+        versions, so the id is looked up here rather than written into the case. One backend is
+        enough: the bindings under test are per-process and identical on every node.
+        """
+        backend_ids = self.get_all_backend_ids()
+        tools.assert_true(len(backend_ids) > 0, "no alive backend to run ADMIN EXECUTE on")
+
+        sql = "admin execute on %s '%s'" % (backend_ids[0], script)
+        res = self.execute_sql(sql, ori=True)
+        tools.assert_true(res["status"], "%s failed: %s" % (sql, res.get("msg", "")))
+
+        printed = "\n".join("\t".join(str(cell) for cell in row) for row in res["result"])
+        tools.assert_regex(
+            printed,
+            pattern,
+            "ADMIN EXECUTE result does not match\n- [script]: %s\n- [exp]: %s\n- [act]: %s"
+            % (script, pattern, printed),
+        )
+        return "OK"
+
     def get_all_backend_ids(self) -> List[str]:
         """Return ids of all alive backends (fallback to all rows if Alive not found)."""
         res = self.execute_sql("show backends;", ori=True)

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3240,24 +3240,30 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
 
         tools.assert_true(False, f"failed to get backend cpu cores [res={res}]")
 
-    def get_any_backend_id(self) -> str:
-        """Return the id of one alive backend.
+    def get_any_worker_node_id(self) -> str:
+        """Return the id of one node that can run ADMIN EXECUTE.
 
-        ADMIN EXECUTE needs a concrete id, and `ALL BACKENDS` only exists on newer versions, so
-        cases look one up instead of naming a node. Which one does not matter for anything that
-        is per-process and identical on every node.
+        Takes the union of backends and compute nodes, the way _get_backend_http_endpoints()
+        does: a shared-data cluster may run only compute nodes, and ADMIN EXECUTE resolves a
+        numeric id through getBackendOrComputeNode(), so either kind serves. Which node is
+        picked does not matter for anything per-process and identical everywhere.
         """
-        backend_ids = self.get_all_backend_ids()
-        tools.assert_true(len(backend_ids) > 0, "no alive backend to run ADMIN EXECUTE on")
-        return backend_ids[0]
+        node_ids = self.get_all_backend_ids()
+        if not node_ids:
+            res = self.execute_sql("show compute nodes;", ori=True)
+            tools.assert_true(res["status"], res["msg"])
+            node_ids = [str(row[0]) for row in res["result"]]
 
-    def assert_backend_script_prints(self, backend_id, script, pattern):
-        """Run a Wren script on `backend_id` and match what it printed against a regex.
+        tools.assert_true(len(node_ids) > 0, "no backend or compute node to run ADMIN EXECUTE on")
+        return node_ids[0]
+
+    def assert_node_script_prints(self, node_id, script, pattern):
+        """Run a Wren script on `node_id` and match what it printed against a regex.
 
         The regex lives here because a `function:` result is compared for equality, and the
         printed text carries per-cluster numbers.
         """
-        sql = "admin execute on %s '%s'" % (backend_id, script)
+        sql = "admin execute on %s '%s'" % (node_id, script)
         res = self.execute_sql(sql, ori=True)
         tools.assert_true(res["status"], "%s failed: %s" % (sql, res.get("msg", "")))
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3240,7 +3240,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
 
         tools.assert_true(False, f"failed to get backend cpu cores [res={res}]")
 
-    def assert_admin_execute_prints(self, script, pattern):
+    def assert_any_backend_script_prints(self, script, pattern):
         """Run a Wren script on one backend and check the printed result against a regex.
 
         ADMIN EXECUTE needs a concrete backend id, and `ALL BACKENDS` only exists on newer

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3240,17 +3240,24 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
 
         tools.assert_true(False, f"failed to get backend cpu cores [res={res}]")
 
-    def assert_any_backend_script_prints(self, script, pattern):
-        """Run a Wren script on one backend and check the printed result against a regex.
+    def get_any_backend_id(self) -> str:
+        """Return the id of one alive backend.
 
-        ADMIN EXECUTE needs a concrete backend id, and `ALL BACKENDS` only exists on newer
-        versions, so the id is looked up here rather than written into the case. One backend is
-        enough: the bindings under test are per-process and identical on every node.
+        ADMIN EXECUTE needs a concrete id, and `ALL BACKENDS` only exists on newer versions, so
+        cases look one up instead of naming a node. Which one does not matter for anything that
+        is per-process and identical on every node.
         """
         backend_ids = self.get_all_backend_ids()
         tools.assert_true(len(backend_ids) > 0, "no alive backend to run ADMIN EXECUTE on")
+        return backend_ids[0]
 
-        sql = "admin execute on %s '%s'" % (backend_ids[0], script)
+    def assert_backend_script_prints(self, backend_id, script, pattern):
+        """Run a Wren script on `backend_id` and match what it printed against a regex.
+
+        The regex lives here because a `function:` result is compared for equality, and the
+        printed text carries per-cluster numbers.
+        """
+        sql = "admin execute on %s '%s'" % (backend_id, script)
         res = self.execute_sql(sql, ori=True)
         tools.assert_true(res["status"], "%s failed: %s" % (sql, res.get("msg", "")))
 

--- a/test/sql/test_script_bindings/R/test_script_object_tostring
+++ b/test/sql/test_script_bindings/R/test_script_object_tostring
@@ -1,14 +1,14 @@
--- name: test_script_object_tostring @native
-[UC]function: be_id=get_any_backend_id()
-function: assert_backend_script_prints('${be_id}', 'System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
+-- name: test_script_object_tostring
+[UC]function: node_id=get_any_worker_node_id()
+function: assert_node_script_prints('${node_id}', 'System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 -- result:
 OK
 -- !result
-function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_node_script_prints('${node_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK
 -- !result
-function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_node_script_prints('${node_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK
 -- !result

--- a/test/sql/test_script_bindings/R/test_script_object_tostring
+++ b/test/sql/test_script_bindings/R/test_script_object_tostring
@@ -1,28 +1,13 @@
 -- name: test_script_object_tostring @native
--- Wren resolves System.print(x) through the getter x.toString (wren.c, System.writeObject_).
--- The script bindings used to register toString as a method only, so printing a bound object
--- produced the placeholder "instance of <Class>" and the text was unreachable that way.
---
--- The scripts say GlobalEnv rather than RuntimeEnv, and the backend id is looked up rather
--- than named, because ALL BACKENDS and RuntimeEnv do not exist on every branch this reaches.
-
--- The id is environment specific, so it is captured rather than asserted.
 [UC]function: be_id=get_any_backend_id()
-
--- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
 function: assert_backend_script_prints('${be_id}', 'System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 -- result:
 OK
 -- !result
-
--- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
 function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK
 -- !result
-
--- The method spelling stays supported: before the getter existed it was the only way to reach
--- the text, so it is what existing scripts use.
 function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK

--- a/test/sql/test_script_bindings/R/test_script_object_tostring
+++ b/test/sql/test_script_bindings/R/test_script_object_tostring
@@ -3,24 +3,27 @@
 -- The script bindings used to register toString as a method only, so printing a bound object
 -- produced the placeholder "instance of <Class>" and the text was unreachable that way.
 --
--- GlobalEnv and StorageEngine are used rather than RuntimeEnv, because GlobalEnv is the
--- spelling that exists on every branch this is expected to reach.
+-- The scripts say GlobalEnv rather than RuntimeEnv, and the backend id is looked up rather
+-- than named, because ALL BACKENDS and RuntimeEnv do not exist on every branch this reaches.
+
+-- The id is environment specific, so it is captured rather than asserted.
+[UC]function: be_id=get_any_backend_id()
 
 -- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
-function: assert_any_backend_script_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
+function: assert_backend_script_prints('${be_id}', 'System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 -- result:
 OK
 -- !result
 
 -- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
-function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK
 -- !result
 
 -- The method spelling stays supported: before the getter existed it was the only way to reach
 -- the text, so it is what existing scripts use.
-function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK
 -- !result

--- a/test/sql/test_script_bindings/R/test_script_object_tostring
+++ b/test/sql/test_script_bindings/R/test_script_object_tostring
@@ -1,0 +1,24 @@
+-- name: test_script_object_tostring @native
+-- Wren resolves System.print(x) through the getter x.toString. The script bindings used to
+-- register toString as a method only, so printing a bound object produced the placeholder
+-- "instance of <Class>" and the text the binding exists to produce was unreachable.
+
+-- Status: the error message must reach the result cell. Tablet 1 does not exist, so
+-- do_compaction() returns InvalidArgument("Not Found tablet:1").
+admin execute on all backends 'System.print(StorageEngine.do_compaction(1, "base"))';
+-- result:
+[REGEX](?s).*Not Found tablet:1.*
+-- !result
+
+-- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
+admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker())';
+-- result:
+[REGEX](?s).*limit: -?\d+; reserve_limit: -?\d+; consumption: \d+.*
+-- !result
+
+-- The method spelling stays available, because before the getter existed it was the only way
+-- to obtain the text and is what existing scripts use.
+admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker().toString())';
+-- result:
+[REGEX](?s).*limit: -?\d+; reserve_limit: -?\d+; consumption: \d+.*
+-- !result

--- a/test/sql/test_script_bindings/R/test_script_object_tostring
+++ b/test/sql/test_script_bindings/R/test_script_object_tostring
@@ -1,24 +1,26 @@
 -- name: test_script_object_tostring @native
--- Wren resolves System.print(x) through the getter x.toString. The script bindings used to
--- register toString as a method only, so printing a bound object produced the placeholder
--- "instance of <Class>" and the text the binding exists to produce was unreachable.
+-- Wren resolves System.print(x) through the getter x.toString (wren.c, System.writeObject_).
+-- The script bindings used to register toString as a method only, so printing a bound object
+-- produced the placeholder "instance of <Class>" and the text was unreachable that way.
+--
+-- GlobalEnv and StorageEngine are used rather than RuntimeEnv, because GlobalEnv is the
+-- spelling that exists on every branch this is expected to reach.
 
--- Status: the error message must reach the result cell. Tablet 1 does not exist, so
--- do_compaction() returns InvalidArgument("Not Found tablet:1").
-admin execute on all backends 'System.print(StorageEngine.do_compaction(1, "base"))';
+-- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
+function: assert_admin_execute_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 -- result:
-[REGEX](?s).*Not Found tablet:1.*
+OK
 -- !result
 
 -- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
-admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker())';
+function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
-[REGEX](?s).*limit: -?\d+; reserve_limit: -?\d+; consumption: \d+.*
+OK
 -- !result
 
--- The method spelling stays available, because before the getter existed it was the only way
--- to obtain the text and is what existing scripts use.
-admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker().toString())';
+-- The method spelling stays supported: before the getter existed it was the only way to reach
+-- the text, so it is what existing scripts use.
+function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
-[REGEX](?s).*limit: -?\d+; reserve_limit: -?\d+; consumption: \d+.*
+OK
 -- !result

--- a/test/sql/test_script_bindings/R/test_script_object_tostring
+++ b/test/sql/test_script_bindings/R/test_script_object_tostring
@@ -7,20 +7,20 @@
 -- spelling that exists on every branch this is expected to reach.
 
 -- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
-function: assert_admin_execute_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
+function: assert_any_backend_script_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 -- result:
 OK
 -- !result
 
 -- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
-function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK
 -- !result
 
 -- The method spelling stays supported: before the getter existed it was the only way to reach
 -- the text, so it is what existing scripts use.
-function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 -- result:
 OK
 -- !result

--- a/test/sql/test_script_bindings/T/test_script_object_tostring
+++ b/test/sql/test_script_bindings/T/test_script_object_tostring
@@ -1,15 +1,17 @@
 -- name: test_script_object_tostring @native
--- Wren resolves System.print(x) through the getter x.toString. The script bindings used to
--- register toString as a method only, so printing a bound object produced the placeholder
--- "instance of <Class>" and the text the binding exists to produce was unreachable.
+-- Wren resolves System.print(x) through the getter x.toString (wren.c, System.writeObject_).
+-- The script bindings used to register toString as a method only, so printing a bound object
+-- produced the placeholder "instance of <Class>" and the text was unreachable that way.
+--
+-- GlobalEnv and StorageEngine are used rather than RuntimeEnv, because GlobalEnv is the
+-- spelling that exists on every branch this is expected to reach.
 
--- Status: the error message must reach the result cell. Tablet 1 does not exist, so
--- do_compaction() returns InvalidArgument("Not Found tablet:1").
-admin execute on all backends 'System.print(StorageEngine.do_compaction(1, "base"))';
+-- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
+function: assert_admin_execute_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 
 -- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
-admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker())';
+function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 
--- The method spelling stays available, because before the getter existed it was the only way
--- to obtain the text and is what existing scripts use.
-admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker().toString())';
+-- The method spelling stays supported: before the getter existed it was the only way to reach
+-- the text, so it is what existing scripts use.
+function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')

--- a/test/sql/test_script_bindings/T/test_script_object_tostring
+++ b/test/sql/test_script_bindings/T/test_script_object_tostring
@@ -1,20 +1,21 @@
--- name: test_script_object_tostring @native
+-- name: test_script_object_tostring
 -- Wren resolves System.print(x) through the getter x.toString (wren.c, System.writeObject_).
 -- The script bindings used to register toString as a method only, so printing a bound object
 -- produced the placeholder "instance of <Class>" and the text was unreachable that way.
 --
--- The scripts say GlobalEnv rather than RuntimeEnv, and the backend id is looked up rather
--- than named, because ALL BACKENDS and RuntimeEnv do not exist on every branch this reaches.
+-- The scripts say GlobalEnv rather than RuntimeEnv, and the node id is looked up rather than
+-- named, because ALL BACKENDS and RuntimeEnv do not exist on every branch this reaches. The
+-- lookup covers compute nodes too, so the case also runs on a shared-data cluster.
 
 -- The id is environment specific, so it is captured rather than asserted.
-[UC]function: be_id=get_any_backend_id()
+[UC]function: node_id=get_any_worker_node_id()
 
 -- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
-function: assert_backend_script_prints('${be_id}', 'System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
+function: assert_node_script_prints('${node_id}', 'System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 
 -- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
-function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_node_script_prints('${node_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 
 -- The method spelling stays supported: before the getter existed it was the only way to reach
 -- the text, so it is what existing scripts use.
-function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_node_script_prints('${node_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')

--- a/test/sql/test_script_bindings/T/test_script_object_tostring
+++ b/test/sql/test_script_bindings/T/test_script_object_tostring
@@ -1,0 +1,15 @@
+-- name: test_script_object_tostring @native
+-- Wren resolves System.print(x) through the getter x.toString. The script bindings used to
+-- register toString as a method only, so printing a bound object produced the placeholder
+-- "instance of <Class>" and the text the binding exists to produce was unreachable.
+
+-- Status: the error message must reach the result cell. Tablet 1 does not exist, so
+-- do_compaction() returns InvalidArgument("Not Found tablet:1").
+admin execute on all backends 'System.print(StorageEngine.do_compaction(1, "base"))';
+
+-- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
+admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker())';
+
+-- The method spelling stays available, because before the getter existed it was the only way
+-- to obtain the text and is what existing scripts use.
+admin execute on all backends 'System.print(RuntimeEnv.GetInstance().process_mem_tracker().toString())';

--- a/test/sql/test_script_bindings/T/test_script_object_tostring
+++ b/test/sql/test_script_bindings/T/test_script_object_tostring
@@ -3,15 +3,18 @@
 -- The script bindings used to register toString as a method only, so printing a bound object
 -- produced the placeholder "instance of <Class>" and the text was unreachable that way.
 --
--- GlobalEnv and StorageEngine are used rather than RuntimeEnv, because GlobalEnv is the
--- spelling that exists on every branch this is expected to reach.
+-- The scripts say GlobalEnv rather than RuntimeEnv, and the backend id is looked up rather
+-- than named, because ALL BACKENDS and RuntimeEnv do not exist on every branch this reaches.
+
+-- The id is environment specific, so it is captured rather than asserted.
+[UC]function: be_id=get_any_backend_id()
 
 -- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
-function: assert_any_backend_script_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
+function: assert_backend_script_prints('${be_id}', 'System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 
 -- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
-function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 
 -- The method spelling stays supported: before the getter existed it was the only way to reach
 -- the text, so it is what existing scripts use.
-function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_backend_script_prints('${be_id}', 'System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')

--- a/test/sql/test_script_bindings/T/test_script_object_tostring
+++ b/test/sql/test_script_bindings/T/test_script_object_tostring
@@ -7,11 +7,11 @@
 -- spelling that exists on every branch this is expected to reach.
 
 -- Status: tablet 1 does not exist, so do_compaction() returns InvalidArgument.
-function: assert_admin_execute_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
+function: assert_any_backend_script_prints('System.print(StorageEngine.do_compaction(1, "base"))', '.*Not Found tablet:1.*')
 
 -- MemTracker: debug_string() is a single line shaped "limit: N; reserve_limit: N; ...".
-function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
 
 -- The method spelling stays supported: before the getter existed it was the only way to reach
 -- the text, so it is what existing scripts use.
-function: assert_admin_execute_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')
+function: assert_any_backend_script_prints('System.print(GlobalEnv.GetInstance().process_mem_tracker().toString())', '.*limit: -?[0-9]+; reserve_limit: -?[0-9]+; consumption: [0-9]+.*')


### PR DESCRIPTION
## Why I'm doing:

`System.print(x)` on the script's foreign classes never printed the text those bindings exist to produce. Observed on a live BE:

```sql
mysql> ADMIN EXECUTE ON 10001 'System.print(HeapProf.getInstance().enable_prof())';
+--------------------+
| result             |
+--------------------+
| instance of Status |
+--------------------+
```

Wren resolves `System.print(x)` through the **getter** `x.toString`. The bindings registered `toString` as a **method**:

```cpp
cls.func<&Status::to_string>("toString");
```

wrenbind17 keeps methods and properties in separate tables and chooses between them on whether the Wren signature carries parentheses (`foreign.hpp`, `findSignature`):

```cpp
if (signature.find('(') != std::string::npos) {
        ... findFunc(signature, isStatic).getMethod();      // toString()
} else {
        return findProp(signature, isStatic).getGetter();   // toString
}
```

So the getter Wren looked for was never registered, and it fell back to the default representation. This is why an operator sees `instance of Status` instead of `OK` or the error message — for a `Status`, that means **a failure reports nothing at all**.

Seven classes are affected: `Status`, `MemTracker`, `TabletSchema`, `EditVersion`, `EditVersionPB`, `EditVersionMetaPB`, `TabletUpdatesPB`.

## What I'm doing:

Register the getter next to each existing method, rather than replacing it.

Replacing looked cleaner until the compatibility direction became clear: because the getter never worked, `System.print(x.toString())` is the **only spelling that has ever produced text**, so it is what any existing runbook or ad-hoc `ADMIN EXECUTE` string is likely to use. Dropping the method would break exactly the people who figured that out. Both spellings work now, since `foreign toString()` and `foreign toString` are distinct Wren signatures.

`Status` needs a small wrapper: `to_string(bool with_context_info = true) const` has a defaulted argument, so its member pointer does not match the zero-argument getter form `propReadonly()` binds (`ForeignGetterDetails` accepts only `R (C::*)()` and `R (C::*)() const`). The other member getters — `TabletSchema::debug_string()` and `EditVersion::to_string()` — fit directly, and the free-function ones go through `propReadonlyExt`.

After this, the statement above reports `OK`, and a failure reports its reason.

## Observability

This is purely a reporting fix for the diagnostic script surface: no signal is added or removed, but `ADMIN EXECUTE` output stops being a placeholder. `Status`-returning bindings — `HeapProf.enable_prof`/`disable_prof` and `StorageEngineRef.do_compaction` — now surface their message instead of `instance of Status`, which is the difference between a visible failure and a silent one.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

`ADMIN EXECUTE` result cells that used to read `instance of <Class>` now carry the object's text. Existing `.toString()` calls keep working.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

A SQL-Tester case covers it, since the behaviour only shows up through a live Wren VM inside `ADMIN EXECUTE` and `script_test` has no harness for driving one. It asserts through `Status` (from `StorageEngine.do_compaction(1, "base")`, whose message for a missing tablet is fixed) and `MemTracker` (whose `debug_string()` has a fixed shape), plus the `.toString()` spelling that has to keep working. The backend id is looked up by a helper rather than written into the case, and the scripts say `GlobalEnv`, because `ALL BACKENDS` and `RuntimeEnv` do not exist on 4.1/4.0. Beyond that, verified two ways — the four getter shapes were compiled in isolation against the vendored wrenbind17 (member const, member const with a defaulted argument via the wrapper, and free-function), and the method/getter split was read out of `findSignature`. `script.cpp` itself cannot be compiled on macOS (`bit_util.h` needs Linux `endian.h`), so it has not been built here; the statement above is the check to re-run on a real BE.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

