### PR TITLE
[BugFix] Reclaim tablet metadata by dropping delete_predicate on compaction and replication archival (backport #76870)

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -306,6 +306,10 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
             delete_delvec_sid_range.emplace_back(it->id(), it->id() + std::max(it->segments_size(), 1) - 1);
             // Collect del files.
             _collect_del_files_above_rebuild_point(&(*it), &collect_del_files);
+            // Drop the delete_predicate before archiving the input rowset into compaction_inputs.
+            // compaction_inputs is consumed only by vacuum/file cleanup, never by readers, so the
+            // predicate is pure metadata bloat once the rowset is compacted away.
+            (*it).clear_delete_predicate();
             _tablet_meta->mutable_compaction_inputs()->Add(std::move(*it));
             it = _tablet_meta->mutable_rowsets()->erase(it);
             del_range_ss << "[" << delete_delvec_sid_range.back().first << "," << delete_delvec_sid_range.back().second

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -370,6 +370,11 @@ private:
             }
             _metadata->set_next_rowset_id(new_next_rowset_id);
             old_rowsets.Swap(_metadata->mutable_compaction_inputs());
+            // Drop delete_predicate on the archived inputs; compaction_inputs is consumed only
+            // by vacuum/file cleanup, never by readers, so the predicate is pure metadata bloat.
+            for (auto& archived : *_metadata->mutable_compaction_inputs()) {
+                archived.clear_delete_predicate();
+            }
 
             _metadata->set_cumulative_point(0);
 
@@ -522,9 +527,13 @@ private:
         const auto end_input_pos = pre_input_pos + 1;
         for (auto iter = first_input_pos; iter != end_input_pos; ++iter) {
             if (iter != last_input_pos) {
+                // Drop the delete_predicate before archiving into compaction_inputs; it is consumed
+                // only by vacuum/file cleanup, never by readers, so it is pure metadata bloat here.
+                (*iter).clear_delete_predicate();
                 _metadata->mutable_compaction_inputs()->Add(std::move(*iter));
             } else {
                 // might be a partial compaction, use real last input rowset
+                last_input_rowset.clear_delete_predicate();
                 _metadata->mutable_compaction_inputs()->Add(std::move(last_input_rowset));
             }
         }
@@ -660,6 +669,11 @@ private:
 
             _metadata->set_cumulative_point(0);
             old_rowsets.Swap(_metadata->mutable_compaction_inputs());
+            // Drop delete_predicate on the archived inputs; compaction_inputs is consumed only
+            // by vacuum/file cleanup, never by readers, so the predicate is pure metadata bloat.
+            for (auto& archived : *_metadata->mutable_compaction_inputs()) {
+                archived.clear_delete_predicate();
+            }
 
             LOG(INFO) << "Apply full replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _metadata->version() << ", new_version: " << _new_version

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -565,6 +565,7 @@ set(EXEC_FILES
         ./storage/lake/lake_persistent_index_test.cpp
         ./storage/lake/replication_txn_manager_test.cpp
         ./storage/lake/persistent_index_sstable_test.cpp
+        ./storage/lake/txn_log_applier_test.cpp
         ./storage/lake/write_combined_txn_log_test.cpp
         ./cache/block_cache/datacache_utils_test.cpp
         ./cache/block_cache/block_cache_hit_rate_counter_test.cpp

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -532,6 +532,56 @@ TEST_F(MetaFileTest, test_unpersistent_del_files_when_compact) {
     }
 }
 
