### PR TITLE
[BugFix] Batch-load Hudi partitions instead of re-reading rollback metadata per partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -100,6 +100,7 @@ public class RemoteFileOperations {
             isRecursive = params.getIsRecursive().get();
         }
         RemoteFileScanContext scanContext = new RemoteFileScanContext(table);
+        scanContext.scanPartitionPaths = partitions.stream().map(Partition::getFullPath).collect(Collectors.toList());
         Map<RemotePathKey, Partition> pathKeyToPartition = Maps.newHashMap();
         for (Partition partition : partitions) {
             RemotePathKey key = RemotePathKey.of(partition.getFullPath(), isRecursive);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileScanContext.java
@@ -19,6 +19,7 @@ import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
 
+import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
 /*
@@ -35,6 +36,11 @@ public class RemoteFileScanContext {
     }
 
     public String tableLocation = null;
+
+    // Every partition path this scan will touch, when the whole set is known before the first
+    // lookup happens. Connectors that can resolve many partitions in one call use it to do so
+    // instead of resolving them one by one. Null when the partitions are discovered lazily.
+    public List<String> scanPartitionPaths = null;
 
     // ---- concurrent initialization -----
     public ReentrantLock lock = new ReentrantLock();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiRemoteFileIO.java
@@ -80,11 +80,31 @@ public class HudiRemoteFileIO implements RemoteFileIO {
                             createInMemoryFileSystemViewWithTimeline(engineContext, metaClient, metadataConfig, timeline);
                     ctx.hudiLastInstant = lastInstant.get();
                     ctx.hudiTimeline = timeline;
+                    loadPartitionsUpfront(ctx);
                 }
             }
         } finally {
             ctx.lock.unlock();
         }
+    }
+
+    /**
+     * Resolve every partition of this scan in one call, when the whole set is known upfront.
+     * <p>
+     * A metadata-table backed view resolves one partition per lookup, and each lookup reopens the
+     * metadata readers, which re-reads the rollback metadata of the data table's timeline. Resolving
+     * the partitions one by one therefore re-reads that metadata once per partition, while a single
+     * batched call reads it once per metadata file slice.
+     */
+    private void loadPartitionsUpfront(RemoteFileScanContext ctx) {
+        if (ctx.scanPartitionPaths == null || ctx.scanPartitionPaths.isEmpty()) {
+            return;
+        }
+        StoragePath basePath = new StoragePath(ctx.tableLocation);
+        List<String> partitionNames = ctx.scanPartitionPaths.stream()
+                .map(path -> FSUtils.getRelativePartitionPath(basePath, new StoragePath(path)))
+                .collect(Collectors.toList());
+        ctx.hudiFsView.loadPartitions(partitionNames);
     }
 
     private void destroyHudiContext(RemoteFileScanContext ctx) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/RemoteFileOperationsTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static com.starrocks.connector.hive.MockedRemoteFileSystem.HDFS_HIVE_TABLE;
 import static io.airlift.concurrent.MoreFutures.getFutureValue;
@@ -439,5 +440,51 @@ public class RemoteFileOperationsTest {
         Assertions.assertEquals(4, result.get(1).getPartitionNames().size());
         Assertions.assertEquals(8, result.get(2).getPartitionNames().size());
         Assertions.assertEquals(2, result.get(3).getPartitionNames().size());
+    }
+
+    @Test
+    public void testScanContextCarriesEveryPartitionPath() {
+        FeConstants.runningUnitTest = true;
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        List<RemoteFileScanContext> observed = java.util.Collections.synchronizedList(new ArrayList<>());
+        RemoteFileIO capturingIO = new RemoteFileIO() {
+            @Override
+            public Map<RemotePathKey, List<RemoteFileDesc>> getRemoteFiles(RemotePathKey pathKey) {
+                observed.add(pathKey.getScanContext());
+                return com.google.common.collect.ImmutableMap.of(pathKey, Lists.newArrayList());
+            }
+
+            @Override
+            public org.apache.hadoop.fs.FileStatus[] getFileStatus(Path... files) {
+                return new org.apache.hadoop.fs.FileStatus[0];
+            }
+        };
+
+        CachingRemoteFileIO cachingIO = new CachingRemoteFileIO(capturingIO, executor, 10, 10, 0.1);
+        RemoteFileOperations ops = new RemoteFileOperations(cachingIO, executor, executor,
+                false, false, new Configuration());
+
+        HiveMetaClient client = new HiveMetastoreTest.MockedHiveMetaClient();
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        Map<String, Partition> partitions =
+                metastore.getPartitionsByNames("db1", "table1", Lists.newArrayList("col1=1", "col1=2"));
+        List<Partition> partitionList = Lists.newArrayList(partitions.values());
+
+        ops.getRemoteFiles(new HudiTable(), partitionList, GetRemoteFilesParams.newBuilder().build());
+
+        Assertions.assertEquals(partitionList.size(), observed.size());
+        // every partition lookup shares one context ...
+        RemoteFileScanContext context = observed.get(0);
+        Assertions.assertNotNull(context);
+        for (RemoteFileScanContext seen : observed) {
+            Assertions.assertSame(context, seen);
+        }
+        // ... and that context knows the whole partition set up front, so connectors able to
+        // resolve many partitions at once do not have to resolve them one by one.
+        Assertions.assertNotNull(context.scanPartitionPaths);
+        List<String> expected = partitionList.stream().map(Partition::getFullPath).sorted().collect(Collectors.toList());
+        List<String> actual = context.scanPartitionPaths.stream().sorted().collect(Collectors.toList());
+        Assertions.assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

With the Hudi metadata table enabled (`enable_hudi_lib_internal_metadata_table`, default `true`), planning a scan over a Hudi table with a long timeline can take minutes and trip `new_planner_optimize_timeout`.

`HudiRemoteFileIO` builds one `HoodieTableFileSystemView` per scan and then resolves **one partition per lookup**:

```
AbstractTableFileSystemView.getLatestMergedFileSlicesBeforeOrOn(partition)   // once per partition
└─ ensurePartitionLoadedCorrectly(String)
   └─ HoodieTableMetadata.getAllFilesInPartition
      └─ BaseTableMetadata.fetchAllFilesInPartition
         └─ getRecordByKey -> getRecordsByKeys([one key])
            └─ lookupKeysFromFileSlice
               ├─ getOrCreateReaders        // reuse == false -> openReaders, no caching
               │  └─ getLogRecordScanner
               │     └─ HoodieTableMetadataUtil.getValidInstantTimestamps
               │        └─ getRollbackedCommits -> readRollbackMetadata
               │           // reads every completed rollback/restore instant in range
               └─ closeReader               // reuse == false -> closed, next partition repeats
```

`createInMemoryFileSystemViewWithTimeline` reaches the `HoodieTableMetadata.create(engineContext, storage, metadataConfig, basePath)` overload, which hardcodes `reuse = false`. With `reuse = false` the metadata readers are never cached, so each partition reopens them, and each open recomputes `getValidInstantTimestamps` — `HoodieBackedTableMetadata` holds no field caching that set.

Scanning **N** partitions on a table with **R** completed rollback instants therefore costs roughly **N × R** metadata file reads. On object storage each read is a HEAD + GET, so this dominates planning: one affected table (1627 partitions, 150 rollback instants) spent 200–430s in `HMS.PARTITIONS.LIST_FS_PARTITIONS` alone.

## What I'm doing:

`RemoteFileOperations.getRemoteFiles` already holds the complete `List<Partition>` before the first lookup happens, so it now records those partition paths on the shared `RemoteFileScanContext`. `HudiRemoteFileIO` resolves that whole set in one `HoodieTableFileSystemView.loadPartitions(List)` call, right after it creates the view.

`loadPartitions` hands all keys to `getRecordsByKeys` at once, so the readers are opened **once per metadata file slice** instead of once per partition — the rollback metadata is read K times rather than N times (K = number of metadata file slices the key set hits; K = 1 for a single-file-group metadata table).

Nothing changes when the metadata table is disabled, and when the partition set is not known upfront (`scanPartitionPaths == null` — e.g. the async lazy-discovery path) the behavior is exactly as before.

### Measured

Built a real Hudi COW table with the metadata table enabled and counted `open()` calls on `.rollback` files with an instrumented `FileSystem`:

| partitions N | rollbacks R | before (per-partition) | N × R | after (`loadPartitions`) | metadata table off |
|---|---|---|---|---|---|
| 20 | 10 | 200 | 200 | 10 | 0 |
| 40 | 20 | 800 | 800 | 20 | 0 |
| 80 | 20 | 1600 | 1600 | 20 | 0 |
| 40 | 40 | 1600 | 1600 | 40 | 0 |
| 100 | 150 | 15000 | 15000 | 150 | 0 |

The `listStatus` counts are identical before and after, so no extra directory listing is introduced.

Running the patched `HudiRemoteFileIO` end to end over the same tables, submitting every partition to a 32-thread pool the way `RemoteFileOperations` does:

| partitions | rollbacks | rollback reads before → after | wall clock before → after |
|---|---|---|---|
| 20 | 20 | 400 → 20 | 4943ms → 34ms |
| 40 | 20 | 800 → 20 | 6939ms → 32ms |
| 80 | 20 | 1600 → 20 | 7221ms → 37ms |

Wall-clock figures are on a local filesystem; the read-count reduction is what carries over to object storage, where each avoided read is a HEAD + GET.

> Draft: still to do before this is ready for review — verification on a test cluster against a Hudi table on S3, to confirm the planning-time reduction end to end rather than only the read counts.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
