### PR TITLE
[BugFix] [3.5] Preserve microseconds when serializing datetime partition bounds

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -339,7 +339,7 @@ public class DateLiteral extends LiteralExpr {
     private long makePackedDatetime() {
         long ymd = ((year * 13 + month) << 5) | day;
         long hms = (hour << 12) | (minute << 6) | second;
-        return ((ymd << 17) | hms) << 24 + microsecond;
+        return (((ymd << 17) | hms) << 24) + microsecond;
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DateLiteralTest.java
@@ -22,7 +22,40 @@ import com.starrocks.common.AnalysisException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+
 public class DateLiteralTest {
+
+    @Test
+    public void testSerializationWithMicroseconds() throws Exception {
+        String[] values = {
+                "2026-09-09 13:50:32.313000",
+                "2026-09-09 14:30:06.957000",
+                "2026-09-09 13:50:32.000001",
+                "2026-09-09 13:50:32.000064",
+                "2026-09-09 13:50:32",
+                "0000-01-01 00:00:00",
+                "9999-12-31 23:59:59.999999"
+        };
+        for (String value : values) {
+            DateLiteral original = new DateLiteral(value, Type.DATETIME);
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            original.write(new DataOutputStream(bytes));
+            DateLiteral restored = DateLiteral.read(new DataInputStream(new ByteArrayInputStream(bytes.toByteArray())));
+            Assertions.assertEquals(original.getType(), restored.getType(), value);
+            Assertions.assertEquals(original.toLocalDateTime(), restored.toLocalDateTime(), value);
+        }
+
+        DateLiteral date = new DateLiteral("2026-09-09", Type.DATE);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        date.write(new DataOutputStream(bytes));
+        DateLiteral restored = DateLiteral.read(new DataInputStream(new ByteArrayInputStream(bytes.toByteArray())));
+        Assertions.assertEquals(Type.DATE, restored.getType());
+        Assertions.assertEquals(date.toLocalDateTime(), restored.toLocalDateTime());
+    }
 
     @Test
     public void TwoDigitYear() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RangePartitionInfoTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc.PartitionRangeType;
 import com.starrocks.sql.ast.PartitionValue;
@@ -47,6 +48,28 @@ public class RangePartitionInfoTest {
     public void setUp() {
         partitionColumns = new LinkedList<Column>();
         singleRangePartitionDescs = new LinkedList<SingleRangePartitionDesc>();
+    }
+
+    @Test
+    public void testDatetimeMicrosecondRangeSerialization() throws Exception {
+        List<Column> columns = Lists.newArrayList(new Column("dt", Type.DATETIME));
+        PartitionKey minimum = PartitionKey.createInfinityPartitionKey(columns, false);
+        PartitionKey first = PartitionKey.createPartitionKey(
+                Lists.newArrayList(new PartitionValue("2026-09-09 13:50:32.313")), columns);
+        PartitionKey second = PartitionKey.createPartitionKey(
+                Lists.newArrayList(new PartitionValue("2026-09-09 14:30:06.957")), columns);
+        Range<PartitionKey> firstRange = Range.closedOpen(minimum, first);
+        Range<PartitionKey> secondRange = Range.closedOpen(first, second);
+        RangePartitionInfo original = new RangePartitionInfo(columns);
+        original.setRange(1L, false, firstRange);
+        original.setRange(2L, false, secondRange);
+        original.setRange(3L, true, secondRange);
+
+        RangePartitionInfo restored = GsonUtils.GSON.fromJson(
+                GsonUtils.GSON.toJson(original), RangePartitionInfo.class);
+        Assertions.assertEquals(firstRange, restored.getRange(1L));
+        Assertions.assertEquals(secondRange, restored.getRange(2L));
+        Assertions.assertEquals(secondRange, restored.getRange(3L));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Fix an operator-precedence error in `DateLiteral.makePackedDatetime()`: fractional seconds are added to the shift distance instead of the shifted datetime value, corrupting serialized partition bounds and potentially preventing metadata replay.

## What I'm doing:

Backport the datetime packing correction from #65002 to branch-3.5 without its broader serialization refactor. Parenthesize the 24-bit shift before adding microseconds: Java otherwise evaluates `24 + microsecond` as the shift distance.

The binary layout and deserialization code remain unchanged. This prevents new corrupted records; it does not repair already corrupted journals.

Add regression coverage for fractional-second DATETIME and DATE round trips, boundary values, and ordinary/temporary partition ranges through Gson serialization. Both new regression tests fail against the original code and pass with the fix.

Observability: reviewed the journal replay exception log (including journal ID), `metaReplayState`, and `canRead`/`isReady` transitions. These diagnostics remain unchanged; no new signal is needed for this packing correction.

Validation:
- `mvn -o -pl fe-core -am test -Dpython=python3 -Dtest=DateLiteralTest,RangePartitionInfoTest -Dsurefire.failIfNoSpecifiedTests=false`: 17 tests passed, no failures or skips.
- Maven Checkstyle: zero violations.
- `git diff --check`: passed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

Fractional-second partition bounds now retain their original values across metadata serialization. Existing valid DATE and whole-second DATETIME encodings are preserved.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

Documentation is not required: this corrects an internal metadata encoding bug and introduces no syntax, configuration, or metrics.

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