+TEST_F(MetaFileTest, test_clear_delete_predicate_when_compact) {
+    // Regression for the metadata-reclaim change: when compaction archives its input
+    // rowsets into compaction_inputs, the (potentially large) delete_predicate must be
+    // dropped from the archived copy. compaction_inputs is consumed only by vacuum/file
+    // cleanup, never by readers, so the predicate is pure metadata bloat once moved.
+    const int64_t tablet_id = 10007;
+    auto tablet = std::make_shared<Tablet>(_tablet_manager.get(), tablet_id);
+    auto metadata = std::make_shared<TabletMetadata>();
+    metadata->set_id(tablet_id);
+    metadata->set_version(10);
+    metadata->set_next_rowset_id(112);
+
+    // Two live rowsets, each carrying a delete_predicate.
+    auto* r0 = metadata->add_rowsets();
+    r0->set_id(110);
+    r0->set_overlapped(false);
+    r0->set_num_rows(10);
+    r0->set_data_size(100);
+    r0->add_segments("aaa.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = metadata->add_rowsets();
+    r1->set_id(111);
+    r1->set_overlapped(false);
+    r1->set_num_rows(20);
+    r1->set_data_size(200);
+    r1->add_segments("bbb.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+
+    // Pre-condition: both live rowsets currently carry the predicate.
+    ASSERT_TRUE(metadata->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(metadata->rowsets(1).has_delete_predicate());
+
+    // Compact 110 + 111 -> archived into compaction_inputs.
+    metadata->set_version(11);
+    MetaFileBuilder builder(*tablet, metadata);
+    TxnLogPB_OpCompaction op_compaction;
+    op_compaction.add_input_rowsets(110);
+    op_compaction.add_input_rowsets(111);
+    RowsetMetadataPB output_rowset;
+    output_rowset.add_segments("ccc.dat");
+    op_compaction.mutable_output_rowset()->CopyFrom(output_rowset);
+    op_compaction.set_compact_version(11);
+    builder.apply_opcompaction(op_compaction, 111, 0);
+
+    // The archived compaction_inputs must NOT retain the delete_predicate.
+    ASSERT_EQ(2, metadata->compaction_inputs_size());
+    EXPECT_FALSE(metadata->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(metadata->compaction_inputs(1).has_delete_predicate());
+}
+
 TEST_F(MetaFileTest, test_trim_partial_compaction_last_input_rowset) {
     auto metadata = std::make_shared<TabletMetadata>();
     metadata->set_id(9);

--- a/be/test/storage/lake/txn_log_applier_test.cpp
+++ b/be/test/storage/lake/txn_log_applier_test.cpp
@@ -1,0 +1,180 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "storage/lake/txn_log_applier.h"
+
+#include <gtest/gtest.h>
+
+#include "runtime/exec_env.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_metadata.h"
+
+namespace starrocks {
+namespace lake {
+
+// Helper to build non-primary key metadata
+MutableTabletMetadataPtr build_non_pk_metadata(int64_t id) {
+    auto meta = std::make_shared<TabletMetadata>();
+    meta->set_id(id);
+    meta->set_version(1);
+    meta->set_next_rowset_id(0);
+    auto* schema = meta->mutable_schema();
+    schema->set_id(100);
+    schema->set_keys_type(DUP_KEYS);
+    return meta;
+}
+
+// Helper to build primary key metadata
+MutableTabletMetadataPtr build_pk_metadata(int64_t id) {
+    auto meta = std::make_shared<TabletMetadata>();
+    meta->set_id(id);
+    meta->set_version(1);
+    meta->set_next_rowset_id(0);
+    auto* schema = meta->mutable_schema();
+    schema->set_id(200);
+    schema->set_keys_type(PRIMARY_KEYS);
+    return meta;
+}
+
+// Regression for the metadata-reclaim change on the non-PK path: when
+// NonPrimaryKeyTxnLogApplier archives compaction input rowsets into
+// compaction_inputs, the delete_predicate must be dropped from the archived copy
+// (covers both the std::move(*iter) branch and the last_input_rowset branch).
+TEST(TxnLogApplierCompactionTest, NonPKCompactionDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40050);
+    auto meta = build_non_pk_metadata(40050);
+    meta->set_next_rowset_id(10);
+
+    // Two adjacent live rowsets, each carrying a delete_predicate.
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_overlapped(false);
+    r0->set_num_rows(10);
+    r0->set_data_size(100);
+    r0->add_segments("seg0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_overlapped(false);
+    r1->set_num_rows(20);
+    r1->set_data_size(200);
+    r1->add_segments("seg1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40050);
+    log->set_txn_id(200);
+    auto* op_compaction = log->mutable_op_compaction();
+    op_compaction->add_input_rowsets(1);
+    op_compaction->add_input_rowsets(2);
+    auto* output = op_compaction->mutable_output_rowset();
+    output->set_num_rows(30);
+    output->set_data_size(300);
+    output->add_segments("out.dat");
+    op_compaction->set_compact_version(2);
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // Input rowsets archived into compaction_inputs must NOT retain delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
+// Regression: non-PK NON-LAKE replication (full snapshot, no tablet_metadata) swaps all superseded
+// old rowsets into compaction_inputs — delete_predicate must be dropped across the Swap too.
+TEST(TxnLogApplierCompactionTest, NonPKNonLakeReplicationDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40061);
+    auto meta = build_non_pk_metadata(40061);
+    meta->set_next_rowset_id(10);
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_num_rows(10);
+    r0->add_segments("old0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_num_rows(20);
+    r1->add_segments("old1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40061);
+    log->set_txn_id(301);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(301);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+    txn_meta->set_incremental_snapshot(false); // full snapshot, no tablet_metadata -> non-lake Swap path
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // All superseded old rowsets are swapped into compaction_inputs without their delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
+// Regression: PK NON-LAKE replication (full snapshot, no tablet_metadata) swaps all superseded old
+// rowsets into compaction_inputs — delete_predicate must be dropped across the Swap too.
+TEST(TxnLogApplierCompactionTest, PKNonLakeReplicationDropsDeletePredicate) {
+    Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), 40071);
+    auto meta = build_pk_metadata(40071);
+    meta->set_next_rowset_id(10);
+    auto* r0 = meta->add_rowsets();
+    r0->set_id(1);
+    r0->set_num_rows(10);
+    r0->add_segments("old0.dat");
+    r0->mutable_delete_predicate()->set_version(1);
+    auto* r1 = meta->add_rowsets();
+    r1->set_id(2);
+    r1->set_num_rows(20);
+    r1->add_segments("old1.dat");
+    r1->mutable_delete_predicate()->set_version(2);
+    ASSERT_TRUE(meta->rowsets(0).has_delete_predicate());
+    ASSERT_TRUE(meta->rowsets(1).has_delete_predicate());
+
+    auto applier = new_txn_log_applier(tablet, meta, 2, false);
+
+    auto log = std::make_shared<TxnLogPB>();
+    log->set_tablet_id(40071);
+    log->set_txn_id(401);
+    auto* op_rep = log->mutable_op_replication();
+    auto* txn_meta = op_rep->mutable_txn_meta();
+    txn_meta->set_txn_id(401);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_snapshot_version(2);
+    txn_meta->set_data_version(0);
+    txn_meta->set_incremental_snapshot(false); // full snapshot, no tablet_metadata -> non-lake Swap path
+
+    ASSERT_TRUE(applier->apply(*log).ok());
+
+    // All superseded old rowsets are swapped into compaction_inputs without their delete_predicate.
+    ASSERT_EQ(2, meta->compaction_inputs_size());
+    EXPECT_FALSE(meta->compaction_inputs(0).has_delete_predicate());
+    EXPECT_FALSE(meta->compaction_inputs(1).has_delete_predicate());
+}
+
+} // namespace lake
+} // namespace starrocks


### PR DESCRIPTION
Backport of #76870 to branch-3.5.

## Why I'm doing:

When a rowset is archived into `compaction_inputs`, its `delete_predicate` is carried along with it. `compaction_inputs` is consumed only by vacuum and file cleanup and is never read by a reader, so from that point on the predicate is pure metadata bloat. A delete heavy table accumulates it on every compaction and on every replication archival, and the tablet metadata grows without bound.

## What I'm doing:

Dropping the predicate at each point where a rowset is archived: the compaction path in `MetaFileBuilder::apply_opcompaction`, the compaction archival in `NonPrimaryKeyTxnLogApplier` (both the iterated inputs and the real last input rowset for a partial compaction), and the replication archival on the primary key and non primary key appliers.

### Backport notes

This branch differs from main, so the change was adapted rather than cherry picked. Every difference is listed here.

**Two archival sites on main do not exist here.** Main also archives inside a lake replication path guarded by `op_replication.has_tablet_metadata()`. That field is not in `TxnLogPB.OpReplication` on this branch, so the path does not exist and neither those two call sites nor the two tests covering them are part of this backport. All FIVE archival sites that do exist on this branch are covered.

**`StorageEnv` does not exist here.** `lake_tablet_manager()` lives on `ExecEnv` on this branch, so the tests use `ExecEnv::GetInstance()`.

**The test file for the applier does not exist here.** `be/test/storage/lake/txn_log_applier_test.cpp` is absent on this branch, so it is added with the two metadata builders the tests need and registered in `be/test/CMakeLists.txt`.

**`new_txn_log_applier` takes four arguments here**, not five. There is no `skip_write_tablet_metadata` parameter on this branch, so the calls pass four.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr
