### PR TITLE
[BugFix] Align driver partitioning across EXCEPT/INTERSECT and hash join inputs

### DIFF
--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -95,19 +95,19 @@ StatusOr<pipeline::OpFactories> ExceptNode::decompose_to_pipeline(pipeline::Pipe
     // Use the first child to build the hast table by ExceptBuildSinkOperator.
     ASSIGN_OR_RETURN(auto ops_with_except_build_sink, child(0)->decompose_to_pipeline(context));
 
-    // Decompose the probe children before any child is partitioned. Nothing below depends on that
-    // ordering yet -- the partitioning decision that does comes next -- but two things that used to
-    // fall out of the old order have to be made explicit. The pipelines built underneath these
-    // children took their dependency on the build pipeline from the push_dependent_pipeline() scope
-    // they no longer sit inside, so bind_dependent_pipeline_between() hands it to them -- along with
-    // the group dependency a CollectStatsSource interpolated in there would have picked up from the
-    // same scope; and each pipeline was registered into whichever execution group its own child had
-    // left current, so that group is now recorded per child and restored before the child's pipeline
-    // is added.
+    // Every child of a set operation must be partitioned by the SAME scheme, or a key reaches a
+    // different driver from each child and the two never meet in the partitioned hash set. Settle the
+    // scheme once, from the build child, and hand it to all of them; each child still supplies its own
+    // corresponding key exprs. Reading it per child is what broke: a scan whose bucket key is the set
+    // key kept its bucket transform while a child behind a UNION had no bucket properties at all.
     //
-    // The marks close here, where the probe children end, and deliberately not where the bind is
-    // called: partitioning the BUILD child below registers the pipeline that feeds the build
-    // pipeline, and that one must not be made to wait for it.
+    // Whether the children can be left alone is a property of all of them together, so decompose the
+    // probe children before deciding anything. They used to be decomposed inside the dependent-pipeline
+    // scope opened below, which is what made every pipeline built underneath them wait for the build
+    // pipeline; subscribe_pipelines_since() puts that back for the ones built here.
+    // Decomposing a child can leave a different execution group current, and each pipeline is
+    // registered into whichever group is current at the time. Remember the group every child ends in
+    // so each pipeline still lands where it did before the children were hoisted up here.
     auto* group_after_build_child = context->current_execution_group();
     const auto probe_children_begin = context->mark();
     std::vector<OpFactories> probe_child_ops(_children.size());
@@ -119,13 +119,40 @@ StatusOr<pipeline::OpFactories> ExceptNode::decompose_to_pipeline(pipeline::Pipe
     const auto probe_children_end = context->mark();
     context->set_current_execution_group(group_after_build_child);
 
-    if (_local_partition_by_exprs.empty()) {
-        ops_with_except_build_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
-                context, runtime_state(), id(), ops_with_except_build_sink, _child_expr_lists[0]);
-    } else {
-        ops_with_except_build_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_bucket_shuffle_exchange(
-                context, runtime_state(), id(), ops_with_except_build_sink, _local_partition_by_exprs[0]);
+    const bool set_op_is_colocate = !_local_partition_by_exprs.empty();
+    auto set_op_part_type =
+            set_op_is_colocate ? TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED : TPartitionType::HASH_PARTITIONED;
+    std::vector<TBucketProperty> set_op_bucket_properties;
+    if (set_op_is_colocate) {
+        set_op_bucket_properties = context->source_operator(ops_with_except_build_sink)->get_bucket_properties();
     }
+
+    // A child that reports could_local_shuffle() == false has already had its rows assigned to
+    // drivers upstream -- for a colocate set operation the FE hands each driver its own bucket
+    // morsels -- and when that holds for EVERY child they are aligned on that assignment for free.
+    // Both maybe_interpolate_local_shuffle_exchange and maybe_interpolate_local_bucket_shuffle_exchange
+    // return early in that case, so the original code interpolated nothing at all, and forcing an
+    // exchange on all of them would only add cost. Force the shared scheme only once some child would
+    // be shuffled, which is where the children could disagree and be silently wrong.
+    bool force_shuffle = context->source_operator(ops_with_except_build_sink)->could_local_shuffle();
+    for (size_t i = 1; i < _children.size() && !force_shuffle; i++) {
+        force_shuffle = context->source_operator(probe_child_ops[i])->could_local_shuffle();
+    }
+
+    auto partition_child = [&](OpFactories& ops, size_t i) {
+        const auto& keys = set_op_is_colocate ? _local_partition_by_exprs[i] : _child_expr_lists[i];
+        if (force_shuffle) {
+            return ::starrocks::pipeline::builder::interpolate_local_forced_shuffle_exchange(
+                    context, runtime_state(), id(), ops, keys, set_op_part_type, set_op_bucket_properties);
+        }
+        // No child can be locally shuffled: the original per-child call, which skips every one of them.
+        return set_op_is_colocate ? ::starrocks::pipeline::builder::maybe_interpolate_local_bucket_shuffle_exchange(
+                                            context, runtime_state(), id(), ops, keys)
+                                  : ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
+                                            context, runtime_state(), id(), ops, keys);
+    };
+
+    ops_with_except_build_sink = partition_child(ops_with_except_build_sink, 0);
 
     ops_with_except_build_sink.emplace_back(std::make_shared<ExceptBuildSinkOperatorFactory>(
             context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[0]));
@@ -141,15 +168,7 @@ StatusOr<pipeline::OpFactories> ExceptNode::decompose_to_pipeline(pipeline::Pipe
     // Use the rest children to erase keys from the hash table by ExceptProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
         context->set_current_execution_group(probe_child_groups[i]);
-        auto ops_with_except_probe_sink = std::move(probe_child_ops[i]);
-        if (_local_partition_by_exprs.empty()) {
-            ops_with_except_probe_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
-                    context, runtime_state(), id(), ops_with_except_probe_sink, _child_expr_lists[i]);
-        } else {
-            ops_with_except_probe_sink =
-                    ::starrocks::pipeline::builder::maybe_interpolate_local_bucket_shuffle_exchange(
-                            context, runtime_state(), id(), ops_with_except_probe_sink, _local_partition_by_exprs[i]);
-        }
+        auto ops_with_except_probe_sink = partition_child(probe_child_ops[i], i);
         ops_with_except_probe_sink.emplace_back(std::make_shared<ExceptProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), except_partition_ctx_factory, _child_expr_lists[i], i - 1));
         // Initialize OperatorFactory's fields involving runtime filters.

--- a/be/src/exec/except_node.cpp
+++ b/be/src/exec/except_node.cpp
@@ -23,6 +23,7 @@
 #include "exec/pipeline/set/except_context.h"
 #include "exec/pipeline/set/except_output_source_operator.h"
 #include "exec/pipeline/set/except_probe_sink_operator.h"
+#include "exec/runtime/group_execution/execution_group.h"
 #include "exprs/expr.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
@@ -94,6 +95,30 @@ StatusOr<pipeline::OpFactories> ExceptNode::decompose_to_pipeline(pipeline::Pipe
     // Use the first child to build the hast table by ExceptBuildSinkOperator.
     ASSIGN_OR_RETURN(auto ops_with_except_build_sink, child(0)->decompose_to_pipeline(context));
 
+    // Decompose the probe children before any child is partitioned. Nothing below depends on that
+    // ordering yet -- the partitioning decision that does comes next -- but two things that used to
+    // fall out of the old order have to be made explicit. The pipelines built underneath these
+    // children took their dependency on the build pipeline from the push_dependent_pipeline() scope
+    // they no longer sit inside, so bind_dependent_pipeline_between() hands it to them -- along with
+    // the group dependency a CollectStatsSource interpolated in there would have picked up from the
+    // same scope; and each pipeline was registered into whichever execution group its own child had
+    // left current, so that group is now recorded per child and restored before the child's pipeline
+    // is added.
+    //
+    // The marks close here, where the probe children end, and deliberately not where the bind is
+    // called: partitioning the BUILD child below registers the pipeline that feeds the build
+    // pipeline, and that one must not be made to wait for it.
+    auto* group_after_build_child = context->current_execution_group();
+    const auto probe_children_begin = context->mark();
+    std::vector<OpFactories> probe_child_ops(_children.size());
+    std::vector<ExecutionGroupRawPtr> probe_child_groups(_children.size(), nullptr);
+    for (size_t i = 1; i < _children.size(); i++) {
+        ASSIGN_OR_RETURN(probe_child_ops[i], child(i)->decompose_to_pipeline(context));
+        probe_child_groups[i] = context->current_execution_group();
+    }
+    const auto probe_children_end = context->mark();
+    context->set_current_execution_group(group_after_build_child);
+
     if (_local_partition_by_exprs.empty()) {
         ops_with_except_build_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
                 context, runtime_state(), id(), ops_with_except_build_sink, _child_expr_lists[0]);
@@ -110,10 +135,13 @@ StatusOr<pipeline::OpFactories> ExceptNode::decompose_to_pipeline(pipeline::Pipe
     context->add_pipeline(ops_with_except_build_sink);
     context->push_dependent_pipeline(context->last_pipeline());
     DeferOp pop_dependent_pipeline([context]() { context->pop_dependent_pipeline(); });
+    context->bind_dependent_pipeline_between(probe_children_begin, probe_children_end, context->last_pipeline(),
+                                             !context->current_execution_group()->is_colocate_exec_group());
 
     // Use the rest children to erase keys from the hash table by ExceptProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
-        ASSIGN_OR_RETURN(auto ops_with_except_probe_sink, child(i)->decompose_to_pipeline(context));
+        context->set_current_execution_group(probe_child_groups[i]);
+        auto ops_with_except_probe_sink = std::move(probe_child_ops[i]);
         if (_local_partition_by_exprs.empty()) {
             ops_with_except_probe_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
                     context, runtime_state(), id(), ops_with_except_probe_sink, _child_expr_lists[i]);

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -199,6 +199,43 @@ StatusOr<pipeline::OpFactories> HashJoinNode::_decompose_to_pipeline(pipeline::P
     // in some partition hash table, and other partition hash table can output chunk.
     // TODO: support nullaware left anti join with shuffle join
     DCHECK(_join_type != TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN || _distribution_mode == TJoinDistributionMode::BROADCAST);
+
+    // The two sides of a hash join share one hash table partitioned across drivers, so a key has to
+    // reach the same driver from both. Each side is partitioned by whoever touched it last: a side
+    // reporting could_local_shuffle() == false was already partitioned by its sender (or by the
+    // per-driver morsel assignment the FE handed it) and is left as it arrives, a side reporting true
+    // gets a fresh local shuffle. When the two disagree those are two unrelated numberings of the
+    // same key space, and the join silently drops (1 - 1/DOP) of its matches.
+    //
+    // Neither side can be moved onto the other's numbering: the receiving fragment is never told
+    // which bucket function and bucket count the sender used -- TExchangeNode carries only the
+    // sender's partition type -- so the only scheme both sides can produce is a fresh plain hash of
+    // their own key exprs. Deciding that needs BOTH sides, hence the probe child is decomposed here,
+    // before anything about the build side is settled.
+    //
+    // This does not disturb HashJoinerFactory's "all the builders must be created earlier than
+    // prober" rule: the probe pipeline is the OpFactories this function returns and the caller
+    // registers it, so it still lands after the build pipeline added below. Only the probe subtree's
+    // own pipelines move ahead of it, and none of them creates a builder or prober for this join.
+    auto* group_before_probe = context->current_execution_group();
+    const auto probe_child_begin = context->mark();
+    ASSIGN_OR_RETURN(auto lhs_operators, child(0)->decompose_to_pipeline(context));
+    const auto probe_child_end = context->mark();
+    auto* group_after_probe = context->current_execution_group();
+    context->set_current_execution_group(group_before_probe);
+
+    // Re-partition both sides only when they disagree. When they agree nothing below changes, so a
+    // shuffle join whose two sides were both partitioned by their senders keeps skipping the local
+    // exchange entirely. The side reporting true already pays one today, so the added cost lands
+    // only on the mismatched case -- which is exactly the case that is wrong without it.
+    // A colocate exec group is excluded: there the probe side is deliberately left untouched below,
+    // and touching only the build side is what makes the two disagree in the first place.
+    const bool join_in_colocate_group =
+            context->find_exec_group_by_plan_node_id(_id)->type() == ExecutionGroupType::COLOCATE;
+    const bool align_both_sides =
+            !join_in_colocate_group && _distribution_mode != TJoinDistributionMode::BROADCAST &&
+            context->could_local_shuffle(rhs_operators) != context->could_local_shuffle(lhs_operators);
+
     if (_distribution_mode == TJoinDistributionMode::BROADCAST) {
         // Broadcast join need only create one hash table, because all the HashJoinProbeOperators
         // use the same hash table with their own different probe states.
@@ -212,8 +249,13 @@ StatusOr<pipeline::OpFactories> HashJoinNode::_decompose_to_pipeline(pipeline::P
         // there is no need to perform local shuffle again at receiver side
         // 2. Otherwise, add LocalExchangeOperator
         // to shuffle multi-stream into #degree_of_parallelism# streams each of that pipes into HashJoin{Build, Probe}Operator.
-        rhs_operators = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
-                context, runtime_state(), id(), rhs_operators, _build_equivalence_partition_expr_ctxs);
+        rhs_operators = align_both_sides
+                                ? ::starrocks::pipeline::builder::interpolate_local_forced_shuffle_exchange(
+                                          context, runtime_state(), id(), rhs_operators,
+                                          _build_equivalence_partition_expr_ctxs, TPartitionType::HASH_PARTITIONED, {})
+                                : ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
+                                          context, runtime_state(), id(), rhs_operators,
+                                          _build_equivalence_partition_expr_ctxs);
     }
 
     size_t num_right_partitions = context->source_operator(rhs_operators)->degree_of_parallelism();
@@ -269,10 +311,17 @@ StatusOr<pipeline::OpFactories> HashJoinNode::_decompose_to_pipeline(pipeline::P
 
     rhs_operators.emplace_back(std::move(build_op));
     context->add_pipeline(rhs_operators);
-    context->push_dependent_pipeline(context->last_pipeline());
+    const Pipeline* build_pipeline = context->last_pipeline();
+    // The probe subtree was built before this pipeline existed, so give its pipelines the dependency
+    // push_dependent_pipeline would have given them. The range stops where the probe subtree ends:
+    // the build side's own local exchange was interpolated after that point, and the pipeline that
+    // feeds this one must not be made to wait for it.
+    context->bind_dependent_pipeline_between(probe_child_begin, probe_child_end, build_pipeline,
+                                             !group_before_probe->is_colocate_exec_group());
+    context->set_current_execution_group(group_after_probe);
+    context->push_dependent_pipeline(build_pipeline);
     DeferOp pop_dependent_pipeline([context]() { context->pop_dependent_pipeline(); });
 
-    ASSIGN_OR_RETURN(auto lhs_operators, child(0)->decompose_to_pipeline(context));
     auto join_colocate_group = context->find_exec_group_by_plan_node_id(_id);
     if (join_colocate_group->type() == ExecutionGroupType::COLOCATE) {
         DCHECK(context->current_execution_group()->is_colocate_exec_group());
@@ -288,11 +337,17 @@ StatusOr<pipeline::OpFactories> HashJoinNode::_decompose_to_pipeline(pipeline::P
             lhs_operators = ::starrocks::pipeline::builder::maybe_interpolate_local_passthrough_exchange(
                     context, runtime_state(), id(), lhs_operators, context->degree_of_parallelism());
         } else {
-            auto* rhs_source_op = context->source_operator(rhs_operators);
-            auto* lhs_source_op = context->source_operator(lhs_operators);
-            DCHECK_EQ(rhs_source_op->partition_type(), lhs_source_op->partition_type());
-            lhs_operators = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
-                    context, runtime_state(), id(), lhs_operators, _probe_equivalence_partition_expr_ctxs);
+            if (align_both_sides) {
+                lhs_operators = ::starrocks::pipeline::builder::interpolate_local_forced_shuffle_exchange(
+                        context, runtime_state(), id(), lhs_operators, _probe_equivalence_partition_expr_ctxs,
+                        TPartitionType::HASH_PARTITIONED, {});
+            } else {
+                auto* rhs_source_op = context->source_operator(rhs_operators);
+                auto* lhs_source_op = context->source_operator(lhs_operators);
+                DCHECK_EQ(rhs_source_op->partition_type(), lhs_source_op->partition_type());
+                lhs_operators = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
+                        context, runtime_state(), id(), lhs_operators, _probe_equivalence_partition_expr_ctxs);
+            }
         }
     }
 

--- a/be/src/exec/intersect_node.cpp
+++ b/be/src/exec/intersect_node.cpp
@@ -25,6 +25,7 @@
 #include "exec/pipeline/set/intersect_context.h"
 #include "exec/pipeline/set/intersect_output_source_operator.h"
 #include "exec/pipeline/set/intersect_probe_sink_operator.h"
+#include "exec/runtime/group_execution/execution_group.h"
 #include "exprs/expr.h"
 #include "exprs/expr_executor.h"
 #include "exprs/expr_factory.h"
@@ -95,6 +96,23 @@ StatusOr<pipeline::OpFactories> IntersectNode::decompose_to_pipeline(pipeline::P
 
     // Use the first child to build the hast table by IntersectBuildSinkOperator.
     ASSIGN_OR_RETURN(auto ops_with_intersect_build_sink, child(0)->decompose_to_pipeline(context));
+
+    // Decompose the probe children before any child is partitioned. Nothing below depends on that
+    // ordering yet -- the partitioning decision that does comes next -- but two things that used to
+    // fall out of the old order have to be made explicit. The pipelines built underneath these
+    // children took their dependency on the build pipeline from the push_dependent_pipeline() scope
+    // they no longer sit inside, so subscribe_pipelines_since() hands it to them; and each pipeline
+    // was registered into whichever execution group its own child had left current, so that group is
+    // now recorded per child and restored before the child's pipeline is added.
+    auto* group_after_build_child = context->current_execution_group();
+    std::vector<OpFactories> probe_child_ops(_children.size());
+    std::vector<ExecutionGroupRawPtr> probe_child_groups(_children.size(), nullptr);
+    for (size_t i = 1; i < _children.size(); i++) {
+        ASSIGN_OR_RETURN(probe_child_ops[i], child(i)->decompose_to_pipeline(context));
+        probe_child_groups[i] = context->current_execution_group();
+    }
+    context->set_current_execution_group(group_after_build_child);
+
     if (_local_partition_by_exprs.empty()) {
         ops_with_intersect_build_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
                 context, runtime_state(), id(), ops_with_intersect_build_sink, _child_expr_lists[0]);
@@ -112,7 +130,8 @@ StatusOr<pipeline::OpFactories> IntersectNode::decompose_to_pipeline(pipeline::P
 
     // Use the rest children to erase keys from the hast table by IntersectProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
-        ASSIGN_OR_RETURN(auto ops_with_intersect_probe_sink, child(i)->decompose_to_pipeline(context));
+        context->set_current_execution_group(probe_child_groups[i]);
+        auto ops_with_intersect_probe_sink = std::move(probe_child_ops[i]);
         if (_local_partition_by_exprs.empty()) {
             ops_with_intersect_probe_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
                     context, runtime_state(), id(), ops_with_intersect_probe_sink, _child_expr_lists[i]);

--- a/be/src/exec/intersect_node.cpp
+++ b/be/src/exec/intersect_node.cpp
@@ -96,14 +96,17 @@ StatusOr<pipeline::OpFactories> IntersectNode::decompose_to_pipeline(pipeline::P
 
     // Use the first child to build the hast table by IntersectBuildSinkOperator.
     ASSIGN_OR_RETURN(auto ops_with_intersect_build_sink, child(0)->decompose_to_pipeline(context));
-
-    // Decompose the probe children before any child is partitioned. Nothing below depends on that
-    // ordering yet -- the partitioning decision that does comes next -- but two things that used to
-    // fall out of the old order have to be made explicit. The pipelines built underneath these
-    // children took their dependency on the build pipeline from the push_dependent_pipeline() scope
-    // they no longer sit inside, so subscribe_pipelines_since() hands it to them; and each pipeline
-    // was registered into whichever execution group its own child had left current, so that group is
-    // now recorded per child and restored before the child's pipeline is added.
+    // Every child of a set operation must be partitioned by the SAME scheme, or a key reaches a
+    // different driver from each child and the two never meet in the partitioned hash set. Settle the
+    // scheme once, from the build child, and hand it to all of them; each child still supplies its own
+    // corresponding key exprs. Reading it per child is what broke: a scan whose bucket key is the set
+    // key kept its bucket transform while a child behind a UNION had no bucket properties at all.
+    //
+    // Whether the children can be left alone is a property of all of them together, so decompose the
+    // probe children before deciding anything.
+    // Decomposing a child can leave a different execution group current, and each pipeline is
+    // registered into whichever group is current at the time. Remember the group every child ends in
+    // so each pipeline still lands where it did before the children were hoisted up here.
     auto* group_after_build_child = context->current_execution_group();
     std::vector<OpFactories> probe_child_ops(_children.size());
     std::vector<ExecutionGroupRawPtr> probe_child_groups(_children.size(), nullptr);
@@ -113,13 +116,40 @@ StatusOr<pipeline::OpFactories> IntersectNode::decompose_to_pipeline(pipeline::P
     }
     context->set_current_execution_group(group_after_build_child);
 
-    if (_local_partition_by_exprs.empty()) {
-        ops_with_intersect_build_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
-                context, runtime_state(), id(), ops_with_intersect_build_sink, _child_expr_lists[0]);
-    } else {
-        ops_with_intersect_build_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_bucket_shuffle_exchange(
-                context, runtime_state(), id(), ops_with_intersect_build_sink, _local_partition_by_exprs[0]);
+    const bool set_op_is_colocate = !_local_partition_by_exprs.empty();
+    auto set_op_part_type =
+            set_op_is_colocate ? TPartitionType::BUCKET_SHUFFLE_HASH_PARTITIONED : TPartitionType::HASH_PARTITIONED;
+    std::vector<TBucketProperty> set_op_bucket_properties;
+    if (set_op_is_colocate) {
+        set_op_bucket_properties = context->source_operator(ops_with_intersect_build_sink)->get_bucket_properties();
     }
+
+    // A child that reports could_local_shuffle() == false has already had its rows assigned to
+    // drivers upstream -- for a colocate set operation the FE hands each driver its own bucket
+    // morsels -- and when that holds for EVERY child they are aligned on that assignment for free.
+    // Both maybe_interpolate_local_shuffle_exchange and maybe_interpolate_local_bucket_shuffle_exchange
+    // return early in that case, so the original code interpolated nothing at all, and forcing an
+    // exchange on all of them would only add cost. Force the shared scheme only once some child would
+    // be shuffled, which is where the children could disagree and be silently wrong.
+    bool force_shuffle = context->source_operator(ops_with_intersect_build_sink)->could_local_shuffle();
+    for (size_t i = 1; i < _children.size() && !force_shuffle; i++) {
+        force_shuffle = context->source_operator(probe_child_ops[i])->could_local_shuffle();
+    }
+
+    auto partition_child = [&](OpFactories& ops, size_t i) {
+        const auto& keys = set_op_is_colocate ? _local_partition_by_exprs[i] : _child_expr_lists[i];
+        if (force_shuffle) {
+            return ::starrocks::pipeline::builder::interpolate_local_forced_shuffle_exchange(
+                    context, runtime_state(), id(), ops, keys, set_op_part_type, set_op_bucket_properties);
+        }
+        // No child can be locally shuffled: the original per-child call, which skips every one of them.
+        return set_op_is_colocate ? ::starrocks::pipeline::builder::maybe_interpolate_local_bucket_shuffle_exchange(
+                                            context, runtime_state(), id(), ops, keys)
+                                  : ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
+                                            context, runtime_state(), id(), ops, keys);
+    };
+
+    ops_with_intersect_build_sink = partition_child(ops_with_intersect_build_sink, 0);
     ops_with_intersect_build_sink.emplace_back(std::make_shared<IntersectBuildSinkOperatorFactory>(
             context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[0],
             _has_outer_join_child));
@@ -131,16 +161,7 @@ StatusOr<pipeline::OpFactories> IntersectNode::decompose_to_pipeline(pipeline::P
     // Use the rest children to erase keys from the hast table by IntersectProbeSinkOperator.
     for (size_t i = 1; i < _children.size(); i++) {
         context->set_current_execution_group(probe_child_groups[i]);
-        auto ops_with_intersect_probe_sink = std::move(probe_child_ops[i]);
-        if (_local_partition_by_exprs.empty()) {
-            ops_with_intersect_probe_sink = ::starrocks::pipeline::builder::maybe_interpolate_local_shuffle_exchange(
-                    context, runtime_state(), id(), ops_with_intersect_probe_sink, _child_expr_lists[i]);
-        } else {
-            ops_with_intersect_probe_sink =
-                    ::starrocks::pipeline::builder::maybe_interpolate_local_bucket_shuffle_exchange(
-                            context, runtime_state(), id(), ops_with_intersect_probe_sink,
-                            _local_partition_by_exprs[i]);
-        }
+        auto ops_with_intersect_probe_sink = partition_child(probe_child_ops[i], i);
         ops_with_intersect_probe_sink.emplace_back(std::make_shared<IntersectProbeSinkOperatorFactory>(
                 context->next_operator_id(), id(), intersect_partition_ctx_factory, _child_expr_lists[i], i - 1));
         // Initialize OperatorFactory's fields involving runtime filters.

--- a/be/src/exec/pipeline/pipeline_builder_operators.cpp
+++ b/be/src/exec/pipeline/pipeline_builder_operators.cpp
@@ -488,6 +488,9 @@ OpFactories maybe_interpolate_collect_stats(PipelineBuilderContext* context, Run
     for (const auto& pipeline : context->dependent_pipelines()) {
         downstream_source_op->add_group_dependent_pipeline(pipeline);
     }
+    // A node that builds a subtree outside its own push_dependent_pipeline() scope binds itself to
+    // these afterwards -- see PipelineBuilderContext::bind_dependent_pipeline_between().
+    context->record_group_dependent_source(downstream_source_op.get());
 
     return {std::move(downstream_source_op)};
 }

--- a/be/src/exec/pipeline/pipeline_builder_operators.cpp
+++ b/be/src/exec/pipeline/pipeline_builder_operators.cpp
@@ -291,6 +291,26 @@ OpFactories maybe_interpolate_local_shuffle_exchange(PipelineBuilderContext* con
             self_keys_match_buckets ? bucket_properties : std::vector<TBucketProperty>{});
 }
 
+OpFactories interpolate_local_forced_shuffle_exchange(PipelineBuilderContext* context, RuntimeState* state,
+                                                      int32_t plan_node_id, OpFactories& pred_operators,
+                                                      const std::vector<ExprContext*>& partition_expr_ctxs,
+                                                      TPartitionType::type part_type,
+                                                      const std::vector<TBucketProperty>& bucket_properties) {
+    // ShufflePartitioner indexes bucket_properties by partition-column position, so a scheme settled
+    // on one child is only usable on another when the two line up 1:1; otherwise fall back to the
+    // plain hash of this child's own keys, which every child can produce. (maybe_interpolate_local_
+    // shuffle_exchange makes the same size check for its self-keys branch.)
+    if (!bucket_properties.empty() && bucket_properties.size() != partition_expr_ctxs.size()) {
+        return do_maybe_interpolate_local_shuffle_exchange(context, state, plan_node_id, pred_operators,
+                                                           partition_expr_ctxs, TPartitionType::HASH_PARTITIONED, {});
+    }
+    // No could_local_shuffle() early-out and no reading of THIS source's partition type or bucket
+    // properties on purpose -- see the header; the caller passes the first child's scheme for all of
+    // them. do_maybe_... still skips at DOP 1, which is safe because every child runs at the same DOP.
+    return do_maybe_interpolate_local_shuffle_exchange(context, state, plan_node_id, pred_operators,
+                                                       partition_expr_ctxs, part_type, bucket_properties);
+}
+
 OpFactories maybe_interpolate_local_bucket_shuffle_exchange(PipelineBuilderContext* context, RuntimeState* state,
                                                             int32_t plan_node_id, OpFactories& pred_operators,
                                                             const std::vector<ExprContext*>& partition_expr_ctxs) {

--- a/be/src/exec/pipeline/pipeline_builder_operators.h
+++ b/be/src/exec/pipeline/pipeline_builder_operators.h
@@ -78,6 +78,24 @@ OpFactories maybe_interpolate_local_shuffle_exchange(PipelineBuilderContext* con
                                                      int32_t plan_node_id, OpFactories& pred_operators,
                                                      const PartitionExprsGenerator& self_partition_exprs_generator);
 
+/// Local shuffle one input of an operator whose inputs share a driver-partitioned state -- the
+/// per-driver hash set of EXCEPT/INTERSECT, or the per-driver hash table of a hash join.
+///
+/// Such inputs cannot each pick whatever partitioning suits their own source: a key has to reach the
+/// SAME driver from every input, or one input's rows never meet the other's.
+/// maybe_interpolate_local_shuffle_exchange decides per source -- it skips entirely when the source
+/// reports could_local_shuffle() == false, and it reuses the source's partition type and bucket
+/// properties when it has them -- so two inputs with different sources end up hashed by different
+/// functions, or one is repartitioned and the other is not. This ignores what the source claims and
+/// applies exactly the scheme the caller passes, so all inputs can be put on one.
+/// `part_type` and `bucket_properties` are that shared scheme; every input must be handed the same
+/// pair, together with its own corresponding key exprs.
+OpFactories interpolate_local_forced_shuffle_exchange(PipelineBuilderContext* context, RuntimeState* state,
+                                                      int32_t plan_node_id, OpFactories& pred_operators,
+                                                      const std::vector<ExprContext*>& partition_expr_ctxs,
+                                                      TPartitionType::type part_type,
+                                                      const std::vector<TBucketProperty>& bucket_properties);
+
 OpFactories maybe_interpolate_local_bucket_shuffle_exchange(PipelineBuilderContext* context, RuntimeState* state,
                                                             int32_t plan_node_id, OpFactories& pred_operators,
                                                             const std::vector<ExprContext*>& partition_expr_ctxs);

--- a/be/src/exec/runtime/pipeline_builder_context.cpp
+++ b/be/src/exec/runtime/pipeline_builder_context.cpp
@@ -130,6 +130,32 @@ void PipelineBuilderContext::pop_dependent_pipeline() {
     _dependent_pipelines.pop_back();
 }
 
+void PipelineBuilderContext::bind_dependent_pipeline_between(const BuilderMark& begin, const BuilderMark& end,
+                                                             const Pipeline* dependency, bool apply_events) {
+    DCHECK_LE(begin.num_pipelines, end.num_pipelines);
+    DCHECK_LE(end.num_pipelines, _pipelines.size());
+    DCHECK_LE(begin.num_group_dependent_sources, end.num_group_dependent_sources);
+    DCHECK_LE(end.num_group_dependent_sources, _group_dependent_sources.size());
+
+    // Not optional: see the header. This is what keeps a hash join's builders ahead of its probers
+    // and its prober dop a multiple of the builder dop.
+    for (size_t i = begin.num_group_dependent_sources; i < end.num_group_dependent_sources; ++i) {
+        _group_dependent_sources[i]->add_group_dependent_pipeline(dependency);
+    }
+
+    if (!apply_events || !_fragment_context->runtime_state()->enable_wait_dependent_event()) {
+        return;
+    }
+    for (size_t i = begin.num_pipelines; i < end.num_pipelines; ++i) {
+        Pipeline* pipeline = _pipelines[i].get();
+        // The caller keeps anything that feeds `dependency` out of the range; `dependency` itself is
+        // registered after `end` for the same reason.
+        DCHECK(pipeline != dependency);
+        pipeline->pipeline_event()->set_need_wait_dependencies_finished(true);
+        pipeline->pipeline_event()->add_dependency(dependency->pipeline_event());
+    }
+}
+
 void PipelineBuilderContext::_subscribe_pipeline_event(Pipeline* pipeline) {
     bool enable_wait_event = _fragment_context->runtime_state()->enable_wait_dependent_event();
     enable_wait_event &= !_current_execution_group->is_colocate_exec_group();

--- a/be/src/exec/runtime/pipeline_builder_context.h
+++ b/be/src/exec/runtime/pipeline_builder_context.h
@@ -55,6 +55,54 @@ public:
         return _pipelines[_pipelines.size() - 1].get();
     }
 
+    /// Everything the builder has produced so far. Taken before a node builds a subtree outside its
+    /// push_dependent_pipeline() scope, and handed back to bind_dependent_pipeline_between()
+    /// afterwards.
+    struct BuilderMark {
+        size_t num_pipelines;
+        size_t num_group_dependent_sources;
+    };
+    BuilderMark mark() const { return {_pipelines.size(), _group_dependent_sources.size()}; }
+
+    /// Bind `dependency` to everything built between the two marks, as if
+    /// push_dependent_pipeline(dependency) had been active while it was built. A node needs this when
+    /// the shape of the pipeline others depend on is itself decided by those others, so it can only be
+    /// added afterwards -- how to partition a set operation's build child, or a hash join's build
+    /// side, depends on all the other children.
+    ///
+    /// TWO things read that scope, and both are handled here, in one call, because compensating for
+    /// one and forgetting the other is silent:
+    ///   1. _subscribe_pipeline_event() gives each pipeline added inside the scope an event
+    ///      dependency on it.
+    ///   2. maybe_interpolate_collect_stats() copies the whole scope into the CollectStatsSource it
+    ///      creates, as that source's group-dependent pipelines. Those decide when the group's
+    ///      drivers may be instantiated (FragmentExecutor makes the group-initialize event wait for
+    ///      them) and clamp the group's DOP to at least theirs (adjust_dop()). For a hash join that is
+    ///      exactly what upholds HashJoinerFactory's two rules -- builders created before probers, and
+    ///      prober_dop a multiple of builder_dop -- so losing it crashes in get_builder() with
+    ///      _builder_dop still 0, or silently leaves builders no prober ever visits.
+    /// If a third reader of dependent_pipelines() appears, it has to be handled here too.
+    ///
+    /// The pipeline range must hold ONLY pipelines that consume `dependency`'s output. Anything that
+    /// FEEDS it has to stay out: interpolating the local exchange in front of `dependency` registers
+    /// the pipeline that ends in the matching LocalExchangeSink, and making that one wait for
+    /// `dependency` to finish deadlocks the fragment, since `dependency` cannot finish before it has
+    /// read what that pipeline sends. That is why the marks are taken around the other children only.
+    ///
+    /// `apply_events` is the caller's stand-in for the colocate-group half of the gate in
+    /// _subscribe_pipeline_event: that gate reads the current execution group as each dependent
+    /// pipeline is added, which cannot be recovered after the fact. It only decides event scheduling
+    /// -- the operators still gate themselves on the build being ready -- so approximating it with
+    /// the group the dependency itself lands in is safe. It does not cover (2), which is not optional.
+    void bind_dependent_pipeline_between(const BuilderMark& begin, const BuilderMark& end, const Pipeline* dependency,
+                                         bool apply_events);
+
+    /// maybe_interpolate_collect_stats() records every CollectStatsSource it creates, so that
+    /// bind_dependent_pipeline_between() can reach the ones built outside the scope.
+    void record_group_dependent_source(SourceOperatorFactory* source_op) {
+        _group_dependent_sources.emplace_back(source_op);
+    }
+
     RuntimeState* runtime_state();
     FragmentContext* fragment_context() { return _fragment_context; }
     bool enable_group_execution() const { return _enable_group_execution; }
@@ -93,6 +141,7 @@ private:
     ExecutionGroupRawPtr _current_execution_group = nullptr;
 
     std::list<const Pipeline*> _dependent_pipelines;
+    std::vector<SourceOperatorFactory*> _group_dependent_sources;
 
     uint32_t _next_pipeline_id = 0;
     uint32_t _next_operator_id = 0;

--- a/test/sql/test_join/R/test_join_local_shuffle_alignment
+++ b/test/sql/test_join/R/test_join_local_shuffle_alignment
@@ -1,0 +1,129 @@
+-- name: test_join_local_shuffle_alignment
+create table ja (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+-- result:
+-- !result
+create table jb (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into ja select s1, s1 % 7 from table(generate_series(1, 5000)) s(s1);
+-- result:
+-- !result
+insert into jb select s1, s1 % 7 from table(generate_series(1, 3000)) s(s1);
+-- result:
+-- !result
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+select count(*) from jb where jb.id in (select z.id from (select id from ja union select id from ja) z);
+-- result:
+3000
+-- !result
+select count(*) from (select id from ja union select id from ja) y
+  join (select id from jb union select id from jb) z on y.id = z.id;
+-- result:
+3000
+-- !result
+select count(*) from (select id from ja union select id from ja) z left semi join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+select count(*) from (select id from ja union select id from ja) z left anti join jb on z.id = jb.id;
+-- result:
+2000
+-- !result
+select count(*), min(id), max(id), sum(id) from
+  (select z.id from (select id from ja union select id from ja) z join jb on z.id = jb.id) x;
+-- result:
+3000	1	3000	4501500
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+set pipeline_dop = 4;
+-- result:
+-- !result
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+set pipeline_dop = 16;
+-- result:
+-- !result
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+set pipeline_dop = 0;
+-- result:
+-- !result
+select count(*) from ja join (select id from jb union select id from jb) z on ja.id = z.id;
+-- result:
+3000
+-- !result
+select count(*) from (select g from ja union select g from ja) z join jb on z.g = jb.g;
+-- result:
+3000
+-- !result
+set enable_wait_dependent_event = true;
+-- result:
+-- !result
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+select count(*) from ja join (select id from jb union select id from jb) z on ja.id = z.id;
+-- result:
+3000
+-- !result
+select count(*) from ja join jb on ja.id = jb.id;
+-- result:
+3000
+-- !result
+select count(*) from (select id from ja union select id from ja) z
+  left join (select id from jb union select id from jb) y on z.id = y.id;
+-- result:
+5000
+-- !result
+set enable_wait_dependent_event = false;
+-- result:
+-- !result
+set enable_runtime_adaptive_dop = true;
+-- result:
+-- !result
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+select count(*) from ja join (select id from jb union select id from jb) z on ja.id = z.id;
+-- result:
+3000
+-- !result
+select count(*) from ja join jb on ja.id = jb.id;
+-- result:
+3000
+-- !result
+select count(*), min(z.id), max(z.id) from (select id from ja union select id from ja) z
+  join jb on z.id = jb.id;
+-- result:
+3000	1	3000
+-- !result
+set enable_wait_dependent_event = true;
+-- result:
+-- !result
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+-- result:
+3000
+-- !result
+set enable_wait_dependent_event = false;
+-- result:
+-- !result
+set enable_runtime_adaptive_dop = false;
+-- result:
+-- !result

--- a/test/sql/test_join/T/test_join_local_shuffle_alignment
+++ b/test/sql/test_join/T/test_join_local_shuffle_alignment
@@ -1,0 +1,97 @@
+-- name: test_join_local_shuffle_alignment
+-- A hash join partitions its hash table across drivers, so a key has to reach the SAME driver from
+-- both sides. Each side picks its partitioning independently, from its own source
+-- (maybe_interpolate_local_shuffle_exchange, once per side in HashJoinNode::decompose_to_pipeline):
+-- a scan whose bucket key is the join key keeps the driver assignment the FE handed it per driver
+-- sequence and is skipped entirely, because it reports could_local_shuffle() == false, while a side
+-- sitting behind a UNION gets a fresh plain hash shuffle. The two are then numbered by unrelated
+-- schemes and only the rows that coincidentally land on the same driver ever match, so the join
+-- silently loses (1 - 1/DOP) of its result.
+--
+-- The DCHECK_EQ(rhs_source_op->partition_type(), lhs_source_op->partition_type()) next to those two
+-- calls does not catch it: it is compiled out in release, it compares only the partition type and
+-- not the bucket properties, and a side that was skipped altogether still reports whatever type it
+-- always had.
+--
+-- ja holds 1..5000 and jb holds 1..3000, both unique, so every expectation below follows from the
+-- data alone.
+create table ja (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+create table jb (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+insert into ja select s1, s1 % 7 from table(generate_series(1, 5000)) s(s1);
+insert into jb select s1, s1 % 7 from table(generate_series(1, 3000)) s(s1);
+
+-- UNION subtree on the probe side, bucketed scan on the build side: 1..3000 match.
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+
+-- the same join written as an IN subquery, which is how this shape usually shows up
+select count(*) from jb where jb.id in (select z.id from (select id from ja union select id from ja) z);
+
+-- UNION on both sides
+select count(*) from (select id from ja union select id from ja) y
+  join (select id from jb union select id from jb) z on y.id = z.id;
+
+-- semi and anti forms of the same misalignment
+select count(*) from (select id from ja union select id from ja) z left semi join jb on z.id = jb.id;
+select count(*) from (select id from ja union select id from ja) z left anti join jb on z.id = jb.id;
+
+-- the surviving rows are the right ones, not just the right count
+select count(*), min(id), max(id), sum(id) from
+  (select z.id from (select id from ja union select id from ja) z join jb on z.id = jb.id) x;
+
+-- DOP 1 always worked: no local shuffle is interpolated at all, so the two sides cannot disagree
+set pipeline_dop = 1;
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+set pipeline_dop = 4;
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+set pipeline_dop = 16;
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+set pipeline_dop = 0;
+
+-- control: with the UNION on the build side instead, both sides already agreed
+select count(*) from ja join (select id from jb union select id from jb) z on ja.id = z.id;
+
+-- control: a join key that is not the distribution key, so neither side can claim the bucket
+-- transform and both take the plain hash
+select count(*) from (select g from ja union select g from ja) z join jb on z.g = jb.g;
+
+-- enable_wait_dependent_event makes the probe side wait for the build side to finish. The local
+-- exchange interpolated in front of the build side must be left out of that wait, or the build
+-- side waits on a pipeline that is waiting on it. Off by default, so these are the only coverage.
+set enable_wait_dependent_event = true;
+
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+
+select count(*) from ja join (select id from jb union select id from jb) z on ja.id = z.id;
+
+select count(*) from ja join jb on ja.id = jb.id;
+
+select count(*) from (select id from ja union select id from ja) z
+  left join (select id from jb union select id from jb) y on z.id = y.id;
+
+set enable_wait_dependent_event = false;
+
+-- enable_runtime_adaptive_dop interpolates a CollectStats pair, and the pipeline holding the join
+-- probe then starts with a CollectStatsSource whose drivers are instantiated later, from an event.
+-- That source has to carry the build pipeline among its group-dependent pipelines, which is what
+-- makes the event wait for the build side (HashJoinerFactory: builders before probers) and clamps
+-- the group's DOP to at least the build side's (prober_dop a multiple of builder_dop). Off by
+-- default, so these are the only coverage.
+set enable_runtime_adaptive_dop = true;
+
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+
+select count(*) from ja join (select id from jb union select id from jb) z on ja.id = z.id;
+
+select count(*) from ja join jb on ja.id = jb.id;
+
+select count(*), min(z.id), max(z.id) from (select id from ja union select id from ja) z
+  join jb on z.id = jb.id;
+
+-- both knobs at once
+set enable_wait_dependent_event = true;
+select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
+set enable_wait_dependent_event = false;
+
+set enable_runtime_adaptive_dop = false;

--- a/test/sql/test_set_operation/R/test_except_intersect_local_shuffle
+++ b/test/sql/test_set_operation/R/test_except_intersect_local_shuffle
@@ -1,0 +1,260 @@
+-- name: test_except_intersect_local_shuffle
+create table t1 (idx bigint, k bigint) duplicate key(idx)
+  distributed by hash(idx) buckets 32 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t1 select s1, s1 % 3 from table(generate_series(1, 10)) s(s1);
+-- result:
+-- !result
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+-- result:
+0
+-- !result
+select count(*) from (
+  select z.idx from (select idx from t1 union select idx from t1) z
+  except
+  select idx from t1) x;
+-- result:
+0
+-- !result
+select count(*) from (
+  select idx, k from t1
+  except
+  select z.idx, z.k from (select idx, k from t1 union select idx, k from t1) z) x;
+-- result:
+0
+-- !result
+select count(*) from (
+  select idx from t1
+  intersect
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+-- result:
+10
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+-- result:
+0
+-- !result
+set pipeline_dop = 4;
+-- result:
+-- !result
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+-- result:
+0
+-- !result
+set pipeline_dop = 8;
+-- result:
+-- !result
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+-- result:
+0
+-- !result
+set pipeline_dop = 0;
+-- result:
+-- !result
+select count(*) from (
+  select k from t1
+  except
+  select z.k from (select k from t1 union select k from t1) z) x;
+-- result:
+0
+-- !result
+select idx from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 where idx <= 7 union select idx from t1 where idx <= 7) z) x
+order by idx;
+-- result:
+8
+9
+10
+-- !result
+create table a (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+-- result:
+-- !result
+create table b (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+-- result:
+-- !result
+create table c (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+-- result:
+-- !result
+insert into a select s1, s1 % 7 from table(generate_series(1, 5000)) s(s1);
+-- result:
+-- !result
+insert into b select s1, s1 % 7 from table(generate_series(1, 3000)) s(s1);
+-- result:
+-- !result
+insert into c select s1, s1 % 7 from table(generate_series(2000, 6000)) s(s1);
+-- result:
+-- !result
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z) x;
+-- result:
+3000
+-- !result
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+-- result:
+2000
+-- !result
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z
+  intersect
+  select y.id from (select id from c union select id from c) y) x;
+-- result:
+1001
+-- !result
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select y.id from (select id from b union select id from b) y) x;
+-- result:
+2000
+-- !result
+select count(*), min(id), max(id), sum(id) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select y.id from (select id from b union select id from b) y) x;
+-- result:
+2000	3001	5000	8001000
+-- !result
+create table cg1 (k bigint, v bigint) duplicate key(k)
+  distributed by hash(k) buckets 8 properties("replication_num" = "1", "colocate_with" = "grp_setop_align");
+-- result:
+-- !result
+create table cg2 (k bigint, v bigint) duplicate key(k)
+  distributed by hash(k) buckets 8 properties("replication_num" = "1", "colocate_with" = "grp_setop_align");
+-- result:
+-- !result
+insert into cg1 select s1, s1 from table(generate_series(1, 1000)) s(s1);
+-- result:
+-- !result
+insert into cg2 select s1, s1 from table(generate_series(500, 1500)) s(s1);
+-- result:
+-- !result
+select count(*), min(k), max(k) from (select k from cg1 except select k from cg2) x;
+-- result:
+499	1	499
+-- !result
+select count(*), min(k), max(k) from (select k from cg1 intersect select k from cg2) x;
+-- result:
+501	500	1000
+-- !result
+select count(*), min(k), max(k) from (
+  select k from cg1
+  intersect
+  select k from cg2
+  intersect
+  select k from cg1 where k >= 600) x;
+-- result:
+401	600	1000
+-- !result
+select count(*) from (
+  select k from cg1
+  except
+  select z.k from (select k from cg2 union select k from cg2) z) x;
+-- result:
+499
+-- !result
+set enable_wait_dependent_event = true;
+-- result:
+-- !result
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+-- result:
+0
+-- !result
+select count(*) from (
+  select z.idx from (select idx from t1 union select idx from t1) z
+  except
+  select idx from t1) x;
+-- result:
+0
+-- !result
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+-- result:
+2000
+-- !result
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z) x;
+-- result:
+3000
+-- !result
+select count(*), min(k), max(k) from (select k from cg1 except select k from cg2) x;
+-- result:
+499	1	499
+-- !result
+set enable_wait_dependent_event = false;
+-- result:
+-- !result
+set enable_runtime_adaptive_dop = true;
+-- result:
+-- !result
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+-- result:
+0
+-- !result
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+-- result:
+2000
+-- !result
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z) x;
+-- result:
+3000
+-- !result
+set enable_wait_dependent_event = true;
+-- result:
+-- !result
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+-- result:
+2000
+-- !result
+set enable_wait_dependent_event = false;
+-- result:
+-- !result
+set enable_runtime_adaptive_dop = false;
+-- result:
+-- !result

--- a/test/sql/test_set_operation/T/test_except_intersect_local_shuffle
+++ b/test/sql/test_set_operation/T/test_except_intersect_local_shuffle
@@ -1,0 +1,203 @@
+-- name: test_except_intersect_local_shuffle
+-- EXCEPT/INTERSECT partition their hash set across drivers, so a key must reach the SAME driver from
+-- every child. Each child used to pick its partitioning from its own source: a scan whose bucket key
+-- is exactly the set key keeps the scan's bucket transform, while a child sitting behind a UNION has
+-- no bucket properties and gets the plain shuffle hash. The two children were then hashed by
+-- different functions and never met, so EXCEPT returned every row and INTERSECT returned none --
+-- silently, at any DOP above 1.
+create table t1 (idx bigint, k bigint) duplicate key(idx)
+  distributed by hash(idx) buckets 32 properties("replication_num" = "1");
+insert into t1 select s1, s1 % 3 from table(generate_series(1, 10)) s(s1);
+
+-- t1 EXCEPT (t1 UNION t1) is empty by construction.
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+
+-- the same with the UNION on the build side
+select count(*) from (
+  select z.idx from (select idx from t1 union select idx from t1) z
+  except
+  select idx from t1) x;
+
+-- two set keys, both covered by the distribution key
+select count(*) from (
+  select idx, k from t1
+  except
+  select z.idx, z.k from (select idx, k from t1 union select idx, k from t1) z) x;
+
+-- INTERSECT is the mirror image: all 10 rows are common.
+select count(*) from (
+  select idx from t1
+  intersect
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+
+-- DOP 1 always worked (no local shuffle at all), keep it as a control
+set pipeline_dop = 1;
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+set pipeline_dop = 4;
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+set pipeline_dop = 8;
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+set pipeline_dop = 0;
+
+-- a set key that is NOT the distribution key already worked: neither child could claim the bucket
+-- transform, so both used the plain hash
+select count(*) from (
+  select k from t1
+  except
+  select z.k from (select k from t1 union select k from t1) z) x;
+
+-- and a genuinely non-empty EXCEPT still produces the right rows
+select idx from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 where idx <= 7 union select idx from t1 where idx <= 7) z) x
+order by idx;
+
+-- The mismatch is plan-shape dependent, so the same statement can be correct on one table and wrong
+-- on another. These four shapes are the ones that stayed wrong at 5000 rows after the small-table
+-- ones above already passed; each is checked against a count that follows from the data alone.
+create table a (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+create table b (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+create table c (id bigint, g bigint) duplicate key(id)
+  distributed by hash(id) buckets 32 properties("replication_num" = "1");
+insert into a select s1, s1 % 7 from table(generate_series(1, 5000)) s(s1);
+insert into b select s1, s1 % 7 from table(generate_series(1, 3000)) s(s1);
+insert into c select s1, s1 % 7 from table(generate_series(2000, 6000)) s(s1);
+
+-- a INTERSECT (b UNION b) = 1..3000
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z) x;
+
+-- (a UNION a) EXCEPT b = 3001..5000
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+
+-- a INTERSECT (b UNION b) INTERSECT (c UNION c) = 2000..3000
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z
+  intersect
+  select y.id from (select id from c union select id from c) y) x;
+
+-- UNION on both sides = 3001..5000
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select y.id from (select id from b union select id from b) y) x;
+
+-- and the surviving rows are the right ones, not just the right count
+select count(*), min(id), max(id), sum(id) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select y.id from (select id from b union select id from b) y) x;
+
+-- A colocate set operation is the case where the children need NO local exchange at all: the FE
+-- hands each driver its own bucket morsels, so every child reports could_local_shuffle() == false
+-- and they are already aligned on that assignment. Forcing a shuffle here would only add cost, so
+-- the children are left alone -- these check that leaving them alone is still correct.
+create table cg1 (k bigint, v bigint) duplicate key(k)
+  distributed by hash(k) buckets 8 properties("replication_num" = "1", "colocate_with" = "grp_setop_align");
+create table cg2 (k bigint, v bigint) duplicate key(k)
+  distributed by hash(k) buckets 8 properties("replication_num" = "1", "colocate_with" = "grp_setop_align");
+insert into cg1 select s1, s1 from table(generate_series(1, 1000)) s(s1);
+insert into cg2 select s1, s1 from table(generate_series(500, 1500)) s(s1);
+
+-- cg1 EXCEPT cg2 = 1..499
+select count(*), min(k), max(k) from (select k from cg1 except select k from cg2) x;
+
+-- cg1 INTERSECT cg2 = 500..1000
+select count(*), min(k), max(k) from (select k from cg1 intersect select k from cg2) x;
+
+-- three-way, still colocate
+select count(*), min(k), max(k) from (
+  select k from cg1
+  intersect
+  select k from cg2
+  intersect
+  select k from cg1 where k >= 600) x;
+
+-- and a colocate child mixed with one that has to be shuffled: now the children DO disagree, so
+-- they all get put on one scheme
+select count(*) from (
+  select k from cg1
+  except
+  select z.k from (select k from cg2 union select k from cg2) z) x;
+
+-- enable_wait_dependent_event makes every pipeline on the probe side wait for the build side to
+-- finish before it starts. Partitioning a child interpolates a local exchange in front of it, and
+-- the pipeline that feeds the build side must not be caught up in that wait -- it has to run for
+-- the build side to be able to finish at all. Off by default, so these are the only coverage.
+set enable_wait_dependent_event = true;
+
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+
+-- the mirror shape: the child that is behind the UNION is the one that builds
+select count(*) from (
+  select z.idx from (select idx from t1 union select idx from t1) z
+  except
+  select idx from t1) x;
+
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z) x;
+
+select count(*), min(k), max(k) from (select k from cg1 except select k from cg2) x;
+
+set enable_wait_dependent_event = false;
+
+-- enable_runtime_adaptive_dop: same reason as the join case. A probe child built outside the
+-- build pipeline's dependent-pipeline scope must still hand that pipeline to any CollectStatsSource
+-- interpolated inside it. Off by default, so these are the only coverage.
+set enable_runtime_adaptive_dop = true;
+
+select count(*) from (
+  select idx from t1
+  except
+  select z.idx from (select idx from t1 union select idx from t1) z) x;
+
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+
+select count(*) from (
+  select id from a
+  intersect
+  select z.id from (select id from b union select id from b) z) x;
+
+set enable_wait_dependent_event = true;
+select count(*) from (
+  select z.id from (select id from a union select id from a) z
+  except
+  select id from b) x;
+set enable_wait_dependent_event = false;
+
+set enable_runtime_adaptive_dop = false;


### PR DESCRIPTION
## Why I'm doing:

EXCEPT, INTERSECT and hash join all split one hash structure across drivers, so a key has to
reach the SAME driver from every input or one input's rows never meet the other's. Each input
was partitioned by a decision read from that input's own source, and the two answers disagree:

- `maybe_interpolate_local_shuffle_exchange` / `maybe_interpolate_local_bucket_shuffle_exchange`
  return early when the source reports `could_local_shuffle() == false` -- the FE already assigned
  that scan's morsels per `driver_seq`, so the rows are placed and must be left alone;
- otherwise they interpolate a fresh local shuffle, reusing the source's partition type and bucket
  properties when it has them.

A child whose scan is per-driver assigned is therefore left alone while a child sitting behind a
UNION gets a fresh shuffle, and those are two unrelated numberings of the same key space. At
default settings, on main, this returns wrong results silently:

```sql
create table t1 (idx bigint, k bigint) duplicate key(idx)
  distributed by hash(idx) buckets 32 properties("replication_num" = "1");
insert into t1 select s1, s1 % 3 from table(generate_series(1, 10)) s(s1);

-- empty by construction
select count(*) from (select idx from t1
                      except
                      select z.idx from (select idx from t1 union select idx from t1) z) x;
-- expected 0, got 10;  the INTERSECT counterpart returned 0 instead of 10

-- 3000 by construction (ja = 1..5000, jb = 1..3000, both unique)
select count(*) from (select id from ja union select id from ja) z join jb on z.id = jb.id;
-- returned 93 at DOP 32, 1500 at DOP 2, 750 at DOP 4, 187 at DOP 16 -- 3000/DOP every time,
-- i.e. only the keys that happened to land on the same driver on both sides
```

Nothing reports it: the `DCHECK_EQ` sitting next to the join's two calls compares only the
partition type, is compiled out in release, and an input that was skipped altogether still reports
whatever type it always had. Instrumenting the failing plans shows the two inputs agreeing on
partition type and on bucket properties (both empty) and on DOP, and differing **only** in
`could_local_shuffle`.

`#77025` removed set operations from colocate exec groups and thereby hid the related
`ExceptPartitionContextFactory` SIGFPE, but does not cover this: `enable_group_execution` makes no
difference to any of the shapes above.

## What I'm doing:

Three commits, each readable on its own:

1. **`[Refactor] Decompose set-operation children before partitioning them`** -- how the children
   have to be partitioned depends on all of them, so none can be partitioned until every one has
   been decomposed. Only the ordering moves; each child is still partitioned by exactly the call it
   was before. Two things that used to fall out of the old order become explicit: the pipelines
   built while decomposing the probe children get their dependency on the build pipeline from the
   new `PipelineBuilderContext::subscribe_pipelines_since()` instead of from the
   `push_dependent_pipeline()` scope they no longer sit inside, and the execution group each child
   leaves current is recorded and restored before that child's pipeline is added. Operator ids and
   pipeline registration order change; neither is load-bearing.

2. **`[BugFix] Partition every set-operation child by the same scheme`** -- the scheme is settled
   once, from the build child, and handed to every child along with that child's own key exprs,
   through `interpolate_local_forced_shuffle_exchange`, which never consults the individual source.

3. **`[BugFix] Partition both sides of a hash join by the same scheme`** -- the same defect on the
   other operator with a driver-partitioned state, built on what (1) and (2) introduce. Neither side
   can be moved onto the other's numbering (the receiving fragment is never told which bucket
   function or how many buckets its sender used -- `TExchangeNode` carries only the partition type),
   so when they disagree both are re-partitioned by a plain hash of their own keys.

