### PR TITLE
[Feature] Define standalone geo descriptors and transport (Contract 2.1)

### DIFF
--- a/be/src/types/CMakeLists.txt
+++ b/be/src/types/CMakeLists.txt
@@ -20,6 +20,7 @@ ADD_BE_LIB(Types
     decimalv2_value.cpp
     int128_to_double.cpp
     hll.cpp
+    geo_type_descriptor.cpp
     json_value.cpp
     json_value_converter.cpp
     simple_json_path.cpp

--- a/be/src/types/geo_type_descriptor.cpp
+++ b/be/src/types/geo_type_descriptor.cpp
@@ -167,15 +167,4 @@ bool is_geo_compute_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDe
     return is_geo_semantically_compatible(lhs.type, rhs.type);
 }
 
-bool is_geo_assignment_compatible(const GeoColumnDescriptor& source, const GeoColumnDescriptor& target) {
-    return is_geo_union_all_compatible(source, target) &&
-           (target.storage.dimension == GEO_DIMENSION_UNKNOWN || target.storage.dimension == GEO_DIMENSION_MIXED ||
-            source.storage.dimension == target.storage.dimension);
-}
-
-bool is_geo_union_all_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs) {
-    return is_geo_compute_compatible(lhs, rhs) && lhs.storage.encoding == GEO_ENCODING_WKB &&
-           rhs.storage.encoding == GEO_ENCODING_WKB;
-}
-
 } // namespace starrocks

--- a/be/src/types/geo_type_descriptor.cpp
+++ b/be/src/types/geo_type_descriptor.cpp
@@ -65,7 +65,7 @@ GeoTypeDescriptor GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
     return result;
 }
 
