### PR TITLE
[BugFix] Ranger servicedef: allow SELECT on row-filter table resource

### DIFF
--- a/conf/ranger/ranger-servicedef-starrocks.json
+++ b/conf/ranger/ranger-servicedef-starrocks.json
@@ -668,7 +668,10 @@
         },
         "lookupSupported": true,
         "mandatory": true,
-        "uiHint": "{ \"singleValue\":true }"
+        "uiHint": "{ \"singleValue\":true }",
+        "accessTypeRestrictions": [
+          "select"
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Why I'm doing:

With the stock `conf/ranger/ranger-servicedef-starrocks.json` registered on Apache Ranger (2.4+, React UI), every StarRocks **Row Level Filter** policy shows an empty **Permissions** column and the "Add Permissions" popover offers no access type, so a row-filter item cannot be saved with `select` from the UI. Policies created through the REST API are stored with `select` and enforced correctly, so this is a servicedef/UI problem, not a plugin one.

Cause: `rowFilterDef.resources` only declare `name/mandatory/matcherOptions/uiHint`. Ranger's servicedef normalization fills the missing attributes, including `accessTypeRestrictions`, from the main resource of the same name. The main `table` resource restricts access types to DDL/DML (`select` is only allowed on `column`), so after registration the row-filter `table` resource carries `["drop","insert","update","refresh","delete","export","alter"]`. The Ranger UI intersects the row-filter access types (`select`) with that list and renders nothing.

## What I'm doing:

Declare `"accessTypeRestrictions": ["select"]` explicitly on the row-filter `table` resource so normalization does not inherit the DDL/DML list. Verified on a live Ranger by applying the same change with `PUT /service/public/v2/api/servicedef/{id}`: the `SELECT` chip renders and saves; policy evaluation is unchanged.

Fixes #78881

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5