### PR TITLE
[BugFix] Report a lambda's hoisted common sub expression dependencies before prepare

### DIFF
--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -248,9 +248,22 @@ int LambdaFunction::get_slot_ids(std::vector<SlotId>* slot_ids) const {
     if (_is_prepared) {
         slot_ids->insert(slot_ids->end(), _captured_slot_ids.begin(), _captured_slot_ids.end());
         return _captured_slot_ids.size();
-    } else {
-        return get_child(0)->get_slot_ids(slot_ids);
     }
+    int num = get_child(0)->get_slot_ids(slot_ids);
+    // The lambda expr alone is not the whole picture: the FE may have hoisted a common sub
+    // expression out of it into this lambda's own common sub expression list, rewriting the body to
+    // reference the hoisted slot instead. A column the hoisted definition depends on - notably an
+    // enclosing lambda's argument - then appears nowhere in the body, so reporting only the body
+    // hides it from callers that run before prepare(), i.e. ArrayMapExpr/ArraySortLambdaExpr::prepare
+    // and extract_outer_common_exprs. Such a caller would judge the surrounding expression
+    // independent of that argument and stop supplying its column, and evaluating this lambda would
+    // then fail to find it. Report the definitions' dependencies as well; prepare() takes the same
+    // children into account when it builds _captured_slot_ids, so both branches stay consistent.
+    const int child_num = get_num_children() - 2 * _common_sub_expr_num;
+    for (auto i = child_num + _common_sub_expr_num; i < child_num + 2 * _common_sub_expr_num; ++i) {
+        num += get_child(i)->get_slot_ids(slot_ids);
+    }
+    return num;
 }
 
 std::string LambdaFunction::debug_string() const {

--- a/test/sql/test_array_fn/R/test_nested_lambda_captured_arg
+++ b/test/sql/test_array_fn/R/test_nested_lambda_captured_arg
@@ -1,0 +1,44 @@
+-- name: test_nested_lambda_captured_arg
+-- A nested array_map whose INNER lambda holds a common sub expression that captures the ENCLOSING
+-- lambda's argument. The FE hoists the duplicated abs(x) into the inner lambda's own common sub
+-- expression list and rewrites its body to reference the hoisted slot, so x appears nowhere in that
+-- body any more. LambdaFunction::get_slot_ids reported the body alone when called before prepare(),
+-- which hid x from ArrayMapExpr::prepare and from extract_outer_common_exprs. The outer lambda was
+-- therefore judged independent of x, stopped putting x into the chunk it passes down, and evaluating
+-- the inner array_map could not find x.
+-- Keeping the two abs(x) separated by y matters: it leaves no x-only subexpression for the FE to
+-- hoist any further, which is what makes the hoist stay in the inner lambda.
+-- Do not add a constant-array form (array_map(x -> array_map(y -> ..., [1,2]), [1,2])): it folds
+-- into a PHYSICAL_VALUES plan where the FE still hoists the reference out of the scope that defines
+-- it, so it fails plan validation until #78645 lands.
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE nlc (k INT, arr ARRAY<BIGINT>) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO nlc VALUES (1, [1, -2]), (2, []), (3, NULL);
+-- result:
+-- !result
+-- used to fail with "Expr evaluate meet error: slot_id N not found (known slots: [...])"
+SELECT k, array_map(x -> array_map(y -> abs(x) + y + abs(x), arr), arr) AS r FROM nlc ORDER BY k;
+-- result:
+1	[[3,0],[5,2]]
+2	[]
+3	None
+-- !result
+-- control: an equivalent single-occurrence form leaves the hoist in the lambda that binds x, so it
+-- was already correct; both forms must agree
+SELECT k, array_map(x -> array_map(y -> abs(x) * 2 + y, arr), arr) AS r FROM nlc ORDER BY k;
+-- result:
+1	[[3,0],[5,2]]
+2	[]
+3	None
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_array_fn/T/test_nested_lambda_captured_arg
+++ b/test/sql/test_array_fn/T/test_nested_lambda_captured_arg
@@ -1,0 +1,28 @@
+-- name: test_nested_lambda_captured_arg
+-- A nested array_map whose INNER lambda holds a common sub expression that captures the ENCLOSING
+-- lambda's argument. The FE hoists the duplicated abs(x) into the inner lambda's own common sub
+-- expression list and rewrites its body to reference the hoisted slot, so x appears nowhere in that
+-- body any more. LambdaFunction::get_slot_ids reported the body alone when called before prepare(),
+-- which hid x from ArrayMapExpr::prepare and from extract_outer_common_exprs. The outer lambda was
+-- therefore judged independent of x, stopped putting x into the chunk it passes down, and evaluating
+-- the inner array_map could not find x.
+-- Keeping the two abs(x) separated by y matters: it leaves no x-only subexpression for the FE to
+-- hoist any further, which is what makes the hoist stay in the inner lambda.
+-- Do not add a constant-array form (array_map(x -> array_map(y -> ..., [1,2]), [1,2])): it folds
+-- into a PHYSICAL_VALUES plan where the FE still hoists the reference out of the scope that defines
+-- it, so it fails plan validation until #78645 lands.
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE nlc (k INT, arr ARRAY<BIGINT>) DUPLICATE KEY(k)
+DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+INSERT INTO nlc VALUES (1, [1, -2]), (2, []), (3, NULL);
+
+-- used to fail with "Expr evaluate meet error: slot_id N not found (known slots: [...])"
+SELECT k, array_map(x -> array_map(y -> abs(x) + y + abs(x), arr), arr) AS r FROM nlc ORDER BY k;
+-- control: an equivalent single-occurrence form leaves the hoist in the lambda that binds x, so it
+-- was already correct; both forms must agree
+SELECT k, array_map(x -> array_map(y -> abs(x) * 2 + y, arr), arr) AS r FROM nlc ORDER BY k;
+
+drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

A nested `array_map` whose **inner** lambda holds a common sub expression that captures the **enclosing** lambda's argument fails to evaluate. Reproducible on `main` with no FE change:

```sql
CREATE TABLE tarray (v1 bigint, v3 ARRAY<bigint>) DUPLICATE KEY(v1)
DISTRIBUTED BY HASH(v1) BUCKETS 1 PROPERTIES ("replication_num" = "1");
INSERT INTO tarray VALUES (1, [1, -2]);

SELECT array_map(x -> array_map(y -> abs(x) + y + abs(x), v3), v3) FROM tarray;
-- ERROR 1064: Expr evaluate meet error: slot_id 11 not found (known slots: [3], num_columns: 1)
```

Release builds return the error above; debug builds hit `DCHECK(is_slot_exist(slot_id))` in `be/src/column/chunk.h` and abort.

The plan is well-formed and passes FE validation. `slot 11` is `x`, the **outer** lambda's argument, and the FE has hoisted the duplicated `abs(x)` into the inner lambda's own common sub expression list:

```
array_map(<slot 11> -> array_map(<slot 12> -> <slot 15> + CAST(<slot 12> AS LARGEINT) + <slot 15>
        lambda common expressions:{<slot 15> <-> abs(<slot 11>)}
        , 3: v3), 3: v3)
```

Because the body was rewritten to reference `<slot 15>`, `x` appears nowhere in it — it survives only inside the hoisted *definition*. And `LambdaFunction::get_slot_ids` reports the body alone when the lambda is not prepared yet:

```cpp
if (_is_prepared) {
    slot_ids->insert(slot_ids->end(), _captured_slot_ids.begin(), _captured_slot_ids.end());
    return _captured_slot_ids.size();
} else {
    return get_child(0)->get_slot_ids(slot_ids);   // body only
}
```

That is exactly the state the callers see: `ArrayMapExpr::prepare` asks for the slot ids *before* it prepares the lambda, and `extract_outer_common_exprs` runs in between. So `x` stayed hidden, and the chain was:

1. `child->get_slot_ids()` on the inner `array_map` returned `{15, 12, 3}` — no `x`.
2. `extract_outer_common_exprs` judged it independent of `x` (`x` is the only entry in `current_lambda_arguments`) and replaced it with a synthetic `ColumnRef`, recording it in `_outer_common_exprs`.
3. The outer lambda's `_captured_slot_ids` no longer mentioned `x`, so `_is_lambda_expr_independent` became `true`.
4. `evaluate_lambda_expr<false, true>` therefore skipped putting the argument into `cur_chunk` (`// if lambda expr doesn't rely on argument, we don't need to put it into cur_chunk`).
5. Evaluating the extracted expression against a `tmp_chunk` built only from `_initial_required_slots` (`{3}` after pruning) left the inner `array_map` looking for `x` in a chunk that does not have it.

`num_columns: 1`, `known slots: [3]` and the `<false, true>` / `<false, false>` template arguments in the stack all match that chain:

```
starrocks::Chunk::get_column_by_slot_id(int)
starrocks::ArrayMapExpr::evaluate_lambda_expr<false, false>(...)   // inner
starrocks::ArrayMapExpr::evaluate_checked(...)
starrocks::ExprContext::evaluate(...)
starrocks::ArrayMapExpr::evaluate_lambda_expr<false, true>(...)    // outer, judged independent
starrocks::ArrayMapExpr::evaluate_checked(...)
starrocks::pipeline::ProjectOperator::push_chunk(...)
```

Two things are worth noting about the shape of the repro:

- The single-occurrence form `array_map(x -> array_map(y -> abs(x) + y, v3), v3)` works, which is the tell: it hoists `abs(x)` into the lambda that *binds* `x`, so nothing has to cross a lambda boundary.
- Separating the two `abs(x)` with `y` is what keeps this a BE-only failure. It leaves no subexpression that mentions the hoisted slot without also mentioning `y`, so the FE has nothing left to hoist outwards. `abs(x) + abs(x) + y` instead produces a plan that the FE's own `InputDependenciesChecker` rejects (`Input dependency cols check failed`) and never reaches the BE — that is the separate FE bug #78645 fixes.

Related to but not fixed by #78769. That change filters the **synthetic** ids in `_outer_common_exprs` out of `ArrayMapExpr::get_slot_ids`; the id lost here is a genuine lambda argument, which is not in that container. Both versions of `ArrayMapExpr::get_slot_ids` call `Expr::get_slot_ids`, reach the unprepared `LambdaFunction::get_slot_ids` and miss `x` identically, so this bug behaves the same before and after #78769 — it is the mirror-image half of the same omission: #78769 stopped over-reporting ids the enclosing chunk cannot have, this stops under-reporting ids it must have.

## What I'm doing:

`LambdaFunction::get_slot_ids` now also walks the common sub expression definition children in the unprepared branch, not just the lambda expr:

```cpp
int num = get_child(0)->get_slot_ids(slot_ids);
const int child_num = get_num_children() - 2 * _common_sub_expr_num;
for (auto i = child_num + _common_sub_expr_num; i < child_num + 2 * _common_sub_expr_num; ++i) {
    num += get_child(i)->get_slot_ids(slot_ids);
}
return num;
```

The child indices mirror `collect_common_sub_exprs`, and `_common_sub_expr_num` is set in the constructor from `TExprNode.output_column`, so it is valid without `prepare()`. With `_common_sub_expr_num == 0` the loop does not run and behaviour is unchanged. `prepare()` already folds the same children into `_captured_slot_ids`, so the two branches now agree instead of disagreeing. The `slot_ids.size() == n` contract that `runtime_filter_probe.cpp` DCHECKs is preserved: every `num +=` adds exactly what that call pushed, and no de-duplication is introduced.

`ArraySortLambdaExpr::prepare` has the same "ask for slot ids, then extract, then prepare" order and is covered by the same fix.

Not moving the `get_slot_ids` call in `ArrayMapExpr::prepare` after `lambda->prepare()`, which would remove the ordering dependency altogether: `_initial_required_slots` has to describe the dependencies as they were *before* extraction, since `extract_outer_common_exprs` rewrites children in place and the extracted expressions are later evaluated against a `tmp_chunk` built from those original columns.

Other `get_slot_ids` callers are unaffected in practice. The scan/predicate paths (`scan_conjuncts_manager.cpp`, `partition_scan_range_pruner.cpp`, `runtime_filter_probe.cpp`) test `get_slot_ids(...) == 1` for single-slot expressions, so extra ids make them fall back rather than misbehave, and the required-column collectors (`global_dict/parser.cpp`, `schema_change.cpp`, `variant_projection.cpp`) only become more conservative. The unprepared branch already reported unpruned lambda argument slots before this change, so the kind of id being surfaced is not new. Everything reached after `prepare()` takes the `_is_prepared` branch and is untouched.

### Observability

Reviewed the signals on this path: the failure is already surfaced end to end, as a `Status::RuntimeError` from `ExprContext::evaluate` carrying the throwing chunk's slot set, annotated by the FE with the reporting backend, plus a full stack in `be.WARNING` via `exception_stack.cpp`. `VLOG(2)` in `extract_outer_common_exprs` already logs each extracted common expression. That was enough to localise this bug from a user-visible error message alone, so no new metric or log is added and none is removed.

### Testing

`test/sql/test_array_fn/{T,R}/test_nested_lambda_captured_arg` covers the **table-backed** form only:

- `array_map(x -> array_map(y -> abs(x) + y + abs(x), arr), arr)` — the case fixed here, over `[1,-2]`, `[]` and `NULL` rows.
- A control that computes the same values through the single-occurrence shape `abs(x) * 2 + y`, which was already correct, so the two must agree.

Verified on a cluster running this fix with an **otherwise unmodified FE**: the first query returns `[[3,0],[5,2]]` for `arr = [1,-2]` instead of failing, and its plan is byte-identical to the one produced by an FE carrying #78645, confirming the failure is BE-only.

**The constant-array form is deliberately not covered.** `array_map(x -> array_map(y -> abs(x) + y + abs(x), [1,2]), [1,2])` folds into a `PHYSICAL_VALUES` plan where the FE still hoists the reference out of the scope that defines it, so on `main` it fails plan validation (`The required cols {6} cannot obtain from input cols {1}`) before reaching the BE. It needs #78645 first. There is a note in the T file so it is not added back prematurely.

Once #78645 lands, that form is worth re-checking rather than assuming it is fixed: with #78645 applied but this fix absent it failed on a different BE path — the all-const branch's captured column size check (`The size of the captured column ... is less than array's size.`, `array_map_expr.cpp:120-123`) — and whether that path is fully covered by this change has not been verified. I am happy to add the case as a follow-up once both are in.

No BE unit test: no existing test in `be/test/exprs/` constructs a lambda carrying FE-supplied common sub expressions (`output_column` is never set there), and hand-building that layout would hard-code an assumption about the plan shape this bug depends on. The SQL test exercises the real FE-to-BE contract instead. Happy to add one modelled on #78769's `nested_array_map_captures_outer_arg_const_input` if reviewers prefer.

### Relationship to #78645

Independent, and this one is safe to land on its own. #78645 fixes the FE so nested lambda hoists stay in the scope that defines them. Its queries currently fail FE validation with `Input dependency cols check failed` and never reach the BE; once it lands they produce valid plans of exactly the shape above, so without this fix they would turn into BE-side failures instead. The BE defect itself predates #78645 and is reachable without it, as the repro in this PR shows.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

Verified that all three branches carry the affected code: the unprepared `return get_child(0)->get_slot_ids(slot_ids);` branch and `ArrayMapExpr`'s `_initial_required_slots` are present on `branch-4.1`, `branch-4.0` and `branch-3.5`. `extract_outer_common_exprs` landed in #51244 (2024-10) and `_initial_required_slots` in #57756 (2025-04), both before 3.5 branched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
