### PR TITLE
[BugFix] Tolerate a light-added column that a lake segment does not contain

### DIFF
--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -344,10 +344,12 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
     // alter legitimately lacks the new column. Build only the indexes whose columns this segment
     // physically holds. Every uid here is already known to the logical schema (validated in run()),
     // so a miss is exactly the light-added case. If nothing is buildable, emit no IDG entry at all.
-    // Note this SKIPS rather than substituting the column's default: an index over synthesized
-    // defaults would advertise coverage of data the segment does not hold. Where a value must be
-    // materialized instead -- the delta-column-group rebuild in tablet_merger.cpp -- the default is
-    // substituted, because there is nothing to skip.
+    // Note this SKIPS rather than substituting the column's default. An index over the synthesized
+    // defaults would not be wrong -- every row of such a segment does read as the default -- but it
+    // would be unusable: with no physical column there is no column reader through which the entry
+    // could be consulted, so building it would only cost I/O. Where a value must instead be
+    // materialized -- the delta column group rebuild in tablet_merger.cpp -- the default is
+    // substituted, because a rebuilt .cols file has to carry every row.
     std::vector<TabletIndexPB> indexes_to_build;
     indexes_to_build.reserve(_indexes_to_build.size());
     for (const auto& ix : _indexes_to_build) {

--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -222,8 +222,10 @@ Status AddIndexSchemaChange::run(TxnLogPB_OpAddIndex* op_add_index) {
     // process-root tracker (or null in bare unit tests); both are safe.
     MemTracker* mem_tracker = CurrentThread::mem_tracker();
 
+    int total_segments = 0;
     for (const auto& rowset : base_metadata->rowsets()) {
         for (int seg_idx = 0; seg_idx < rowset.segment_metas_size(); ++seg_idx) {
+            ++total_segments;
             uint32_t rssid = get_rssid(rowset, seg_idx);
             // Capture by value to keep task self-contained; the `rowset`
             // reference would dangle if we captured by reference and the
@@ -260,6 +262,15 @@ Status AddIndexSchemaChange::run(TxnLogPB_OpAddIndex* op_add_index) {
         }
     }
     Status run_st = runner.wait();
+    if (run_st.ok() && op_add_index->segment_entries_size() < total_segments) {
+        // Both counts are read on this thread after every task has completed, so no synchronization
+        // is needed. Logged once per tablet: it gives an operator the denominator behind the
+        // segment_entries count, which is otherwise indistinguishable from a fully indexed tablet.
+        const int skipped = total_segments - op_add_index->segment_entries_size();
+        LOG(INFO) << "AddIndexSchemaChange: tablet " << _new_tablet.id() << " indexed "
+                  << op_add_index->segment_entries_size() << " of " << total_segments << " segments; " << skipped
+                  << " hold none of the indexed columns (light ADD COLUMN does not rewrite data)";
+    }
     if (!run_st.ok()) {
         // Best-effort remove any .idx files already written by tasks that
         // succeeded before the first failure. The caller (schema_change.cpp)
@@ -333,6 +344,10 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
     // alter legitimately lacks the new column. Build only the indexes whose columns this segment
     // physically holds. Every uid here is already known to the logical schema (validated in run()),
     // so a miss is exactly the light-added case. If nothing is buildable, emit no IDG entry at all.
+    // Note this SKIPS rather than substituting the column's default: an index over synthesized
+    // defaults would advertise coverage of data the segment does not hold. Where a value must be
+    // materialized instead -- the delta-column-group rebuild in tablet_merger.cpp -- the default is
+    // substituted, because there is nothing to skip.
     std::vector<TabletIndexPB> indexes_to_build;
     indexes_to_build.reserve(_indexes_to_build.size());
     for (const auto& ix : _indexes_to_build) {
@@ -340,9 +355,11 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
         for (int i = 0; i < ix.col_unique_id_size(); i++) {
             if (segment->column_with_uid(ix.col_unique_id(i)) == nullptr) {
                 segment_holds_every_column = false;
-                LOG(INFO) << "AddIndexSchemaChange: skip index " << ix.index_id() << " on segment " << rssid
-                          << " of tablet " << _new_tablet.id() << ": column uid " << ix.col_unique_id(i)
-                          << " is absent from the segment (light ADD COLUMN does not rewrite data)";
+                // Per segment per index, so INFO would be O(segments) on a wide tablet; run() logs a
+                // single per-tablet summary instead.
+                VLOG(2) << "AddIndexSchemaChange: skip index " << ix.index_id() << " on segment " << rssid
+                        << " of tablet " << _new_tablet.id() << ": column uid " << ix.col_unique_id(i)
+                        << " is absent from the segment (light ADD COLUMN does not rewrite data)";
                 break;
             }
         }
@@ -434,8 +451,11 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
     RETURN_IF_ERROR(idx_writer.finalize());
 
     // 4. Populate the IDG entry that the caller will hang off OpAddIndex. This MUST mirror the build
-    //    loop above: a key advertising an index the .idx file does not contain makes readers trust it
-    //    and fail with Corruption (column_reader.cpp bitmap/bloom lookup paths).
+    //    loop above, because the entry describes what the .idx file actually contains. A key for an
+    //    index the file lacks is wrong metadata: it is inert for a column the segment omits entirely
+    //    (the reader finds no column reader and never consults the entry), but a reader that does
+    //    reach such a key trusts it and fails with Corruption (column_reader.cpp bitmap/bloom
+    //    lookup paths).
     for (const auto& ix : indexes_to_build) {
         auto* k = out_entry->add_keys();
         k->set_col_unique_id(ix.col_unique_id(0));

--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -183,6 +183,25 @@ Status AddIndexSchemaChange::run(TxnLogPB_OpAddIndex* op_add_index) {
         op_add_index->add_new_indexes()->CopyFrom(ix);
     }
 
+    // Validate every declared index column against the LOGICAL schema up front. Only a uid that the
+    // schema knows may later be treated as "physically absent from this segment because a light
+    // ADD COLUMN did not rewrite data"; a uid the schema does not know at all is a caller error and
+    // must keep failing here rather than being silently skipped per segment.
+    {
+        auto tablet_schema = _new_tablet.get_schema();
+        for (const auto& ix : _indexes_to_build) {
+            if (ix.col_unique_id_size() == 0) {
+                return Status::InternalError("TabletIndex has no columns");
+            }
+            for (int i = 0; i < ix.col_unique_id_size(); i++) {
+                if (tablet_schema->field_index(ix.col_unique_id(i)) < 0) {
+                    return Status::InternalError(
+                            strings::Substitute("column with unique_id $0 not found in schema", ix.col_unique_id(i)));
+                }
+            }
+        }
+    }
+
     SegmentTaskRunner runner(_lake_schema_change_pool, config::lake_schema_change_per_tablet_parallelism);
 
     auto base_metadata = _base_tablet.metadata();
@@ -218,7 +237,12 @@ Status AddIndexSchemaChange::run(TxnLogPB_OpAddIndex* op_add_index) {
                 // on task exit, leaving the pool thread's TLS clean.
                 SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
                 IndexDeltaGroupEntryPB entry;
-                RETURN_IF_ERROR(build_idg_for_segment(rowset_copy, seg_idx, rssid, &entry));
+                bool built = false;
+                RETURN_IF_ERROR(build_idg_for_segment(rowset_copy, seg_idx, rssid, &entry, &built));
+                if (!built) {
+                    // This segment holds none of the indexed columns; leave it without an entry.
+                    return Status::OK();
+                }
                 std::lock_guard<std::mutex> lg(_op_mtx);
                 auto* se = op_add_index->add_segment_entries();
                 se->set_segment_id(rssid);
@@ -268,8 +292,9 @@ void AddIndexSchemaChange::cleanup_written_idx_files() {
 }
 
 Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowset_meta, uint32_t seg_idx_in_rowset,
-                                                   uint32_t rssid, IndexDeltaGroupEntryPB* out_entry) {
+                                                   uint32_t rssid, IndexDeltaGroupEntryPB* out_entry, bool* out_built) {
     DCHECK(out_entry != nullptr);
+    DCHECK(out_built != nullptr);
 
     const auto& seg_name = rowset_meta.segment_metas(seg_idx_in_rowset).filename();
     // segments in rowset_meta carry relative filenames; resolve them against
@@ -303,6 +328,32 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
                      _tablet_mgr->load_segment(seg_fileinfo, seg_idx_in_rowset, &footer_size_hint, read_opts,
                                                /*fill_meta_cache*/ true, tablet_schema));
 
+    // A light ADD COLUMN swaps the schema without rewriting data, so a segment written before the
+    // alter legitimately lacks the new column. Build only the indexes whose columns this segment
+    // physically holds. Every uid here is already known to the logical schema (validated in run()),
+    // so a miss is exactly the light-added case. If nothing is buildable, emit no IDG entry at all.
+    std::vector<TabletIndexPB> indexes_to_build;
+    indexes_to_build.reserve(_indexes_to_build.size());
+    for (const auto& ix : _indexes_to_build) {
+        bool segment_holds_every_column = true;
+        for (int i = 0; i < ix.col_unique_id_size(); i++) {
+            if (segment->column_with_uid(ix.col_unique_id(i)) == nullptr) {
+                segment_holds_every_column = false;
+                LOG(INFO) << "AddIndexSchemaChange: skip index " << ix.index_id() << " on segment " << rssid
+                          << " of tablet " << _new_tablet.id() << ": column uid " << ix.col_unique_id(i)
+                          << " is absent from the segment (light ADD COLUMN does not rewrite data)";
+                break;
+            }
+        }
+        if (segment_holds_every_column) {
+            indexes_to_build.push_back(ix);
+        }
+    }
+    if (indexes_to_build.empty()) {
+        *out_built = false;
+        return Status::OK();
+    }
+
     // 2. Allocate the .idx file. Default WritableFileOptions leave
     //    skip_fill_local_cache=false so writes populate local cache,
     //    mirroring the DCG .cols behaviour — the first query after the
@@ -332,7 +383,7 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
     //    IndexFileWriter. Unsupported types are a soft failure at this
     //    phase (NotSupported); the caller will abort the txn log and the
     //    .idx file will be garbage-collected as an orphan.
-    for (const auto& ix : _indexes_to_build) {
+    for (const auto& ix : indexes_to_build) {
         if (ix.col_unique_id_size() == 0) {
             return Status::InternalError("TabletIndex has no columns");
         }
@@ -381,8 +432,10 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
 
     RETURN_IF_ERROR(idx_writer.finalize());
 
-    // 4. Populate the IDG entry that the caller will hang off OpAddIndex.
-    for (const auto& ix : _indexes_to_build) {
+    // 4. Populate the IDG entry that the caller will hang off OpAddIndex. This MUST mirror the build
+    //    loop above: a key advertising an index the .idx file does not contain makes readers trust it
+    //    and fail with Corruption (column_reader.cpp bitmap/bloom lookup paths).
+    for (const auto& ix : indexes_to_build) {
         auto* k = out_entry->add_keys();
         k->set_col_unique_id(ix.col_unique_id(0));
         k->set_index_type(ix.index_type());
@@ -393,6 +446,7 @@ Status AddIndexSchemaChange::build_idg_for_segment(const RowsetMetadataPB& rowse
         out_entry->set_encryption_meta(encryption_meta);
     }
     out_entry->set_file_size(static_cast<int64_t>(idx_writer.file_size()));
+    *out_built = true;
     return Status::OK();
 }
 

--- a/be/src/storage/lake/add_index_schema_change.cpp
+++ b/be/src/storage/lake/add_index_schema_change.cpp
@@ -263,7 +263,8 @@ Status AddIndexSchemaChange::run(TxnLogPB_OpAddIndex* op_add_index) {
     if (!run_st.ok()) {
         // Best-effort remove any .idx files already written by tasks that
         // succeeded before the first failure. The caller (schema_change.cpp)
-        // will fall back to the legacy rewrite path; without this cleanup
+        // surfaces the error so FE cancels the alter -- it deliberately does
+        // NOT fall back to the legacy rewrite path -- so without this cleanup
         // the orphan .idx files would sit on object storage until a later
         // compaction or vacuum reclaims them, and could also confuse any
         // tool that scans segment dirs.

--- a/be/src/storage/lake/add_index_schema_change.h
+++ b/be/src/storage/lake/add_index_schema_change.h
@@ -42,9 +42,13 @@ class IndexFileWriter;
 // Orchestrates the ADD INDEX fast-path for a single lake tablet alter job.
 //
 // Given a base tablet + a set of new indexes, this class walks every
-// rowset/segment of the base tablet's visible version, builds one .idx file
-// per segment containing all new index blobs, and fills an OpAddIndex TxnLog
-// whose SegmentEntries reference the .idx files by relative path.
+// rowset/segment of the base tablet's visible version, builds at most one .idx
+// file per segment holding the indexes whose columns that segment physically
+// contains, and fills an OpAddIndex TxnLog whose SegmentEntries reference the
+// .idx files by relative path. A segment holding none of the indexed columns --
+// possible after a light ADD COLUMN, which does not rewrite data -- gets no
+// file and no entry. So SegmentEntries is not necessarily one per segment, and
+// an entry does not necessarily carry every requested index.
 //
 // Per-segment work is submitted to SegmentTaskRunner (which runs on the
 // dedicated lake_schema_change pool). Errors propagate through the runner's

--- a/be/src/storage/lake/add_index_schema_change.h
+++ b/be/src/storage/lake/add_index_schema_change.h
@@ -100,7 +100,8 @@ private:
     // Best-effort remove every .idx file whose path we recorded in
     // `_written_paths`. Called from `run()` when the overall build fails so
     // we don't leak objects on S3 when the ADD INDEX fast path aborts and
-    // the caller falls back to the legacy rewrite path. Errors here are
+    // the caller surfaces the error to cancel the alter -- it deliberately
+    // does NOT fall back to the legacy rewrite path. Errors here are
     // swallowed (logged): the cleanup is a courtesy, vacuum still reclaims
     // these files later as orphans.
     void cleanup_written_idx_files();

--- a/be/src/storage/lake/add_index_schema_change.h
+++ b/be/src/storage/lake/add_index_schema_change.h
@@ -75,8 +75,12 @@ private:
     // TabletManager::load_segment, opens one column iterator per index to
     // build, dispatches to the per-index-type builder, finalizes the
     // IndexFileWriter, and fills the caller-supplied IDG entry.
+    // |out_built| is set false when this segment holds none of the indexed columns -- a light
+    // ADD COLUMN does not rewrite data, so a pre-existing segment can legitimately lack one. The
+    // caller then emits no IDG entry for the segment; index presence is per segment
+    // (LakeIndexDeltaGroupLoader::load) and a reader with no entry falls back to an unindexed scan.
     Status build_idg_for_segment(const RowsetMetadataPB& rowset_meta, uint32_t seg_idx_in_rowset, uint32_t rssid,
-                                 IndexDeltaGroupEntryPB* out_entry);
+                                 IndexDeltaGroupEntryPB* out_entry, bool* out_built);
 
     // Build a BITMAP index for `column` of an already-opened Segment and
     // write its blob into `target_wfile`. The resulting ColumnIndexMetaPB is

--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -1316,12 +1316,20 @@ StatusOr<std::shared_ptr<Segment>> open_source_dcg_segment(TabletManager* tablet
                          /*partial_rowset_footer=*/nullptr, /*lake_io_opts=*/LakeIOOptions{}, tablet_manager);
 }
 
+// Which kind of segment a column range is being read from. A light ADD COLUMN
+// swaps the tablet schema without rewriting data, so a canonical data segment
+// written before it can legitimately lack a column the schema declares, and the
+// declared default is the right fill. A .cols file, by contrast, claims exactly
+// the UIDs listed in its DCG entry (TabletSchema::create_with_uid), so a column
+// missing there is corruption and must keep failing.
+enum class SegmentKind { CanonicalBase, DeltaColumnGroup };
+
 // Helper: read [row_begin, row_end) rows of |column_unique_id| from |segment|,
 // previously opened with |entry_schema| which must contain that UID. The
 // column values are appended to |destination|.
 Status read_column_range_from_segment(const std::shared_ptr<Segment>& segment, const TabletSchemaCSPtr& entry_schema,
                                       uint32_t column_unique_id, rowid_t row_begin, rowid_t row_end,
-                                      Column* destination) {
+                                      Column* destination, SegmentKind segment_kind) {
     const int32_t column_index = entry_schema->field_index(static_cast<ColumnUID>(column_unique_id));
     if (column_index < 0) {
         return Status::Corruption(
@@ -1330,7 +1338,10 @@ Status read_column_range_from_segment(const std::shared_ptr<Segment>& segment, c
     const auto& tablet_column = entry_schema->column(column_index);
     OlapReaderStatistics reader_statistics;
 
-    ASSIGN_OR_RETURN(auto column_iterator, segment->new_column_iterator(tablet_column, /*path=*/nullptr));
+    ASSIGN_OR_RETURN(auto column_iterator,
+                     segment_kind == SegmentKind::CanonicalBase
+                             ? segment->new_column_iterator_or_default(tablet_column, /*path=*/nullptr)
+                             : segment->new_column_iterator(tablet_column, /*path=*/nullptr));
 
     // Build a RandomAccessFile for the segment's file (required by
     // ColumnIteratorOptions::read_file). Segment's new_iterator path is too
@@ -1495,12 +1506,15 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
             if (window.is_gap) {
                 // No source DCG entry claims these rows (their old tablet was
                 // compacted away). They are masked by the merge gap delvec and
-                // never returned, so fill from the canonical base segment: real,
-                // already-indexed values keep the rebuilt .cols encodings and
-                // secondary indexes valid.
+                // never returned, so any valid value of the column is a correct
+                // fill; read the canonical base segment so the values stay
+                // consistent with the rest of the rebuilt .cols and its
+                // secondary indexes. A segment written before a light ADD COLUMN
+                // of this column does not contain it, and the declared default
+                // is substituted there.
                 RETURN_IF_ERROR(read_column_range_from_segment(base_segment, full_tablet_schema, unique_id,
                                                                window.range.begin(), window.range.end(),
-                                                               output_column.get()));
+                                                               output_column.get(), SegmentKind::CanonicalBase));
                 continue;
             }
             const DcgSurvivingEntry* selected_source = nullptr;
@@ -1511,7 +1525,7 @@ StatusOr<DeltaColumnGroupVerPB> rebuild_dcg_for_target_segment(
             ASSIGN_OR_RETURN(auto source_segment, get_source_segment(selected_source));
             RETURN_IF_ERROR(read_column_range_from_segment(source_segment, entry_schemas[selected_source], unique_id,
                                                            window.range.begin(), window.range.end(),
-                                                           output_column.get()));
+                                                           output_column.get(), SegmentKind::DeltaColumnGroup));
         }
 
         if (output_column->size() != static_cast<size_t>(num_rows_in_target)) {

--- a/be/test/storage/lake/add_index_schema_change_test.cpp
+++ b/be/test/storage/lake/add_index_schema_change_test.cpp
@@ -146,6 +146,40 @@ protected:
         return metadata;
     }
 
+    // A 6th column the base rowset writer does not write, so a segment written with the base schema
+    // legitimately lacks it -- the post-light-ADD-COLUMN state. `type` picks INT or VARCHAR so the
+    // same helper serves the bitmap/bloom cases and the ngram case.
+    int64_t publish_light_added_column(int64_t tablet_id, int64_t version, const char* name, const char* type) {
+        ASSIGN_OR_ABORT(auto published, _tablet_manager->get_tablet_metadata(tablet_id, version));
+        auto mutated = std::make_shared<TabletMetadata>(*published);
+        auto* schema = mutated->mutable_schema();
+        // A fresh schema id + bumped schema version, matching real schema evolution. WITHOUT this the
+        // helper is broken: TableSchemaService::_get_local_schema returns
+        // _tablet_mgr->get_cached_schema(schema_id) BEFORE consulting the tablet metadata
+        // (table_schema_service.cpp:145-149), and put_tablet_metadata refreshes the metadata caches
+        // but NOT the schema-id cache (tablet_manager.cpp:542). Since the rowset writers pass only
+        // schema->id() to DeltaWriterBuilder (add_index_schema_change_test.cpp:182), reusing the id
+        // would hand the six-column writer the stale FIVE-column schema (delta_writer.cpp:600) and it
+        // would emit another segment without c5 -- silently invalidating the "exactly one IDG entry"
+        // assertion.
+        schema->set_id(next_id());
+        schema->set_schema_version(schema->schema_version() + 1);
+        auto* col = schema->add_column();
+        col->set_unique_id(_c5_uid);
+        col->set_name(name);
+        col->set_type(type);
+        if (std::string(type) == "VARCHAR") {
+            col->set_length(32);
+        }
+        col->set_is_key(false);
+        col->set_is_nullable(true);
+        col->set_default_value("7");
+        col->set_aggregation("NONE");
+        CHECK_OK(_tablet_manager->put_tablet_metadata(*mutated));
+        CHECK_OK(_tablet_manager->create_schema_file(tablet_id, *schema));
+        return version;
+    }
+
     // Build a chunk with `nrows` rows and append it as a single segment via
     // DeltaWriter, advancing the tablet to version 2. Each call writes one
     // rowset; call twice to produce a 2-rowset / 2-segment tablet at v3.
@@ -229,6 +263,7 @@ protected:
     const int32_t _c2_uid = 102;
     const int32_t _c3_uid = 103;
     const int32_t _c4_uid = 104; // CHAR column, exercises feed_index_from_column's repad path
+    const int32_t _c5_uid = 105; // added by a light ADD COLUMN, absent from segments written earlier
 
     std::unique_ptr<MemTracker> _mem_tracker;
     std::shared_ptr<FixedLocationProvider> _location_provider;
@@ -1260,6 +1295,94 @@ TEST_F(AddIndexSchemaChangeTest, run_bitmap_pool_thread_inherits_mem_limit) {
     sc_tracker.release(sc_tracker.consumption());
     ASSERT_FALSE(st.ok());
     EXPECT_TRUE(st.is_mem_limit_exceeded()) << st.to_string();
+}
+
+// A light ADD COLUMN does not rewrite data, so a segment written before the alter legitimately lacks
+// the new column. Building an index on that column must succeed and simply emit no IDG entry for the
+// segment -- index presence is per segment (LakeIndexDeltaGroupLoader::load returns OK with an empty
+// result), and a reader with no entry falls back to an unindexed scan with the predicate retained.
+TEST_F(AddIndexSchemaChangeTest, run_bitmap_on_light_added_column_emits_no_entry) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/5);
+    version = publish_light_added_column(base_tablet_id, version, "c5", "INT");
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BITMAP, _c5_uid)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    TxnLogPB_OpAddIndex op;
+    ASSERT_OK(sc.run(&op));
+    EXPECT_EQ(0, op.segment_entries_size()) << "the only segment has no c5, so no entry may be emitted";
+}
+
+// Regression guard for the mixed-index case. With two indexes where the segment holds one column and
+// not the other, the .idx file contains only the buildable index -- so the IDG entry must advertise
+// only that one. Advertising both would make a reader trust a key the file lacks and return
+// Corruption (column_reader.cpp bitmap/bloom lookup paths).
+TEST_F(AddIndexSchemaChangeTest, run_mixed_indexes_advertises_only_the_buildable_one) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/5);
+    version = publish_light_added_column(base_tablet_id, version, "c5", "INT");
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BITMAP, _c1_uid),  // present in the segment
+                                       make_index(IndexType::BITMAP, _c5_uid)}; // absent
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    TxnLogPB_OpAddIndex op;
+    ASSERT_OK(sc.run(&op));
+    ASSERT_EQ(1, op.segment_entries_size());
+    const auto& entry = op.segment_entries(0).entry();
+    ASSERT_EQ(1, entry.keys_size()) << "the entry must not advertise an index the .idx file lacks";
+    EXPECT_EQ(_c1_uid, entry.keys(0).col_unique_id());
+}
+
+// Same shape as run_bitmap_on_light_added_column_emits_no_entry, through the plain-bloom builder:
+// build_bloom_for_column reaches the strict column iterator before its own null-reader check, so it
+// too must be guarded by the per-segment presence filter.
+TEST_F(AddIndexSchemaChangeTest, run_plain_bloom_on_light_added_column_emits_no_entry) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/5);
+    version = publish_light_added_column(base_tablet_id, version, "c5", "INT");
+
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::BLOOM_FILTER, _c5_uid)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    TxnLogPB_OpAddIndex op;
+    ASSERT_OK(sc.run(&op));
+    EXPECT_EQ(0, op.segment_entries_size()) << "the only segment has no c5, so no entry may be emitted";
+}
+
+// Same shape again for NGRAMBF, which needs a VARCHAR column and real index_properties (mirrors
+// run_ngrambf_with_index_properties). NGRAMBF shares BloomFilterIndexWriter with plain bloom but
+// takes a different branch in build_idg_for_segment's switch, so it needs its own coverage.
+TEST_F(AddIndexSchemaChangeTest, run_ngram_bloom_on_light_added_column_emits_no_entry) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/5);
+    version = publish_light_added_column(base_tablet_id, version, "c5", "VARCHAR");
+
+    // index_properties JSON as produced by TabletIndex::to_schema_pb.
+    const std::string props = R"({"properties":{"bloom_filter_fpp":"0.05","gram_num":"3","case_sensitive":"true"}})";
+    auto vt = versioned_at(base_tablet_id, version);
+    std::vector<TabletIndexPB> indexes{make_index(IndexType::NGRAMBF, _c5_uid, /*index_id=*/0, props)};
+    AddIndexSchemaChange sc(_tablet_manager.get(), next_id(), vt, vt, indexes, /*alter_version=*/version);
+
+    TxnLogPB_OpAddIndex op;
+    ASSERT_OK(sc.run(&op));
+    EXPECT_EQ(0, op.segment_entries_size()) << "the only segment has no c5, so no entry may be emitted";
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/add_index_schema_change_test.cpp
+++ b/be/test/storage/lake/add_index_schema_change_test.cpp
@@ -24,6 +24,7 @@
 #include "base/utility/defer_op.h"
 #include "column/binary_column.h"
 #include "column/chunk.h"
+#include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
 #include "column/fixed_length_column.h"
 #include "column/nullable_column.h"
@@ -49,6 +50,7 @@
 #include "storage/lake/join_path.h"
 #include "storage/lake/schema_change.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
 #include "storage/lake/test_util.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/versioned_tablet.h"
@@ -60,6 +62,7 @@
 #include "storage/types.h"
 #include "storage_primitive/column_predicate.h"
 #include "storage_primitive/column_predicate_factory.h"
+#include "storage_primitive/predicate_tree/predicate_tree.hpp"
 #include "storage_primitive/range.h"
 
 namespace starrocks::lake {
@@ -229,6 +232,90 @@ protected:
         delta_writer->close();
         CHECK_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
         return version + 1;
+    }
+
+    // Same as write_one_rowset, but for a schema that has already grown c5 (post-light-ADD-COLUMN),
+    // so the segment this produces physically carries a c5 value and is eligible for an IDG entry.
+    int64_t write_one_rowset_with_c5(int64_t base_tablet_id, int64_t version, std::shared_ptr<TabletSchema> schema,
+                                     int nrows, int32_t c5, const std::string& vstr_prefix = "row") {
+        auto vschema = std::make_shared<Schema>(ChunkHelper::convert_schema(schema));
+        auto col_c0 = Int32Column::create();
+        auto col_c1 = Int32Column::create();
+        auto col_c2 = BinaryColumn::create();
+        auto col_c3 = Int32Column::create();
+        auto null_col_c3 = NullableColumn::create(std::move(col_c3), NullColumn::create());
+        auto col_c4 = BinaryColumn::create();
+        auto col_c5 = Int32Column::create();
+        auto null_col_c5 = NullableColumn::create(std::move(col_c5), NullColumn::create());
+        for (int i = 0; i < nrows; ++i) {
+            col_c0->append_datum(Datum(i + 1));
+            col_c1->append_datum(Datum(i * 7 + 3));
+            col_c2->append_datum(Datum(Slice(vstr_prefix + std::to_string(i))));
+            if (i % 3 == 0) {
+                null_col_c3->append_default();
+            } else {
+                null_col_c3->append_datum(Datum(i * 11));
+            }
+            col_c4->append_datum(Datum(Slice("ch" + std::to_string(i % 4))));
+            null_col_c5->append_datum(Datum(c5));
+        }
+        Chunk chunk({std::move(col_c0), std::move(col_c1), std::move(col_c2), std::move(null_col_c3), std::move(col_c4),
+                     std::move(null_col_c5)},
+                    vschema);
+        std::vector<uint32_t> indexes(nrows);
+        for (int i = 0; i < nrows; ++i) indexes[i] = i;
+
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_manager.get())
+                                                   .set_tablet_id(base_tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_schema_id(schema->id())
+                                                   .build());
+        CHECK_OK(delta_writer->open());
+        CHECK_OK(delta_writer->write(chunk, indexes.data(), indexes.size()));
+        CHECK_OK(delta_writer->finish_with_txnlog());
+        delta_writer->close();
+        CHECK_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
+        return version + 1;
+    }
+
+    // Open a TabletReader over the published metadata at `version` with an equality predicate on c5,
+    // and return how many rows match. Used to pin that a segment with no per-segment index for c5 is
+    // still scanned with the predicate evaluated row by row, rather than skipped or having its
+    // predicate silently dropped.
+    int64_t count_rows_matching_c5(int64_t tablet_id, int64_t version, int32_t value) {
+        ASSIGN_OR_ABORT(auto metadata, _tablet_manager->get_tablet_metadata(tablet_id, version));
+        auto schema = TabletSchema::create(metadata->schema());
+        auto read_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(schema));
+
+        const auto c5_index = static_cast<ColumnId>(read_schema->num_fields() - 1);
+        auto type_info = get_type_info(TYPE_INT);
+        std::unique_ptr<ColumnPredicate> pred(new_column_eq_predicate(type_info, c5_index, std::to_string(value)));
+        PredicateAndNode root;
+        root.add_child(PredicateColumnNode(pred.get()));
+
+        TabletReader reader(_tablet_manager.get(), metadata, *read_schema);
+        CHECK_OK(reader.prepare());
+        TabletReaderParams params;
+        params.pred_tree = PredicateTree::create(std::move(root));
+        CHECK_OK(reader.open(params));
+
+        int64_t total_rows = 0;
+        auto read_chunk = ChunkFactory::new_chunk(*read_schema, 1024);
+        while (true) {
+            read_chunk->reset();
+            auto st = reader.get_next(read_chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            CHECK_OK(st);
+            total_rows += read_chunk->num_rows();
+        }
+        reader.close();
+        return total_rows;
     }
 
     // Construct a single-column TabletIndexPB.
