### PR TITLE
[UT] Cover the constant-array nested lambda captured-argument case

### DIFF
--- a/test/sql/test_array_fn/R/test_nested_lambda_captured_arg
+++ b/test/sql/test_array_fn/R/test_nested_lambda_captured_arg
@@ -1,16 +1,4 @@
 -- name: test_nested_lambda_captured_arg
--- A nested array_map whose INNER lambda holds a common sub expression that captures the ENCLOSING
--- lambda's argument. The FE hoists the duplicated abs(x) into the inner lambda's own common sub
--- expression list and rewrites its body to reference the hoisted slot, so x appears nowhere in that
--- body any more. LambdaFunction::get_slot_ids reported the body alone when called before prepare(),
--- which hid x from ArrayMapExpr::prepare and from extract_outer_common_exprs. The outer lambda was
--- therefore judged independent of x, stopped putting x into the chunk it passes down, and evaluating
--- the inner array_map could not find x.
--- Keeping the two abs(x) separated by y matters: it leaves no x-only subexpression for the FE to
--- hoist any further, which is what makes the hoist stay in the inner lambda.
--- Do not add a constant-array form (array_map(x -> array_map(y -> ..., [1,2]), [1,2])): it folds
--- into a PHYSICAL_VALUES plan where the FE still hoists the reference out of the scope that defines
--- it, so it fails plan validation until #78645 lands.
 create database db_${uuid0};
 -- result:
 -- !result
@@ -24,20 +12,21 @@ DISTRIBUTED BY HASH(k) BUCKETS 1 PROPERTIES ("replication_num" = "1");
 INSERT INTO nlc VALUES (1, [1, -2]), (2, []), (3, NULL);
 -- result:
 -- !result
--- used to fail with "Expr evaluate meet error: slot_id N not found (known slots: [...])"
 SELECT k, array_map(x -> array_map(y -> abs(x) + y + abs(x), arr), arr) AS r FROM nlc ORDER BY k;
 -- result:
 1	[[3,0],[5,2]]
 2	[]
 3	None
 -- !result
--- control: an equivalent single-occurrence form leaves the hoist in the lambda that binds x, so it
--- was already correct; both forms must agree
 SELECT k, array_map(x -> array_map(y -> abs(x) * 2 + y, arr), arr) AS r FROM nlc ORDER BY k;
 -- result:
 1	[[3,0],[5,2]]
 2	[]
 3	None
+-- !result
+SELECT array_map(x -> array_map(y -> abs(x) + y + abs(x), [1,2]), [1,2]);
+-- result:
+[[3,4],[5,6]]
 -- !result
 drop database db_${uuid0};
 -- result:

--- a/test/sql/test_array_fn/T/test_nested_lambda_captured_arg
+++ b/test/sql/test_array_fn/T/test_nested_lambda_captured_arg
@@ -8,9 +8,10 @@
 -- the inner array_map could not find x.
 -- Keeping the two abs(x) separated by y matters: it leaves no x-only subexpression for the FE to
 -- hoist any further, which is what makes the hoist stay in the inner lambda.
--- Do not add a constant-array form (array_map(x -> array_map(y -> ..., [1,2]), [1,2])): it folds
--- into a PHYSICAL_VALUES plan where the FE still hoists the reference out of the scope that defines
--- it, so it fails plan validation until #78645 lands.
+-- The constant-array form needs the FE-side fix from #78645 as well: without it the FE hoists the
+-- reference out of the scope that defines it and InputDependenciesChecker rejects the plan before
+-- the BE sees it. It earns its place because folding into a PHYSICAL_VALUES plan makes it take the
+-- all-const branch of ArrayMapExpr::evaluate_lambda_expr, which the table-backed case never does.
 
 create database db_${uuid0};
 use db_${uuid0};
@@ -24,5 +25,8 @@ SELECT k, array_map(x -> array_map(y -> abs(x) + y + abs(x), arr), arr) AS r FRO
 -- control: an equivalent single-occurrence form leaves the hoist in the lambda that binds x, so it
 -- was already correct; both forms must agree
 SELECT k, array_map(x -> array_map(y -> abs(x) * 2 + y, arr), arr) AS r FROM nlc ORDER BY k;
+
+-- constant-array form, taking the all-const evaluation branch (see header)
+SELECT array_map(x -> array_map(y -> abs(x) + y + abs(x), [1,2]), [1,2]);
 
 drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Follow-up to #78915, which fixed the BE side of a nested `array_map` whose inner lambda holds a common sub expression capturing the enclosing lambda's argument. Its test deliberately covered only the table-backed form, because the constant-array form additionally needed the FE-side fix in #78645:

```sql
SELECT array_map(x -> array_map(y -> abs(x) + y + abs(x), [1,2]), [1,2]);
```

Before #78645, this folded into a `PHYSICAL_VALUES` plan where the FE still hoisted the reference out of the scope that defines it, so `InputDependenciesChecker` rejected it (`The required cols {6} cannot obtain from input cols {1}`) before it ever reached the BE. It could not be part of a BE-only change. #78645 has since merged, so the case can be added.

The form is worth covering beyond being one more query: folding into `PHYSICAL_VALUES` makes it take the `all_const_input` branch of `ArrayMapExpr::evaluate_lambda_expr`, which the table-backed case never reaches. With #78645 applied but #78915 absent it failed on that branch's captured column size check (`The size of the captured column ... is less than array's size.`, `array_map_expr.cpp:120-123`) rather than the `slot_id N not found` path the table-backed case hits.

## What I'm doing:

Adds one statement to the existing `test_nested_lambda_captured_arg` case and replaces the header note that told readers not to add it yet with an explanation of why the form is interesting and what it now depends on.

Test-only change; no production code is touched.

### Verification status

Run against a cluster carrying both #78645 and #78915: the statement returns `[[3,4],[5,6]]` and the whole case passes.

That settles the open question #78915's description left behind. With #78645 applied but #78915 absent, this form failed on the all-const branch's captured column size check (`The size of the captured column ... is less than array's size.`, `array_map_expr.cpp:120-123`) rather than the `slot_id N not found` path the table-backed case hits, so it was not obvious that #78915 covered it. It does; no further BE work is needed for that branch.

The expected-results file is the output of `run.py -r` rather than hand-written. That drops the comments the previous version mirrored into it — they stay in the T file, which is where they belong.

### Observability

Test-only change. No metric, log or config is added, removed or altered, and the diagnostics on this path (the `Status::RuntimeError` carrying the throwing chunk's slot set, the `be.WARNING` stack, and `VLOG(2)` in `extract_outer_common_exprs`) are untouched.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

Deliberately not backported. #78915 was auto-backported, so `test_nested_lambda_captured_arg` already exists on `branch-4.1`, `branch-4.0` and `branch-3.5`, but #78645 is not on any of them yet, so this statement would fail there. `branch-3.5` is the harder case: it predates the #60815 refactor of `ScalarOperatorsReuse` (no `usedColumns`, recursive dependency scans), so #78645 will not cherry-pick cleanly and needs a hand-ported version. Worth revisiting once the FE fix is actually present on a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
