### PR TITLE
[Tool] ci-report: drop the full clone from BE-REPORT

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -372,14 +372,23 @@ jobs:
       BASE_REF: ${{ needs.INFO.outputs.BASE_REF }}
       bucket_prefix: ${{ needs.INFO.outputs.BUCKET_PREFIX }}
       SKIP_COV: ${{ needs.INFO.outputs.SKIP_COV }}
+      # Scratch dir, deliberately not the tracked `be/`. See FE_UT_UNPACK_DIR.
+      BE_UT_UNPACK_DIR: be-ut-report
     steps:
       - name: CLEAN
         run: |
           rm -rf ${{ github.workspace }} && mkdir -p ${{ github.workspace }}
 
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
+      # No checkout here on purpose: this job never reads repo source. Its
+      # inputs are the OSS objects downloaded below (be_ut_coverage.xml /
+      # base_version.txt / diff.txt), /var/lib/ci-tool and /var/local/env --
+      # exactly like FE-REPORT and JAVA-EXTENSION-REPORT, neither of which
+      # checks anything out. The `fetch-depth: 0` clone that used to sit here
+      # cost ~158s of pure fetch per run (1394 branches + 307 tags, no reuse
+      # because CLEAN wipes the workspace first), and it checked out
+      # origin/main rather than the PR head, so the tree was not even the code
+      # under test. The only thing it really provided was a `be/` directory for
+      # the download step to cd into; ${BE_UT_UNPACK_DIR} replaces that.
 
       - name: Download BE UT XML
         id: download-ut-xml
@@ -395,7 +404,7 @@ jobs:
               echo "::error::BE UT failed!"
               exit 1
             fi
-            cd be
+            rm -rf ${BE_UT_UNPACK_DIR} && mkdir ${BE_UT_UNPACK_DIR} && cd ${BE_UT_UNPACK_DIR}
             ossutil64 --config-file ~/.ossutilconfig cp ${oss_path}/be_ut_coverage.xml . -f 1>/dev/null
             ossutil64 --config-file ~/.ossutilconfig cp ${oss_path}/base_version.txt . -f 1>/dev/null
             ossutil64 --config-file ~/.ossutilconfig cp ${oss_path}/diff.txt . -f 1>/dev/null
@@ -442,7 +451,7 @@ jobs:
           && !contains(github.event.workflow_run.head_branch, '-sync-pr-')
           && !startsWith(github.event.workflow_run.head_branch, 'mergify/')
         env:
-          be_path: ${{ github.workspace }}/be
+          be_path: ${{ github.workspace }}/${{ env.BE_UT_UNPACK_DIR }}
           merge_outcome: ${{ steps.merge.outcome }}
           total_xml: ${{ steps.merge.outputs.COV_XML }}
         run: |

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -443,11 +443,23 @@ jobs:
           ./bin/gen_be_cov.sh ${REPO} ${BASE_REF} ${PR_NUMBER} ${HEAD_SHA}
 
       # Incremental Total Coverage
+      #
+      # The SKIP_COV guard is needed here too, not just on `merge`: SKIP_COV
+      # also sends the download step above into its else branch, which
+      # downloads nothing. Without it, a [UT]-titled PR that touched be/ (so
+      # BE UT ran and size != 0) still reached this step, and the
+      # `merge_outcome == skipped` fallback below read a be_ut_coverage.xml /
+      # diff.txt that were never downloaded -- FileNotFoundException, and a
+      # red BE-REPORT nobody sees, since this job's check run lands on the
+      # default branch rather than the PR (workflow_run). See #77990 and run
+      # 32167039568. That else branch has already published an empty-coverage
+      # status by this point, so skipping here leaves no gap.
       - name: Publish Incremental Coverage Report - Total
         if: >
           always()
           && steps.download-ut-xml.outputs.size != '0'
           && steps.download-ut-xml.outcome == 'success'
+          && env.SKIP_COV != 'true'
           && !contains(github.event.workflow_run.head_branch, '-sync-pr-')
           && !startsWith(github.event.workflow_run.head_branch, 'mergify/')
         env:


### PR DESCRIPTION
## Why I'm doing:

### 1. The `fetch-depth: 0` clone in BE-REPORT

`BE-REPORT` in `ci-report.yml` ran `actions/checkout` with `fetch-depth: 0`. Measured on the run for #78877 (job `102378068606`):

| phase | window | cost |
|---|---|---|
| Fetching the repository | 07:32:22.91 → 07:35:00.78 | **157.9s** |
| Checking out the ref | 07:35:00.78 → 07:35:03.94 | 3.2s |
| whole step | | **161.4s** of the job's 13m33s |

The fetch pulls the full history plus every remote ref (`1394` `* [new branch]` + `307` `* [new tag]` lines in the log), and none of it is reusable: the preceding `CLEAN` step does `rm -rf ${{ github.workspace }}`, so every run starts from `Initialized empty Git repository`.

**Nothing in the job reads repo source.** Step by step:

- `Download BE UT XML` — pulls `be_ut_res` / `be_ut_coverage.xml` / `base_version.txt` / `diff.txt` from OSS
- `Merge BE Total Coverage` — `cp -rf /var/lib/ci-tool ./ci-tool`, then the build artifacts and gcda are fetched from OSS *inside the ECI container*
- `Publish Incremental Coverage Report` — `ln -s /var/local/env/coverchecker`, and cover-checker consumes the cobertura XML plus `-d diff.txt -dt file`

This is the same shape as `FE-REPORT` and `JAVA-EXTENSION-REPORT`, neither of which checks anything out — the whole workflow only has one other `actions/checkout`, in `SONAR_FE_CHECKER`, which genuinely needs source.

There is also a correctness argument. The checkout resolved to `git checkout --force -B main refs/remotes/origin/main`, landing on `c3f38761`, while #78877's head is `c042223c` — the tree it produced was not the code under test, so it could not have been a meaningful input to anything.

## What I'm doing:

The checkout's only real contribution was creating the `be/` directory that the download step `cd`-ed into. That is replaced with a `BE_UT_UNPACK_DIR` scratch dir, following the `FE_UT_UNPACK_DIR` precedent from #78548: a scratch name cannot collide with a tracked path, so a workspace that still holds a checkout on a shared self-hosted runner cannot make `mkdir` fail and silently skip the `cd`.

Expected: `BE-REPORT` drops from ~13m33s to ~10m50s, deterministically, plus one less GB-scale clone per run on the shared `quick` runner pool (`Clean ENV` uses `rm -rf ${{ github.workspace }}/*`, whose glob skips `.git`, so today that clone sits on disk until the next run's `CLEAN`).

### Validation

Note for reviewers: **this change cannot be exercised by this PR's own CI.** `ci-report.yml` is `workflow_run`-triggered, and GitHub always runs the default-branch copy of such a workflow, so the run that reports on this PR uses `main`'s version, not this one.

What has been checked:

- [x] YAML parses; `BE-REPORT` resolves to 5 steps (checkout gone) with `BE_UT_UNPACK_DIR` in the job env
- [x] The patched `Download BE UT XML` body, extracted verbatim from the YAML and run under `bash -e` in an empty workspace with `ossutil64` stubbed: exit 0, `be_ut_coverage.xml` / `base_version.txt` / `diff.txt` land in `be-ut-report/`, and `$GITHUB_OUTPUT` gets both `size=` and `base_version=`
- [ ] Post-merge: the next PR on `main` should still get its `BE Incremental Coverage Report` comment and a green `Be Cover Checker`. That is the one thing only a real run can confirm, since `Publish` depends on `${be_path}/diff.txt` resolving to the new directory.
- [x] Change 1 was exercised end to end by temporarily touching a `be/` file on this branch, which made BE UT run and the coverage merge execute for real (11m03s). It confirmed the pipeline gating but not the change itself, since `workflow_run` ran `main`'s copy: the run's step list still contained `Run actions/checkout@v6`, at 180s. Two independent measurements of that step now exist: 161s on #78877, 180s here — ~20% of the job both times.
- [ ] Post-merge: a `[UT]`-titled PR touching `be/` should now leave BE-REPORT green with only the empty-coverage status, instead of failing in the publish step.

### 2. `Publish Incremental Coverage Report - Total` is missing the SKIP_COV guard

Pre-existing bug, found while reviewing change 1; **not caused by it**.

`Merge BE Total Coverage` is guarded by `env.SKIP_COV != 'true'`; the publish step was not, and it deliberately runs under `always()` so it can still publish UT-only coverage when the merge fails. That fallback assumes the download step took its `if` branch. SKIP_COV breaks the assumption, because it is also part of that step's condition and sends it into the `else` branch, which downloads nothing:

| scenario | `size` | `SKIP_COV` | download | merge | publish | result |
|---|---|---|---|---|---|---|
| normal PR touching be/ | 1 | false | if branch, diff.txt present | runs | runs | ok |
| PR not touching be/ | 0 | false | else branch | skipped (size) | skipped (size) | ok |
| **`[UT]` PR touching be/** | **1** | **true** | **else branch, nothing downloaded** | skipped (SKIP_COV) | **runs** | **fails** |

#77990 (`[UT] Fix unstable BE UT`) hit the third row in run [32167039568](https://github.com/StarRocks/starrocks/actions/runs/32167039568):

```
SKIP_COV:      true
be_path:       /home/runner/_work/starrocks/starrocks/be
merge_outcome: skipped
total_xml:                       # unset, since merge produced no output
Caused by: java.io.FileNotFoundException:
  /home/runner/_work/starrocks/starrocks/be/diff.txt (No such file or directory)
```

Note the `be_path` there is the old `.../be` created by the checkout: the directory existed, the files in it never did. That is why change 1 neither causes nor worsens this — the exception is the same either way, only the path string differs.

The failure was also invisible: the `else` branch had already posted `Be Cover Checker 0 / 0 pass`, and BE-REPORT's own check run lands on the default branch rather than the PR head (workflow_run again), so #77990 merged green while its BE-REPORT was red in the Actions tab, with no notification (`notify.sh` keys on the parent pipeline's conclusion).

Adding `&& env.SKIP_COV != 'true'` to the publish step leaves no gap: the `else` branch publishes the empty-coverage status itself, which is what SKIP_COV is for.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)