@@ -1398,6 +1485,56 @@ TEST_F(AddIndexSchemaChangeTest, run_ngram_bloom_on_light_added_column_emits_no_
     TxnLogPB_OpAddIndex op;
     ASSERT_OK(sc.run(&op));
     EXPECT_EQ(0, op.segment_entries_size()) << "the only segment has no c5, so no entry may be emitted";
+}
+
+// The load-bearing guarantee behind the skip: a segment with no IDG entry for an indexed column is
+// still SCANNED, with the predicate evaluated row by row rather than erased. Assert on RESULTS, not
+// metadata -- a shape assertion cannot tell a retained predicate from a dropped one.
+TEST_F(AddIndexSchemaChangeTest, unindexed_segment_still_matches_predicates_on_light_added_column) {
+    auto base_metadata = create_base_tablet_metadata();
+    auto base_tablet_id = base_metadata->id();
+    CHECK_OK(_tablet_manager->put_tablet_metadata(*base_metadata));
+    auto base_schema = TabletSchema::create(base_metadata->schema());
+
+    // Rowset 1: written BEFORE the light ADD COLUMN, so its segment has no c5 and will get no IDG
+    // entry. Its rows must read c5 as the declared default 7.
+    int64_t version = write_one_rowset(base_tablet_id, /*version=*/1, base_schema, /*nrows=*/4);
+    version = publish_light_added_column(base_tablet_id, version, "c5", "INT");
+
+    // Rowset 2: written AFTER, physically carrying c5 = 42, so it DOES get an IDG entry.
+    ASSIGN_OR_ABORT(auto wide_metadata, _tablet_manager->get_tablet_metadata(base_tablet_id, version));
+    auto wide_schema = TabletSchema::create(wide_metadata->schema());
+    version = write_one_rowset_with_c5(base_tablet_id, version, wide_schema, /*nrows=*/3, /*c5=*/42);
+
+    // Build the BITMAP index on c5 through the handler, then publish so the op is applied.
+    TAlterTabletReqV2 request;
+    request.__set_base_tablet_id(base_tablet_id);
+    request.__set_new_tablet_id(base_tablet_id);
+    request.__set_alter_version(version);
+    request.__set_txn_id(next_id());
+    request.__set_only_add_index(true);
+    TOlapTableIndex ix;
+    ix.__set_index_id(next_id());
+    ix.__set_index_type(TIndexType::BITMAP);
+    ix.__set_columns({"c5"});
+    request.__set_indexes_to_add({ix});
+    SchemaChangeHandler handler(_tablet_manager.get());
+    ASSERT_OK(handler.process_alter_tablet(request));
+    CHECK_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, request.txn_id).status());
+    version++;
+
+    // Exactly one segment (the newer one) is indexed.
+    ASSIGN_OR_ABORT(auto after, _tablet_manager->get_tablet_metadata(base_tablet_id, version));
+    ASSERT_TRUE(after->has_idg_meta());
+    EXPECT_EQ(1, after->idg_meta().idgs_size());
+
+    // Now the point of the test: scan with a predicate on c5 and check ROW COUNTS.
+    //   c5 == 7  -> the 4 rows of the UNINDEXED segment (they read as the declared default)
+    //   c5 == 42 -> the 3 rows of the indexed segment
+    //   c5 == 99 -> none
+    EXPECT_EQ(4, count_rows_matching_c5(base_tablet_id, version, /*value=*/7));
+    EXPECT_EQ(3, count_rows_matching_c5(base_tablet_id, version, /*value=*/42));
+    EXPECT_EQ(0, count_rows_matching_c5(base_tablet_id, version, /*value=*/99));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/add_index_schema_change_test.cpp
+++ b/be/test/storage/lake/add_index_schema_change_test.cpp
@@ -41,6 +41,7 @@
 #include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
 #include "storage/lake/delta_writer.h"
