### PR TITLE
[BugFix] Decode unaligned binary plain page offsets safely

### DIFF
--- a/be/src/storage/rowset/binary_plain_page.cpp
+++ b/be/src/storage/rowset/binary_plain_page.cpp
@@ -65,8 +65,9 @@ Status BinaryPlainPageDecoder<Type>::init() {
     _num_elems = decode_fixed32_le((const uint8_t*)&_data[_data.get_size() - sizeof(uint32_t)]);
     _offsets_pos = static_cast<uint32_t>(_data.get_size()) - (_num_elems + 1) * static_cast<uint32_t>(sizeof(uint32_t));
     if (!_delta_offset) {
-        // Absolute offsets: alias directly into the page (zero-copy).
-        _offsets_ptr = reinterpret_cast<uint32_t*>(_data.data + _offsets_pos);
+        // The string payload has arbitrary length, so the absolute-offset trailer is not
+        // guaranteed to be uint32-aligned. Keep it as bytes and decode each value safely.
+        _encoded_offsets = reinterpret_cast<const uint8_t*>(_data.data + _offsets_pos);
     } else {
         // Delta-encoded: prefix-sum the on-disk deltas into an owned absolute-offset array so
         // that every other decoder method (which expects absolute offsets) is unchanged.
@@ -77,10 +78,8 @@ Status BinaryPlainPageDecoder<Type>::init() {
             acc += decode_fixed32_le(deltas + i * sizeof(uint32_t));
             _abs_offsets[i] = acc;
         }
-        _offsets_ptr = _abs_offsets.data();
         _offsets_materialized = true;
     }
-    // TODO: align offset
 
     if (_data.size < config::small_dictionary_page_size) {
         _parsed_datas = std::vector<Slice>();
@@ -256,13 +255,7 @@ bool BinaryPlainPageDecoder<Type>::append_range(uint32_t idx, uint32_t end, Colu
             auto* dst_offsets = offsets_buf.data() + current_offset_sz;
             // vectorized loop
             for (uint32_t i = idx; i < end - 1; i++) {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-                auto offset = _offsets_ptr[i + 1];
-#else
-                // direct call offset_uncheck() will break auto-vectorized
-                // maybe we can remove this condition compile after we upgrade the toolchain
                 auto offset = offset_uncheck(i + 1);
-#endif
                 const uint64_t current_offset = begin_offset + static_cast<uint64_t>(offset - page_data_offset);
                 *dst_offsets++ = static_cast<OffsetValue>(current_offset);
             }
@@ -376,13 +369,7 @@ Status BinaryPlainPageDecoder<Type>::next_range_with_filter(
 
         const uint32_t page_data_offset = offset_uncheck(idx);
         for (uint32_t i = idx; i < end - 1; i++) {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-            auto offset = _offsets_ptr[i + 1];
-#else
-            // direct call offset_uncheck() will break auto-vectorized
-            // maybe we can remove this condition compile after we upgrade the toolchain
             auto offset = offset_uncheck(i + 1);
-#endif
 
             uint32_t current_offset = offset - page_data_offset;
             temp_offsets.set(i - idx + 1, current_offset);

--- a/be/src/storage/rowset/binary_plain_page.h
+++ b/be/src/storage/rowset/binary_plain_page.h
@@ -201,7 +201,7 @@ class BinaryPlainPageDecoder final : public PageDecoder {
 public:
     // delta_offset must match how the page was written (selected by the column encoding:
     // PLAIN_ENCODING_DELTA_OFFSET -> true). When true, init() reconstructs absolute offsets
-    // from the on-disk deltas; otherwise it aliases the absolute offsets in the page.
+    // from the on-disk deltas; otherwise it decodes absolute offsets from the page.
     explicit BinaryPlainPageDecoder(Slice data, bool delta_offset = false) : _data(data), _delta_offset(delta_offset) {}
 
     Status init() override;
@@ -306,13 +306,7 @@ public:
             using OffsetValue = typename std::decay_t<decltype(offsets_buf)>::value_type;
             offsets_buf[0] = 0; // Start from 0
             for (uint32_t i = 0; i < _num_elems - 1; ++i) {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-                auto offset = _offsets_ptr[i + 1];
-#else
-                // direct call offset_uncheck() will break auto-vectorized
-                // maybe we can remove this condition compile after we upgrade the toolchain
                 auto offset = offset_uncheck(i + 1);
-#endif
                 // Convert absolute offset to relative offset from base
                 uint32_t current_offset = offset - base_offset;
                 offsets_buf[i + 1] = static_cast<OffsetValue>(current_offset);
@@ -343,20 +337,10 @@ private:
     uint32_t offset(int idx) const { return idx < _num_elems ? offset_uncheck(idx) : _offsets_pos; }
 
     uint32_t offset_uncheck(int idx) const {
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-        // On little-endian, _offsets_ptr always points at native-order absolute offsets:
-        // either aliased into the page (legacy) or the reconstructed buffer (delta).
-        return _offsets_ptr[idx];
-#else
-        // On big-endian, delta pages were reconstructed into a native-order owned buffer in
-        // init(); read it directly. Legacy pages still decode the little-endian page bytes.
         if (_offsets_materialized) {
-            return _offsets_ptr[idx];
+            return _abs_offsets[idx];
         }
-        const uint32_t pos = _offsets_pos + idx * static_cast<uint32_t>(sizeof(uint32_t));
-        const auto* const p = reinterpret_cast<const uint8_t*>(&_data[pos]);
-        return decode_fixed32_le(p);
-#endif
+        return decode_fixed32_le(_encoded_offsets + idx * sizeof(uint32_t));
     }
 
     Status next_range_with_filter(uint32_t idx, uint32_t end, Column* dst,
@@ -386,13 +370,12 @@ private:
 
     uint32_t _num_elems{0};
     uint32_t _offsets_pos{0};
-    // Points at the absolute-offset array. For legacy pages this aliases into `_data`
-    // (zero-copy). For delta-encoded pages it points at `_abs_offsets`, reconstructed in init().
-    uint32_t* _offsets_ptr = nullptr;
+    // Points at the little-endian absolute-offset trailer for legacy pages. The trailer follows
+    // arbitrary-length string data and therefore must remain byte-addressed.
+    const uint8_t* _encoded_offsets = nullptr;
     // Owns the absolute offsets reconstructed from on-disk deltas; empty for legacy pages.
     std::vector<uint32_t> _abs_offsets;
-    // True when `_offsets_ptr` points at the native-order `_abs_offsets` buffer (delta pages)
-    // rather than aliasing the little-endian page bytes. Used by the big-endian read path.
+    // True when offsets were reconstructed into the native-order `_abs_offsets` buffer.
     bool _offsets_materialized = false;
 
     // Index of the currently seeked element in the page.

--- a/be/test/storage/rowset/binary_plain_page_test.cpp
+++ b/be/test/storage/rowset/binary_plain_page_test.cpp
@@ -36,6 +36,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
 #include <cstdio>
 #include <vector>
 
@@ -123,6 +124,29 @@ public:
 TEST_F(BinaryPlainPageTest, test_seek_by_value) {
     TestBinarySeekByValueSmallPage<BinaryPlainPageBuilder, BinaryPlainPageDecoder<TYPE_VARCHAR>, false>();
     TestBinarySeekByValueSmallPage<BinaryPlainPageBuilder, BinaryPlainPageDecoder<TYPE_VARCHAR>, true>();
+}
+
+TEST_F(BinaryPlainPageTest, test_unaligned_absolute_offset_trailer) {
+    PageBuilderOptions options;
+    options.data_page_size = 256 * 1024;
+    BinaryPlainPageBuilder builder(options);
+    Slice slices[] = {"a", "bc"};
+
+    ASSERT_EQ(2, builder.add(reinterpret_cast<const uint8_t*>(slices), 2));
+    OwnedSlice owned_slice = builder.finish()->build();
+    const Slice page = owned_slice.slice();
+    const size_t offsets_pos = page.size - (builder.count() + 1) * sizeof(uint32_t);
+    const auto trailer_address = reinterpret_cast<uintptr_t>(page.data + offsets_pos);
+    ASSERT_NE(0u, trailer_address % alignof(uint32_t));
+
+    BinaryPlainPageDecoder<TYPE_VARCHAR> decoder(page);
+    ASSERT_OK(decoder.init());
+
+    auto column = BinaryColumn::create();
+    size_t size = builder.count();
+    ASSERT_OK(decoder.next_batch(&size, column.get()));
+    ASSERT_EQ(2, size);
+    ASSERT_EQ("['a', 'bc']", column->debug_string());
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
## Why I'm doing:

`BinaryPlainPageDecoder` aliases the absolute-offset trailer after an arbitrary-length string payload as `uint32_t*`. If the payload length is not divisible by four, the trailer is not naturally aligned and indexed reads through that pointer invoke undefined behavior. This can be reported by UBSAN and may fault on strict-alignment architectures.

The existing binary plain page test data already demonstrates the page shape: `"Hello"`, `","`, and `"StarRocks"` produce a 15-byte payload followed by the offset trailer.

## What I'm doing:

- Keep legacy absolute-offset trailers byte-addressed.
- Decode every legacy absolute offset with `decode_fixed32_le`.
- Route append, filtered-read, and zero-copy offset construction through the same alignment-safe helper.
- Preserve the existing native-order materialized-offset path for delta-offset pages.
- Add `BinaryPlainPageTest.test_unaligned_absolute_offset_trailer`, which constructs a three-byte payload, verifies that the trailer is actually unaligned, and decodes both values.

The on-disk format and decoded results are unchanged for both legacy and delta-offset encodings.

Observability review: this decoder path does not own metrics, logs, traces, or profiles. The change only replaces undefined typed loads with alignment-safe decoding, so existing Status propagation and surrounding observability remain unchanged.

Fixes #78884

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Tests:

Passed locally:

- Docker image `starrocks/dev-env-ubuntu:latest` on Linux aarch64, Release build:
  ```bash
  ulimit -n 65536
  BUILD_TYPE=Release ./run-be-ut.sh \
    --build-target starrocks_dw_test \
    --module starrocks_dw_test \
    --gtest_filter BinaryPlainPageTest.test_unaligned_absolute_offset_trailer \
    --without-java-ext \
    --without-debug-symbol-split \
    --without-tenann \
    --without-paimon-cpp \
    --without-connector-benchmark \
    -j 2
  ```
  Result: `1 test from 1 test suite ran`; `[ PASSED ] 1 test`.
- `python3 build-support/check_be_module_boundaries.py --mode full`
- `python3 build-support/render_be_agents.py --check`
- `git diff --check`

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