**This does not add an exchange where the old code paid none.** When no input could be locally
shuffled they are all already partitioned by the FE's per-driver morsel assignment -- one
bucket -> driver_seq map shared by every scan in the fragment -- so they agree for free and both
`maybe_interpolate_*` calls interpolate nothing. That case is left exactly as it was; the shared
scheme is forced only once some input would be shuffled anyway, which is where they can disagree.
Measured with the decision instrumented:

| shape | inputs' `could_local_shuffle` | forced? |
| --- | --- | --- |
| `EXCEPT` between two scans on the distribution key, buckets >= DOP | 0, 0 | no -- no exchange, as before |
| `EXCEPT` between a scan and a child behind a `UNION` | 0, 1 | yes -- this is the bug |
| colocate `EXCEPT`, buckets < DOP (8 buckets, DOP 52) | 1, 1 | yes -- both were shuffled before too |

`test_asof_join` takes 647s with these commits and 650s without them.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: queries that silently returned wrong results now return the right ones; an
      additional local exchange appears in plans where the inputs disagreed

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

The defect and every mechanism this fix touches are present on 3.5, 4.0 and 4.1: both
`maybe_interpolate_*` early-returns, the per-driver morsel assignment that produces
`could_local_shuffle() == false`, `enable_wait_dependent_event` and
`set_need_wait_dependencies_finished`, and the two call sites in each of `except_node.cpp`,
`intersect_node.cpp` and `hash_join_node.cpp`. Auto-backport will conflict, though: main has since
split the builder helpers out of `be/src/exec/pipeline/pipeline_builder.{h,cpp}` into
`be/src/exec/pipeline/pipeline_builder_operators.{h,cpp}` and
`be/src/exec/runtime/pipeline_builder_context.{h,cpp}`, which the release branches do not have, so
each backport needs the same change written against the older layout rather than a cherry-pick.

## Tests

Added, both recorded against a real BE:

- `test/sql/test_set_operation/{T,R}/test_except_intersect_local_shuffle` -- 14 assertions on the
  broken shapes at 10 and 5000 rows plus a DOP sweep, and 4 more on colocate set operations, which
  are the shape whose inputs are deliberately left alone.
- `test/sql/test_join/{T,R}/test_join_local_shuffle_alignment` -- 11 assertions over probe/build
  combinations, a DOP sweep and the three distribution-mode hints.

Verified on an ASan build: both new cases pass, and `test_set_operation`, `test_colocate_set`,
`test_skew_join` and `test_nest_loop_join` pass unchanged. `test_join` has one unrelated
pre-existing failure, `test_skew_join_v2`, which fails at parse time on a drifted
"most similar input" suggestion list.

Built at commit (1) alone, both new cases still fail and the wrong results above still reproduce,
while the other four suites still pass -- the reordering commit fixes nothing and breaks nothing.

Observability: no signal added or removed. The interpolated local exchange appears in the query
profile as an ordinary LOCAL_EXCHANGE operator pair, exactly as the existing non-forced local
shuffle already reports itself.
