### PR TITLE
[Tool] TEMP: touch BE source to measure BE-REPORT after #78905

### DIFF
--- a/be/src/base/status.cpp
+++ b/be/src/base/status.cpp
@@ -366,3 +366,9 @@ bool Status::is_moved_from(const char* state) {
 }
 
 } // namespace starrocks
+
+// DO NOT MERGE -- temporary marker so the `be/!(test)**` paths filter fires and
+// this PR runs BE UT + the BE total coverage merge, to measure BE-REPORT after
+// the checkout removal in #78905. Comment only: no coverable line is added, so
+// the incremental coverage report stays at 0/0. This PR will be closed, not
+// merged.


### PR DESCRIPTION
> [!WARNING]
> **Temporary PR — DO NOT MERGE. It will be closed once the measurement is taken.**

## Why I'm doing:

#78905 removed the `fetch-depth: 0` `actions/checkout` from `BE-REPORT`, which measured **161s** on #78877 and **180s** on #78905 — about 20% of that job, twice over.

Because `ci-report.yml` is `workflow_run`-triggered, GitHub always runs the **default-branch** copy of it, so that change could not be exercised by its own PR: the run reporting on #78905 still had `Run actions/checkout@v6` in its step list, at 180s. Now that it is on `main` (`658a514`), the change is live and can be measured.

## What I'm doing:

A comment-only change to `be/src/base/status.cpp`, purely to make CI run the coverage path. The gating is by **path**, not content: `dorny/paths-filter`'s `be: ['be/!(test)**', ...]` fires, which gates `be-ut`; BE UT then uploads `flag/be_ut_res`, which is the `size != '0'` condition that gates `Merge BE Total Coverage`. A comment adds no coverable line, so the incremental coverage report stays at `0/0` and cannot trip cover-checker's `--threshold 80`.

Expected, if #78905 worked:

| | before (measured) | after (this PR) |
|---|---|---|
| `Run actions/checkout@v6` | 161s / 180s | **step absent** |
| BE-REPORT step count | 8 | **5** |
| `Merge BE Total Coverage` | 10m33s / 11m03s | unchanged |
| BE-REPORT total | 13m33s / 14m28s | **~11m30s** |

The step that must be watched is `Publish Incremental Coverage Report - Total`: it reads `${be_path}/diff.txt`, and #78905 moved that directory from the checkout-provided `be/` to a `be-ut-report/` scratch dir. That path resolution was only ever verified locally with a stubbed `ossutil64`; this run is the first real one.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