+#include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/index_delta_group.h"
 #include "storage/lake/index_delta_group_loader.h"
@@ -158,7 +159,7 @@ protected:
         // _tablet_mgr->get_cached_schema(schema_id) BEFORE consulting the tablet metadata
         // (table_schema_service.cpp:145-149), and put_tablet_metadata refreshes the metadata caches
         // but NOT the schema-id cache (tablet_manager.cpp:542). Since the rowset writers pass only
-        // schema->id() to DeltaWriterBuilder (add_index_schema_change_test.cpp:182), reusing the id
+        // schema->id() to DeltaWriterBuilder (add_index_schema_change_test.cpp:223), reusing the id
         // would hand the six-column writer the stale FIVE-column schema (delta_writer.cpp:600) and it
         // would emit another segment without c5 -- silently invalidating the "exactly one IDG entry"
         // assertion.
@@ -1316,6 +1317,20 @@ TEST_F(AddIndexSchemaChangeTest, run_bitmap_on_light_added_column_emits_no_entry
     TxnLogPB_OpAddIndex op;
     ASSERT_OK(sc.run(&op));
     EXPECT_EQ(0, op.segment_entries_size()) << "the only segment has no c5, so no entry may be emitted";
+
+    // Pins the presence filter's PLACEMENT, not just its effect: it must run before the .idx
+    // allocation. Were it to move below, every assertion above would still hold while each skipped
+    // segment left an empty .idx object (and a _written_paths entry) behind -- orphan objects on
+    // every such ALTER, with no red test.
+    const std::string segment_dir = lake::join_path(kTestGroupPath, lake::kSegmentDirectoryName);
+    int idx_files = 0;
+    ASSIGN_OR_ABORT(auto fs, FileSystemFactory::CreateSharedFromString(segment_dir));
+    ASSERT_OK(fs->iterate_dir(segment_dir, [&](std::string_view name) {
+        idx_files += is_idx(name);
+        return true;
+    }));
+    EXPECT_EQ(0, idx_files) << "a fully skipped segment must allocate no index file, or the ALTER "
+                               "leaves orphan .idx objects behind";
 }
 
 // Regression guard for the mixed-index case. With two indexes where the segment holds one column and

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1259,6 +1259,47 @@ protected:
         return segment_file_size;
     }
 