-GeoTypeDescriptor GeoTypeDescriptor::from_protobuf(const PGeoTypeDesc& protobuf) {
+GeoTypeDescriptor GeoTypeDescriptor::from_protobuf(const GeoTypeDescPB& protobuf) {
     GeoTypeDescriptor result;
     result.logical_type = protobuf.logical_type();
     result.coordinate_system = protobuf.coordinate_system();
@@ -85,8 +85,8 @@ TGeoTypeDesc GeoTypeDescriptor::to_thrift() const {
     return result;
 }
 
-PGeoTypeDesc GeoTypeDescriptor::to_protobuf() const {
-    PGeoTypeDesc result;
+GeoTypeDescPB GeoTypeDescriptor::to_protobuf() const {
+    GeoTypeDescPB result;
     result.set_logical_type(logical_type);
     result.set_coordinate_system(coordinate_system);
     result.set_edge_algorithm(edge_algorithm);
@@ -109,7 +109,7 @@ GeoStorageDescriptor GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& th
     return result;
 }
 
-GeoStorageDescriptor GeoStorageDescriptor::from_protobuf(const PGeoStorageDesc& protobuf) {
+GeoStorageDescriptor GeoStorageDescriptor::from_protobuf(const GeoStorageDescPB& protobuf) {
     GeoStorageDescriptor result;
     result.encoding = protobuf.encoding();
     result.dimension = protobuf.dimension();
@@ -125,8 +125,8 @@ TGeoStorageDesc GeoStorageDescriptor::to_thrift() const {
     return result;
 }
 
-PGeoStorageDesc GeoStorageDescriptor::to_protobuf() const {
-    PGeoStorageDesc result;
+GeoStorageDescPB GeoStorageDescriptor::to_protobuf() const {
+    GeoStorageDescPB result;
     result.set_encoding(encoding);
     result.set_dimension(dimension);
     result.set_validation_state(validation_state);
@@ -138,7 +138,7 @@ GeoColumnDescriptor GeoColumnDescriptor::from_thrift(const TGeoColumnDesc& thrif
             thrift.__isset.storage ? GeoStorageDescriptor::from_thrift(thrift.storage) : GeoStorageDescriptor{}};
 }
 
-GeoColumnDescriptor GeoColumnDescriptor::from_protobuf(const PGeoColumnDesc& protobuf) {
+GeoColumnDescriptor GeoColumnDescriptor::from_protobuf(const GeoColumnDescPB& protobuf) {
     return {GeoTypeDescriptor::from_protobuf(protobuf.type()), GeoStorageDescriptor::from_protobuf(protobuf.storage())};
 }
 
@@ -149,8 +149,8 @@ TGeoColumnDesc GeoColumnDescriptor::to_thrift() const {
     return result;
 }
 
-PGeoColumnDesc GeoColumnDescriptor::to_protobuf() const {
-    PGeoColumnDesc result;
+GeoColumnDescPB GeoColumnDescriptor::to_protobuf() const {
+    GeoColumnDescPB result;
     *result.mutable_type() = type.to_protobuf();
     *result.mutable_storage() = storage.to_protobuf();
     return result;

--- a/be/src/types/geo_type_descriptor.cpp
+++ b/be/src/types/geo_type_descriptor.cpp
@@ -47,15 +47,19 @@ static_assert(static_cast<int>(TGeoValidationState::SEMANTICALLY_VALIDATED) ==
 
 } // namespace
 
+// Normalize unknown Thrift enum numbers at the input boundary; support policy belongs to callers.
 GeoTypeDescriptor GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
     GeoTypeDescriptor result;
-    result.logical_type =
-            thrift.__isset.logical_type ? static_cast<PGeoLogicalType>(thrift.logical_type) : GEO_LOGICAL_TYPE_UNKNOWN;
-    result.coordinate_system = thrift.__isset.coordinate_system
-                                       ? static_cast<PGeoCoordinateSystem>(thrift.coordinate_system)
-                                       : GEO_COORDINATE_SYSTEM_UNKNOWN;
-    result.edge_algorithm = thrift.__isset.edge_algorithm ? static_cast<PGeoEdgeAlgorithm>(thrift.edge_algorithm)
-                                                          : GEO_EDGE_ALGORITHM_UNKNOWN;
+    result.logical_type = thrift.__isset.logical_type && PGeoLogicalType_IsValid(thrift.logical_type)
+                                  ? static_cast<PGeoLogicalType>(thrift.logical_type)
+                                  : GEO_LOGICAL_TYPE_UNKNOWN;
+    result.coordinate_system =
+            thrift.__isset.coordinate_system && PGeoCoordinateSystem_IsValid(thrift.coordinate_system)
+                    ? static_cast<PGeoCoordinateSystem>(thrift.coordinate_system)
+                    : GEO_COORDINATE_SYSTEM_UNKNOWN;
+    result.edge_algorithm = thrift.__isset.edge_algorithm && PGeoEdgeAlgorithm_IsValid(thrift.edge_algorithm)
+                                    ? static_cast<PGeoEdgeAlgorithm>(thrift.edge_algorithm)
+                                    : GEO_EDGE_ALGORITHM_UNKNOWN;
     if (thrift.__isset.crs) result.crs = thrift.crs;
     if (thrift.__isset.srid) result.srid = thrift.srid;
     return result;
@@ -63,9 +67,9 @@ GeoTypeDescriptor GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
 
 GeoTypeDescriptor GeoTypeDescriptor::from_protobuf(const PGeoTypeDesc& protobuf) {
     GeoTypeDescriptor result;
-    result.logical_type = static_cast<PGeoLogicalType>(protobuf.logical_type());
-    result.coordinate_system = static_cast<PGeoCoordinateSystem>(protobuf.coordinate_system());
-    result.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(protobuf.edge_algorithm());
+    result.logical_type = protobuf.logical_type();
+    result.coordinate_system = protobuf.coordinate_system();
+    result.edge_algorithm = protobuf.edge_algorithm();
     result.crs = protobuf.crs();
     if (protobuf.has_srid()) result.srid = protobuf.srid();
     return result;
@@ -73,9 +77,9 @@ GeoTypeDescriptor GeoTypeDescriptor::from_protobuf(const PGeoTypeDesc& protobuf)
 
 TGeoTypeDesc GeoTypeDescriptor::to_thrift() const {
     TGeoTypeDesc result;
-    result.__set_logical_type(static_cast<int32_t>(logical_type));
-    result.__set_coordinate_system(static_cast<int32_t>(coordinate_system));
-    result.__set_edge_algorithm(static_cast<int32_t>(edge_algorithm));
+    result.__set_logical_type(static_cast<TGeoLogicalType::type>(logical_type));
+    result.__set_coordinate_system(static_cast<TGeoCoordinateSystem::type>(coordinate_system));
+    result.__set_edge_algorithm(static_cast<TGeoEdgeAlgorithm::type>(edge_algorithm));
     result.__set_crs(crs);
     if (srid) result.__set_srid(*srid);
     return result;
@@ -83,9 +87,9 @@ TGeoTypeDesc GeoTypeDescriptor::to_thrift() const {
 
 PGeoTypeDesc GeoTypeDescriptor::to_protobuf() const {
     PGeoTypeDesc result;
-    result.set_logical_type(static_cast<int32_t>(logical_type));
-    result.set_coordinate_system(static_cast<int32_t>(coordinate_system));
-    result.set_edge_algorithm(static_cast<int32_t>(edge_algorithm));
+    result.set_logical_type(logical_type);
+    result.set_coordinate_system(coordinate_system);
+    result.set_edge_algorithm(edge_algorithm);
     result.set_crs(crs);
     if (srid) result.set_srid(*srid);
     return result;
@@ -93,9 +97,13 @@ PGeoTypeDesc GeoTypeDescriptor::to_protobuf() const {
 
 GeoStorageDescriptor GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& thrift) {
     GeoStorageDescriptor result;
-    result.encoding = thrift.__isset.encoding ? static_cast<PGeoEncoding>(thrift.encoding) : GEO_ENCODING_UNKNOWN;
-    result.dimension = thrift.__isset.dimension ? static_cast<PGeoDimension>(thrift.dimension) : GEO_DIMENSION_UNKNOWN;
-    result.validation_state = thrift.__isset.validation_state
+    result.encoding = thrift.__isset.encoding && PGeoEncoding_IsValid(thrift.encoding)
+                              ? static_cast<PGeoEncoding>(thrift.encoding)
+                              : GEO_ENCODING_UNKNOWN;
+    result.dimension = thrift.__isset.dimension && PGeoDimension_IsValid(thrift.dimension)
+                               ? static_cast<PGeoDimension>(thrift.dimension)
+                               : GEO_DIMENSION_UNKNOWN;
+    result.validation_state = thrift.__isset.validation_state && PGeoValidationState_IsValid(thrift.validation_state)
                                       ? static_cast<PGeoValidationState>(thrift.validation_state)
                                       : GEO_VALIDATION_STATE_UNKNOWN;
     return result;
@@ -103,25 +111,25 @@ GeoStorageDescriptor GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& th
 
 GeoStorageDescriptor GeoStorageDescriptor::from_protobuf(const PGeoStorageDesc& protobuf) {
     GeoStorageDescriptor result;
-    result.encoding = static_cast<PGeoEncoding>(protobuf.encoding());
-    result.dimension = static_cast<PGeoDimension>(protobuf.dimension());
-    result.validation_state = static_cast<PGeoValidationState>(protobuf.validation_state());
+    result.encoding = protobuf.encoding();
+    result.dimension = protobuf.dimension();
+    result.validation_state = protobuf.validation_state();
     return result;
 }
 
 TGeoStorageDesc GeoStorageDescriptor::to_thrift() const {
     TGeoStorageDesc result;
-    result.__set_encoding(static_cast<int32_t>(encoding));
-    result.__set_dimension(static_cast<int32_t>(dimension));
-    result.__set_validation_state(static_cast<int32_t>(validation_state));
+    result.__set_encoding(static_cast<TGeoEncoding::type>(encoding));
+    result.__set_dimension(static_cast<TGeoDimension::type>(dimension));
+    result.__set_validation_state(static_cast<TGeoValidationState::type>(validation_state));
     return result;
 }
 
 PGeoStorageDesc GeoStorageDescriptor::to_protobuf() const {
     PGeoStorageDesc result;
-    result.set_encoding(static_cast<int32_t>(encoding));
-    result.set_dimension(static_cast<int32_t>(dimension));
-    result.set_validation_state(static_cast<int32_t>(validation_state));
+    result.set_encoding(encoding);
+    result.set_dimension(dimension);
+    result.set_validation_state(validation_state);
     return result;
 }
 

--- a/be/src/types/geo_type_descriptor.cpp
+++ b/be/src/types/geo_type_descriptor.cpp
@@ -50,15 +50,15 @@ static_assert(static_cast<int>(TGeoValidationState::SEMANTICALLY_VALIDATED) ==
 // Normalize unknown Thrift enum numbers at the input boundary; support policy belongs to callers.
 GeoTypeDescriptor GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
     GeoTypeDescriptor result;
-    result.logical_type = thrift.__isset.logical_type && PGeoLogicalType_IsValid(thrift.logical_type)
-                                  ? static_cast<PGeoLogicalType>(thrift.logical_type)
+    result.logical_type = thrift.__isset.logical_type && GeoLogicalTypePB_IsValid(thrift.logical_type)
+                                  ? static_cast<GeoLogicalTypePB>(thrift.logical_type)
                                   : GEO_LOGICAL_TYPE_UNKNOWN;
     result.coordinate_system =
-            thrift.__isset.coordinate_system && PGeoCoordinateSystem_IsValid(thrift.coordinate_system)
-                    ? static_cast<PGeoCoordinateSystem>(thrift.coordinate_system)
+            thrift.__isset.coordinate_system && GeoCoordinateSystemPB_IsValid(thrift.coordinate_system)
+                    ? static_cast<GeoCoordinateSystemPB>(thrift.coordinate_system)
                     : GEO_COORDINATE_SYSTEM_UNKNOWN;
-    result.edge_algorithm = thrift.__isset.edge_algorithm && PGeoEdgeAlgorithm_IsValid(thrift.edge_algorithm)
-                                    ? static_cast<PGeoEdgeAlgorithm>(thrift.edge_algorithm)
+    result.edge_algorithm = thrift.__isset.edge_algorithm && GeoEdgeAlgorithmPB_IsValid(thrift.edge_algorithm)
+                                    ? static_cast<GeoEdgeAlgorithmPB>(thrift.edge_algorithm)
                                     : GEO_EDGE_ALGORITHM_UNKNOWN;
     if (thrift.__isset.crs) result.crs = thrift.crs;
     if (thrift.__isset.srid) result.srid = thrift.srid;
@@ -97,14 +97,14 @@ GeoTypeDescPB GeoTypeDescriptor::to_protobuf() const {
 
 GeoStorageDescriptor GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& thrift) {
     GeoStorageDescriptor result;
-    result.encoding = thrift.__isset.encoding && PGeoEncoding_IsValid(thrift.encoding)
-                              ? static_cast<PGeoEncoding>(thrift.encoding)
+    result.encoding = thrift.__isset.encoding && GeoEncodingPB_IsValid(thrift.encoding)
+                              ? static_cast<GeoEncodingPB>(thrift.encoding)
                               : GEO_ENCODING_UNKNOWN;
-    result.dimension = thrift.__isset.dimension && PGeoDimension_IsValid(thrift.dimension)
-                               ? static_cast<PGeoDimension>(thrift.dimension)
+    result.dimension = thrift.__isset.dimension && GeoDimensionPB_IsValid(thrift.dimension)
+                               ? static_cast<GeoDimensionPB>(thrift.dimension)
                                : GEO_DIMENSION_UNKNOWN;
-    result.validation_state = thrift.__isset.validation_state && PGeoValidationState_IsValid(thrift.validation_state)
-                                      ? static_cast<PGeoValidationState>(thrift.validation_state)
+    result.validation_state = thrift.__isset.validation_state && GeoValidationStatePB_IsValid(thrift.validation_state)
+                                      ? static_cast<GeoValidationStatePB>(thrift.validation_state)
                                       : GEO_VALIDATION_STATE_UNKNOWN;
     return result;
 }

--- a/be/src/types/geo_type_descriptor.cpp
+++ b/be/src/types/geo_type_descriptor.cpp
@@ -1,0 +1,324 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/geo_type_descriptor.h"
+
+#include <tuple>
+
+namespace starrocks {
+namespace {
+
+static_assert(static_cast<int>(TGeoLogicalType::UNKNOWN) == GEO_LOGICAL_TYPE_UNKNOWN);
+static_assert(static_cast<int>(TGeoLogicalType::GEOGRAPHY) == GEO_LOGICAL_TYPE_GEOGRAPHY);
+static_assert(static_cast<int>(TGeoLogicalType::GEOMETRY) == GEO_LOGICAL_TYPE_GEOMETRY);
+static_assert(static_cast<int>(TGeoCoordinateSystem::UNKNOWN) == GEO_COORDINATE_SYSTEM_UNKNOWN);
+static_assert(static_cast<int>(TGeoCoordinateSystem::SPHERICAL) == GEO_COORDINATE_SYSTEM_SPHERICAL);
+static_assert(static_cast<int>(TGeoCoordinateSystem::CARTESIAN) == GEO_COORDINATE_SYSTEM_CARTESIAN);
+static_assert(static_cast<int>(TGeoEdgeAlgorithm::UNKNOWN) == GEO_EDGE_ALGORITHM_UNKNOWN);
+static_assert(static_cast<int>(TGeoEdgeAlgorithm::SPHERICAL) == GEO_EDGE_ALGORITHM_SPHERICAL);
+static_assert(static_cast<int>(TGeoEdgeAlgorithm::VINCENTY) == GEO_EDGE_ALGORITHM_VINCENTY);
+static_assert(static_cast<int>(TGeoEdgeAlgorithm::THOMAS) == GEO_EDGE_ALGORITHM_THOMAS);
+static_assert(static_cast<int>(TGeoEdgeAlgorithm::ANDOYER) == GEO_EDGE_ALGORITHM_ANDOYER);
+static_assert(static_cast<int>(TGeoEdgeAlgorithm::KARNEY) == GEO_EDGE_ALGORITHM_KARNEY);
+static_assert(static_cast<int>(TGeoEdgeAlgorithm::PLANAR) == GEO_EDGE_ALGORITHM_PLANAR);
+static_assert(static_cast<int>(TGeoEncoding::UNKNOWN) == GEO_ENCODING_UNKNOWN);
+static_assert(static_cast<int>(TGeoEncoding::WKB) == GEO_ENCODING_WKB);
+static_assert(static_cast<int>(TGeoDimension::UNKNOWN) == GEO_DIMENSION_UNKNOWN);
+static_assert(static_cast<int>(TGeoDimension::XY) == GEO_DIMENSION_XY);
+static_assert(static_cast<int>(TGeoDimension::XYZ) == GEO_DIMENSION_XYZ);
+static_assert(static_cast<int>(TGeoDimension::XYM) == GEO_DIMENSION_XYM);
+static_assert(static_cast<int>(TGeoDimension::XYZM) == GEO_DIMENSION_XYZM);
+static_assert(static_cast<int>(TGeoDimension::MIXED) == GEO_DIMENSION_MIXED);
+static_assert(static_cast<int>(TGeoValidationState::UNKNOWN) == GEO_VALIDATION_STATE_UNKNOWN);
+static_assert(static_cast<int>(TGeoValidationState::UNVALIDATED) == GEO_VALIDATION_STATE_UNVALIDATED);
+static_assert(static_cast<int>(TGeoValidationState::STRUCTURALLY_VALIDATED) ==
+              GEO_VALIDATION_STATE_STRUCTURALLY_VALIDATED);
+static_assert(static_cast<int>(TGeoValidationState::SEMANTICALLY_VALIDATED) ==
+              GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED);
+
+template <typename Enum>
+Status check_enum(const std::optional<Enum>& value, bool (*is_valid)(int), const char* field) {
+    if (value && !is_valid(static_cast<int>(*value))) {
+        return Status::NotSupported(std::string("Unknown geo enum value for ") + field + ": " +
+                                    std::to_string(static_cast<int>(*value)));
+    }
+    return Status::OK();
+}
+
+// Both descriptor messages use fields 1..3 for enums. A proto2 unknown enum
+// can coexist with a known value for the same field, so has_*() is insufficient.
+template <typename Message>
+Status check_unknown_enums(const Message& message) {
+    const auto& fields = message.unknown_fields();
+    for (int i = 0; i < fields.field_count(); ++i) {
+        const auto& field = fields.field(i);
+        if (field.number() >= 1 && field.number() <= 3) {
+            return Status::NotSupported("Unknown geo enum wire value at field " + std::to_string(field.number()));
+        }
+    }
+    return Status::OK();
+}
+
+Status check_enums(const GeoTypeDescriptor& desc) {
+    RETURN_IF_ERROR(check_enum(desc.logical_type, PGeoLogicalType_IsValid, "logical_type"));
+    RETURN_IF_ERROR(check_enum(desc.coordinate_system, PGeoCoordinateSystem_IsValid, "coordinate_system"));
+    RETURN_IF_ERROR(check_enum(desc.edge_algorithm, PGeoEdgeAlgorithm_IsValid, "edge_algorithm"));
+    return Status::OK();
+}
+
+Status check_enums(const GeoStorageDescriptor& desc) {
+    RETURN_IF_ERROR(check_enum(desc.encoding, PGeoEncoding_IsValid, "encoding"));
+    RETURN_IF_ERROR(check_enum(desc.dimension, PGeoDimension_IsValid, "dimension"));
+    RETURN_IF_ERROR(check_enum(desc.validation_state, PGeoValidationState_IsValid, "validation_state"));
+    return Status::OK();
+}
+
+bool has_wkb_storage(const GeoColumnDescriptor& desc) {
+    return desc.storage && desc.storage->encoding == TGeoEncoding::WKB;
+}
+
+} // namespace
+
+StatusOr<GeoTypeDescriptor> GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
+    GeoTypeDescriptor result;
+    if (thrift.__isset.logical_type) {
+        result.logical_type = thrift.logical_type;
+    }
+    if (thrift.__isset.coordinate_system) {
+        result.coordinate_system = thrift.coordinate_system;
+    }
+    if (thrift.__isset.edge_algorithm) {
+        result.edge_algorithm = thrift.edge_algorithm;
+    }
+    if (thrift.__isset.crs) {
+        result.crs = thrift.crs;
+    }
+    if (thrift.__isset.srid) {
+        result.srid = thrift.srid;
+    }
+    RETURN_IF_ERROR(check_enums(result));
+    return result;
+}
+
+StatusOr<GeoTypeDescriptor> GeoTypeDescriptor::from_protobuf(const PGeoTypeDesc& protobuf) {
+    RETURN_IF_ERROR(check_unknown_enums(protobuf));
+    GeoTypeDescriptor result;
+    if (protobuf.has_logical_type()) {
+        result.logical_type = static_cast<TGeoLogicalType::type>(protobuf.logical_type());
+    }
+    if (protobuf.has_coordinate_system()) {
+        result.coordinate_system = static_cast<TGeoCoordinateSystem::type>(protobuf.coordinate_system());
+    }
+    if (protobuf.has_edge_algorithm()) {
+        result.edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(protobuf.edge_algorithm());
+    }
+    if (protobuf.has_crs()) {
+        result.crs = protobuf.crs();
+    }
+    if (protobuf.has_srid()) {
+        result.srid = protobuf.srid();
+    }
+    return result;
+}
+
+StatusOr<TGeoTypeDesc> GeoTypeDescriptor::to_thrift() const {
+    RETURN_IF_ERROR(check_enums(*this));
+    TGeoTypeDesc result;
+    if (logical_type) {
+        result.__set_logical_type(*logical_type);
+    }
+    if (coordinate_system) {
+        result.__set_coordinate_system(*coordinate_system);
+    }
+    if (edge_algorithm) {
+        result.__set_edge_algorithm(*edge_algorithm);
+    }
+    if (crs) {
+        result.__set_crs(*crs);
+    }
+    if (srid) {
+        result.__set_srid(*srid);
+    }
+    return result;
+}
+
+StatusOr<PGeoTypeDesc> GeoTypeDescriptor::to_protobuf() const {
+    RETURN_IF_ERROR(check_enums(*this));
+    PGeoTypeDesc result;
+    if (logical_type) {
+        result.set_logical_type(static_cast<PGeoLogicalType>(*logical_type));
+    }
+    if (coordinate_system) {
+        result.set_coordinate_system(static_cast<PGeoCoordinateSystem>(*coordinate_system));
+    }
+    if (edge_algorithm) {
+        result.set_edge_algorithm(static_cast<PGeoEdgeAlgorithm>(*edge_algorithm));
+    }
+    if (crs) {
+        result.set_crs(*crs);
+    }
+    if (srid) {
+        result.set_srid(*srid);
+    }
+    return result;
+}
+
+bool GeoTypeDescriptor::operator==(const GeoTypeDescriptor& rhs) const {
+    return std::tie(logical_type, coordinate_system, edge_algorithm, crs, srid) ==
+           std::tie(rhs.logical_type, rhs.coordinate_system, rhs.edge_algorithm, rhs.crs, rhs.srid);
+}
+
+StatusOr<GeoStorageDescriptor> GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& thrift) {
+    GeoStorageDescriptor result;
+    if (thrift.__isset.encoding) {
+        result.encoding = thrift.encoding;
+    }
+    if (thrift.__isset.dimension) {
+        result.dimension = thrift.dimension;
+    }
+    if (thrift.__isset.validation_state) {
+        result.validation_state = thrift.validation_state;
+    }
+    RETURN_IF_ERROR(check_enums(result));
+    return result;
+}
+
+StatusOr<GeoStorageDescriptor> GeoStorageDescriptor::from_protobuf(const PGeoStorageDesc& protobuf) {
+    RETURN_IF_ERROR(check_unknown_enums(protobuf));
+    GeoStorageDescriptor result;
+    if (protobuf.has_encoding()) {
+        result.encoding = static_cast<TGeoEncoding::type>(protobuf.encoding());
+    }
+    if (protobuf.has_dimension()) {
+        result.dimension = static_cast<TGeoDimension::type>(protobuf.dimension());
+    }
+    if (protobuf.has_validation_state()) {
+        result.validation_state = static_cast<TGeoValidationState::type>(protobuf.validation_state());
+    }
+    return result;
+}
+
+StatusOr<TGeoStorageDesc> GeoStorageDescriptor::to_thrift() const {
+    RETURN_IF_ERROR(check_enums(*this));
+    TGeoStorageDesc result;
+    if (encoding) {
+        result.__set_encoding(*encoding);
+    }
+    if (dimension) {
+        result.__set_dimension(*dimension);
+    }
+    if (validation_state) {
+        result.__set_validation_state(*validation_state);
+    }
+    return result;
+}
+
+StatusOr<PGeoStorageDesc> GeoStorageDescriptor::to_protobuf() const {
+    RETURN_IF_ERROR(check_enums(*this));
+    PGeoStorageDesc result;
+    if (encoding) {
+        result.set_encoding(static_cast<PGeoEncoding>(*encoding));
+    }
+    if (dimension) {
+        result.set_dimension(static_cast<PGeoDimension>(*dimension));
+    }
+    if (validation_state) {
+        result.set_validation_state(static_cast<PGeoValidationState>(*validation_state));
+    }
+    return result;
+}
+
+bool GeoStorageDescriptor::operator==(const GeoStorageDescriptor& rhs) const {
+    return std::tie(encoding, dimension, validation_state) ==
+           std::tie(rhs.encoding, rhs.dimension, rhs.validation_state);
+}
+
+StatusOr<GeoColumnDescriptor> GeoColumnDescriptor::from_thrift(const TGeoColumnDesc& thrift) {
+    GeoColumnDescriptor result;
+    if (thrift.__isset.type) {
+        ASSIGN_OR_RETURN(result.type, GeoTypeDescriptor::from_thrift(thrift.type));
+    }
+    if (thrift.__isset.storage) {
+        ASSIGN_OR_RETURN(result.storage, GeoStorageDescriptor::from_thrift(thrift.storage));
+    }
+    return result;
+}
+
+StatusOr<GeoColumnDescriptor> GeoColumnDescriptor::from_protobuf(const PGeoColumnDesc& protobuf) {
+    GeoColumnDescriptor result;
+    if (protobuf.has_type()) {
+        ASSIGN_OR_RETURN(result.type, GeoTypeDescriptor::from_protobuf(protobuf.type()));
+    }
+    if (protobuf.has_storage()) {
+        ASSIGN_OR_RETURN(result.storage, GeoStorageDescriptor::from_protobuf(protobuf.storage()));
+    }
+    return result;
+}
+
+StatusOr<TGeoColumnDesc> GeoColumnDescriptor::to_thrift() const {
+    TGeoColumnDesc result;
+    if (type) {
+        ASSIGN_OR_RETURN(auto value, type->to_thrift());
+        result.__set_type(value);
+    }
+    if (storage) {
+        ASSIGN_OR_RETURN(auto value, storage->to_thrift());
+        result.__set_storage(value);
+    }
+    return result;
+}
+
+StatusOr<PGeoColumnDesc> GeoColumnDescriptor::to_protobuf() const {
+    PGeoColumnDesc result;
+    if (type) {
+        ASSIGN_OR_RETURN(auto value, type->to_protobuf());
+        *result.mutable_type() = std::move(value);
+    }
+    if (storage) {
+        ASSIGN_OR_RETURN(auto value, storage->to_protobuf());
+        *result.mutable_storage() = std::move(value);
+    }
+    return result;
+}
+
+bool GeoColumnDescriptor::operator==(const GeoColumnDescriptor& rhs) const {
+    return std::tie(type, storage) == std::tie(rhs.type, rhs.storage);
+}
+
+bool is_geo_semantically_compatible(const GeoTypeDescriptor& lhs, const GeoTypeDescriptor& rhs) {
+    return lhs.logical_type && *lhs.logical_type != TGeoLogicalType::UNKNOWN && lhs.coordinate_system &&
+           *lhs.coordinate_system != TGeoCoordinateSystem::UNKNOWN && lhs.edge_algorithm &&
+           *lhs.edge_algorithm != TGeoEdgeAlgorithm::UNKNOWN && lhs.crs && !lhs.crs->empty() &&
+           lhs.logical_type == rhs.logical_type && lhs.coordinate_system == rhs.coordinate_system &&
+           lhs.edge_algorithm == rhs.edge_algorithm && lhs.crs == rhs.crs;
+}
+
+bool is_geo_compute_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs) {
+    return lhs.type && rhs.type && is_geo_semantically_compatible(*lhs.type, *rhs.type);
+}
+
+bool is_geo_assignment_compatible(const GeoColumnDescriptor& source, const GeoColumnDescriptor& target) {
+    if (!is_geo_union_all_compatible(source, target)) {
+        return false;
+    }
+    const auto dimension = target.storage->dimension.value_or(TGeoDimension::UNKNOWN);
+    return dimension == TGeoDimension::UNKNOWN || dimension == TGeoDimension::MIXED ||
+           source.storage->dimension == dimension;
+}
+
+bool is_geo_union_all_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs) {
+    return is_geo_compute_compatible(lhs, rhs) && has_wkb_storage(lhs) && has_wkb_storage(rhs);
+}
+
+} // namespace starrocks

--- a/be/src/types/geo_type_descriptor.cpp
+++ b/be/src/types/geo_type_descriptor.cpp
@@ -14,8 +14,6 @@
 
 #include "types/geo_type_descriptor.h"
 
-#include <tuple>
-
 namespace starrocks {
 namespace {
 
@@ -47,278 +45,129 @@ static_assert(static_cast<int>(TGeoValidationState::STRUCTURALLY_VALIDATED) ==
 static_assert(static_cast<int>(TGeoValidationState::SEMANTICALLY_VALIDATED) ==
               GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED);
 
-template <typename Enum>
-Status check_enum(const std::optional<Enum>& value, bool (*is_valid)(int), const char* field) {
-    if (value && !is_valid(static_cast<int>(*value))) {
-        return Status::NotSupported(std::string("Unknown geo enum value for ") + field + ": " +
-                                    std::to_string(static_cast<int>(*value)));
-    }
-    return Status::OK();
-}
-
-// Both descriptor messages use fields 1..3 for enums. A proto2 unknown enum
-// can coexist with a known value for the same field, so has_*() is insufficient.
-template <typename Message>
-Status check_unknown_enums(const Message& message) {
-    const auto& fields = message.unknown_fields();
-    for (int i = 0; i < fields.field_count(); ++i) {
-        const auto& field = fields.field(i);
-        if (field.number() >= 1 && field.number() <= 3) {
-            return Status::NotSupported("Unknown geo enum wire value at field " + std::to_string(field.number()));
-        }
-    }
-    return Status::OK();
-}
-
-Status check_enums(const GeoTypeDescriptor& desc) {
-    RETURN_IF_ERROR(check_enum(desc.logical_type, PGeoLogicalType_IsValid, "logical_type"));
-    RETURN_IF_ERROR(check_enum(desc.coordinate_system, PGeoCoordinateSystem_IsValid, "coordinate_system"));
-    RETURN_IF_ERROR(check_enum(desc.edge_algorithm, PGeoEdgeAlgorithm_IsValid, "edge_algorithm"));
-    return Status::OK();
-}
-
-Status check_enums(const GeoStorageDescriptor& desc) {
-    RETURN_IF_ERROR(check_enum(desc.encoding, PGeoEncoding_IsValid, "encoding"));
-    RETURN_IF_ERROR(check_enum(desc.dimension, PGeoDimension_IsValid, "dimension"));
-    RETURN_IF_ERROR(check_enum(desc.validation_state, PGeoValidationState_IsValid, "validation_state"));
-    return Status::OK();
-}
-
-bool has_wkb_storage(const GeoColumnDescriptor& desc) {
-    return desc.storage && desc.storage->encoding == TGeoEncoding::WKB;
-}
-
 } // namespace
 
-StatusOr<GeoTypeDescriptor> GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
+GeoTypeDescriptor GeoTypeDescriptor::from_thrift(const TGeoTypeDesc& thrift) {
     GeoTypeDescriptor result;
-    if (thrift.__isset.logical_type) {
-        result.logical_type = thrift.logical_type;
-    }
-    if (thrift.__isset.coordinate_system) {
-        result.coordinate_system = thrift.coordinate_system;
-    }
-    if (thrift.__isset.edge_algorithm) {
-        result.edge_algorithm = thrift.edge_algorithm;
-    }
-    if (thrift.__isset.crs) {
-        result.crs = thrift.crs;
-    }
-    if (thrift.__isset.srid) {
-        result.srid = thrift.srid;
-    }
-    RETURN_IF_ERROR(check_enums(result));
+    result.logical_type =
+            thrift.__isset.logical_type ? static_cast<PGeoLogicalType>(thrift.logical_type) : GEO_LOGICAL_TYPE_UNKNOWN;
+    result.coordinate_system = thrift.__isset.coordinate_system
+                                       ? static_cast<PGeoCoordinateSystem>(thrift.coordinate_system)
+                                       : GEO_COORDINATE_SYSTEM_UNKNOWN;
+    result.edge_algorithm = thrift.__isset.edge_algorithm ? static_cast<PGeoEdgeAlgorithm>(thrift.edge_algorithm)
+                                                          : GEO_EDGE_ALGORITHM_UNKNOWN;
+    if (thrift.__isset.crs) result.crs = thrift.crs;
+    if (thrift.__isset.srid) result.srid = thrift.srid;
     return result;
 }
 
-StatusOr<GeoTypeDescriptor> GeoTypeDescriptor::from_protobuf(const PGeoTypeDesc& protobuf) {
-    RETURN_IF_ERROR(check_unknown_enums(protobuf));
+GeoTypeDescriptor GeoTypeDescriptor::from_protobuf(const PGeoTypeDesc& protobuf) {
     GeoTypeDescriptor result;
-    if (protobuf.has_logical_type()) {
-        result.logical_type = static_cast<TGeoLogicalType::type>(protobuf.logical_type());
-    }
-    if (protobuf.has_coordinate_system()) {
-        result.coordinate_system = static_cast<TGeoCoordinateSystem::type>(protobuf.coordinate_system());
-    }
-    if (protobuf.has_edge_algorithm()) {
-        result.edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(protobuf.edge_algorithm());
-    }
-    if (protobuf.has_crs()) {
-        result.crs = protobuf.crs();
-    }
-    if (protobuf.has_srid()) {
-        result.srid = protobuf.srid();
-    }
+    result.logical_type = static_cast<PGeoLogicalType>(protobuf.logical_type());
+    result.coordinate_system = static_cast<PGeoCoordinateSystem>(protobuf.coordinate_system());
+    result.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(protobuf.edge_algorithm());
+    result.crs = protobuf.crs();
+    if (protobuf.has_srid()) result.srid = protobuf.srid();
     return result;
 }
 
-StatusOr<TGeoTypeDesc> GeoTypeDescriptor::to_thrift() const {
-    RETURN_IF_ERROR(check_enums(*this));
+TGeoTypeDesc GeoTypeDescriptor::to_thrift() const {
     TGeoTypeDesc result;
-    if (logical_type) {
-        result.__set_logical_type(*logical_type);
-    }
-    if (coordinate_system) {
-        result.__set_coordinate_system(*coordinate_system);
-    }
-    if (edge_algorithm) {
-        result.__set_edge_algorithm(*edge_algorithm);
-    }
-    if (crs) {
-        result.__set_crs(*crs);
-    }
-    if (srid) {
-        result.__set_srid(*srid);
-    }
+    result.__set_logical_type(static_cast<int32_t>(logical_type));
+    result.__set_coordinate_system(static_cast<int32_t>(coordinate_system));
+    result.__set_edge_algorithm(static_cast<int32_t>(edge_algorithm));
+    result.__set_crs(crs);
+    if (srid) result.__set_srid(*srid);
     return result;
 }
 
-StatusOr<PGeoTypeDesc> GeoTypeDescriptor::to_protobuf() const {
-    RETURN_IF_ERROR(check_enums(*this));
+PGeoTypeDesc GeoTypeDescriptor::to_protobuf() const {
     PGeoTypeDesc result;
-    if (logical_type) {
-        result.set_logical_type(static_cast<PGeoLogicalType>(*logical_type));
-    }
-    if (coordinate_system) {
-        result.set_coordinate_system(static_cast<PGeoCoordinateSystem>(*coordinate_system));
-    }
-    if (edge_algorithm) {
-        result.set_edge_algorithm(static_cast<PGeoEdgeAlgorithm>(*edge_algorithm));
-    }
-    if (crs) {
-        result.set_crs(*crs);
-    }
-    if (srid) {
-        result.set_srid(*srid);
-    }
+    result.set_logical_type(static_cast<int32_t>(logical_type));
+    result.set_coordinate_system(static_cast<int32_t>(coordinate_system));
+    result.set_edge_algorithm(static_cast<int32_t>(edge_algorithm));
+    result.set_crs(crs);
+    if (srid) result.set_srid(*srid);
     return result;
 }
 
-bool GeoTypeDescriptor::operator==(const GeoTypeDescriptor& rhs) const {
-    return std::tie(logical_type, coordinate_system, edge_algorithm, crs, srid) ==
-           std::tie(rhs.logical_type, rhs.coordinate_system, rhs.edge_algorithm, rhs.crs, rhs.srid);
-}
-
-StatusOr<GeoStorageDescriptor> GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& thrift) {
+GeoStorageDescriptor GeoStorageDescriptor::from_thrift(const TGeoStorageDesc& thrift) {
     GeoStorageDescriptor result;
-    if (thrift.__isset.encoding) {
-        result.encoding = thrift.encoding;
-    }
-    if (thrift.__isset.dimension) {
-        result.dimension = thrift.dimension;
-    }
-    if (thrift.__isset.validation_state) {
-        result.validation_state = thrift.validation_state;
-    }
-    RETURN_IF_ERROR(check_enums(result));
+    result.encoding = thrift.__isset.encoding ? static_cast<PGeoEncoding>(thrift.encoding) : GEO_ENCODING_UNKNOWN;
+    result.dimension = thrift.__isset.dimension ? static_cast<PGeoDimension>(thrift.dimension) : GEO_DIMENSION_UNKNOWN;
+    result.validation_state = thrift.__isset.validation_state
+                                      ? static_cast<PGeoValidationState>(thrift.validation_state)
+                                      : GEO_VALIDATION_STATE_UNKNOWN;
     return result;
 }
 
-StatusOr<GeoStorageDescriptor> GeoStorageDescriptor::from_protobuf(const PGeoStorageDesc& protobuf) {
-    RETURN_IF_ERROR(check_unknown_enums(protobuf));
+GeoStorageDescriptor GeoStorageDescriptor::from_protobuf(const PGeoStorageDesc& protobuf) {
     GeoStorageDescriptor result;
-    if (protobuf.has_encoding()) {
-        result.encoding = static_cast<TGeoEncoding::type>(protobuf.encoding());
-    }
-    if (protobuf.has_dimension()) {
-        result.dimension = static_cast<TGeoDimension::type>(protobuf.dimension());
-    }
-    if (protobuf.has_validation_state()) {
-        result.validation_state = static_cast<TGeoValidationState::type>(protobuf.validation_state());
-    }
+    result.encoding = static_cast<PGeoEncoding>(protobuf.encoding());
+    result.dimension = static_cast<PGeoDimension>(protobuf.dimension());
+    result.validation_state = static_cast<PGeoValidationState>(protobuf.validation_state());
     return result;
 }
 
-StatusOr<TGeoStorageDesc> GeoStorageDescriptor::to_thrift() const {
-    RETURN_IF_ERROR(check_enums(*this));
+TGeoStorageDesc GeoStorageDescriptor::to_thrift() const {
     TGeoStorageDesc result;
-    if (encoding) {
-        result.__set_encoding(*encoding);
-    }
-    if (dimension) {
-        result.__set_dimension(*dimension);
-    }
-    if (validation_state) {
-        result.__set_validation_state(*validation_state);
-    }
+    result.__set_encoding(static_cast<int32_t>(encoding));
+    result.__set_dimension(static_cast<int32_t>(dimension));
+    result.__set_validation_state(static_cast<int32_t>(validation_state));
     return result;
 }
 
-StatusOr<PGeoStorageDesc> GeoStorageDescriptor::to_protobuf() const {
-    RETURN_IF_ERROR(check_enums(*this));
+PGeoStorageDesc GeoStorageDescriptor::to_protobuf() const {
     PGeoStorageDesc result;
-    if (encoding) {
-        result.set_encoding(static_cast<PGeoEncoding>(*encoding));
-    }
-    if (dimension) {
-        result.set_dimension(static_cast<PGeoDimension>(*dimension));
-    }
-    if (validation_state) {
-        result.set_validation_state(static_cast<PGeoValidationState>(*validation_state));
-    }
+    result.set_encoding(static_cast<int32_t>(encoding));
+    result.set_dimension(static_cast<int32_t>(dimension));
+    result.set_validation_state(static_cast<int32_t>(validation_state));
     return result;
 }
 
-bool GeoStorageDescriptor::operator==(const GeoStorageDescriptor& rhs) const {
-    return std::tie(encoding, dimension, validation_state) ==
-           std::tie(rhs.encoding, rhs.dimension, rhs.validation_state);
+GeoColumnDescriptor GeoColumnDescriptor::from_thrift(const TGeoColumnDesc& thrift) {
+    return {thrift.__isset.type ? GeoTypeDescriptor::from_thrift(thrift.type) : GeoTypeDescriptor{},
+            thrift.__isset.storage ? GeoStorageDescriptor::from_thrift(thrift.storage) : GeoStorageDescriptor{}};
 }
 
-StatusOr<GeoColumnDescriptor> GeoColumnDescriptor::from_thrift(const TGeoColumnDesc& thrift) {
-    GeoColumnDescriptor result;
-    if (thrift.__isset.type) {
-        ASSIGN_OR_RETURN(result.type, GeoTypeDescriptor::from_thrift(thrift.type));
-    }
-    if (thrift.__isset.storage) {
-        ASSIGN_OR_RETURN(result.storage, GeoStorageDescriptor::from_thrift(thrift.storage));
-    }
-    return result;
+GeoColumnDescriptor GeoColumnDescriptor::from_protobuf(const PGeoColumnDesc& protobuf) {
+    return {GeoTypeDescriptor::from_protobuf(protobuf.type()), GeoStorageDescriptor::from_protobuf(protobuf.storage())};
 }
 
-StatusOr<GeoColumnDescriptor> GeoColumnDescriptor::from_protobuf(const PGeoColumnDesc& protobuf) {
-    GeoColumnDescriptor result;
-    if (protobuf.has_type()) {
-        ASSIGN_OR_RETURN(result.type, GeoTypeDescriptor::from_protobuf(protobuf.type()));
-    }
-    if (protobuf.has_storage()) {
-        ASSIGN_OR_RETURN(result.storage, GeoStorageDescriptor::from_protobuf(protobuf.storage()));
-    }
-    return result;
-}
-
-StatusOr<TGeoColumnDesc> GeoColumnDescriptor::to_thrift() const {
+TGeoColumnDesc GeoColumnDescriptor::to_thrift() const {
     TGeoColumnDesc result;
-    if (type) {
-        ASSIGN_OR_RETURN(auto value, type->to_thrift());
-        result.__set_type(value);
-    }
-    if (storage) {
-        ASSIGN_OR_RETURN(auto value, storage->to_thrift());
-        result.__set_storage(value);
-    }
+    result.__set_type(type.to_thrift());
+    result.__set_storage(storage.to_thrift());
     return result;
 }
 
-StatusOr<PGeoColumnDesc> GeoColumnDescriptor::to_protobuf() const {
+PGeoColumnDesc GeoColumnDescriptor::to_protobuf() const {
     PGeoColumnDesc result;
-    if (type) {
-        ASSIGN_OR_RETURN(auto value, type->to_protobuf());
-        *result.mutable_type() = std::move(value);
-    }
-    if (storage) {
-        ASSIGN_OR_RETURN(auto value, storage->to_protobuf());
-        *result.mutable_storage() = std::move(value);
-    }
+    *result.mutable_type() = type.to_protobuf();
+    *result.mutable_storage() = storage.to_protobuf();
     return result;
-}
-
-bool GeoColumnDescriptor::operator==(const GeoColumnDescriptor& rhs) const {
-    return std::tie(type, storage) == std::tie(rhs.type, rhs.storage);
 }
 
 bool is_geo_semantically_compatible(const GeoTypeDescriptor& lhs, const GeoTypeDescriptor& rhs) {
-    return lhs.logical_type && *lhs.logical_type != TGeoLogicalType::UNKNOWN && lhs.coordinate_system &&
-           *lhs.coordinate_system != TGeoCoordinateSystem::UNKNOWN && lhs.edge_algorithm &&
-           *lhs.edge_algorithm != TGeoEdgeAlgorithm::UNKNOWN && lhs.crs && !lhs.crs->empty() &&
+    return lhs.logical_type != GEO_LOGICAL_TYPE_UNKNOWN && lhs.coordinate_system != GEO_COORDINATE_SYSTEM_UNKNOWN &&
+           lhs.edge_algorithm != GEO_EDGE_ALGORITHM_UNKNOWN && !lhs.crs.empty() &&
            lhs.logical_type == rhs.logical_type && lhs.coordinate_system == rhs.coordinate_system &&
            lhs.edge_algorithm == rhs.edge_algorithm && lhs.crs == rhs.crs;
 }
 
 bool is_geo_compute_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs) {
-    return lhs.type && rhs.type && is_geo_semantically_compatible(*lhs.type, *rhs.type);
+    return is_geo_semantically_compatible(lhs.type, rhs.type);
 }
 
 bool is_geo_assignment_compatible(const GeoColumnDescriptor& source, const GeoColumnDescriptor& target) {
-    if (!is_geo_union_all_compatible(source, target)) {
-        return false;
-    }
-    const auto dimension = target.storage->dimension.value_or(TGeoDimension::UNKNOWN);
-    return dimension == TGeoDimension::UNKNOWN || dimension == TGeoDimension::MIXED ||
-           source.storage->dimension == dimension;
+    return is_geo_union_all_compatible(source, target) &&
+           (target.storage.dimension == GEO_DIMENSION_UNKNOWN || target.storage.dimension == GEO_DIMENSION_MIXED ||
+            source.storage.dimension == target.storage.dimension);
 }
 
 bool is_geo_union_all_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs) {
-    return is_geo_compute_compatible(lhs, rhs) && has_wkb_storage(lhs) && has_wkb_storage(rhs);
+    return is_geo_compute_compatible(lhs, rhs) && lhs.storage.encoding == GEO_ENCODING_WKB &&
+           rhs.storage.encoding == GEO_ENCODING_WKB;
 }
 
 } // namespace starrocks

--- a/be/src/types/geo_type_descriptor.h
+++ b/be/src/types/geo_type_descriptor.h
@@ -28,9 +28,9 @@ namespace starrocks {
 // the generated proto2 enum accessors, without interpreting unknown fields.
 // Callers supply declared enum values and decide which semantics an operation supports.
 struct GeoTypeDescriptor {
-    PGeoLogicalType logical_type = GEO_LOGICAL_TYPE_UNKNOWN;
-    PGeoCoordinateSystem coordinate_system = GEO_COORDINATE_SYSTEM_UNKNOWN;
-    PGeoEdgeAlgorithm edge_algorithm = GEO_EDGE_ALGORITHM_UNKNOWN;
+    GeoLogicalTypePB logical_type = GEO_LOGICAL_TYPE_UNKNOWN;
+    GeoCoordinateSystemPB coordinate_system = GEO_COORDINATE_SYSTEM_UNKNOWN;
+    GeoEdgeAlgorithmPB edge_algorithm = GEO_EDGE_ALGORITHM_UNKNOWN;
     std::string crs;
     std::optional<int32_t> srid;
 
@@ -44,9 +44,9 @@ struct GeoTypeDescriptor {
 };
 
 struct GeoStorageDescriptor {
-    PGeoEncoding encoding = GEO_ENCODING_UNKNOWN;
-    PGeoDimension dimension = GEO_DIMENSION_UNKNOWN;
-    PGeoValidationState validation_state = GEO_VALIDATION_STATE_UNKNOWN;
+    GeoEncodingPB encoding = GEO_ENCODING_UNKNOWN;
+    GeoDimensionPB dimension = GEO_DIMENSION_UNKNOWN;
+    GeoValidationStatePB validation_state = GEO_VALIDATION_STATE_UNKNOWN;
 
     static GeoStorageDescriptor from_thrift(const TGeoStorageDesc& thrift);
     static GeoStorageDescriptor from_protobuf(const GeoStorageDescPB& protobuf);

--- a/be/src/types/geo_type_descriptor.h
+++ b/be/src/types/geo_type_descriptor.h
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "common/statusor.h"
+#include "gen_cpp/Types_types.h"
+#include "gen_cpp/types.pb.h"
+
+namespace starrocks {
+
+// Standalone metadata, not a native SQL type. Preserve optional-field presence,
+// including explicit UNKNOWN. Reject unrecognized enum numbers at conversion
+// boundaries; never substitute a supported default. No payload inspection here.
+struct GeoTypeDescriptor {
+    std::optional<TGeoLogicalType::type> logical_type;
+    std::optional<TGeoCoordinateSystem::type> coordinate_system;
+    std::optional<TGeoEdgeAlgorithm::type> edge_algorithm;
+    std::optional<std::string> crs;
+    std::optional<int32_t> srid;
+
+    static StatusOr<GeoTypeDescriptor> from_thrift(const TGeoTypeDesc& thrift);
+    static StatusOr<GeoTypeDescriptor> from_protobuf(const PGeoTypeDesc& protobuf);
+    StatusOr<TGeoTypeDesc> to_thrift() const;
+    StatusOr<PGeoTypeDesc> to_protobuf() const;
+
+    // Exact metadata equality, NOT SQL type compatibility.
+    bool operator==(const GeoTypeDescriptor& rhs) const;
+    bool operator!=(const GeoTypeDescriptor& rhs) const { return !(*this == rhs); }
+};
+
+struct GeoStorageDescriptor {
+    std::optional<TGeoEncoding::type> encoding;
+    std::optional<TGeoDimension::type> dimension;
+    std::optional<TGeoValidationState::type> validation_state;
+
+    static StatusOr<GeoStorageDescriptor> from_thrift(const TGeoStorageDesc& thrift);
+    static StatusOr<GeoStorageDescriptor> from_protobuf(const PGeoStorageDesc& protobuf);
+    StatusOr<TGeoStorageDesc> to_thrift() const;
+    StatusOr<PGeoStorageDesc> to_protobuf() const;
+
+    // Exact metadata equality, NOT SQL type compatibility.
+    bool operator==(const GeoStorageDescriptor& rhs) const;
+    bool operator!=(const GeoStorageDescriptor& rhs) const { return !(*this == rhs); }
+};
+
+struct GeoColumnDescriptor {
+    std::optional<GeoTypeDescriptor> type;
+    std::optional<GeoStorageDescriptor> storage;
+
+    static StatusOr<GeoColumnDescriptor> from_thrift(const TGeoColumnDesc& thrift);
+    static StatusOr<GeoColumnDescriptor> from_protobuf(const PGeoColumnDesc& protobuf);
+    StatusOr<TGeoColumnDesc> to_thrift() const;
+    StatusOr<PGeoColumnDesc> to_protobuf() const;
+
+    // Exact metadata equality, NOT SQL type compatibility.
+    bool operator==(const GeoColumnDescriptor& rhs) const;
+    bool operator!=(const GeoColumnDescriptor& rhs) const { return !(*this == rhs); }
+};
+
+// Compatibility operates on recognized descriptor enum values (checked at
+// conversion boundaries), without repeating wire validation at each call site.
+// Conservative CRS comparison: identifiers must be present, nonempty and equal.
+// No alias normalization, reprojection or inference from the optional parsed SRID.
+bool is_geo_semantically_compatible(const GeoTypeDescriptor& lhs, const GeoTypeDescriptor& rhs);
+
+// Semantic compatibility only: does not enable an algorithm/function or prove
+// row-level dimensions. Encoding and producer-validation state are not overload identity.
+bool is_geo_compute_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs);
+
+// No payload conversion. Both sides must declare WKB; validation state is irrelevant.
+// UNKNOWN/MIXED (or absent) target dimension is unconstrained. A constrained target
+// requires the same guaranteed source dimension, without dropping coordinates.
+bool is_geo_assignment_compatible(const GeoColumnDescriptor& source, const GeoColumnDescriptor& target);
+
+// Unlike assignment, UNION ALL may combine dimensions without relabeling rows.
+// Result dimension must be derived separately; compatibility is not an XY guarantee.
+bool is_geo_union_all_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs);
+
+} // namespace starrocks

--- a/be/src/types/geo_type_descriptor.h
+++ b/be/src/types/geo_type_descriptor.h
@@ -35,9 +35,9 @@ struct GeoTypeDescriptor {
     std::optional<int32_t> srid;
 
     static GeoTypeDescriptor from_thrift(const TGeoTypeDesc& thrift);
-    static GeoTypeDescriptor from_protobuf(const PGeoTypeDesc& protobuf);
+    static GeoTypeDescriptor from_protobuf(const GeoTypeDescPB& protobuf);
     TGeoTypeDesc to_thrift() const;
-    PGeoTypeDesc to_protobuf() const;
+    GeoTypeDescPB to_protobuf() const;
 
     // Exact normalized metadata equality, not SQL type compatibility.
     bool operator==(const GeoTypeDescriptor& rhs) const = default;
@@ -49,9 +49,9 @@ struct GeoStorageDescriptor {
     PGeoValidationState validation_state = GEO_VALIDATION_STATE_UNKNOWN;
 
     static GeoStorageDescriptor from_thrift(const TGeoStorageDesc& thrift);
-    static GeoStorageDescriptor from_protobuf(const PGeoStorageDesc& protobuf);
+    static GeoStorageDescriptor from_protobuf(const GeoStorageDescPB& protobuf);
     TGeoStorageDesc to_thrift() const;
-    PGeoStorageDesc to_protobuf() const;
+    GeoStorageDescPB to_protobuf() const;
 
     // Exact normalized metadata equality, not SQL type compatibility.
     bool operator==(const GeoStorageDescriptor& rhs) const = default;
@@ -62,9 +62,9 @@ struct GeoColumnDescriptor {
     GeoStorageDescriptor storage;
 
     static GeoColumnDescriptor from_thrift(const TGeoColumnDesc& thrift);
-    static GeoColumnDescriptor from_protobuf(const PGeoColumnDesc& protobuf);
+    static GeoColumnDescriptor from_protobuf(const GeoColumnDescPB& protobuf);
     TGeoColumnDesc to_thrift() const;
-    PGeoColumnDesc to_protobuf() const;
+    GeoColumnDescPB to_protobuf() const;
 
     bool operator==(const GeoColumnDescriptor& rhs) const = default;
 };

--- a/be/src/types/geo_type_descriptor.h
+++ b/be/src/types/geo_type_descriptor.h
@@ -17,78 +17,71 @@
 #include <optional>
 #include <string>
 
-#include "common/statusor.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/types.pb.h"
 
 namespace starrocks {
 
-// Standalone metadata, not a native SQL type. Preserve optional-field presence,
-// including explicit UNKNOWN. Reject unrecognized enum numbers at conversion
-// boundaries; never substitute a supported default. No payload inspection here.
+// Normalized internal metadata, not a native SQL type. Missing wire fields become
+// UNKNOWN / empty CRS / default subdescriptors; only parsed SRID retains presence.
+// Fixed-underlying-type enums preserve unrecognized int32 values. Conversion is
+// policy-free: callers decide which kinds, algorithms, CRS and dimensions they support.
 struct GeoTypeDescriptor {
-    std::optional<TGeoLogicalType::type> logical_type;
-    std::optional<TGeoCoordinateSystem::type> coordinate_system;
-    std::optional<TGeoEdgeAlgorithm::type> edge_algorithm;
-    std::optional<std::string> crs;
+    PGeoLogicalType logical_type = GEO_LOGICAL_TYPE_UNKNOWN;
+    PGeoCoordinateSystem coordinate_system = GEO_COORDINATE_SYSTEM_UNKNOWN;
+    PGeoEdgeAlgorithm edge_algorithm = GEO_EDGE_ALGORITHM_UNKNOWN;
+    std::string crs;
     std::optional<int32_t> srid;
 
-    static StatusOr<GeoTypeDescriptor> from_thrift(const TGeoTypeDesc& thrift);
-    static StatusOr<GeoTypeDescriptor> from_protobuf(const PGeoTypeDesc& protobuf);
-    StatusOr<TGeoTypeDesc> to_thrift() const;
-    StatusOr<PGeoTypeDesc> to_protobuf() const;
+    static GeoTypeDescriptor from_thrift(const TGeoTypeDesc& thrift);
+    static GeoTypeDescriptor from_protobuf(const PGeoTypeDesc& protobuf);
+    TGeoTypeDesc to_thrift() const;
+    PGeoTypeDesc to_protobuf() const;
 
-    // Exact metadata equality, NOT SQL type compatibility.
-    bool operator==(const GeoTypeDescriptor& rhs) const;
-    bool operator!=(const GeoTypeDescriptor& rhs) const { return !(*this == rhs); }
+    // Exact normalized metadata equality, not SQL type compatibility.
+    bool operator==(const GeoTypeDescriptor& rhs) const = default;
 };
 
 struct GeoStorageDescriptor {
-    std::optional<TGeoEncoding::type> encoding;
-    std::optional<TGeoDimension::type> dimension;
-    std::optional<TGeoValidationState::type> validation_state;
+    PGeoEncoding encoding = GEO_ENCODING_UNKNOWN;
+    PGeoDimension dimension = GEO_DIMENSION_UNKNOWN;
+    PGeoValidationState validation_state = GEO_VALIDATION_STATE_UNKNOWN;
 
-    static StatusOr<GeoStorageDescriptor> from_thrift(const TGeoStorageDesc& thrift);
-    static StatusOr<GeoStorageDescriptor> from_protobuf(const PGeoStorageDesc& protobuf);
-    StatusOr<TGeoStorageDesc> to_thrift() const;
-    StatusOr<PGeoStorageDesc> to_protobuf() const;
+    static GeoStorageDescriptor from_thrift(const TGeoStorageDesc& thrift);
+    static GeoStorageDescriptor from_protobuf(const PGeoStorageDesc& protobuf);
+    TGeoStorageDesc to_thrift() const;
+    PGeoStorageDesc to_protobuf() const;
 
-    // Exact metadata equality, NOT SQL type compatibility.
-    bool operator==(const GeoStorageDescriptor& rhs) const;
-    bool operator!=(const GeoStorageDescriptor& rhs) const { return !(*this == rhs); }
+    // Exact normalized metadata equality, not SQL type compatibility.
+    bool operator==(const GeoStorageDescriptor& rhs) const = default;
 };
 
 struct GeoColumnDescriptor {
-    std::optional<GeoTypeDescriptor> type;
-    std::optional<GeoStorageDescriptor> storage;
+    GeoTypeDescriptor type;
+    GeoStorageDescriptor storage;
 
-    static StatusOr<GeoColumnDescriptor> from_thrift(const TGeoColumnDesc& thrift);
-    static StatusOr<GeoColumnDescriptor> from_protobuf(const PGeoColumnDesc& protobuf);
-    StatusOr<TGeoColumnDesc> to_thrift() const;
-    StatusOr<PGeoColumnDesc> to_protobuf() const;
+    static GeoColumnDescriptor from_thrift(const TGeoColumnDesc& thrift);
+    static GeoColumnDescriptor from_protobuf(const PGeoColumnDesc& protobuf);
+    TGeoColumnDesc to_thrift() const;
+    PGeoColumnDesc to_protobuf() const;
 
-    // Exact metadata equality, NOT SQL type compatibility.
-    bool operator==(const GeoColumnDescriptor& rhs) const;
-    bool operator!=(const GeoColumnDescriptor& rhs) const { return !(*this == rhs); }
+    bool operator==(const GeoColumnDescriptor& rhs) const = default;
 };
 
-// Compatibility operates on recognized descriptor enum values (checked at
-// conversion boundaries), without repeating wire validation at each call site.
-// Conservative CRS comparison: identifiers must be present, nonempty and equal.
-// No alias normalization, reprojection or inference from the optional parsed SRID.
+// Callers establish supported semantics before using these compatibility predicates.
+// CRS identifiers must be nonempty and equal: no alias normalization, reprojection
+// or inference from the optional parsed SRID.
 bool is_geo_semantically_compatible(const GeoTypeDescriptor& lhs, const GeoTypeDescriptor& rhs);
 
-// Semantic compatibility only: does not enable an algorithm/function or prove
-// row-level dimensions. Encoding and producer-validation state are not overload identity.
+// Semantic compatibility is not capability validation or a row-dimension guarantee.
+// Encoding and producer-validation state do not determine overload identity.
 bool is_geo_compute_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs);
 
-// No payload conversion. Both sides must declare WKB; validation state is irrelevant.
-// UNKNOWN/MIXED (or absent) target dimension is unconstrained. A constrained target
-// requires the same guaranteed source dimension, without dropping coordinates.
+// No payload conversion: both sides must declare WKB. UNKNOWN/MIXED target dimension
+// is unconstrained; otherwise the source must guarantee the same dimension.
 bool is_geo_assignment_compatible(const GeoColumnDescriptor& source, const GeoColumnDescriptor& target);
 
-// Unlike assignment, UNION ALL may combine dimensions without relabeling rows.
-// Result dimension must be derived separately; compatibility is not an XY guarantee.
+// UNION ALL may combine dimensions; derive the result dimension separately.
 bool is_geo_union_all_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs);
 
 } // namespace starrocks

--- a/be/src/types/geo_type_descriptor.h
+++ b/be/src/types/geo_type_descriptor.h
@@ -24,8 +24,9 @@ namespace starrocks {
 
 // Normalized internal metadata, not a native SQL type. Missing wire fields become
 // UNKNOWN / empty CRS / default subdescriptors; only parsed SRID retains presence.
-// Fixed-underlying-type enums preserve unrecognized int32 values. Conversion is
-// policy-free: callers decide which kinds, algorithms, CRS and dimensions they support.
+// Unrecognized Thrift enum values normalize to UNKNOWN. Protobuf conversions use
+// the generated proto2 enum accessors, without interpreting unknown fields.
+// Callers supply declared enum values and decide which semantics an operation supports.
 struct GeoTypeDescriptor {
     PGeoLogicalType logical_type = GEO_LOGICAL_TYPE_UNKNOWN;
     PGeoCoordinateSystem coordinate_system = GEO_COORDINATE_SYSTEM_UNKNOWN;

--- a/be/src/types/geo_type_descriptor.h
+++ b/be/src/types/geo_type_descriptor.h
@@ -78,11 +78,4 @@ bool is_geo_semantically_compatible(const GeoTypeDescriptor& lhs, const GeoTypeD
 // Encoding and producer-validation state do not determine overload identity.
 bool is_geo_compute_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs);
 
-// No payload conversion: both sides must declare WKB. UNKNOWN/MIXED target dimension
-// is unconstrained; otherwise the source must guarantee the same dimension.
-bool is_geo_assignment_compatible(const GeoColumnDescriptor& source, const GeoColumnDescriptor& target);
-
-// UNION ALL may combine dimensions; derive the result dimension separately.
-bool is_geo_union_all_compatible(const GeoColumnDescriptor& lhs, const GeoColumnDescriptor& rhs);
-
 } // namespace starrocks

--- a/be/test/types/CMakeLists.txt
+++ b/be/test/types/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TYPES_TEST_FILES
     decimalv3_test.cpp
     datetime_value_test.cpp
     hll_test.cpp
+    geo_type_descriptor_test.cpp
     int128_arithmetic_ops_test.cpp
     json_value_test.cpp
     logical_type_test.cpp

--- a/be/test/types/geo_type_descriptor_test.cpp
+++ b/be/test/types/geo_type_descriptor_test.cpp
@@ -161,8 +161,6 @@ TEST(GeoTypeDescriptorTest, AlgorithmsRemainDistinctForCompatibility) {
             source.type.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(left);
             target.type.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(right);
             EXPECT_EQ(left == right, is_geo_compute_compatible(source, target));
-            EXPECT_EQ(left == right, is_geo_assignment_compatible(source, target));
-            EXPECT_EQ(left == right, is_geo_union_all_compatible(source, target));
         }
     }
 }
@@ -355,12 +353,7 @@ TEST(GeoTypeDescriptorTest, ValidationStateAndParsedSridAreNotTypeIdentity) {
         EXPECT_NE(source, target);
         EXPECT_TRUE(is_geo_semantically_compatible(source.type, target.type));
         EXPECT_TRUE(is_geo_compute_compatible(source, target));
-        EXPECT_TRUE(is_geo_assignment_compatible(source, target));
-        EXPECT_TRUE(is_geo_union_all_compatible(source, target));
     }
-    auto target = source;
-    target.storage.validation_state = GEO_VALIDATION_STATE_UNKNOWN;
-    EXPECT_TRUE(is_geo_assignment_compatible(source, target));
 }
 
 TEST(GeoTypeDescriptorTest, SemanticMismatchIsNotImplicitlyConverted) {
@@ -382,8 +375,6 @@ TEST(GeoTypeDescriptorTest, SemanticMismatchIsNotImplicitlyConverted) {
             break; // Not an axis-order-safe CRS84 alias.
         }
         EXPECT_FALSE(is_geo_compute_compatible(source, target));
-        EXPECT_FALSE(is_geo_assignment_compatible(source, target));
-        EXPECT_FALSE(is_geo_union_all_compatible(source, target));
     }
     EXPECT_FALSE(is_geo_compute_compatible({}, {}));
     auto incomplete = source;
@@ -394,40 +385,29 @@ TEST(GeoTypeDescriptorTest, SemanticMismatchIsNotImplicitlyConverted) {
     EXPECT_FALSE(is_geo_compute_compatible(incomplete, incomplete));
 }
 
-TEST(GeoTypeDescriptorTest, EncodingAffectsTransportNotComputeIdentity) {
+TEST(GeoTypeDescriptorTest, EncodingDoesNotAffectSemanticComparison) {
     const auto source = geography();
     auto target = source;
     target.storage.encoding = GEO_ENCODING_UNKNOWN;
+    EXPECT_NE(source, target);
     EXPECT_TRUE(is_geo_compute_compatible(source, target));
-    EXPECT_FALSE(is_geo_assignment_compatible(source, target));
-    EXPECT_FALSE(is_geo_assignment_compatible(target, source));
-    EXPECT_FALSE(is_geo_union_all_compatible(source, target));
     target.storage = GeoStorageDescriptor{};
     EXPECT_TRUE(is_geo_compute_compatible(source, target));
-    EXPECT_FALSE(is_geo_assignment_compatible(source, target));
 }
 
-TEST(GeoTypeDescriptorTest, DimensionGuaranteesAreDirectional) {
+TEST(GeoTypeDescriptorTest, DimensionDoesNotAffectSemanticComparison) {
     for (int source_dim = GEO_DIMENSION_UNKNOWN; source_dim <= GEO_DIMENSION_MIXED; ++source_dim) {
         for (int target_dim = GEO_DIMENSION_UNKNOWN; target_dim <= GEO_DIMENSION_MIXED; ++target_dim) {
             auto source = geography();
             auto target = geography();
             source.storage.dimension = static_cast<PGeoDimension>(source_dim);
             target.storage.dimension = static_cast<PGeoDimension>(target_dim);
-            const bool assignable = target_dim == GEO_DIMENSION_UNKNOWN || target_dim == GEO_DIMENSION_MIXED ||
-                                    source_dim == target_dim;
-            EXPECT_EQ(assignable, is_geo_assignment_compatible(source, target));
-            EXPECT_TRUE(is_geo_union_all_compatible(source, target));
-            EXPECT_TRUE(is_geo_compute_compatible(source, target)); // Row checks are a later compute contract.
+            EXPECT_EQ(source_dim == target_dim, source == target);
+            EXPECT_TRUE(is_geo_semantically_compatible(source.type, target.type));
+            // Semantic comparison neither derives a result dimension nor checks row dimensions.
+            EXPECT_TRUE(is_geo_compute_compatible(source, target));
         }
     }
-    auto source = geography();
-    auto target = geography();
-    source.storage.dimension = GEO_DIMENSION_UNKNOWN;
-    EXPECT_FALSE(is_geo_assignment_compatible(source, target));
-    target.storage.dimension = GEO_DIMENSION_UNKNOWN;
-    EXPECT_TRUE(is_geo_assignment_compatible(source, target));
-    EXPECT_TRUE(is_geo_union_all_compatible(source, target));
 }
 
 } // namespace

--- a/be/test/types/geo_type_descriptor_test.cpp
+++ b/be/test/types/geo_type_descriptor_test.cpp
@@ -14,8 +14,13 @@
 
 #include "types/geo_type_descriptor.h"
 
+#include <google/protobuf/descriptor.pb.h>
+#include <google/protobuf/dynamic_message.h>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <gtest/gtest.h>
 #include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/protocol/TCompactProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
 
 #include <array>
@@ -25,18 +30,19 @@ namespace starrocks {
 namespace {
 
 using apache::thrift::protocol::TBinaryProtocol;
+using apache::thrift::protocol::TCompactProtocol;
 using apache::thrift::transport::TMemoryBuffer;
 
 GeoColumnDescriptor geography() {
-    return {GeoTypeDescriptor{TGeoLogicalType::GEOGRAPHY, TGeoCoordinateSystem::SPHERICAL, TGeoEdgeAlgorithm::SPHERICAL,
+    return {GeoTypeDescriptor{GEO_LOGICAL_TYPE_GEOGRAPHY, GEO_COORDINATE_SYSTEM_SPHERICAL, GEO_EDGE_ALGORITHM_SPHERICAL,
                               "OGC:CRS84", std::nullopt},
-            GeoStorageDescriptor{TGeoEncoding::WKB, TGeoDimension::XY, TGeoValidationState::UNVALIDATED}};
+            GeoStorageDescriptor{GEO_ENCODING_WKB, GEO_DIMENSION_XY, GEO_VALIDATION_STATE_UNVALIDATED}};
 }
 
-template <typename Thrift>
+template <typename Protocol = TBinaryProtocol, typename Thrift>
 Thrift thrift_wire_round_trip(const Thrift& input) {
     auto buffer = std::make_shared<TMemoryBuffer>();
-    TBinaryProtocol protocol(buffer);
+    Protocol protocol(buffer);
     input.write(&protocol);
     Thrift output;
     output.read(&protocol);
@@ -45,49 +51,40 @@ Thrift thrift_wire_round_trip(const Thrift& input) {
 
 template <typename Descriptor>
 void check_round_trip(const Descriptor& expected) {
-    auto thrift = expected.to_thrift();
-    ASSERT_TRUE(thrift.ok()) << thrift.status();
-    auto decoded_thrift = Descriptor::from_thrift(thrift_wire_round_trip(*thrift));
-    ASSERT_TRUE(decoded_thrift.ok()) << decoded_thrift.status();
-    EXPECT_EQ(expected, *decoded_thrift);
-
+    EXPECT_EQ(expected, Descriptor::from_thrift(thrift_wire_round_trip(expected.to_thrift())));
+    EXPECT_EQ(expected, Descriptor::from_thrift(thrift_wire_round_trip<TCompactProtocol>(expected.to_thrift())));
     auto protobuf = expected.to_protobuf();
-    ASSERT_TRUE(protobuf.ok()) << protobuf.status();
-    auto parsed = *protobuf;
+    auto parsed = protobuf;
     parsed.Clear();
-    ASSERT_TRUE(parsed.ParseFromString(protobuf->SerializeAsString()));
-    auto decoded_protobuf = Descriptor::from_protobuf(parsed);
-    ASSERT_TRUE(decoded_protobuf.ok()) << decoded_protobuf.status();
-    EXPECT_EQ(expected, *decoded_protobuf);
-
-    auto cross_wire = decoded_thrift->to_protobuf();
-    ASSERT_TRUE(cross_wire.ok()) << cross_wire.status();
-    auto cross_desc = Descriptor::from_protobuf(*cross_wire);
-    ASSERT_TRUE(cross_desc.ok()) << cross_desc.status();
-    EXPECT_EQ(expected, *cross_desc);
+    ASSERT_TRUE(parsed.ParseFromString(protobuf.SerializeAsString()));
+    EXPECT_EQ(expected, Descriptor::from_protobuf(parsed));
+    const auto from_thrift = Descriptor::from_thrift(thrift_wire_round_trip(expected.to_thrift()));
+    EXPECT_EQ(expected, Descriptor::from_protobuf(from_thrift.to_protobuf()));
+    const auto from_proto = Descriptor::from_protobuf(parsed);
+    EXPECT_EQ(expected, Descriptor::from_thrift(from_proto.to_thrift()));
 }
 
 TEST(GeoTypeDescriptorTest, AllAlgorithmsAndStorageStatesRoundTrip) {
-    const std::array algorithms = {TGeoEdgeAlgorithm::UNKNOWN,  TGeoEdgeAlgorithm::SPHERICAL,
-                                   TGeoEdgeAlgorithm::VINCENTY, TGeoEdgeAlgorithm::THOMAS,
-                                   TGeoEdgeAlgorithm::ANDOYER,  TGeoEdgeAlgorithm::KARNEY,
-                                   TGeoEdgeAlgorithm::PLANAR};
+    const std::array algorithms = {GEO_EDGE_ALGORITHM_UNKNOWN,  GEO_EDGE_ALGORITHM_SPHERICAL,
+                                   GEO_EDGE_ALGORITHM_VINCENTY, GEO_EDGE_ALGORITHM_THOMAS,
+                                   GEO_EDGE_ALGORITHM_ANDOYER,  GEO_EDGE_ALGORITHM_KARNEY,
+                                   GEO_EDGE_ALGORITHM_PLANAR};
     for (auto algorithm : algorithms) {
-        for (int dim = TGeoDimension::UNKNOWN; dim <= TGeoDimension::MIXED; ++dim) {
-            for (int state = TGeoValidationState::UNKNOWN; state <= TGeoValidationState::SEMANTICALLY_VALIDATED;
+        for (int dim = GEO_DIMENSION_UNKNOWN; dim <= GEO_DIMENSION_MIXED; ++dim) {
+            for (int state = GEO_VALIDATION_STATE_UNKNOWN; state <= GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED;
                  ++state) {
                 SCOPED_TRACE(::testing::Message() << algorithm << "/" << dim << "/" << state);
                 auto desc = geography();
-                desc.type->edge_algorithm = algorithm;
-                if (algorithm == TGeoEdgeAlgorithm::PLANAR) {
-                    desc.type->logical_type = TGeoLogicalType::GEOMETRY;
-                    desc.type->coordinate_system = TGeoCoordinateSystem::CARTESIAN;
+                desc.type.edge_algorithm = algorithm;
+                if (algorithm == GEO_EDGE_ALGORITHM_PLANAR) {
+                    desc.type.logical_type = GEO_LOGICAL_TYPE_GEOMETRY;
+                    desc.type.coordinate_system = GEO_COORDINATE_SYSTEM_CARTESIAN;
                 }
-                desc.type->srid = 4326;
-                desc.storage->dimension = static_cast<TGeoDimension::type>(dim);
-                desc.storage->validation_state = static_cast<TGeoValidationState::type>(state);
-                check_round_trip(*desc.type);
-                check_round_trip(*desc.storage);
+                desc.type.srid = 4326;
+                desc.storage.dimension = static_cast<PGeoDimension>(dim);
+                desc.storage.validation_state = static_cast<PGeoValidationState>(state);
+                check_round_trip(desc.type);
+                check_round_trip(desc.storage);
                 check_round_trip(desc);
             }
         }
@@ -158,12 +155,12 @@ TEST(GeoTypeDescriptorTest, WireOrdinalsRemainStable) {
 }
 
 TEST(GeoTypeDescriptorTest, AlgorithmsRemainDistinctForCompatibility) {
-    for (int left = TGeoEdgeAlgorithm::SPHERICAL; left <= TGeoEdgeAlgorithm::PLANAR; ++left) {
-        for (int right = TGeoEdgeAlgorithm::SPHERICAL; right <= TGeoEdgeAlgorithm::PLANAR; ++right) {
+    for (int left = GEO_EDGE_ALGORITHM_SPHERICAL; left <= GEO_EDGE_ALGORITHM_PLANAR; ++left) {
+        for (int right = GEO_EDGE_ALGORITHM_SPHERICAL; right <= GEO_EDGE_ALGORITHM_PLANAR; ++right) {
             auto source = geography();
             auto target = geography();
-            source.type->edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(left);
-            target.type->edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(right);
+            source.type.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(left);
+            target.type.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(right);
             EXPECT_EQ(left == right, is_geo_compute_compatible(source, target));
             EXPECT_EQ(left == right, is_geo_assignment_compatible(source, target));
             EXPECT_EQ(left == right, is_geo_union_all_compatible(source, target));
@@ -171,55 +168,52 @@ TEST(GeoTypeDescriptorTest, AlgorithmsRemainDistinctForCompatibility) {
     }
 }
 
-TEST(GeoTypeDescriptorTest, OptionalFieldsPreservePresence) {
-    check_round_trip(GeoTypeDescriptor{});
-    check_round_trip(GeoStorageDescriptor{});
+TEST(GeoTypeDescriptorTest, MissingFieldsNormalizeWithoutGuessingSemantics) {
+    EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_thrift(TGeoTypeDesc{}));
+    EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_protobuf(PGeoTypeDesc{}));
+    EXPECT_EQ(GeoStorageDescriptor{}, GeoStorageDescriptor::from_thrift(TGeoStorageDesc{}));
+    EXPECT_EQ(GeoStorageDescriptor{}, GeoStorageDescriptor::from_protobuf(PGeoStorageDesc{}));
+    EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_thrift(TGeoColumnDesc{}));
+    EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_protobuf(PGeoColumnDesc{}));
     check_round_trip(GeoColumnDescriptor{});
-    check_round_trip(GeoColumnDescriptor{GeoTypeDescriptor{}, GeoStorageDescriptor{}});
-    // Each optional field independently, including explicit default values.
-    for (int field = 0; field < 5; ++field) {
-        GeoTypeDescriptor desc;
-        switch (field) {
-        case 0:
-            desc.logical_type = TGeoLogicalType::UNKNOWN;
-            break;
-        case 1:
-            desc.coordinate_system = TGeoCoordinateSystem::UNKNOWN;
-            break;
-        case 2:
-            desc.edge_algorithm = TGeoEdgeAlgorithm::UNKNOWN;
-            break;
-        case 3:
-            desc.crs = "";
-            break;
-        case 4:
-            desc.srid = 0;
-            break;
-        }
-        check_round_trip(desc);
-        EXPECT_NE(desc, GeoTypeDescriptor{});
-        check_round_trip(GeoColumnDescriptor{desc, std::nullopt});
-    }
-    for (int field = 0; field < 3; ++field) {
-        GeoStorageDescriptor desc;
-        switch (field) {
-        case 0:
-            desc.encoding = TGeoEncoding::UNKNOWN;
-            break;
-        case 1:
-            desc.dimension = TGeoDimension::UNKNOWN;
-            break;
-        case 2:
-            desc.validation_state = TGeoValidationState::UNKNOWN;
-            break;
-        }
-        check_round_trip(desc);
-        EXPECT_NE(desc, GeoStorageDescriptor{});
-        check_round_trip(GeoColumnDescriptor{std::nullopt, desc});
-    }
+
+    TGeoTypeDesc type;
+    type.__set_logical_type(TGeoLogicalType::UNKNOWN);
+    type.__set_coordinate_system(TGeoCoordinateSystem::UNKNOWN);
+    type.__set_edge_algorithm(TGeoEdgeAlgorithm::UNKNOWN);
+    type.__set_crs("");
+    EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_thrift(type));
+    const auto normalized = GeoTypeDescriptor{}.to_protobuf();
+    EXPECT_EQ(GEO_LOGICAL_TYPE_UNKNOWN, normalized.logical_type());
+    EXPECT_EQ(GEO_EDGE_ALGORITHM_UNKNOWN, normalized.edge_algorithm());
+    EXPECT_TRUE(normalized.crs().empty());
+    EXPECT_FALSE(normalized.has_srid());
+
+    // Unset Thrift fields are not active, even if their backing values were modified.
+    TGeoTypeDesc unset;
+    unset.logical_type = TGeoLogicalType::GEOGRAPHY;
+    unset.crs = "OGC:CRS84";
+    EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_thrift(unset));
+    TGeoColumnDesc column;
+    column.__set_type(type);
+    column.__set_storage(TGeoStorageDesc{});
+    EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_thrift(column));
+    EXPECT_FALSE(is_geo_compute_compatible({}, {}));
 }
 
-// Construct actual wire bytes rather than relying on generated enum setters.
+TEST(GeoTypeDescriptorTest, SridRetainsMeaningfulPresence) {
+    auto desc = geography();
+    check_round_trip(desc);
+    EXPECT_FALSE(desc.type.to_protobuf().has_srid());
+    EXPECT_FALSE(desc.type.to_thrift().__isset.srid);
+    desc.type.srid = 0;
+    check_round_trip(desc);
+    EXPECT_TRUE(desc.type.to_protobuf().has_srid());
+    EXPECT_TRUE(desc.type.to_thrift().__isset.srid);
+    EXPECT_NE(desc, geography());
+}
+
+// Same numeric wire encoding as the original enum fields, with no generated setter.
 template <typename Thrift>
 Thrift thrift_enum_wire(int16_t field, int32_t value) {
     auto buffer = std::make_shared<TMemoryBuffer>();
@@ -235,114 +229,138 @@ Thrift thrift_enum_wire(int16_t field, int32_t value) {
     return parsed;
 }
 
-TEST(GeoTypeDescriptorTest, UnknownThriftEnumsAreRejectedBeforeConversion) {
-    for (auto value : {127, -1, std::numeric_limits<int32_t>::max()}) {
+std::string protobuf_enum_wire(int field, int32_t value) {
+    std::string bytes;
+    {
+        google::protobuf::io::StringOutputStream stream(&bytes);
+        google::protobuf::io::CodedOutputStream output(&stream);
+        output.WriteTag(field << 3);
+        output.WriteVarint64(static_cast<uint64_t>(static_cast<int64_t>(value)));
+    }
+    return bytes;
+}
+
+template <typename Message>
+int32_t enum_number(const Message& message, int field) {
+    return message.GetReflection()->GetInt32(message, message.GetDescriptor()->FindFieldByNumber(field));
+}
+
+constexpr std::array unknown_values = {127, -1, std::numeric_limits<int32_t>::max(),
+                                       std::numeric_limits<int32_t>::min()};
+
+TEST(GeoTypeDescriptorTest, UnknownNumbersSurviveBothTransports) {
+    for (int32_t value : unknown_values) {
         for (int16_t field = 1; field <= 3; ++field) {
             SCOPED_TRACE(::testing::Message() << field << "/" << value);
-            const auto type = thrift_enum_wire<TGeoTypeDesc>(field, value);
-            EXPECT_TRUE(GeoTypeDescriptor::from_thrift(type).status().is_not_supported());
-            const auto storage = thrift_enum_wire<TGeoStorageDesc>(field, value);
-            EXPECT_TRUE(GeoStorageDescriptor::from_thrift(storage).status().is_not_supported());
-            TGeoColumnDesc column;
-            column.__set_type(type);
-            EXPECT_TRUE(GeoColumnDescriptor::from_thrift(column).status().is_not_supported());
-            column = TGeoColumnDesc{};
-            column.__set_storage(storage);
-            EXPECT_TRUE(GeoColumnDescriptor::from_thrift(column).status().is_not_supported());
+            const auto type = GeoTypeDescriptor::from_thrift(thrift_enum_wire<TGeoTypeDesc>(field, value));
+            const auto storage = GeoStorageDescriptor::from_thrift(thrift_enum_wire<TGeoStorageDesc>(field, value));
+            EXPECT_EQ(value, enum_number(type.to_protobuf(), field));
+            EXPECT_EQ(value, enum_number(storage.to_protobuf(), field));
+            check_round_trip(type);
+            check_round_trip(storage);
+            check_round_trip(GeoColumnDescriptor{type, storage});
+
+            PGeoTypeDesc type_pb;
+            PGeoStorageDesc storage_pb;
+            ASSERT_TRUE(type_pb.ParseFromString(protobuf_enum_wire(field, value)));
+            ASSERT_TRUE(storage_pb.ParseFromString(protobuf_enum_wire(field, value)));
+            EXPECT_TRUE(type_pb.unknown_fields().empty());
+            EXPECT_TRUE(storage_pb.unknown_fields().empty());
+            EXPECT_EQ(type, GeoTypeDescriptor::from_protobuf(type_pb));
+            EXPECT_EQ(storage, GeoStorageDescriptor::from_protobuf(storage_pb));
         }
     }
 }
 
-template <typename Proto, typename Descriptor>
-void check_unknown_protobuf_enum(int field, int32_t value) {
-    // Serialization followed by parsing places closed-enum values in unknown_fields().
-    Proto input;
-    input.mutable_unknown_fields()->AddVarint(field, static_cast<uint64_t>(static_cast<int64_t>(value)));
-    for (bool include_known_value : {false, true}) {
-        if (include_known_value) {
-            const auto* enum_field = input.GetDescriptor()->FindFieldByNumber(field);
-            input.GetReflection()->SetEnum(&input, enum_field, enum_field->enum_type()->value(0));
-        }
-        Proto parsed;
-        ASSERT_TRUE(parsed.ParseFromString(input.SerializeAsString()));
-        ASSERT_EQ(1, parsed.unknown_fields().field_count());
-        EXPECT_EQ(static_cast<uint64_t>(static_cast<int64_t>(value)), parsed.unknown_fields().field(0).varint());
-        EXPECT_TRUE(Descriptor::from_protobuf(parsed).status().is_not_supported());
-    }
-}
-
-TEST(GeoTypeDescriptorTest, Proto2ClosedEnumsAreRejectedEvenAlongsideKnownValues) {
-    for (auto value : {127, -1, std::numeric_limits<int32_t>::max()}) {
+TEST(GeoTypeDescriptorTest, DirectProtobufSettersPreserveUnknownNumbers) {
+    // Unlike closed-enum setters, int32 setters work identically with/without NDEBUG.
+    for (int32_t value : unknown_values) {
+        PGeoTypeDesc type;
+        type.set_logical_type(value);
+        type.set_coordinate_system(value);
+        type.set_edge_algorithm(value);
+        PGeoStorageDesc storage;
+        storage.set_encoding(value);
+        storage.set_dimension(value);
+        storage.set_validation_state(value);
+        const auto type_desc = GeoTypeDescriptor::from_protobuf(type);
+        const auto storage_desc = GeoStorageDescriptor::from_protobuf(storage);
         for (int field = 1; field <= 3; ++field) {
-            SCOPED_TRACE(::testing::Message() << field << "/" << value);
-            check_unknown_protobuf_enum<PGeoTypeDesc, GeoTypeDescriptor>(field, value);
-            check_unknown_protobuf_enum<PGeoStorageDesc, GeoStorageDescriptor>(field, value);
-            PGeoColumnDesc column;
-            column.mutable_type()->mutable_unknown_fields()->AddVarint(field, value);
-            PGeoColumnDesc parsed;
-            ASSERT_TRUE(parsed.ParseFromString(column.SerializeAsString()));
-            EXPECT_TRUE(GeoColumnDescriptor::from_protobuf(parsed).status().is_not_supported());
-            column.Clear();
-            column.mutable_storage()->mutable_unknown_fields()->AddVarint(field, value);
-            ASSERT_TRUE(parsed.ParseFromString(column.SerializeAsString()));
-            EXPECT_TRUE(GeoColumnDescriptor::from_protobuf(parsed).status().is_not_supported());
+            EXPECT_EQ(value, enum_number(type_desc.to_protobuf(), field));
+            EXPECT_EQ(value, enum_number(storage_desc.to_protobuf(), field));
+        }
+        check_round_trip(GeoColumnDescriptor{type_desc, storage_desc});
+    }
+}
+
+TEST(GeoTypeDescriptorTest, LegacyProto2UnknownFieldSetRemainsReadable) {
+    // Model a closed-enum producer: unknown values go into its unknown-field set.
+    // After serialization the current int32 schema must recover their exact values.
+    google::protobuf::FileDescriptorProto file;
+    file.set_name("legacy_geo_test.proto");
+    file.set_syntax("proto2");
+    auto* enumeration = file.add_enum_type();
+    enumeration->set_name("LegacyEnum");
+    auto* zero = enumeration->add_value();
+    zero->set_name("UNKNOWN");
+    zero->set_number(0);
+    auto* message = file.add_message_type();
+    message->set_name("LegacyGeo");
+    for (int i = 1; i <= 3; ++i) {
+        auto* field = message->add_field();
+        field->set_name("field" + std::to_string(i));
+        field->set_number(i);
+        field->set_label(google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
+        field->set_type(google::protobuf::FieldDescriptorProto::TYPE_ENUM);
+        field->set_type_name(".LegacyEnum");
+    }
+    google::protobuf::DescriptorPool pool;
+    const auto* schema = pool.BuildFile(file);
+    ASSERT_NE(nullptr, schema);
+    google::protobuf::DynamicMessageFactory factory(&pool);
+    std::unique_ptr<google::protobuf::Message> legacy(factory.GetPrototype(schema->message_type(0))->New());
+    for (int32_t value : unknown_values) {
+        for (int field = 1; field <= 3; ++field) {
+            for (bool known_first : {false, true}) {
+                const auto bytes =
+                        (known_first ? protobuf_enum_wire(field, 0) : std::string{}) + protobuf_enum_wire(field, value);
+                ASSERT_TRUE(legacy->ParseFromString(bytes));
+                ASSERT_EQ(1, legacy->GetReflection()->GetUnknownFields(*legacy).field_count());
+                const auto relayed = legacy->SerializeAsString();
+                PGeoTypeDesc type;
+                PGeoStorageDesc storage;
+                ASSERT_TRUE(type.ParseFromString(relayed));
+                ASSERT_TRUE(storage.ParseFromString(relayed));
+                EXPECT_EQ(value, enum_number(GeoTypeDescriptor::from_protobuf(type).to_protobuf(), field));
+                EXPECT_EQ(value, enum_number(GeoStorageDescriptor::from_protobuf(storage).to_protobuf(), field));
+            }
         }
     }
 }
 
-TEST(GeoTypeDescriptorTest, UnrecognizedEnumsCannotBeSerializedFromLocalDescriptors) {
-    {
-        GeoTypeDescriptor desc;
-        desc.logical_type = static_cast<TGeoLogicalType::type>(127);
-        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
-        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
-    }
-    {
-        GeoTypeDescriptor desc;
-        desc.coordinate_system = static_cast<TGeoCoordinateSystem::type>(127);
-        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
-        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
-    }
-    {
-        GeoTypeDescriptor desc;
-        desc.edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(127);
-        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
-        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
-    }
-    {
-        GeoStorageDescriptor desc;
-        desc.encoding = static_cast<TGeoEncoding::type>(127);
-        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
-        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
-    }
-    {
-        GeoStorageDescriptor desc;
-        desc.dimension = static_cast<TGeoDimension::type>(127);
-        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
-        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
-    }
-    {
-        GeoStorageDescriptor desc;
-        desc.validation_state = static_cast<TGeoValidationState::type>(127);
-        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
-        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
-    }
+TEST(GeoTypeDescriptorTest, CallerChoosesSupportedAlgorithm) {
+    auto input = geography().type.to_protobuf();
+    input.set_edge_algorithm(127);
+    const auto desc = GeoTypeDescriptor::from_protobuf(input);
+    // Conversion preserves the value. The consuming caller decides whether to reject.
+    EXPECT_FALSE(PGeoEdgeAlgorithm_IsValid(desc.edge_algorithm));
+    EXPECT_EQ(127, desc.to_protobuf().edge_algorithm());
 }
 
 TEST(GeoTypeDescriptorTest, ValidationStateAndParsedSridAreNotTypeIdentity) {
     auto source = geography();
-    for (int state = TGeoValidationState::UNKNOWN; state <= TGeoValidationState::SEMANTICALLY_VALIDATED; ++state) {
+    for (int state = GEO_VALIDATION_STATE_UNKNOWN; state <= GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED; ++state) {
         auto target = source;
-        target.storage->validation_state = static_cast<TGeoValidationState::type>(state);
-        target.type->srid = 4326;
+        target.storage.validation_state = static_cast<PGeoValidationState>(state);
+        target.type.srid = 4326;
         EXPECT_NE(source, target);
-        EXPECT_TRUE(is_geo_semantically_compatible(*source.type, *target.type));
+        EXPECT_TRUE(is_geo_semantically_compatible(source.type, target.type));
         EXPECT_TRUE(is_geo_compute_compatible(source, target));
         EXPECT_TRUE(is_geo_assignment_compatible(source, target));
         EXPECT_TRUE(is_geo_union_all_compatible(source, target));
     }
     auto target = source;
-    target.storage->validation_state.reset();
+    target.storage.validation_state = GEO_VALIDATION_STATE_UNKNOWN;
     EXPECT_TRUE(is_geo_assignment_compatible(source, target));
 }
 
@@ -352,16 +370,16 @@ TEST(GeoTypeDescriptorTest, SemanticMismatchIsNotImplicitlyConverted) {
         auto target = source;
         switch (field) {
         case 0:
-            target.type->logical_type = TGeoLogicalType::GEOMETRY;
+            target.type.logical_type = GEO_LOGICAL_TYPE_GEOMETRY;
             break;
         case 1:
-            target.type->coordinate_system = TGeoCoordinateSystem::CARTESIAN;
+            target.type.coordinate_system = GEO_COORDINATE_SYSTEM_CARTESIAN;
             break;
         case 2:
-            target.type->edge_algorithm = TGeoEdgeAlgorithm::KARNEY;
+            target.type.edge_algorithm = GEO_EDGE_ALGORITHM_KARNEY;
             break;
         case 3:
-            target.type->crs = "EPSG:4326";
+            target.type.crs = "EPSG:4326";
             break; // Not an axis-order-safe CRS84 alias.
         }
         EXPECT_FALSE(is_geo_compute_compatible(source, target));
@@ -370,38 +388,34 @@ TEST(GeoTypeDescriptorTest, SemanticMismatchIsNotImplicitlyConverted) {
     }
     EXPECT_FALSE(is_geo_compute_compatible({}, {}));
     auto incomplete = source;
-    incomplete.type->crs.reset();
-    EXPECT_FALSE(is_geo_compute_compatible(incomplete, incomplete));
-    incomplete.type->crs = "";
+    incomplete.type.crs.clear();
     EXPECT_FALSE(is_geo_compute_compatible(incomplete, incomplete));
     incomplete = source;
-    incomplete.type->edge_algorithm = TGeoEdgeAlgorithm::UNKNOWN;
+    incomplete.type.edge_algorithm = GEO_EDGE_ALGORITHM_UNKNOWN;
     EXPECT_FALSE(is_geo_compute_compatible(incomplete, incomplete));
 }
 
 TEST(GeoTypeDescriptorTest, EncodingAffectsTransportNotComputeIdentity) {
     const auto source = geography();
     auto target = source;
-    target.storage->encoding = TGeoEncoding::UNKNOWN;
+    target.storage.encoding = GEO_ENCODING_UNKNOWN;
     EXPECT_TRUE(is_geo_compute_compatible(source, target));
     EXPECT_FALSE(is_geo_assignment_compatible(source, target));
     EXPECT_FALSE(is_geo_assignment_compatible(target, source));
     EXPECT_FALSE(is_geo_union_all_compatible(source, target));
-    target.storage->encoding.reset();
-    EXPECT_FALSE(is_geo_union_all_compatible(source, target));
-    target.storage.reset();
+    target.storage = GeoStorageDescriptor{};
     EXPECT_TRUE(is_geo_compute_compatible(source, target));
     EXPECT_FALSE(is_geo_assignment_compatible(source, target));
 }
 
 TEST(GeoTypeDescriptorTest, DimensionGuaranteesAreDirectional) {
-    for (int source_dim = TGeoDimension::UNKNOWN; source_dim <= TGeoDimension::MIXED; ++source_dim) {
-        for (int target_dim = TGeoDimension::UNKNOWN; target_dim <= TGeoDimension::MIXED; ++target_dim) {
+    for (int source_dim = GEO_DIMENSION_UNKNOWN; source_dim <= GEO_DIMENSION_MIXED; ++source_dim) {
+        for (int target_dim = GEO_DIMENSION_UNKNOWN; target_dim <= GEO_DIMENSION_MIXED; ++target_dim) {
             auto source = geography();
             auto target = geography();
-            source.storage->dimension = static_cast<TGeoDimension::type>(source_dim);
-            target.storage->dimension = static_cast<TGeoDimension::type>(target_dim);
-            const bool assignable = target_dim == TGeoDimension::UNKNOWN || target_dim == TGeoDimension::MIXED ||
+            source.storage.dimension = static_cast<PGeoDimension>(source_dim);
+            target.storage.dimension = static_cast<PGeoDimension>(target_dim);
+            const bool assignable = target_dim == GEO_DIMENSION_UNKNOWN || target_dim == GEO_DIMENSION_MIXED ||
                                     source_dim == target_dim;
             EXPECT_EQ(assignable, is_geo_assignment_compatible(source, target));
             EXPECT_TRUE(is_geo_union_all_compatible(source, target));
@@ -410,9 +424,9 @@ TEST(GeoTypeDescriptorTest, DimensionGuaranteesAreDirectional) {
     }
     auto source = geography();
     auto target = geography();
-    source.storage->dimension.reset();
+    source.storage.dimension = GEO_DIMENSION_UNKNOWN;
     EXPECT_FALSE(is_geo_assignment_compatible(source, target));
-    target.storage->dimension.reset();
+    target.storage.dimension = GEO_DIMENSION_UNKNOWN;
     EXPECT_TRUE(is_geo_assignment_compatible(source, target));
     EXPECT_TRUE(is_geo_union_all_compatible(source, target));
 }

--- a/be/test/types/geo_type_descriptor_test.cpp
+++ b/be/test/types/geo_type_descriptor_test.cpp
@@ -141,16 +141,16 @@ TEST(GeoTypeDescriptorTest, WireOrdinalsRemainStable) {
     EXPECT_EQ(2, GEO_VALIDATION_STATE_STRUCTURALLY_VALIDATED);
     EXPECT_EQ(3, TGeoValidationState::SEMANTICALLY_VALIDATED);
     EXPECT_EQ(3, GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED);
-    EXPECT_EQ(1, PGeoTypeDesc::kLogicalTypeFieldNumber);
-    EXPECT_EQ(2, PGeoTypeDesc::kCoordinateSystemFieldNumber);
-    EXPECT_EQ(3, PGeoTypeDesc::kEdgeAlgorithmFieldNumber);
-    EXPECT_EQ(4, PGeoTypeDesc::kCrsFieldNumber);
-    EXPECT_EQ(5, PGeoTypeDesc::kSridFieldNumber);
-    EXPECT_EQ(1, PGeoStorageDesc::kEncodingFieldNumber);
-    EXPECT_EQ(2, PGeoStorageDesc::kDimensionFieldNumber);
-    EXPECT_EQ(3, PGeoStorageDesc::kValidationStateFieldNumber);
-    EXPECT_EQ(1, PGeoColumnDesc::kTypeFieldNumber);
-    EXPECT_EQ(2, PGeoColumnDesc::kStorageFieldNumber);
+    EXPECT_EQ(1, GeoTypeDescPB::kLogicalTypeFieldNumber);
+    EXPECT_EQ(2, GeoTypeDescPB::kCoordinateSystemFieldNumber);
+    EXPECT_EQ(3, GeoTypeDescPB::kEdgeAlgorithmFieldNumber);
+    EXPECT_EQ(4, GeoTypeDescPB::kCrsFieldNumber);
+    EXPECT_EQ(5, GeoTypeDescPB::kSridFieldNumber);
+    EXPECT_EQ(1, GeoStorageDescPB::kEncodingFieldNumber);
+    EXPECT_EQ(2, GeoStorageDescPB::kDimensionFieldNumber);
+    EXPECT_EQ(3, GeoStorageDescPB::kValidationStateFieldNumber);
+    EXPECT_EQ(1, GeoColumnDescPB::kTypeFieldNumber);
+    EXPECT_EQ(2, GeoColumnDescPB::kStorageFieldNumber);
 }
 
 TEST(GeoTypeDescriptorTest, AlgorithmsRemainDistinctForCompatibility) {
@@ -167,11 +167,11 @@ TEST(GeoTypeDescriptorTest, AlgorithmsRemainDistinctForCompatibility) {
 
 TEST(GeoTypeDescriptorTest, MissingFieldsNormalizeWithoutGuessingSemantics) {
     EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_thrift(TGeoTypeDesc{}));
-    EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_protobuf(PGeoTypeDesc{}));
+    EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_protobuf(GeoTypeDescPB{}));
     EXPECT_EQ(GeoStorageDescriptor{}, GeoStorageDescriptor::from_thrift(TGeoStorageDesc{}));
-    EXPECT_EQ(GeoStorageDescriptor{}, GeoStorageDescriptor::from_protobuf(PGeoStorageDesc{}));
+    EXPECT_EQ(GeoStorageDescriptor{}, GeoStorageDescriptor::from_protobuf(GeoStorageDescPB{}));
     EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_thrift(TGeoColumnDesc{}));
-    EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_protobuf(PGeoColumnDesc{}));
+    EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_protobuf(GeoColumnDescPB{}));
     check_round_trip(GeoColumnDescriptor{});
 
     TGeoTypeDesc type;
@@ -239,17 +239,17 @@ std::string protobuf_enum_wire(int field, int32_t value) {
 
 TEST(GeoTypeDescriptorTest, WireFieldsUseDeclaredEnums) {
     static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.logical_type), TGeoLogicalType::type>);
-    static_assert(std::is_same_v<decltype(PGeoTypeDesc{}.logical_type()), PGeoLogicalType>);
+    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.logical_type()), PGeoLogicalType>);
     static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.coordinate_system), TGeoCoordinateSystem::type>);
-    static_assert(std::is_same_v<decltype(PGeoTypeDesc{}.coordinate_system()), PGeoCoordinateSystem>);
+    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.coordinate_system()), PGeoCoordinateSystem>);
     static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.edge_algorithm), TGeoEdgeAlgorithm::type>);
-    static_assert(std::is_same_v<decltype(PGeoTypeDesc{}.edge_algorithm()), PGeoEdgeAlgorithm>);
+    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.edge_algorithm()), PGeoEdgeAlgorithm>);
     static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.encoding), TGeoEncoding::type>);
-    static_assert(std::is_same_v<decltype(PGeoStorageDesc{}.encoding()), PGeoEncoding>);
+    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.encoding()), PGeoEncoding>);
     static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.dimension), TGeoDimension::type>);
-    static_assert(std::is_same_v<decltype(PGeoStorageDesc{}.dimension()), PGeoDimension>);
+    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.dimension()), PGeoDimension>);
     static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.validation_state), TGeoValidationState::type>);
-    static_assert(std::is_same_v<decltype(PGeoStorageDesc{}.validation_state()), PGeoValidationState>);
+    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.validation_state()), PGeoValidationState>);
 }
 
 constexpr std::array unknown_values = {127, -1, std::numeric_limits<int32_t>::max(),
@@ -287,8 +287,8 @@ TEST(GeoTypeDescriptorTest, UnknownProtobufWireEnumsUseUnknownDefault) {
     for (int32_t value : unknown_values) {
         for (int field = 1; field <= 3; ++field) {
             SCOPED_TRACE(::testing::Message() << field << "/" << value);
-            PGeoTypeDesc type;
-            PGeoStorageDesc storage;
+            GeoTypeDescPB type;
+            GeoStorageDescPB storage;
             ASSERT_TRUE(type.ParseFromString(protobuf_enum_wire(field, value)));
             ASSERT_TRUE(storage.ParseFromString(protobuf_enum_wire(field, value)));
             // Closed-enum parsing leaves the field unset; its declared default is UNKNOWN.
@@ -298,7 +298,7 @@ TEST(GeoTypeDescriptorTest, UnknownProtobufWireEnumsUseUnknownDefault) {
             EXPECT_EQ(1, storage.unknown_fields().field_count());
             EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_protobuf(type));
             EXPECT_EQ(GeoStorageDescriptor{}, GeoStorageDescriptor::from_protobuf(storage));
-            PGeoColumnDesc column;
+            GeoColumnDescPB column;
             *column.mutable_type() = type;
             *column.mutable_storage() = storage;
             EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_protobuf(column));
@@ -319,8 +319,8 @@ TEST(GeoTypeDescriptorTest, ProtobufKnownEnumsAreNotOverriddenByUnknownFields) {
                 const auto unknown = protobuf_enum_wire(field, value);
                 const auto type_bytes = expected.type.to_protobuf().SerializeAsString();
                 const auto storage_bytes = expected.storage.to_protobuf().SerializeAsString();
-                PGeoTypeDesc type;
-                PGeoStorageDesc storage;
+                GeoTypeDescPB type;
+                GeoStorageDescPB storage;
                 ASSERT_TRUE(type.ParseFromString(known_first ? type_bytes + unknown : unknown + type_bytes));
                 ASSERT_TRUE(storage.ParseFromString(known_first ? storage_bytes + unknown : unknown + storage_bytes));
                 EXPECT_EQ(1, type.unknown_fields().field_count());

--- a/be/test/types/geo_type_descriptor_test.cpp
+++ b/be/test/types/geo_type_descriptor_test.cpp
@@ -14,8 +14,6 @@
 
 #include "types/geo_type_descriptor.h"
 
-#include <google/protobuf/descriptor.pb.h>
-#include <google/protobuf/dynamic_message.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl_lite.h>
 #include <gtest/gtest.h>
@@ -25,6 +23,7 @@
 
 #include <array>
 #include <limits>
+#include <type_traits>
 
 namespace starrocks {
 namespace {
@@ -213,7 +212,7 @@ TEST(GeoTypeDescriptorTest, SridRetainsMeaningfulPresence) {
     EXPECT_NE(desc, geography());
 }
 
-// Same numeric wire encoding as the original enum fields, with no generated setter.
+// Construct an unknown enum on the wire without invoking a generated enum setter.
 template <typename Thrift>
 Thrift thrift_enum_wire(int16_t field, int32_t value) {
     auto buffer = std::make_shared<TMemoryBuffer>();
@@ -240,99 +239,96 @@ std::string protobuf_enum_wire(int field, int32_t value) {
     return bytes;
 }
 
-template <typename Message>
-int32_t enum_number(const Message& message, int field) {
-    return message.GetReflection()->GetInt32(message, message.GetDescriptor()->FindFieldByNumber(field));
+TEST(GeoTypeDescriptorTest, WireFieldsUseDeclaredEnums) {
+    static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.logical_type), TGeoLogicalType::type>);
+    static_assert(std::is_same_v<decltype(PGeoTypeDesc{}.logical_type()), PGeoLogicalType>);
+    static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.coordinate_system), TGeoCoordinateSystem::type>);
+    static_assert(std::is_same_v<decltype(PGeoTypeDesc{}.coordinate_system()), PGeoCoordinateSystem>);
+    static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.edge_algorithm), TGeoEdgeAlgorithm::type>);
+    static_assert(std::is_same_v<decltype(PGeoTypeDesc{}.edge_algorithm()), PGeoEdgeAlgorithm>);
+    static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.encoding), TGeoEncoding::type>);
+    static_assert(std::is_same_v<decltype(PGeoStorageDesc{}.encoding()), PGeoEncoding>);
+    static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.dimension), TGeoDimension::type>);
+    static_assert(std::is_same_v<decltype(PGeoStorageDesc{}.dimension()), PGeoDimension>);
+    static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.validation_state), TGeoValidationState::type>);
+    static_assert(std::is_same_v<decltype(PGeoStorageDesc{}.validation_state()), PGeoValidationState>);
 }
 
 constexpr std::array unknown_values = {127, -1, std::numeric_limits<int32_t>::max(),
                                        std::numeric_limits<int32_t>::min()};
 
-TEST(GeoTypeDescriptorTest, UnknownNumbersSurviveBothTransports) {
+TEST(GeoTypeDescriptorTest, UnknownThriftEnumsNormalizeToUnknown) {
     for (int32_t value : unknown_values) {
         for (int16_t field = 1; field <= 3; ++field) {
             SCOPED_TRACE(::testing::Message() << field << "/" << value);
-            const auto type = GeoTypeDescriptor::from_thrift(thrift_enum_wire<TGeoTypeDesc>(field, value));
-            const auto storage = GeoStorageDescriptor::from_thrift(thrift_enum_wire<TGeoStorageDesc>(field, value));
-            EXPECT_EQ(value, enum_number(type.to_protobuf(), field));
-            EXPECT_EQ(value, enum_number(storage.to_protobuf(), field));
+            auto type_wire = thrift_enum_wire<TGeoTypeDesc>(field, value);
+            type_wire.__set_crs("OGC:CRS84");
+            type_wire.__set_srid(4326);
+            const auto storage_wire = thrift_enum_wire<TGeoStorageDesc>(field, value);
+            const auto type = GeoTypeDescriptor::from_thrift(type_wire);
+            const auto storage = GeoStorageDescriptor::from_thrift(storage_wire);
+            GeoTypeDescriptor expected;
+            expected.crs = "OGC:CRS84";
+            expected.srid = 4326;
+            EXPECT_EQ(expected, type);
+            EXPECT_EQ(GeoStorageDescriptor{}, storage);
             check_round_trip(type);
             check_round_trip(storage);
-            check_round_trip(GeoColumnDescriptor{type, storage});
-
-            PGeoTypeDesc type_pb;
-            PGeoStorageDesc storage_pb;
-            ASSERT_TRUE(type_pb.ParseFromString(protobuf_enum_wire(field, value)));
-            ASSERT_TRUE(storage_pb.ParseFromString(protobuf_enum_wire(field, value)));
-            EXPECT_TRUE(type_pb.unknown_fields().empty());
-            EXPECT_TRUE(storage_pb.unknown_fields().empty());
-            EXPECT_EQ(type, GeoTypeDescriptor::from_protobuf(type_pb));
-            EXPECT_EQ(storage, GeoStorageDescriptor::from_protobuf(storage_pb));
+            TGeoColumnDesc column;
+            column.__set_type(type_wire);
+            column.__set_storage(storage_wire);
+            const GeoColumnDescriptor normalized{expected, {}};
+            EXPECT_EQ(normalized, GeoColumnDescriptor::from_thrift(column));
+            check_round_trip(normalized);
+            EXPECT_FALSE(is_geo_compute_compatible(normalized, normalized));
         }
     }
 }
 
-TEST(GeoTypeDescriptorTest, DirectProtobufSettersPreserveUnknownNumbers) {
-    // Unlike closed-enum setters, int32 setters work identically with/without NDEBUG.
+TEST(GeoTypeDescriptorTest, UnknownProtobufWireEnumsUseUnknownDefault) {
     for (int32_t value : unknown_values) {
-        PGeoTypeDesc type;
-        type.set_logical_type(value);
-        type.set_coordinate_system(value);
-        type.set_edge_algorithm(value);
-        PGeoStorageDesc storage;
-        storage.set_encoding(value);
-        storage.set_dimension(value);
-        storage.set_validation_state(value);
-        const auto type_desc = GeoTypeDescriptor::from_protobuf(type);
-        const auto storage_desc = GeoStorageDescriptor::from_protobuf(storage);
         for (int field = 1; field <= 3; ++field) {
-            EXPECT_EQ(value, enum_number(type_desc.to_protobuf(), field));
-            EXPECT_EQ(value, enum_number(storage_desc.to_protobuf(), field));
+            SCOPED_TRACE(::testing::Message() << field << "/" << value);
+            PGeoTypeDesc type;
+            PGeoStorageDesc storage;
+            ASSERT_TRUE(type.ParseFromString(protobuf_enum_wire(field, value)));
+            ASSERT_TRUE(storage.ParseFromString(protobuf_enum_wire(field, value)));
+            // Closed-enum parsing leaves the field unset; its declared default is UNKNOWN.
+            EXPECT_FALSE(type.GetReflection()->HasField(type, type.GetDescriptor()->FindFieldByNumber(field)));
+            EXPECT_FALSE(storage.GetReflection()->HasField(storage, storage.GetDescriptor()->FindFieldByNumber(field)));
+            EXPECT_EQ(1, type.unknown_fields().field_count());
+            EXPECT_EQ(1, storage.unknown_fields().field_count());
+            EXPECT_EQ(GeoTypeDescriptor{}, GeoTypeDescriptor::from_protobuf(type));
+            EXPECT_EQ(GeoStorageDescriptor{}, GeoStorageDescriptor::from_protobuf(storage));
+            PGeoColumnDesc column;
+            *column.mutable_type() = type;
+            *column.mutable_storage() = storage;
+            EXPECT_EQ(GeoColumnDescriptor{}, GeoColumnDescriptor::from_protobuf(column));
+            check_round_trip(GeoColumnDescriptor::from_protobuf(column));
+            // Internal descriptors are normalized metadata, not an unknown-field relay.
+            EXPECT_TRUE(GeoTypeDescriptor::from_protobuf(type).to_protobuf().unknown_fields().empty());
+            EXPECT_TRUE(GeoStorageDescriptor::from_protobuf(storage).to_protobuf().unknown_fields().empty());
         }
-        check_round_trip(GeoColumnDescriptor{type_desc, storage_desc});
     }
 }
 
-TEST(GeoTypeDescriptorTest, LegacyProto2UnknownFieldSetRemainsReadable) {
-    // Model a closed-enum producer: unknown values go into its unknown-field set.
-    // After serialization the current int32 schema must recover their exact values.
-    google::protobuf::FileDescriptorProto file;
-    file.set_name("legacy_geo_test.proto");
-    file.set_syntax("proto2");
-    auto* enumeration = file.add_enum_type();
-    enumeration->set_name("LegacyEnum");
-    auto* zero = enumeration->add_value();
-    zero->set_name("UNKNOWN");
-    zero->set_number(0);
-    auto* message = file.add_message_type();
-    message->set_name("LegacyGeo");
-    for (int i = 1; i <= 3; ++i) {
-        auto* field = message->add_field();
-        field->set_name("field" + std::to_string(i));
-        field->set_number(i);
-        field->set_label(google::protobuf::FieldDescriptorProto::LABEL_OPTIONAL);
-        field->set_type(google::protobuf::FieldDescriptorProto::TYPE_ENUM);
-        field->set_type_name(".LegacyEnum");
-    }
-    google::protobuf::DescriptorPool pool;
-    const auto* schema = pool.BuildFile(file);
-    ASSERT_NE(nullptr, schema);
-    google::protobuf::DynamicMessageFactory factory(&pool);
-    std::unique_ptr<google::protobuf::Message> legacy(factory.GetPrototype(schema->message_type(0))->New());
+TEST(GeoTypeDescriptorTest, ProtobufKnownEnumsAreNotOverriddenByUnknownFields) {
+    const auto expected = geography();
     for (int32_t value : unknown_values) {
         for (int field = 1; field <= 3; ++field) {
             for (bool known_first : {false, true}) {
-                const auto bytes =
-                        (known_first ? protobuf_enum_wire(field, 0) : std::string{}) + protobuf_enum_wire(field, value);
-                ASSERT_TRUE(legacy->ParseFromString(bytes));
-                ASSERT_EQ(1, legacy->GetReflection()->GetUnknownFields(*legacy).field_count());
-                const auto relayed = legacy->SerializeAsString();
+                SCOPED_TRACE(::testing::Message() << field << "/" << value << "/" << known_first);
+                const auto unknown = protobuf_enum_wire(field, value);
+                const auto type_bytes = expected.type.to_protobuf().SerializeAsString();
+                const auto storage_bytes = expected.storage.to_protobuf().SerializeAsString();
                 PGeoTypeDesc type;
                 PGeoStorageDesc storage;
-                ASSERT_TRUE(type.ParseFromString(relayed));
-                ASSERT_TRUE(storage.ParseFromString(relayed));
-                EXPECT_EQ(value, enum_number(GeoTypeDescriptor::from_protobuf(type).to_protobuf(), field));
-                EXPECT_EQ(value, enum_number(GeoStorageDescriptor::from_protobuf(storage).to_protobuf(), field));
+                ASSERT_TRUE(type.ParseFromString(known_first ? type_bytes + unknown : unknown + type_bytes));
+                ASSERT_TRUE(storage.ParseFromString(known_first ? storage_bytes + unknown : unknown + storage_bytes));
+                EXPECT_EQ(1, type.unknown_fields().field_count());
+                EXPECT_EQ(1, storage.unknown_fields().field_count());
+                EXPECT_EQ(expected.type, GeoTypeDescriptor::from_protobuf(type));
+                EXPECT_EQ(expected.storage, GeoStorageDescriptor::from_protobuf(storage));
             }
         }
     }
@@ -340,11 +336,14 @@ TEST(GeoTypeDescriptorTest, LegacyProto2UnknownFieldSetRemainsReadable) {
 
 TEST(GeoTypeDescriptorTest, CallerChoosesSupportedAlgorithm) {
     auto input = geography().type.to_protobuf();
-    input.set_edge_algorithm(127);
+    input.set_edge_algorithm(GEO_EDGE_ALGORITHM_KARNEY);
     const auto desc = GeoTypeDescriptor::from_protobuf(input);
-    // Conversion preserves the value. The consuming caller decides whether to reject.
-    EXPECT_FALSE(PGeoEdgeAlgorithm_IsValid(desc.edge_algorithm));
-    EXPECT_EQ(127, desc.to_protobuf().edge_algorithm());
+    // A declared algorithm survives conversion, even if this caller only supports SPHERICAL.
+    const auto supports_algorithm = [](const GeoTypeDescriptor& type) {
+        return type.edge_algorithm == GEO_EDGE_ALGORITHM_SPHERICAL;
+    };
+    EXPECT_FALSE(supports_algorithm(desc));
+    EXPECT_EQ(GEO_EDGE_ALGORITHM_KARNEY, desc.to_protobuf().edge_algorithm());
 }
 
 TEST(GeoTypeDescriptorTest, ValidationStateAndParsedSridAreNotTypeIdentity) {

--- a/be/test/types/geo_type_descriptor_test.cpp
+++ b/be/test/types/geo_type_descriptor_test.cpp
@@ -80,8 +80,8 @@ TEST(GeoTypeDescriptorTest, AllAlgorithmsAndStorageStatesRoundTrip) {
                     desc.type.coordinate_system = GEO_COORDINATE_SYSTEM_CARTESIAN;
                 }
                 desc.type.srid = 4326;
-                desc.storage.dimension = static_cast<PGeoDimension>(dim);
-                desc.storage.validation_state = static_cast<PGeoValidationState>(state);
+                desc.storage.dimension = static_cast<GeoDimensionPB>(dim);
+                desc.storage.validation_state = static_cast<GeoValidationStatePB>(state);
                 check_round_trip(desc.type);
                 check_round_trip(desc.storage);
                 check_round_trip(desc);
@@ -158,8 +158,8 @@ TEST(GeoTypeDescriptorTest, AlgorithmsRemainDistinctForCompatibility) {
         for (int right = GEO_EDGE_ALGORITHM_SPHERICAL; right <= GEO_EDGE_ALGORITHM_PLANAR; ++right) {
             auto source = geography();
             auto target = geography();
-            source.type.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(left);
-            target.type.edge_algorithm = static_cast<PGeoEdgeAlgorithm>(right);
+            source.type.edge_algorithm = static_cast<GeoEdgeAlgorithmPB>(left);
+            target.type.edge_algorithm = static_cast<GeoEdgeAlgorithmPB>(right);
             EXPECT_EQ(left == right, is_geo_compute_compatible(source, target));
         }
     }
@@ -239,17 +239,17 @@ std::string protobuf_enum_wire(int field, int32_t value) {
 
 TEST(GeoTypeDescriptorTest, WireFieldsUseDeclaredEnums) {
     static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.logical_type), TGeoLogicalType::type>);
-    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.logical_type()), PGeoLogicalType>);
+    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.logical_type()), GeoLogicalTypePB>);
     static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.coordinate_system), TGeoCoordinateSystem::type>);
-    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.coordinate_system()), PGeoCoordinateSystem>);
+    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.coordinate_system()), GeoCoordinateSystemPB>);
     static_assert(std::is_same_v<decltype(TGeoTypeDesc{}.edge_algorithm), TGeoEdgeAlgorithm::type>);
-    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.edge_algorithm()), PGeoEdgeAlgorithm>);
+    static_assert(std::is_same_v<decltype(GeoTypeDescPB{}.edge_algorithm()), GeoEdgeAlgorithmPB>);
     static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.encoding), TGeoEncoding::type>);
-    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.encoding()), PGeoEncoding>);
+    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.encoding()), GeoEncodingPB>);
     static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.dimension), TGeoDimension::type>);
-    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.dimension()), PGeoDimension>);
+    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.dimension()), GeoDimensionPB>);
     static_assert(std::is_same_v<decltype(TGeoStorageDesc{}.validation_state), TGeoValidationState::type>);
-    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.validation_state()), PGeoValidationState>);
+    static_assert(std::is_same_v<decltype(GeoStorageDescPB{}.validation_state()), GeoValidationStatePB>);
 }
 
 constexpr std::array unknown_values = {127, -1, std::numeric_limits<int32_t>::max(),
@@ -348,7 +348,7 @@ TEST(GeoTypeDescriptorTest, ValidationStateAndParsedSridAreNotTypeIdentity) {
     auto source = geography();
     for (int state = GEO_VALIDATION_STATE_UNKNOWN; state <= GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED; ++state) {
         auto target = source;
-        target.storage.validation_state = static_cast<PGeoValidationState>(state);
+        target.storage.validation_state = static_cast<GeoValidationStatePB>(state);
         target.type.srid = 4326;
         EXPECT_NE(source, target);
         EXPECT_TRUE(is_geo_semantically_compatible(source.type, target.type));
@@ -400,8 +400,8 @@ TEST(GeoTypeDescriptorTest, DimensionDoesNotAffectSemanticComparison) {
         for (int target_dim = GEO_DIMENSION_UNKNOWN; target_dim <= GEO_DIMENSION_MIXED; ++target_dim) {
             auto source = geography();
             auto target = geography();
-            source.storage.dimension = static_cast<PGeoDimension>(source_dim);
-            target.storage.dimension = static_cast<PGeoDimension>(target_dim);
+            source.storage.dimension = static_cast<GeoDimensionPB>(source_dim);
+            target.storage.dimension = static_cast<GeoDimensionPB>(target_dim);
             EXPECT_EQ(source_dim == target_dim, source == target);
             EXPECT_TRUE(is_geo_semantically_compatible(source.type, target.type));
             // Semantic comparison neither derives a result dimension nor checks row dimensions.

--- a/be/test/types/geo_type_descriptor_test.cpp
+++ b/be/test/types/geo_type_descriptor_test.cpp
@@ -1,0 +1,421 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/geo_type_descriptor.h"
+
+#include <gtest/gtest.h>
+#include <thrift/protocol/TBinaryProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+
+#include <array>
+#include <limits>
+
+namespace starrocks {
+namespace {
+
+using apache::thrift::protocol::TBinaryProtocol;
+using apache::thrift::transport::TMemoryBuffer;
+
+GeoColumnDescriptor geography() {
+    return {GeoTypeDescriptor{TGeoLogicalType::GEOGRAPHY, TGeoCoordinateSystem::SPHERICAL, TGeoEdgeAlgorithm::SPHERICAL,
+                              "OGC:CRS84", std::nullopt},
+            GeoStorageDescriptor{TGeoEncoding::WKB, TGeoDimension::XY, TGeoValidationState::UNVALIDATED}};
+}
+
+template <typename Thrift>
+Thrift thrift_wire_round_trip(const Thrift& input) {
+    auto buffer = std::make_shared<TMemoryBuffer>();
+    TBinaryProtocol protocol(buffer);
+    input.write(&protocol);
+    Thrift output;
+    output.read(&protocol);
+    return output;
+}
+
+template <typename Descriptor>
+void check_round_trip(const Descriptor& expected) {
+    auto thrift = expected.to_thrift();
+    ASSERT_TRUE(thrift.ok()) << thrift.status();
+    auto decoded_thrift = Descriptor::from_thrift(thrift_wire_round_trip(*thrift));
+    ASSERT_TRUE(decoded_thrift.ok()) << decoded_thrift.status();
+    EXPECT_EQ(expected, *decoded_thrift);
+
+    auto protobuf = expected.to_protobuf();
+    ASSERT_TRUE(protobuf.ok()) << protobuf.status();
+    auto parsed = *protobuf;
+    parsed.Clear();
+    ASSERT_TRUE(parsed.ParseFromString(protobuf->SerializeAsString()));
+    auto decoded_protobuf = Descriptor::from_protobuf(parsed);
+    ASSERT_TRUE(decoded_protobuf.ok()) << decoded_protobuf.status();
+    EXPECT_EQ(expected, *decoded_protobuf);
+
+    auto cross_wire = decoded_thrift->to_protobuf();
+    ASSERT_TRUE(cross_wire.ok()) << cross_wire.status();
+    auto cross_desc = Descriptor::from_protobuf(*cross_wire);
+    ASSERT_TRUE(cross_desc.ok()) << cross_desc.status();
+    EXPECT_EQ(expected, *cross_desc);
+}
+
+TEST(GeoTypeDescriptorTest, AllAlgorithmsAndStorageStatesRoundTrip) {
+    const std::array algorithms = {TGeoEdgeAlgorithm::UNKNOWN,  TGeoEdgeAlgorithm::SPHERICAL,
+                                   TGeoEdgeAlgorithm::VINCENTY, TGeoEdgeAlgorithm::THOMAS,
+                                   TGeoEdgeAlgorithm::ANDOYER,  TGeoEdgeAlgorithm::KARNEY,
+                                   TGeoEdgeAlgorithm::PLANAR};
+    for (auto algorithm : algorithms) {
+        for (int dim = TGeoDimension::UNKNOWN; dim <= TGeoDimension::MIXED; ++dim) {
+            for (int state = TGeoValidationState::UNKNOWN; state <= TGeoValidationState::SEMANTICALLY_VALIDATED;
+                 ++state) {
+                SCOPED_TRACE(::testing::Message() << algorithm << "/" << dim << "/" << state);
+                auto desc = geography();
+                desc.type->edge_algorithm = algorithm;
+                if (algorithm == TGeoEdgeAlgorithm::PLANAR) {
+                    desc.type->logical_type = TGeoLogicalType::GEOMETRY;
+                    desc.type->coordinate_system = TGeoCoordinateSystem::CARTESIAN;
+                }
+                desc.type->srid = 4326;
+                desc.storage->dimension = static_cast<TGeoDimension::type>(dim);
+                desc.storage->validation_state = static_cast<TGeoValidationState::type>(state);
+                check_round_trip(*desc.type);
+                check_round_trip(*desc.storage);
+                check_round_trip(desc);
+            }
+        }
+    }
+}
+
+TEST(GeoTypeDescriptorTest, WireOrdinalsRemainStable) {
+    EXPECT_EQ(0, TGeoLogicalType::UNKNOWN);
+    EXPECT_EQ(0, GEO_LOGICAL_TYPE_UNKNOWN);
+    EXPECT_EQ(1, TGeoLogicalType::GEOGRAPHY);
+    EXPECT_EQ(1, GEO_LOGICAL_TYPE_GEOGRAPHY);
+    EXPECT_EQ(2, TGeoLogicalType::GEOMETRY);
+    EXPECT_EQ(2, GEO_LOGICAL_TYPE_GEOMETRY);
+    EXPECT_EQ(0, TGeoCoordinateSystem::UNKNOWN);
+    EXPECT_EQ(0, GEO_COORDINATE_SYSTEM_UNKNOWN);
+    EXPECT_EQ(1, TGeoCoordinateSystem::SPHERICAL);
+    EXPECT_EQ(1, GEO_COORDINATE_SYSTEM_SPHERICAL);
+    EXPECT_EQ(2, TGeoCoordinateSystem::CARTESIAN);
+    EXPECT_EQ(2, GEO_COORDINATE_SYSTEM_CARTESIAN);
+    EXPECT_EQ(0, TGeoEdgeAlgorithm::UNKNOWN);
+    EXPECT_EQ(0, GEO_EDGE_ALGORITHM_UNKNOWN);
+    EXPECT_EQ(1, TGeoEdgeAlgorithm::SPHERICAL);
+    EXPECT_EQ(1, GEO_EDGE_ALGORITHM_SPHERICAL);
+    EXPECT_EQ(2, TGeoEdgeAlgorithm::VINCENTY);
+    EXPECT_EQ(2, GEO_EDGE_ALGORITHM_VINCENTY);
+    EXPECT_EQ(3, TGeoEdgeAlgorithm::THOMAS);
+    EXPECT_EQ(3, GEO_EDGE_ALGORITHM_THOMAS);
+    EXPECT_EQ(4, TGeoEdgeAlgorithm::ANDOYER);
+    EXPECT_EQ(4, GEO_EDGE_ALGORITHM_ANDOYER);
+    EXPECT_EQ(5, TGeoEdgeAlgorithm::KARNEY);
+    EXPECT_EQ(5, GEO_EDGE_ALGORITHM_KARNEY);
+    EXPECT_EQ(6, TGeoEdgeAlgorithm::PLANAR);
+    EXPECT_EQ(6, GEO_EDGE_ALGORITHM_PLANAR);
+    EXPECT_EQ(0, TGeoEncoding::UNKNOWN);
+    EXPECT_EQ(0, GEO_ENCODING_UNKNOWN);
+    EXPECT_EQ(1, TGeoEncoding::WKB);
+    EXPECT_EQ(1, GEO_ENCODING_WKB);
+    EXPECT_EQ(0, TGeoDimension::UNKNOWN);
+    EXPECT_EQ(0, GEO_DIMENSION_UNKNOWN);
+    EXPECT_EQ(1, TGeoDimension::XY);
+    EXPECT_EQ(1, GEO_DIMENSION_XY);
+    EXPECT_EQ(2, TGeoDimension::XYZ);
+    EXPECT_EQ(2, GEO_DIMENSION_XYZ);
+    EXPECT_EQ(3, TGeoDimension::XYM);
+    EXPECT_EQ(3, GEO_DIMENSION_XYM);
+    EXPECT_EQ(4, TGeoDimension::XYZM);
+    EXPECT_EQ(4, GEO_DIMENSION_XYZM);
+    EXPECT_EQ(5, TGeoDimension::MIXED);
+    EXPECT_EQ(5, GEO_DIMENSION_MIXED);
+    EXPECT_EQ(0, TGeoValidationState::UNKNOWN);
+    EXPECT_EQ(0, GEO_VALIDATION_STATE_UNKNOWN);
+    EXPECT_EQ(1, TGeoValidationState::UNVALIDATED);
+    EXPECT_EQ(1, GEO_VALIDATION_STATE_UNVALIDATED);
+    EXPECT_EQ(2, TGeoValidationState::STRUCTURALLY_VALIDATED);
+    EXPECT_EQ(2, GEO_VALIDATION_STATE_STRUCTURALLY_VALIDATED);
+    EXPECT_EQ(3, TGeoValidationState::SEMANTICALLY_VALIDATED);
+    EXPECT_EQ(3, GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED);
+    EXPECT_EQ(1, PGeoTypeDesc::kLogicalTypeFieldNumber);
+    EXPECT_EQ(2, PGeoTypeDesc::kCoordinateSystemFieldNumber);
+    EXPECT_EQ(3, PGeoTypeDesc::kEdgeAlgorithmFieldNumber);
+    EXPECT_EQ(4, PGeoTypeDesc::kCrsFieldNumber);
+    EXPECT_EQ(5, PGeoTypeDesc::kSridFieldNumber);
+    EXPECT_EQ(1, PGeoStorageDesc::kEncodingFieldNumber);
+    EXPECT_EQ(2, PGeoStorageDesc::kDimensionFieldNumber);
+    EXPECT_EQ(3, PGeoStorageDesc::kValidationStateFieldNumber);
+    EXPECT_EQ(1, PGeoColumnDesc::kTypeFieldNumber);
+    EXPECT_EQ(2, PGeoColumnDesc::kStorageFieldNumber);
+}
+
+TEST(GeoTypeDescriptorTest, AlgorithmsRemainDistinctForCompatibility) {
+    for (int left = TGeoEdgeAlgorithm::SPHERICAL; left <= TGeoEdgeAlgorithm::PLANAR; ++left) {
+        for (int right = TGeoEdgeAlgorithm::SPHERICAL; right <= TGeoEdgeAlgorithm::PLANAR; ++right) {
+            auto source = geography();
+            auto target = geography();
+            source.type->edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(left);
+            target.type->edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(right);
+            EXPECT_EQ(left == right, is_geo_compute_compatible(source, target));
+            EXPECT_EQ(left == right, is_geo_assignment_compatible(source, target));
+            EXPECT_EQ(left == right, is_geo_union_all_compatible(source, target));
+        }
+    }
+}
+
+TEST(GeoTypeDescriptorTest, OptionalFieldsPreservePresence) {
+    check_round_trip(GeoTypeDescriptor{});
+    check_round_trip(GeoStorageDescriptor{});
+    check_round_trip(GeoColumnDescriptor{});
+    check_round_trip(GeoColumnDescriptor{GeoTypeDescriptor{}, GeoStorageDescriptor{}});
+    // Each optional field independently, including explicit default values.
+    for (int field = 0; field < 5; ++field) {
+        GeoTypeDescriptor desc;
+        switch (field) {
+        case 0:
+            desc.logical_type = TGeoLogicalType::UNKNOWN;
+            break;
+        case 1:
+            desc.coordinate_system = TGeoCoordinateSystem::UNKNOWN;
+            break;
+        case 2:
+            desc.edge_algorithm = TGeoEdgeAlgorithm::UNKNOWN;
+            break;
+        case 3:
+            desc.crs = "";
+            break;
+        case 4:
+            desc.srid = 0;
+            break;
+        }
+        check_round_trip(desc);
+        EXPECT_NE(desc, GeoTypeDescriptor{});
+        check_round_trip(GeoColumnDescriptor{desc, std::nullopt});
+    }
+    for (int field = 0; field < 3; ++field) {
+        GeoStorageDescriptor desc;
+        switch (field) {
+        case 0:
+            desc.encoding = TGeoEncoding::UNKNOWN;
+            break;
+        case 1:
+            desc.dimension = TGeoDimension::UNKNOWN;
+            break;
+        case 2:
+            desc.validation_state = TGeoValidationState::UNKNOWN;
+            break;
+        }
+        check_round_trip(desc);
+        EXPECT_NE(desc, GeoStorageDescriptor{});
+        check_round_trip(GeoColumnDescriptor{std::nullopt, desc});
+    }
+}
+
+// Construct actual wire bytes rather than relying on generated enum setters.
+template <typename Thrift>
+Thrift thrift_enum_wire(int16_t field, int32_t value) {
+    auto buffer = std::make_shared<TMemoryBuffer>();
+    TBinaryProtocol protocol(buffer);
+    protocol.writeStructBegin("geo");
+    protocol.writeFieldBegin("enum", apache::thrift::protocol::T_I32, field);
+    protocol.writeI32(value);
+    protocol.writeFieldEnd();
+    protocol.writeFieldStop();
+    protocol.writeStructEnd();
+    Thrift parsed;
+    parsed.read(&protocol);
+    return parsed;
+}
+
+TEST(GeoTypeDescriptorTest, UnknownThriftEnumsAreRejectedBeforeConversion) {
+    for (auto value : {127, -1, std::numeric_limits<int32_t>::max()}) {
+        for (int16_t field = 1; field <= 3; ++field) {
+            SCOPED_TRACE(::testing::Message() << field << "/" << value);
+            const auto type = thrift_enum_wire<TGeoTypeDesc>(field, value);
+            EXPECT_TRUE(GeoTypeDescriptor::from_thrift(type).status().is_not_supported());
+            const auto storage = thrift_enum_wire<TGeoStorageDesc>(field, value);
+            EXPECT_TRUE(GeoStorageDescriptor::from_thrift(storage).status().is_not_supported());
+            TGeoColumnDesc column;
+            column.__set_type(type);
+            EXPECT_TRUE(GeoColumnDescriptor::from_thrift(column).status().is_not_supported());
+            column = TGeoColumnDesc{};
+            column.__set_storage(storage);
+            EXPECT_TRUE(GeoColumnDescriptor::from_thrift(column).status().is_not_supported());
+        }
+    }
+}
+
+template <typename Proto, typename Descriptor>
+void check_unknown_protobuf_enum(int field, int32_t value) {
+    // Serialization followed by parsing places closed-enum values in unknown_fields().
+    Proto input;
+    input.mutable_unknown_fields()->AddVarint(field, static_cast<uint64_t>(static_cast<int64_t>(value)));
+    for (bool include_known_value : {false, true}) {
+        if (include_known_value) {
+            const auto* enum_field = input.GetDescriptor()->FindFieldByNumber(field);
+            input.GetReflection()->SetEnum(&input, enum_field, enum_field->enum_type()->value(0));
+        }
+        Proto parsed;
+        ASSERT_TRUE(parsed.ParseFromString(input.SerializeAsString()));
+        ASSERT_EQ(1, parsed.unknown_fields().field_count());
+        EXPECT_EQ(static_cast<uint64_t>(static_cast<int64_t>(value)), parsed.unknown_fields().field(0).varint());
+        EXPECT_TRUE(Descriptor::from_protobuf(parsed).status().is_not_supported());
+    }
+}
+
+TEST(GeoTypeDescriptorTest, Proto2ClosedEnumsAreRejectedEvenAlongsideKnownValues) {
+    for (auto value : {127, -1, std::numeric_limits<int32_t>::max()}) {
+        for (int field = 1; field <= 3; ++field) {
+            SCOPED_TRACE(::testing::Message() << field << "/" << value);
+            check_unknown_protobuf_enum<PGeoTypeDesc, GeoTypeDescriptor>(field, value);
+            check_unknown_protobuf_enum<PGeoStorageDesc, GeoStorageDescriptor>(field, value);
+            PGeoColumnDesc column;
+            column.mutable_type()->mutable_unknown_fields()->AddVarint(field, value);
+            PGeoColumnDesc parsed;
+            ASSERT_TRUE(parsed.ParseFromString(column.SerializeAsString()));
+            EXPECT_TRUE(GeoColumnDescriptor::from_protobuf(parsed).status().is_not_supported());
+            column.Clear();
+            column.mutable_storage()->mutable_unknown_fields()->AddVarint(field, value);
+            ASSERT_TRUE(parsed.ParseFromString(column.SerializeAsString()));
+            EXPECT_TRUE(GeoColumnDescriptor::from_protobuf(parsed).status().is_not_supported());
+        }
+    }
+}
+
+TEST(GeoTypeDescriptorTest, UnrecognizedEnumsCannotBeSerializedFromLocalDescriptors) {
+    {
+        GeoTypeDescriptor desc;
+        desc.logical_type = static_cast<TGeoLogicalType::type>(127);
+        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
+        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
+    }
+    {
+        GeoTypeDescriptor desc;
+        desc.coordinate_system = static_cast<TGeoCoordinateSystem::type>(127);
+        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
+        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
+    }
+    {
+        GeoTypeDescriptor desc;
+        desc.edge_algorithm = static_cast<TGeoEdgeAlgorithm::type>(127);
+        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
+        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
+    }
+    {
+        GeoStorageDescriptor desc;
+        desc.encoding = static_cast<TGeoEncoding::type>(127);
+        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
+        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
+    }
+    {
+        GeoStorageDescriptor desc;
+        desc.dimension = static_cast<TGeoDimension::type>(127);
+        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
+        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
+    }
+    {
+        GeoStorageDescriptor desc;
+        desc.validation_state = static_cast<TGeoValidationState::type>(127);
+        EXPECT_TRUE(desc.to_thrift().status().is_not_supported());
+        EXPECT_TRUE(desc.to_protobuf().status().is_not_supported());
+    }
+}
+
+TEST(GeoTypeDescriptorTest, ValidationStateAndParsedSridAreNotTypeIdentity) {
+    auto source = geography();
+    for (int state = TGeoValidationState::UNKNOWN; state <= TGeoValidationState::SEMANTICALLY_VALIDATED; ++state) {
+        auto target = source;
+        target.storage->validation_state = static_cast<TGeoValidationState::type>(state);
+        target.type->srid = 4326;
+        EXPECT_NE(source, target);
+        EXPECT_TRUE(is_geo_semantically_compatible(*source.type, *target.type));
+        EXPECT_TRUE(is_geo_compute_compatible(source, target));
+        EXPECT_TRUE(is_geo_assignment_compatible(source, target));
+        EXPECT_TRUE(is_geo_union_all_compatible(source, target));
+    }
+    auto target = source;
+    target.storage->validation_state.reset();
+    EXPECT_TRUE(is_geo_assignment_compatible(source, target));
+}
+
+TEST(GeoTypeDescriptorTest, SemanticMismatchIsNotImplicitlyConverted) {
+    const auto source = geography();
+    for (int field = 0; field < 4; ++field) {
+        auto target = source;
+        switch (field) {
+        case 0:
+            target.type->logical_type = TGeoLogicalType::GEOMETRY;
+            break;
+        case 1:
+            target.type->coordinate_system = TGeoCoordinateSystem::CARTESIAN;
+            break;
+        case 2:
+            target.type->edge_algorithm = TGeoEdgeAlgorithm::KARNEY;
+            break;
+        case 3:
+            target.type->crs = "EPSG:4326";
+            break; // Not an axis-order-safe CRS84 alias.
+        }
+        EXPECT_FALSE(is_geo_compute_compatible(source, target));
+        EXPECT_FALSE(is_geo_assignment_compatible(source, target));
+        EXPECT_FALSE(is_geo_union_all_compatible(source, target));
+    }
+    EXPECT_FALSE(is_geo_compute_compatible({}, {}));
+    auto incomplete = source;
+    incomplete.type->crs.reset();
+    EXPECT_FALSE(is_geo_compute_compatible(incomplete, incomplete));
+    incomplete.type->crs = "";
+    EXPECT_FALSE(is_geo_compute_compatible(incomplete, incomplete));
+    incomplete = source;
+    incomplete.type->edge_algorithm = TGeoEdgeAlgorithm::UNKNOWN;
+    EXPECT_FALSE(is_geo_compute_compatible(incomplete, incomplete));
+}
+
+TEST(GeoTypeDescriptorTest, EncodingAffectsTransportNotComputeIdentity) {
+    const auto source = geography();
+    auto target = source;
+    target.storage->encoding = TGeoEncoding::UNKNOWN;
+    EXPECT_TRUE(is_geo_compute_compatible(source, target));
+    EXPECT_FALSE(is_geo_assignment_compatible(source, target));
+    EXPECT_FALSE(is_geo_assignment_compatible(target, source));
+    EXPECT_FALSE(is_geo_union_all_compatible(source, target));
+    target.storage->encoding.reset();
+    EXPECT_FALSE(is_geo_union_all_compatible(source, target));
+    target.storage.reset();
+    EXPECT_TRUE(is_geo_compute_compatible(source, target));
+    EXPECT_FALSE(is_geo_assignment_compatible(source, target));
+}
+
+TEST(GeoTypeDescriptorTest, DimensionGuaranteesAreDirectional) {
+    for (int source_dim = TGeoDimension::UNKNOWN; source_dim <= TGeoDimension::MIXED; ++source_dim) {
+        for (int target_dim = TGeoDimension::UNKNOWN; target_dim <= TGeoDimension::MIXED; ++target_dim) {
+            auto source = geography();
+            auto target = geography();
+            source.storage->dimension = static_cast<TGeoDimension::type>(source_dim);
+            target.storage->dimension = static_cast<TGeoDimension::type>(target_dim);
+            const bool assignable = target_dim == TGeoDimension::UNKNOWN || target_dim == TGeoDimension::MIXED ||
+                                    source_dim == target_dim;
+            EXPECT_EQ(assignable, is_geo_assignment_compatible(source, target));
+            EXPECT_TRUE(is_geo_union_all_compatible(source, target));
+            EXPECT_TRUE(is_geo_compute_compatible(source, target)); // Row checks are a later compute contract.
+        }
+    }
+    auto source = geography();
+    auto target = geography();
+    source.storage->dimension.reset();
+    EXPECT_FALSE(is_geo_assignment_compatible(source, target));
+    target.storage->dimension.reset();
+    EXPECT_TRUE(is_geo_assignment_compatible(source, target));
+    EXPECT_TRUE(is_geo_union_all_compatible(source, target));
+}
+
+} // namespace
+} // namespace starrocks

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -246,3 +246,67 @@ enum PrimaryKeyEncodingTypePB {
     PK_ENCODING_TYPE_V1 = 1;
     PK_ENCODING_TYPE_V2 = 2;
 }
+
+// Metadata recognition does not enable computation for an edge algorithm.
+enum PGeoLogicalType {
+    GEO_LOGICAL_TYPE_UNKNOWN = 0;
+    GEO_LOGICAL_TYPE_GEOGRAPHY = 1;
+    GEO_LOGICAL_TYPE_GEOMETRY = 2;
+}
+
+enum PGeoCoordinateSystem {
+    GEO_COORDINATE_SYSTEM_UNKNOWN = 0;
+    GEO_COORDINATE_SYSTEM_SPHERICAL = 1;
+    GEO_COORDINATE_SYSTEM_CARTESIAN = 2;
+}
+
+enum PGeoEdgeAlgorithm {
+    GEO_EDGE_ALGORITHM_UNKNOWN = 0;
+    GEO_EDGE_ALGORITHM_SPHERICAL = 1;
+    GEO_EDGE_ALGORITHM_VINCENTY = 2;
+    GEO_EDGE_ALGORITHM_THOMAS = 3;
+    GEO_EDGE_ALGORITHM_ANDOYER = 4;
+    GEO_EDGE_ALGORITHM_KARNEY = 5;
+    GEO_EDGE_ALGORITHM_PLANAR = 6;
+}
+
+enum PGeoEncoding {
+    GEO_ENCODING_UNKNOWN = 0;
+    GEO_ENCODING_WKB = 1;
+}
+
+enum PGeoDimension {
+    GEO_DIMENSION_UNKNOWN = 0;
+    GEO_DIMENSION_XY = 1;
+    GEO_DIMENSION_XYZ = 2;
+    GEO_DIMENSION_XYM = 3;
+    GEO_DIMENSION_XYZM = 4;
+    GEO_DIMENSION_MIXED = 5;
+}
+
+enum PGeoValidationState {
+    GEO_VALIDATION_STATE_UNKNOWN = 0;
+    GEO_VALIDATION_STATE_UNVALIDATED = 1;
+    GEO_VALIDATION_STATE_STRUCTURALLY_VALIDATED = 2;
+    GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED = 3;
+}
+
+// Standalone descriptors; not attached to PTypeDesc until native type integration.
+message PGeoTypeDesc {
+    optional PGeoLogicalType logical_type = 1;
+    optional PGeoCoordinateSystem coordinate_system = 2;
+    optional PGeoEdgeAlgorithm edge_algorithm = 3;
+    optional string crs = 4;
+    optional int32 srid = 5;
+}
+
+message PGeoStorageDesc {
+    optional PGeoEncoding encoding = 1;
+    optional PGeoDimension dimension = 2;
+    optional PGeoValidationState validation_state = 3;
+}
+
+message PGeoColumnDesc {
+    optional PGeoTypeDesc type = 1;
+    optional PGeoStorageDesc storage = 2;
+}

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -292,18 +292,26 @@ enum PGeoValidationState {
 }
 
 // Standalone descriptors; not attached to PTypeDesc until native type integration.
+// Enum numbers use int32 so unknown values survive transport; callers validate support.
 message PGeoTypeDesc {
-    optional PGeoLogicalType logical_type = 1;
-    optional PGeoCoordinateSystem coordinate_system = 2;
-    optional PGeoEdgeAlgorithm edge_algorithm = 3;
+    // PGeoLogicalType
+    optional int32 logical_type = 1;
+    // PGeoCoordinateSystem
+    optional int32 coordinate_system = 2;
+    // PGeoEdgeAlgorithm
+    optional int32 edge_algorithm = 3;
     optional string crs = 4;
     optional int32 srid = 5;
 }
 
+// Enum numbers use int32 so unknown values survive transport; callers validate support.
 message PGeoStorageDesc {
-    optional PGeoEncoding encoding = 1;
-    optional PGeoDimension dimension = 2;
-    optional PGeoValidationState validation_state = 3;
+    // PGeoEncoding
+    optional int32 encoding = 1;
+    // PGeoDimension
+    optional int32 dimension = 2;
+    // PGeoValidationState
+    optional int32 validation_state = 3;
 }
 
 message PGeoColumnDesc {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -292,26 +292,18 @@ enum PGeoValidationState {
 }
 
 // Standalone descriptors; not attached to PTypeDesc until native type integration.
-// Enum numbers use int32 so unknown values survive transport; callers validate support.
 message PGeoTypeDesc {
-    // PGeoLogicalType
-    optional int32 logical_type = 1;
-    // PGeoCoordinateSystem
-    optional int32 coordinate_system = 2;
-    // PGeoEdgeAlgorithm
-    optional int32 edge_algorithm = 3;
+    optional PGeoLogicalType logical_type = 1;
+    optional PGeoCoordinateSystem coordinate_system = 2;
+    optional PGeoEdgeAlgorithm edge_algorithm = 3;
     optional string crs = 4;
     optional int32 srid = 5;
 }
 
-// Enum numbers use int32 so unknown values survive transport; callers validate support.
 message PGeoStorageDesc {
-    // PGeoEncoding
-    optional int32 encoding = 1;
-    // PGeoDimension
-    optional int32 dimension = 2;
-    // PGeoValidationState
-    optional int32 validation_state = 3;
+    optional PGeoEncoding encoding = 1;
+    optional PGeoDimension dimension = 2;
+    optional PGeoValidationState validation_state = 3;
 }
 
 message PGeoColumnDesc {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -248,19 +248,19 @@ enum PrimaryKeyEncodingTypePB {
 }
 
 // Metadata recognition does not enable computation for an edge algorithm.
-enum PGeoLogicalType {
+enum GeoLogicalTypePB {
     GEO_LOGICAL_TYPE_UNKNOWN = 0;
     GEO_LOGICAL_TYPE_GEOGRAPHY = 1;
     GEO_LOGICAL_TYPE_GEOMETRY = 2;
 }
 
-enum PGeoCoordinateSystem {
+enum GeoCoordinateSystemPB {
     GEO_COORDINATE_SYSTEM_UNKNOWN = 0;
     GEO_COORDINATE_SYSTEM_SPHERICAL = 1;
     GEO_COORDINATE_SYSTEM_CARTESIAN = 2;
 }
 
-enum PGeoEdgeAlgorithm {
+enum GeoEdgeAlgorithmPB {
     GEO_EDGE_ALGORITHM_UNKNOWN = 0;
     GEO_EDGE_ALGORITHM_SPHERICAL = 1;
     GEO_EDGE_ALGORITHM_VINCENTY = 2;
@@ -270,12 +270,12 @@ enum PGeoEdgeAlgorithm {
     GEO_EDGE_ALGORITHM_PLANAR = 6;
 }
 
-enum PGeoEncoding {
+enum GeoEncodingPB {
     GEO_ENCODING_UNKNOWN = 0;
     GEO_ENCODING_WKB = 1;
 }
 
-enum PGeoDimension {
+enum GeoDimensionPB {
     GEO_DIMENSION_UNKNOWN = 0;
     GEO_DIMENSION_XY = 1;
     GEO_DIMENSION_XYZ = 2;
@@ -284,7 +284,7 @@ enum PGeoDimension {
     GEO_DIMENSION_MIXED = 5;
 }
 
-enum PGeoValidationState {
+enum GeoValidationStatePB {
     GEO_VALIDATION_STATE_UNKNOWN = 0;
     GEO_VALIDATION_STATE_UNVALIDATED = 1;
     GEO_VALIDATION_STATE_STRUCTURALLY_VALIDATED = 2;
@@ -293,17 +293,17 @@ enum PGeoValidationState {
 
 // Standalone descriptors; not attached to PTypeDesc until native type integration.
 message GeoTypeDescPB {
-    optional PGeoLogicalType logical_type = 1;
-    optional PGeoCoordinateSystem coordinate_system = 2;
-    optional PGeoEdgeAlgorithm edge_algorithm = 3;
+    optional GeoLogicalTypePB logical_type = 1;
+    optional GeoCoordinateSystemPB coordinate_system = 2;
+    optional GeoEdgeAlgorithmPB edge_algorithm = 3;
     optional string crs = 4;
     optional int32 srid = 5;
 }
 
 message GeoStorageDescPB {
-    optional PGeoEncoding encoding = 1;
-    optional PGeoDimension dimension = 2;
-    optional PGeoValidationState validation_state = 3;
+    optional GeoEncodingPB encoding = 1;
+    optional GeoDimensionPB dimension = 2;
+    optional GeoValidationStatePB validation_state = 3;
 }
 
 message GeoColumnDescPB {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -292,7 +292,7 @@ enum PGeoValidationState {
 }
 
 // Standalone descriptors; not attached to PTypeDesc until native type integration.
-message PGeoTypeDesc {
+message GeoTypeDescPB {
     optional PGeoLogicalType logical_type = 1;
     optional PGeoCoordinateSystem coordinate_system = 2;
     optional PGeoEdgeAlgorithm edge_algorithm = 3;
@@ -300,13 +300,13 @@ message PGeoTypeDesc {
     optional int32 srid = 5;
 }
 
-message PGeoStorageDesc {
+message GeoStorageDescPB {
     optional PGeoEncoding encoding = 1;
     optional PGeoDimension dimension = 2;
     optional PGeoValidationState validation_state = 3;
 }
 
-message PGeoColumnDesc {
-    optional PGeoTypeDesc type = 1;
-    optional PGeoStorageDesc storage = 2;
+message GeoColumnDescPB {
+    optional GeoTypeDescPB type = 1;
+    optional GeoStorageDescPB storage = 2;
 }

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -774,18 +774,26 @@ enum TGeoValidationState {
 }
 
 // Standalone descriptors; not attached to TTypeDesc until native type integration.
+// Enum numbers use i32 so unknown values survive transport; callers validate support.
 struct TGeoTypeDesc {
-    1: optional TGeoLogicalType logical_type
-    2: optional TGeoCoordinateSystem coordinate_system
-    3: optional TGeoEdgeAlgorithm edge_algorithm
+    // TGeoLogicalType
+    1: optional i32 logical_type
+    // TGeoCoordinateSystem
+    2: optional i32 coordinate_system
+    // TGeoEdgeAlgorithm
+    3: optional i32 edge_algorithm
     4: optional string crs
     5: optional i32 srid
 }
 
+// Enum numbers use i32 so unknown values survive transport; callers validate support.
 struct TGeoStorageDesc {
-    1: optional TGeoEncoding encoding
-    2: optional TGeoDimension dimension
-    3: optional TGeoValidationState validation_state
+    // TGeoEncoding
+    1: optional i32 encoding
+    // TGeoDimension
+    2: optional i32 dimension
+    // TGeoValidationState
+    3: optional i32 validation_state
 }
 
 struct TGeoColumnDesc {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -774,26 +774,18 @@ enum TGeoValidationState {
 }
 
 // Standalone descriptors; not attached to TTypeDesc until native type integration.
-// Enum numbers use i32 so unknown values survive transport; callers validate support.
 struct TGeoTypeDesc {
-    // TGeoLogicalType
-    1: optional i32 logical_type
-    // TGeoCoordinateSystem
-    2: optional i32 coordinate_system
-    // TGeoEdgeAlgorithm
-    3: optional i32 edge_algorithm
+    1: optional TGeoLogicalType logical_type
+    2: optional TGeoCoordinateSystem coordinate_system
+    3: optional TGeoEdgeAlgorithm edge_algorithm
     4: optional string crs
     5: optional i32 srid
 }
 
-// Enum numbers use i32 so unknown values survive transport; callers validate support.
 struct TGeoStorageDesc {
-    // TGeoEncoding
-    1: optional i32 encoding
-    // TGeoDimension
-    2: optional i32 dimension
-    // TGeoValidationState
-    3: optional i32 validation_state
+    1: optional TGeoEncoding encoding
+    2: optional TGeoDimension dimension
+    3: optional TGeoValidationState validation_state
 }
 
 struct TGeoColumnDesc {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -728,3 +728,67 @@ struct TTabletRange {
     3: optional bool lower_bound_included
     4: optional bool upper_bound_included
 }
+
+// Metadata recognition does not enable computation for an edge algorithm.
+enum TGeoLogicalType {
+    UNKNOWN = 0,
+    GEOGRAPHY = 1,
+    GEOMETRY = 2
+}
+
+enum TGeoCoordinateSystem {
+    UNKNOWN = 0,
+    SPHERICAL = 1,
+    CARTESIAN = 2
+}
+
+enum TGeoEdgeAlgorithm {
+    UNKNOWN = 0,
+    SPHERICAL = 1,
+    VINCENTY = 2,
+    THOMAS = 3,
+    ANDOYER = 4,
+    KARNEY = 5,
+    PLANAR = 6
+}
+
+enum TGeoEncoding {
+    UNKNOWN = 0,
+    WKB = 1
+}
+
+enum TGeoDimension {
+    UNKNOWN = 0,
+    XY = 1,
+    XYZ = 2,
+    XYM = 3,
+    XYZM = 4,
+    MIXED = 5
+}
+
+enum TGeoValidationState {
+    UNKNOWN = 0,
+    UNVALIDATED = 1,
+    STRUCTURALLY_VALIDATED = 2,
+    SEMANTICALLY_VALIDATED = 3
+}
+
+// Standalone descriptors; not attached to TTypeDesc until native type integration.
+struct TGeoTypeDesc {
+    1: optional TGeoLogicalType logical_type
+    2: optional TGeoCoordinateSystem coordinate_system
+    3: optional TGeoEdgeAlgorithm edge_algorithm
+    4: optional string crs
+    5: optional i32 srid
+}
+
+struct TGeoStorageDesc {
+    1: optional TGeoEncoding encoding
+    2: optional TGeoDimension dimension
+    3: optional TGeoValidationState validation_state
+}
+
+struct TGeoColumnDesc {
+    1: optional TGeoTypeDesc type
+    2: optional TGeoStorageDesc storage
+}


### PR DESCRIPTION
## Why I'm doing:

This is the focused, descriptor-only first slice of Contract 2.1 in #78693, following the merged Iceberg/Parquet foundation (#78700, #78701, #78713).

WKB alone cannot distinguish GEOGRAPHY from GEOMETRY or carry CRS and edge semantics. This PR establishes independently testable metadata and transport contracts before native primitive types are integrated. It reworks the earlier prototype in #78667 from main, without bringing over its premature TypeDescriptor integration.

## What I'm doing:

- Add standalone GeoTypeDescriptor, GeoStorageDescriptor and GeoColumnDescriptor with optional Thrift/protobuf counterparts.
- Represent SPHERICAL, VINCENTY, THOMAS, ANDOYER, KARNEY and PLANAR distinctly. Recognizing an algorithm in metadata does not enable computation.
- Normalize the internal descriptors to plain enum values, an empty CRS and default subdescriptors when fields are absent; only parsed SRID retains optional presence. This does not infer default GEO semantics. Wire fields remain optional.
- Use the declared enum types for all six GEO enum fields in both Thrift and protobuf; enum constants and field numbers remain unchanged. The i32/int32 substitutions from the previous revision have been removed.
- Normalize unrecognized Thrift enum numbers to the internal UNKNOWN value at the input boundary. Basic converters return values directly, without StatusOr or operation-specific validation; callers decide which semantics an operation supports.
- Use the generated proto2 enum accessors without scanning unknown_fields(). An unknown-only enum on the wire leaves its field unset and reads as UNKNOWN; if a known value is also present for the same field, the known value is retained. Internal descriptors are normalized metadata, not an unknown-field relay. Programmatic callers must supply declared protobuf/internal enum values; these converters do not add validation for invalid values injected through casts.
- Separate exact normalized metadata equality from semantic comparison. The compute-compatibility helper delegates to semantic comparison only; it does not authorize an operation or establish row-level dimension support. Producer-validation state, storage encoding/dimension and the parsed SRID cache do not determine semantic identity; CRS identifiers are compared conservatively without alias normalization or reprojection.
- Preserve encoding and dimension metadata in descriptor round trips without adding BE assignment or UNION ALL policy.
- Append the new schema definitions at the end of Types.thrift and types.proto, preserving the location of existing definitions.
- Register focused descriptor tests in types_test.

### Scope

Following review with Stephen, the BE assignment and UNION ALL helpers and their operation-specific tests are deferred until concrete callers are introduced, together with FE/BE consistency tests. This PR is limited to descriptors, transport, and semantic comparison. FE remains responsible for assignment compatibility, UNION ALL type resolution, and the resulting dimension.

No native GEOGRAPHY/GEOMETRY primitive integration, TypeDescriptor attachment, VARBINARY proxy, GeoColumn, reader changes, SQL functions, payload parsing, capability gates or persistence integration. Existing readers and legacy spatial behavior remain unchanged. Native primitive authority/consistency checks belong to the next separately reviewed slice.

This PR does not close #78693 or complete all of Contract 2.1/Milestone 2.

### Validation

- **14 focused GeoTypeDescriptorTest cases passed under ASAN with leak detection**, covering all six algorithms, normalization of absent fields, optional SRID, stable wire ordinals, declared enum field types, unknown Thrift enum normalization, proto2 unknown-only and known-plus-unknown wire values, and semantic-comparison matrices (including encoding/dimension independence). Normalized descriptors round-trip through Thrift binary/compact and protobuf.
- **The same 14 tests passed with ASAN and NDEBUG**, verifying the assertions-disabled build with the supported input contract. This is not an optimized release build or a test of invalid values injected via protobuf enum setters.
- Both focused test variants were rebuilt and rerun after removing the assignment/UNION ALL helpers. They compile the current descriptor/test sources against the generated C++ schemas and link existing read-only Base/Gutil/StarRocksGen build-support libraries. This was **not** a complete types_test rebuild.
- C++ and Java Thrift/protobuf generation passed after restoring the declared enum field types; C++ sources were formatted with the repository clang-format configuration.
- **35 schema-checker unit tests passed**.
- Full schema compatibility against the base commit e234554fa0, BE module boundaries, generated AGENTS checks and git diff --check passed.
- **Full BE/FE builds and the complete types_test suite have not been run locally.**

### Observability

Reviewed the existing Status-based error handling used by type helpers. Following review, these standalone converters no longer emit validation errors: support checks and diagnostics belong to their consuming callers when the descriptors are integrated. No query, scan, profile, metric or existing reader path is changed. No new operational metrics or logging are needed for this standalone, not-yet-integrated metadata layer.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The new standalone contracts are not connected to existing execution paths.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

No public native feature is enabled, so no user-documentation or backport change is requested.

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
