### PR TITLE
[BugFix] Delegate getDeleteFiles in UnifiedMetadata so Iceberg equality deletes work via unified catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.unified;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
@@ -52,10 +53,13 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.thrift.TSinkCommitInfo;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.starrocks.catalog.Table.TableType.DELTALAKE;
@@ -250,6 +254,13 @@ public class UnifiedMetadata implements ConnectorMetadata, DelegatingConnectorMe
     public List<PartitionInfo> getPartitions(Table table, List<String> partitionNames) {
         ConnectorMetadata metadata = metadataOfTable(table);
         return metadata.getPartitions(table, partitionNames);
+    }
+
+    @Override
+    public Set<DeleteFile> getDeleteFiles(IcebergTable icebergTable, Long snapshotId,
+                                          ScalarOperator predicate, FileContent fileContent) {
+        ConnectorMetadata metadata = metadataOfTable(icebergTable);
+        return metadata.getDeleteFiles(icebergTable, snapshotId, predicate, fileContent);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -16,6 +16,7 @@ package com.starrocks.connector.unified;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.DeltaLakeTable;
 import com.starrocks.catalog.HiveTable;
@@ -55,6 +56,8 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,6 +66,7 @@ import org.wildfly.common.Assert;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.starrocks.catalog.Table.TableType.DELTALAKE;
 import static com.starrocks.catalog.Table.TableType.HIVE;
@@ -303,6 +307,12 @@ public class UnifiedMetadataTest {
             }
 
             {
+                icebergMetadata.getDeleteFiles(icebergTable, 1L, null, FileContent.EQUALITY_DELETES);
+                result = ImmutableSet.of();
+                times = 1;
+            }
+
+            {
                 icebergMetadata.refreshTable("test_db", icebergTable, ImmutableList.of(), false);
                 times = 1;
             }
@@ -336,6 +346,9 @@ public class UnifiedMetadataTest {
         assertEquals(ImmutableList.of(), remoteFileInfos);
         List<PartitionInfo> partitionInfos = unifiedMetadata.getPartitions(icebergTable, ImmutableList.of());
         assertEquals(ImmutableList.of(), partitionInfos);
+        Set<DeleteFile> deleteFiles =
+                unifiedMetadata.getDeleteFiles(icebergTable, 1L, null, FileContent.EQUALITY_DELETES);
+        assertEquals(ImmutableSet.of(), deleteFiles);
         unifiedMetadata.refreshTable("test_db", icebergTable, ImmutableList.of(), false);
         unifiedMetadata.finishSink("test_db", "test_tbl", ImmutableList.of(), null);
         createTableStmt.setEngineName("iceberg");


### PR DESCRIPTION
## Why I'm doing:

Querying an Iceberg table that has **equality delete files** through a **Unified catalog** fails at plan time:

```
mysql> SELECT * FROM hive.db.table LIMIT 10;
ERROR 1064 (HY000): This connector doesn't support getting delete files
```

The same table works fine through an `iceberg` catalog pointing at the same Hive Metastore.

`IcebergEqualityDeleteRewriteRule` calls `ConnectorMetadata.getDeleteFiles(...)` via `MetadataMgr`. `UnifiedMetadata` delegates most Iceberg-specific calls (`getRemoteFiles`, `getPartitions`, `getSerializedMetaSpec`, `getTableStatistics`, ...) to the underlying `IcebergMetadata`, but it never overrides `getDeleteFiles`, so the default implementation in `ConnectorMetadata` throws.

Tables with only position deletes are not affected because they do not go through the equality-delete rewrite rule, which is why this only shows up on Flink CDC / upsert-style Iceberg tables.

Reproduced on 4.1.3 (`4.1.3-8a8e186`); the missing override is still present on `main`, `branch-4.1` and `branch-4.0`.

This was previously reported in #57393 and fixed by #57394 (approved in 2025-04 but never merged, now conflicting with `main`). The issue was auto-closed as stale. This PR supersedes #57394 and follows the same approach as #77749, which closed the analogous gaps for `TRUNCATE TABLE` / `ALTER TABLE` in the unified catalog.

## What I'm doing:

- `UnifiedMetadata`: override `getDeleteFiles` and delegate to the metadata of the table's actual type, consistent with the other Iceberg delegations in this class.
- `UnifiedMetadataTest`: extend the Iceberg delegation test to assert `getDeleteFiles` is forwarded to `IcebergMetadata`.

Fixes #57393
Supersedes #57394

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Queries on Iceberg tables with equality delete files through a Unified catalog now succeed instead of failing with `This connector doesn't support getting delete files`.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