+    // Write a real Segment file that contains ONLY the key column c0 = [0..num_rows).
+    // This is what a segment written before a light `ADD COLUMN c1` looks like on
+    // disk: the schema swap does not rewrite data, so the column is absent from
+    // the footer even though the tablet schema declares it.
+    uint64_t write_c0_only_segment(int64_t tablet_id, const std::string& segment_name, int num_rows) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        schema_pb.set_id(2002);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_num_rows_per_row_block(65535);
+        auto* c0 = schema_pb.add_column();
+        c0->set_unique_id(1001);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+
+        auto tablet_schema = TabletSchema::create(schema_pb);
+        auto segment_path = _tablet_manager->segment_location(tablet_id, segment_name);
+
+        WritableFileOptions fopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        auto wfile_or = fs::new_writable_file(fopts, segment_path);
+        CHECK_OK(wfile_or.status());
+
+        SegmentWriterOptions opts;
+        SegmentWriter writer(std::move(wfile_or.value()), 0, tablet_schema, opts);
+        CHECK_OK(writer.init());
+
+        auto col0 = Int32Column::create();
+        std::vector<int> v0(num_rows);
+        for (int i = 0; i < num_rows; ++i) v0[i] = i;
+        col0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        auto chunk_schema = std::make_shared<Schema>(ChunkHelper::convert_schema(tablet_schema));
+        auto chunk = std::make_shared<Chunk>(Columns{std::move(col0)}, chunk_schema);
+        CHECK_OK(writer.append_chunk(*chunk));
+
+        uint64_t segment_file_size = 0, index_size = 0, footer_position = 0;
+        CHECK_OK(writer.finalize(&segment_file_size, &index_size, &footer_position));
+        return segment_file_size;
+    }
+
     std::vector<std::pair<uint64_t, int64_t>> write_two_column_bundled_segments(
             int64_t tablet_id, const std::string& bundle_name, int num_rows,
             const std::function<int(int)>& source_value_of, int key_start = 0) {
@@ -1410,13 +1451,20 @@ protected:
     // base segment. Verifies the rebuilt .cols row values (surviving children's
     // updates on their windows, base values on the gap) and that a gap delvec
     // masks the compacted child's rows.
-    void run_dcg_conflict_gap_rebuild_case(int compacted_index, int64_t txn_id) {
+    //
+    // With |c1_added_without_data_rewrite|, c1 instead arrives through a light
+    // ADD COLUMN: the base segment predates it and carries only c0, while the
+    // schema declares c1 with a default. The gap window then has no base values
+    // to copy and must fall back to that declared default.
+    void run_dcg_conflict_gap_rebuild_case(int compacted_index, int64_t txn_id,
+                                           bool c1_added_without_data_rewrite = false) {
         const int64_t base_version = 1;
         const int64_t new_version = 2;
         constexpr int kNumRows = 30;
         constexpr int kRangeRows = 10; // three equal key ranges: [0,10) [10,20) [20,30)
         constexpr int64_t kSchemaId = 4001;
         constexpr uint32_t kSharedRowsetId = 1;
+        constexpr int kC1Default = 7;
 
         const int64_t child_ids[3] = {next_id(), next_id(), next_id()};
         const int64_t merged_tablet = next_id();
@@ -1428,7 +1476,9 @@ protected:
         auto update_of = [](int child_index, int row) { return row + 100000 * (child_index + 1); };
         const std::string shared_segment_name = "shared_seg.dat";
         const uint64_t base_segment_size =
-                write_two_column_segment(merged_tablet, shared_segment_name, kNumRows, base_value_of);
+                c1_added_without_data_rewrite
+                        ? write_c0_only_segment(merged_tablet, shared_segment_name, kNumRows)
+                        : write_two_column_segment(merged_tablet, shared_segment_name, kNumRows, base_value_of);
 
         auto set_key_range = [&](TabletRangePB* range, int lower_key, int upper_key) {
             range->set_lower_bound_included(true);
@@ -1446,6 +1496,11 @@ protected:
             meta->set_next_rowset_id(10);
             const auto [c0_uid, c1_uid] = set_two_column_pk_schema(meta.get(), kSchemaId);
             (void)c0_uid;
+            if (c1_added_without_data_rewrite) {
+                // A light ADD COLUMN requires the new column to be nullable or to
+                // carry a default, so the reader always has something to fill with.
+                meta->mutable_schema()->mutable_column(1)->set_default_value(std::to_string(kC1Default));
+            }
             set_key_range(meta->mutable_range(), lower, upper);
 
             if (i == compacted_index) {
@@ -1548,7 +1603,10 @@ protected:
         ASSERT_EQ(kNumRows, static_cast<int>(values.size()));
         for (int row = 0; row < kNumRows; ++row) {
             const int range_index = row / kRangeRows;
-            const int expected = (range_index == compacted_index) ? base_value_of(row) : update_of(range_index, row);
+            int expected = update_of(range_index, row);
+            if (range_index == compacted_index) {
+                expected = c1_added_without_data_rewrite ? kC1Default : base_value_of(row);
+            }
             EXPECT_EQ(expected, values[row]) << "row " << row << " (range " << range_index << ")";
         }
     }
@@ -14720,6 +14778,127 @@ TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_with_gap_middle_c
 
 TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_conflict_with_gap_last_child_compacts) {
     run_dcg_conflict_gap_rebuild_case(/*compacted_index=*/2, /*txn_id=*/3103);
+}
+
+// Same gap rebuild, but c1 was introduced by a light ADD COLUMN that did not
+// rewrite the pre-existing base segment. The gap window therefore reads a column
+// the base segment does not physically contain; the rebuild must fill the
+// declared default instead of failing.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_dcg_gap_fill_with_light_added_column) {
+    run_dcg_conflict_gap_rebuild_case(/*compacted_index=*/1, /*txn_id=*/3104,
+                                      /*c1_added_without_data_rewrite=*/true);
+}
+
+// A .cols file claims exactly the column UIDs listed in its DCG entry, so a UID
+// the file does not physically contain is corruption and must keep failing --
+// substituting a default there would silently persist wrong values into the
+// rebuilt .cols. Both children's entries claim c1 and c2, but their .cols files
+// carry only c1; c2 exists in the tablet schema (with a default, so a
+// default-tolerant read would succeed) and is therefore not caught by the
+// rebuild schema's own missing-UID guard.
+TEST_F(LakeTabletReshardTest, test_tablet_merging_donor_dcg_missing_column_still_fails) {
+    const int64_t base_version = 1;
+    const int64_t new_version = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t merged_tablet = next_id();
+    prepare_tablet_dirs(child_a);
+    prepare_tablet_dirs(child_b);
+    prepare_tablet_dirs(merged_tablet);
+
+    constexpr int kNumRows = 20;
+    constexpr int kBoundary = 10; // child A owns [0, 10), child B owns [10, 20)
+    constexpr uint32_t kSegmentRssid = 1;
+    constexpr int64_t kSchemaId = 4001;
+    constexpr int64_t kTxnId = 3105;
+    constexpr int32_t kC2Uid = 1003;
+
+    auto base_value_of = [](int row) { return row * 10; };
+    const std::string shared_segment_name = "shared_seg.dat";
+    const uint64_t base_segment_size =
+            write_two_column_segment(merged_tablet, shared_segment_name, kNumRows, base_value_of);
+
+    // Each child's .cols file physically holds c1 only.
+    const std::string cols_a_name = lake::gen_cols_filename(kTxnId);
+    const std::string cols_b_name = lake::gen_cols_filename(kTxnId + 1);
+    auto a_cell = [&](int row) { return row < kBoundary ? row + 100000 : base_value_of(row); };
+    auto b_cell = [&](int row) { return row >= kBoundary ? row + 200000 : base_value_of(row); };
+    write_c1_only_cols_file(child_a, cols_a_name, kNumRows, a_cell);
+    write_c1_only_cols_file(child_b, cols_b_name, kNumRows, b_cell);
+
+    auto build_child = [&](int64_t tablet_id, int lower_key, int upper_key, const std::string& cols_filename) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(base_version);
+        metadata->set_next_rowset_id(10);
+        const auto [c0_uid, c1_uid] = set_two_column_pk_schema(metadata.get(), kSchemaId);
+        (void)c0_uid;
+        auto* c2 = metadata->mutable_schema()->add_column();
+        c2->set_unique_id(kC2Uid);
+        c2->set_name("c2");
+        c2->set_type("INT");
+        c2->set_is_key(false);
+        c2->set_is_nullable(false);
+        c2->set_aggregation("REPLACE");
+        c2->set_default_value("42");
+
+        auto* tablet_range = metadata->mutable_range();
+        tablet_range->set_lower_bound_included(true);
+        tablet_range->set_upper_bound_included(false);
+        *tablet_range->mutable_lower_bound() = generate_sort_key(lower_key);
+        *tablet_range->mutable_upper_bound() = generate_sort_key(upper_key);
+
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(kSegmentRssid);
+        rowset->set_version(base_version);
+        rowset->set_num_rows(kNumRows);
+        rowset->set_data_size(base_segment_size);
+        auto* segment_meta = rowset->add_segment_metas();
+        segment_meta->set_filename(shared_segment_name);
+        segment_meta->set_size(base_segment_size);
+        segment_meta->set_shared(true);
+        stamp_physical_identity_uid(rowset, shared_segment_name); // same UID across siblings => one canonical rowset
+        *rowset->mutable_range()->mutable_lower_bound() = generate_sort_key(lower_key);
+        *rowset->mutable_range()->mutable_upper_bound() = generate_sort_key(upper_key);
+        rowset->mutable_range()->set_lower_bound_included(true);
+        rowset->mutable_range()->set_upper_bound_included(false);
+        (*metadata->mutable_rowset_to_schema())[kSegmentRssid] = kSchemaId;
+
+        // The entry over-claims: it names c2 as well, but the file has only c1.
+        auto& dcg = (*metadata->mutable_dcg_meta()->mutable_dcgs())[kSegmentRssid];
+        dcg.add_column_files(cols_filename);
+        auto* claimed = dcg.add_unique_column_ids();
+        claimed->add_column_ids(c1_uid);
+        claimed->add_column_ids(kC2Uid);
+        dcg.add_versions(1);
+        dcg.add_shared_files(false);
+        return metadata;
+    };
+
+    EXPECT_OK(put_tablet_metadata(build_child(child_a, 0, kBoundary, cols_a_name)));
+    EXPECT_OK(put_tablet_metadata(build_child(child_b, kBoundary, kNumRows, cols_b_name)));
+
+    ReshardingTabletInfoPB resharding_tablet;
+    auto& merging_tablet = *resharding_tablet.mutable_merging_tablet_info();
+    merging_tablet.add_old_tablet_ids(child_a);
+    merging_tablet.add_old_tablet_ids(child_b);
+    merging_tablet.set_new_tablet_id(merged_tablet);
+
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(kTxnId + 2);
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto st = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet, base_version, new_version,
+                                              txn_info, false, tablet_metadatas, tablet_ranges);
+    ASSERT_FALSE(st.ok());
+    EXPECT_TRUE(st.is_not_found()) << st.to_string();
+    // The message must name the .cols file and the claimed-but-absent UID, which
+    // proves the read reached the strict column iterator rather than tripping the
+    // rebuild schema's missing-UID guard first.
+    EXPECT_NE(std::string::npos, st.to_string().find(fmt::format("column of id {}", kC2Uid))) << st.to_string();
+    EXPECT_NE(std::string::npos, st.to_string().find(cols_a_name)) << st.to_string();
 }
 
 // When two children's DCG entries share a .cols filename but the entry


