### PR TITLE
[Tool] reverse sync: rename cd-contributed label to PAI-contributed (dual-accept)

### DIFF
--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -10,7 +10,8 @@ run-name: "Repo Sync(CD PR #${{ inputs.PR_ID }} [${{ inputs.BRANCH }}])"
 # Labels on the created SR PR (see "compute labels" step) — NO `sync` label on purpose:
 # pr-checker/ci-pipeline skip sync-labeled PRs, and we WANT native CI + native auto-backport.
 # (`sync` is CelerData's opt-OUT of auto-backport; the reverse direction opts IN.)
-#   - `cd-contributed` : provenance + FORWARD anti-loop marker (forward SR->CD skips it)
+#   - `PAI-contributed`: provenance + FORWARD anti-loop marker (forward SR->CD skips it;
+#                        renamed from `cd-contributed`, consumers accept both in transition)
 #   - `<version>`      : from BACKPORT_BRANCHES (branch-4.1 -> 4.1), so ci-merged auto-
 #                        backports to SR release branches via mergify on merge
 #   - `SHA:<commit>`   : source recovery
@@ -165,7 +166,7 @@ jobs:
       # Build the SR PR label set. NO `sync` label on purpose: pr-checker / ci-pipeline skip
       # sync-labeled PRs, and we WANT the SR PR to run native CI and be auto-backported by
       # ci-merged's mergify. (`sync` is CelerData's opt-OUT of auto-backport; we opt IN.)
-      #   cd-contributed -> provenance + forward anti-loop marker
+      #   PAI-contributed -> provenance + forward anti-loop marker
       #   <version>      -> BACKPORT_BRANCHES mapped to SR version labels (branch-4.1 -> 4.1),
       #                     so ci-merged fans out to SR branches via mergify on merge
       #   SHA / conflict -> source recovery + conflict flag
@@ -174,9 +175,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
-          # Ensure the cd-contributed label exists (adding a non-existent label 422s).
-          gh label create cd-contributed -R ${{ github.repository }} -c 5319e7 -f >/dev/null 2>&1 || true
-          labels="cd-contributed"
+          # Ensure the PAI-contributed label exists (adding a non-existent label 422s).
+          # Renamed from cd-contributed; consumers (ci-sync.yml, contributed-backport-label.yml,
+          # sync_checker.py) accept both during the transition.
+          gh label create PAI-contributed -R ${{ github.repository }} -c 5319e7 -f >/dev/null 2>&1 || true
+          labels="PAI-contributed"
           for b in $(echo "${{ inputs.BACKPORT_BRANCHES }}" | tr ',' ' '); do
             v="${b#branch-}"
             [ -n "$v" ] && labels="${labels},${v}"

--- a/.github/workflows/cd-repo-sync.yml
+++ b/.github/workflows/cd-repo-sync.yml
@@ -176,8 +176,9 @@ jobs:
           GH_TOKEN: ${{ secrets.SYNC_PAT }}
         run: |
           # Ensure the PAI-contributed label exists (adding a non-existent label 422s).
-          # Renamed from cd-contributed; consumers (ci-sync.yml, contributed-backport-label.yml,
-          # sync_checker.py) accept both during the transition.
+          # Renamed from cd-contributed; consumers accept both during the transition:
+          # ci-sync.yml + contributed-backport-label.yml (this repo), and sync_checker.py
+          # (StarRocks/elastic-service, not this repo — updated in companion PR #1464).
           gh label create PAI-contributed -R ${{ github.repository }} -c 5319e7 -f >/dev/null 2>&1 || true
           labels="PAI-contributed"
           for b in $(echo "${{ inputs.BACKPORT_BRANCHES }}" | tr ',' ' '); do

--- a/.github/workflows/ci-sync.yml
+++ b/.github/workflows/ci-sync.yml
@@ -39,7 +39,8 @@ jobs:
           #                        "sync" (e.g. the retired `cd-sync`) trips it too. A
           #                        `sync`-labelled change that mirrorship needs is
           #                        backfilled by hand, not by this workflow.
-          #   `cd-contributed`  -> came up from CelerData; skip the CD path only.
+          #   `PAI-contributed` -> came up from CelerData; skip the CD path only.
+          #                        (renamed from `cd-contributed`; both accepted in transition.)
           #   `ms-contributed`  -> came up from mirrorship; skip the MS path only.
           #
           # Mergify backports do NOT inherit these labels, so recompute from the source
@@ -54,7 +55,8 @@ jobs:
           # Whole-line match, like the mergify fallback below and
           # contributed-backport-label.yml. (The `sync` test above is a substring match; see
           # the marker list.)
-          echo "${labels}" | grep -qx 'cd-contributed' && skip_cd=true
+          # Accept the old `cd-contributed` or the new `PAI-contributed` (rename transition).
+          echo "${labels}" | grep -qxE 'cd-contributed|PAI-contributed' && skip_cd=true
           echo "${labels}" | grep -qx 'ms-contributed' && skip_ms=true
 
           if [[ "$skip_cd" != "true" || "$skip_ms" != "true" ]]; then
@@ -66,7 +68,7 @@ jobs:
             fi
             if [[ -n "$src" ]]; then
               src_labels=$(gh pr view "$src" -R ${{ github.repository }} --json labels -q '.labels[].name' || true)
-              echo "${src_labels}" | grep -qx 'cd-contributed' && skip_cd=true
+              echo "${src_labels}" | grep -qxE 'cd-contributed|PAI-contributed' && skip_cd=true
               echo "${src_labels}" | grep -qx 'ms-contributed' && skip_ms=true
             fi
           fi

--- a/.github/workflows/contributed-backport-label.yml
+++ b/.github/workflows/contributed-backport-label.yml
@@ -2,20 +2,23 @@ name: Contributed Backport Label
 run-name: Contributed Backport Label(#${{ github.event.number }})
 
 # Anti-loop helper for the CD->SR reverse sync. A mergify backport PR does NOT inherit
-# labels, so backporting a `cd-contributed` main PR would lose the marker and let ci-sync.yml
+# labels, so backporting a `PAI-contributed` main PR would lose the marker and let ci-sync.yml
 # bounce the fix back to CelerData. When a backport PR opens against a release branch, if its
-# source main PR carries `cd-contributed`, add `cd-contributed` to this backport PR too —
+# source main PR carries the contributed marker, add `PAI-contributed` to this backport PR too —
 # before it can merge — so the forward anti-loop skips it.
 #
-# Generic name reserves room for other `*-contributed` sources later; today only
-# `cd-contributed` is handled.
+# RENAME TRANSITION (cd-contributed -> PAI-contributed): producers now emit `PAI-contributed`;
+# the source-PR check below accepts EITHER the old `cd-contributed` or the new `PAI-contributed`
+# so in-flight PRs still labeled with the old name keep working until they are migrated.
+#
+# Generic name reserves room for other `*-contributed` sources later.
 
 on:
   pull_request_target:
     types: [opened]
     # All release branches (glob) — no need to update when a new branch is cut. `main`
     # is not matched. Over-triggering is harmless: the job early-exits unless the PR is a
-    # backport whose source main PR carries cd-contributed.
+    # backport whose source main PR carries the contributed marker.
     branches:
       - 'branch-*'
 
@@ -26,7 +29,7 @@ permissions:
 
 jobs:
   add_label:
-    name: Add cd-contributed label to backport PRs
+    name: Add PAI-contributed label to backport PRs
     if: github.repository == 'StarRocks/starrocks'
     runs-on: ubuntu-latest
     env:
@@ -36,7 +39,7 @@ jobs:
       HEAD_REF: ${{ github.event.pull_request.head.ref }}
       TITLE: ${{ github.event.pull_request.title }}
     steps:
-      - name: add cd-contributed if source main PR has it
+      - name: add PAI-contributed if source main PR has it
         run: |
           set -eo pipefail
           # A mergify backport PR: head `mergify/bp/<branch>/pr-<SR_main>`, or title `(backport #N)`.
@@ -49,11 +52,12 @@ jobs:
           if [[ -z "$src" ]]; then
             echo "not a backport PR; nothing to do"; exit 0
           fi
-          # Does the source (main) PR carry cd-contributed?
-          if gh pr view "$src" -R "$REPO" --json labels -q '.labels[].name' | grep -qx 'cd-contributed'; then
-            gh label create cd-contributed -R "$REPO" -c 5319e7 -f >/dev/null 2>&1 || true
-            gh pr edit "$PR_NUMBER" -R "$REPO" --add-label cd-contributed
-            echo "added cd-contributed to #$PR_NUMBER (source main #$src)"
+          # Does the source (main) PR carry the contributed marker? Accept the old
+          # `cd-contributed` or the new `PAI-contributed` during the rename transition.
+          if gh pr view "$src" -R "$REPO" --json labels -q '.labels[].name' | grep -qxE 'cd-contributed|PAI-contributed'; then
+            gh label create PAI-contributed -R "$REPO" -c 5319e7 -f >/dev/null 2>&1 || true
+            gh pr edit "$PR_NUMBER" -R "$REPO" --add-label PAI-contributed
+            echo "added PAI-contributed to #$PR_NUMBER (source main #$src)"
           else
-            echo "source main #$src has no cd-contributed; skip"
+            echo "source main #$src has no contributed marker; skip"
           fi


### PR DESCRIPTION
## Why I'm doing:

The CD→SR reverse-sync provenance/anti-loop label is being rebranded from `cd-contributed` to `PAI-contributed` (PhoenixAI). The label is the load-bearing FORWARD anti-loop marker: forward SR→CD sync (`ci-sync.yml`) skips any PR carrying it, so if producers and consumers of the label ever disagree, a reverse-contributed PR would bounce back to CelerData (a sync loop). This PR renames it atomically with a dual-accept transition so nothing loops.

## What I'm doing:

Label-only rename (`cd-contributed` → `PAI-contributed`) across the reverse-sync flow:

- **Producers now emit `PAI-contributed`:** `cd-repo-sync.yml` (labels the reverse-synced SR PR), `contributed-backport-label.yml` (propagates the marker to mergify backport PRs, which don't inherit labels).
- **Consumers dual-accept `cd-contributed` OR `PAI-contributed`:** `ci-sync.yml` forward anti-loop (both the PR's own labels and the mergify-source fallback), `contributed-backport-label.yml` source-PR check. This keeps PRs already labeled with the old name working until they are migrated; a follow-up will relabel open PRs and then drop the old-name acceptance.

Out of scope (intentionally): the head branch naming `<branch>-cd-contributed-pr-<id>` is unchanged (internal, not user-visible; renaming it risks TSP dedup on in-flight PRs). `ms-contributed` (mirrorship provenance) is untouched.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5