### PR DESCRIPTION
## Why I'm doing:

A "light" `ADD COLUMN` on a shared-data table swaps the tablet schema without rewriting data, so
segments written before the alter legitimately do not contain the new column. Two lake paths read
such a column with the strict `Segment::new_column_iterator`, which returns `NotFound` when the
column is absent from the segment footer. Both fail today on valid data:

1. **ADD INDEX fast path** — building an index on a light-added column fails the whole ALTER,
   because the pre-existing segments do not carry that column. Two plain-SQL sequences reach this,
   both after an `ALTER TABLE ... ADD COLUMN`: `CREATE INDEX` on that column (arrives as BITMAP),
   and `ALTER TABLE ... SET ("bloom_filter_columns" = ...)` naming that column (arrives as
   BLOOM_FILTER, and this fast path is enabled by default).
2. **Tablet merge delta column group rebuild** — the gap-window fill reads the canonical base
   segment and aborts the whole publish with `NotFound` over data that is valid.

## What I'm doing:

**ADD INDEX fast path** — probe each segment with `Segment::column_with_uid` and build only the
indexes whose columns that segment physically holds; a segment holding none of them gets no index
file and no index-delta-group entry. Index presence is already per segment, and a reader with no
entry falls back to an unindexed scan with the predicate retained, so results stay correct. The
probe is the same `_column_readers` lookup that makes the strict iterator return `NotFound`, so it
cannot skip an index whose build would have succeeded, nor keep one whose build would fail.

Both the build loop and the entry's key list are filtered from the same computed list. Filtering
only the build loop would leave the entry advertising a key whose `.idx` file lacks that index; the
filter also runs before the index file is allocated, so a fully skipped segment writes no object.

This path **skips** rather than substituting the column's default. An index over the synthesized
defaults would not be wrong — every row of such a segment does read as the default — but with no
physical column there is no column reader through which the entry could be consulted, so building it
would only cost I/O.

**Tablet merge** — `read_column_range_from_segment` had two callers with different correctness
requirements. The gap-window fill reads the canonical base segment, where an absent light-added
column is legitimate and the declared default is the right fill; the other caller reads a donor
`.cols` file, which claims exactly the column unique ids its entry names, so an absent column there
is genuine corruption and must keep failing. A `SegmentKind` parameter selects the tolerant iterator
for the base read and keeps the strict one for the donor read. Relaxing the donor read instead would
make the merge *succeed* and persist a synthesized default into the rebuilt `.cols` for a column the
donor never held, so the distinction is load-bearing rather than stylistic.

The tolerant iterator is what the ordinary query path already uses for canonical lake segments, so
this makes the merge path consistent with reads rather than special-casing it. At that site it also
covers CHAR-length casting and the extended-column path, both likewise correct there.

**Scope limit on the merge half.** This fixes the `NotFound` failure, which is the one reproduced
end-to-end below. It does **not** cover the case where the target rowset is pinned in
`rowset_to_schema` to a schema that predates the light `ADD COLUMN`: there
`resolve_rowset_schema_pb` returns that historical schema, `create_with_uid` silently drops the
column's unique id, and the rebuild aborts with `NotSupported` before this read is reached. Closing
that needs the rebuild and default column definitions to come from the current schema while the
historical schema is retained only for base-segment sort-key and window interpretation — a change to
which schema drives column definitions in the rebuild, which deserves its own change and its own
test rather than being folded in here. Tracked as a follow-up; see the review thread on this PR.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Two behaviour changes, both turning a failure into success:

- An `ADD INDEX` / `CREATE INDEX` / `SET ("bloom_filter_columns"=...)` that previously failed on a
  table with a light-added column now succeeds, indexing only the segments that physically hold the
  column. Query results are unchanged: a segment with no entry is scanned with the predicate
  evaluated per row. Coverage is not permanently partial — compaction rewrites those segments with
  the column present, and a later index build over them emits entries normally.
- A tablet merge that previously aborted its publish with `NotFound` over valid data now completes.
  This is the half that backports, so it is the behaviour change a release reviewer sees.

## Observability

Reviewed both end-to-end paths. No new signal was needed; the changes to existing ones are:

- The per-segment skip is logged at VLOG with the reason and the column unique id, and `run()` emits
  one INFO summary per tablet giving indexed / total / skipped. The summary exists because the
  entry count alone cannot be told apart from a fully indexed tablet, and it is per tablet rather
  than per segment so a wide tablet does not produce one INFO line per segment.
- `lake_idg_files_written_total` needed no change and got none: it already counts emitted entries
  rather than segments, so it stays exact when some segments are skipped.
- The merge path's failure logging is unchanged; the donor read still fails loudly on genuine
  corruption, and the new guard test asserts that message. One gap is left in place deliberately: a
  rebuild failure returns `NotFound` without incrementing a counter, while the not-supported and
  success outcomes both do. Closing that would widen a change kept minimal for backporting.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Unit tests, 284 passing (`AddIndexSchemaChangeTest` 30, `LakeTabletReshardTest` 254). Each new test
was verified to fail when its target is reverted, rather than only to pass:

- Reverting either the build loop or the key-emission filter turns the mixed-index test red.
- Moving the presence filter below the index-file allocation leaves every other assertion green
  while leaking one empty `.idx` per skipped segment; a directory assertion catches exactly that.
- A read-path test asserts row counts through a `TabletReader` with an equality predicate on the
  light-added column, so a change that dropped the residual predicate or over-pruned the unindexed
  segment fails here rather than silently returning wrong rows. The counts cannot be produced by
  zone-map pruning, since `DefaultValueColumnIterator::get_row_ranges_by_zone_map` is a no-op that
  returns the full range.
- The donor guard test passes both before and after this change by design: it exists so a later
  refactor cannot relax the donor read and mask corruption. Switching that call site to the tolerant
  iterator turns it red.

No user-facing config, metric, or syntax is added or renamed, so no documentation change applies.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

Only the `tablet_merger.cpp` half applies to 4.1, which has the same helper and the same two call
sites and already declares the default-substituting iterator. `tablet_merger.cpp` does not exist on
4.0, so 4.0 and 3.5 are deliberately not selected. On 4.1 the surrounding field/column helpers read
`ChunkHelper::*` a few lines above this change, so the backport's 3-way merge is worth confirming
rather than assuming.

## Follow-ups, not in this PR

- The index-type support checks run after the per-segment presence check, so an unsupported index
  type declared on a column absent from every segment would succeed as a no-op instead of being
  rejected. The types that reach this path today (BITMAP, BLOOM_FILTER) are both supported, so this
  is not reachable now; worth revisiting before any additional type is routed here.
- A vector-index build performs the same strict read, but no current route queues a build for a
  segment lacking its vector column: a candidate requires a non-empty vector index id list,
  `CREATE VECTOR INDEX` disables fast schema evolution, and its rewrite force-builds existing vector
  data inline. Left alone here.
- `build_bloom_for_column`'s doc comment contains a pre-existing half-finished sentence, untouched
  by this PR.
- The delta-column-group rebuild still fails with `NotSupported` when the target rowset is pinned to
  a schema predating a light `ADD COLUMN` (see the scope limit above). The existing reshard fixture
  cannot exercise it, because it populates no `historical_schemas` entry and so always resolves to
  the merged current schema.
- Two defects found while running the cluster e2e for this PR, both reproduced on clean `main` and
  therefore not introduced here: `CREATE INDEX` immediately after `ADD COLUMN` failing with
  `column ... not found in new schema`, and a CN `SIGSEGV` in `MemTable::insert` on an `INSERT` that
  supplies a light-added column. Details and stacks are in the e2e comment on this PR.
