### PR TITLE
[BugFix] Fix binding of Python objects and casting of `ARRAY`, `MAP` and `STRUCT` columns

### DIFF
--- a/contrib/starrocks-python-client/starrocks/datatype.py
+++ b/contrib/starrocks-python-client/starrocks/datatype.py
@@ -21,8 +21,10 @@ import re
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type, Union
 
 import sqlalchemy.dialects.mysql.types as mysql_types
+from sqlalchemy import cast, func
 from sqlalchemy.engine import Dialect
 from sqlalchemy.sql import sqltypes
+from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.types import UserDefinedType
 
 
@@ -166,6 +168,25 @@ class StructuredType(UserDefinedType):
         """
         raise NotImplementedError("get_sub_item_types is not implemented for this pure Structuredtype")
 
+    def bind_processor(self, dialect: Dialect) -> Callable[[Optional[Any]], Optional[str]]:
+        """
+        Encode Python values (list, dict, ...) as JSON text for binding.
+
+        The DBAPI driver has no native encoding for structured types, so
+        values are sent as a JSON string and cast to the target structured
+        type at bind time; see ``bind_expression``.
+        """
+        def process(value: Optional[Any]) -> Optional[str]:
+            if value is None:
+                return None
+            return json.dumps(value, default=str)
+
+        return process
+
+    def bind_expression(self, bindvalue: ColumnElement) -> ColumnElement:
+        """Cast the JSON-encoded bind parameter to this structured type."""
+        return cast(bindvalue, self)
+
 
 class ARRAY(StructuredType):
     """
@@ -258,6 +279,14 @@ class MAP(StructuredType):
             types.update(self.value_type.get_sub_item_types())
         return types
 
+    def bind_expression(self, bindvalue: ColumnElement) -> ColumnElement:
+        """Cast the JSON-encoded bind parameter to this MAP type.
+
+        Unlike ``ARRAY``, StarRocks does not support casting a VARCHAR
+        directly to ``MAP``; the value must be parsed to ``JSON`` first.
+        """
+        return cast(func.parse_json(bindvalue), self)
+
     def result_processor(self, dialect: Dialect, coltype: object):
         key_processor = self.key_type.result_processor(dialect, coltype)
         value_processor = self.value_type.result_processor(dialect, coltype)
@@ -313,6 +342,24 @@ class STRUCT(StructuredType):
         }
         super().__init__()
 
+    def adapt(self, cls, **kw):
+        """Return a shallow copy rather than reconstructing via the default adapter.
+
+        ``TypeEngine.adapt`` reconstructs an instance via
+        ``util.constructor_copy``, which matches ``obj.__dict__`` entries to
+        ``__init__`` parameter names. Since ``STRUCT.__init__`` takes
+        ``*fields``/``**kwfields`` rather than named parameters matching
+        ``field_tuples``, that reconstruction silently drops all fields,
+        producing an empty ``STRUCT<>``. There is only one implementation of
+        this type, so adaptation copies ``__dict__`` directly instead.
+        """
+        if cls is not type(self):
+            return super().adapt(cls, **kw)
+        new = cls.__new__(cls)
+        new.__dict__.update(self.__dict__)
+        new.__dict__.update(kw)
+        return new
+
     @property
     def python_type(self) -> Optional[Type[Any]]:
         return None
@@ -337,6 +384,14 @@ class STRUCT(StructuredType):
             if hasattr(type_, 'get_sub_item_types'):
                 types.update(type_.get_sub_item_types())
         return types
+
+    def bind_expression(self, bindvalue: ColumnElement) -> ColumnElement:
+        """Cast the JSON-encoded bind parameter to this STRUCT type.
+
+        Unlike ``ARRAY``, StarRocks does not support casting a VARCHAR
+        directly to ``STRUCT``; the value must be parsed to ``JSON`` first.
+        """
+        return cast(func.parse_json(bindvalue), self)
 
     def result_processor(self, dialect: Dialect, coltype: object):
         processors = {

--- a/contrib/starrocks-python-client/starrocks/dialect.py
+++ b/contrib/starrocks-python-client/starrocks/dialect.py
@@ -88,6 +88,7 @@ from .datatype import (
     SMALLINT,
     STRING,
     STRUCT,
+    StructuredType,
     TINYINT,
     VARBINARY,
     VARCHAR,
@@ -292,7 +293,7 @@ class StarRocksSQLCompiler(MySQLCompiler):
     ):
         if type_ is None:
             type_ = typeclause.type.dialect_impl(self.dialect)
-        if isinstance(type_, sqltypes.Boolean):
+        if isinstance(type_, (sqltypes.Boolean, StructuredType)):
             return self.dialect.type_compiler_instance.process(type_)
         return super().visit_typeclause(typeclause, type_, **kw)
 

--- a/contrib/starrocks-python-client/test/integration/test_bind_processor.py
+++ b/contrib/starrocks-python-client/test/integration/test_bind_processor.py
@@ -1,0 +1,210 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration tests verifying that ARRAY, MAP, and STRUCT columns accept
+Python-native bind parameters (list, dict) via ``sqlalchemy.insert()``,
+rather than requiring hand-written literal SQL.
+
+These are the write-side counterpart to test_result_processor.py: without
+``bind_processor``/``bind_expression`` support, the DBAPI driver falls back
+to escaping lists/dicts as SQL tuples (e.g. ``('a', 'b')``), which StarRocks
+rejects as invalid syntax for a structured-type literal.
+"""
+import logging
+import uuid
+
+import pytest
+from sqlalchemy import Column, Integer, MetaData, Table, insert, select
+from sqlalchemy.engine import Engine
+
+from starrocks.datatype import ARRAY, INTEGER, MAP, STRUCT, VARCHAR
+
+
+logger = logging.getLogger(__name__)
+
+# One suffix per worker process — computed once at import time.
+_SUFFIX = uuid.uuid4().hex[:8]
+
+
+def _rows(engine: Engine, table: Table):
+    with engine.connect() as conn:
+        return {row.id: row for row in conn.execute(select(table).order_by(table.c.id))}
+
+
+class TestArrayBindExpression:
+    """ARRAY columns must accept Python lists as bind parameters."""
+
+    @pytest.fixture(scope="class")
+    def table(self, sr_root_engine: Engine):
+        name = f"test_bind_array_{_SUFFIX}"
+        metadata = MetaData()
+        t = Table(
+            name,
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("int_arr", ARRAY(INTEGER)),
+            Column("str_arr", ARRAY(VARCHAR(50))),
+            Column("nested", ARRAY(ARRAY(INTEGER))),
+            starrocks_distributed_by="HASH(id) BUCKETS 1",
+            starrocks_properties={"replication_num": "1"},
+        )
+        with sr_root_engine.begin() as conn:
+            metadata.drop_all(conn)
+            metadata.create_all(conn)
+
+        yield t
+
+        with sr_root_engine.begin() as conn:
+            metadata.drop_all(conn)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seed(self, sr_root_engine: Engine, table: Table):
+        with sr_root_engine.begin() as conn:
+            conn.execute(
+                insert(table),
+                [
+                    {"id": 1, "int_arr": [1, 2, 3], "str_arr": ["a", "b"], "nested": [[1, 2], [3]]},
+                    {"id": 2, "int_arr": [9], "str_arr": ["x"], "nested": [[5]]},
+                    {"id": 3, "int_arr": None, "str_arr": None, "nested": None},
+                ],
+            )
+
+    def test_array_of_ints_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[1].int_arr == [1, 2, 3]
+
+    def test_array_of_strings_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[1].str_arr == ["a", "b"]
+
+    def test_nested_array_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[1].nested == [[1, 2], [3]]
+
+    def test_null_array_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[3].int_arr is None
+        assert rows[3].str_arr is None
+        assert rows[3].nested is None
+
+    def test_single_element_array_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[2].int_arr == [9]
+        assert rows[2].str_arr == ["x"]
+
+
+class TestMapBindExpression:
+    """MAP columns must accept Python dicts as bind parameters."""
+
+    @pytest.fixture(scope="class")
+    def table(self, sr_root_engine: Engine):
+        name = f"test_bind_map_{_SUFFIX}"
+        metadata = MetaData()
+        t = Table(
+            name,
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("kv", MAP(VARCHAR(20), INTEGER)),
+            Column("nested", MAP(VARCHAR(20), ARRAY(INTEGER))),
+            starrocks_distributed_by="HASH(id) BUCKETS 1",
+            starrocks_properties={"replication_num": "1"},
+        )
+        with sr_root_engine.begin() as conn:
+            metadata.drop_all(conn)
+            metadata.create_all(conn)
+
+        yield t
+
+        with sr_root_engine.begin() as conn:
+            metadata.drop_all(conn)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seed(self, sr_root_engine: Engine, table: Table):
+        with sr_root_engine.begin() as conn:
+            conn.execute(
+                insert(table),
+                [
+                    {"id": 1, "kv": {"a": 1, "b": 2}, "nested": {"x": [1, 2], "y": [3]}},
+                    {"id": 2, "kv": {"z": 99}, "nested": {"m": []}},
+                    {"id": 3, "kv": None, "nested": None},
+                ],
+            )
+
+    def test_map_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[1].kv == {"a": 1, "b": 2}
+
+    def test_map_with_array_values_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[1].nested == {"x": [1, 2], "y": [3]}
+
+    def test_null_map_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[3].kv is None
+        assert rows[3].nested is None
+
+
+class TestStructBindExpression:
+    """STRUCT columns must accept Python dicts as bind parameters."""
+
+    @pytest.fixture(scope="class")
+    def table(self, sr_root_engine: Engine):
+        name = f"test_bind_struct_{_SUFFIX}"
+        metadata = MetaData()
+        t = Table(
+            name,
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("info", STRUCT(name=VARCHAR(50), age=INTEGER)),
+            Column("nested", STRUCT(tags=ARRAY(VARCHAR(20)), score=INTEGER)),
+            starrocks_distributed_by="HASH(id) BUCKETS 1",
+            starrocks_properties={"replication_num": "1"},
+        )
+        with sr_root_engine.begin() as conn:
+            metadata.drop_all(conn)
+            metadata.create_all(conn)
+
+        yield t
+
+        with sr_root_engine.begin() as conn:
+            metadata.drop_all(conn)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def seed(self, sr_root_engine: Engine, table: Table):
+        with sr_root_engine.begin() as conn:
+            conn.execute(
+                insert(table),
+                [
+                    {
+                        "id": 1,
+                        "info": {"name": "Alice", "age": 30},
+                        "nested": {"tags": ["go", "python"], "score": 9},
+                    },
+                    {"id": 2, "info": None, "nested": None},
+                ],
+            )
+
+    def test_struct_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[1].info == {"name": "Alice", "age": 30}
+
+    def test_struct_with_array_field_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[1].nested == {"tags": ["go", "python"], "score": 9}
+
+    def test_null_struct_round_trips(self, sr_root_engine: Engine, table: Table):
+        rows = _rows(sr_root_engine, table)
+        assert rows[2].info is None
+        assert rows[2].nested is None

--- a/contrib/starrocks-python-client/test/unit/test_structured_type.py
+++ b/contrib/starrocks-python-client/test/unit/test_structured_type.py
@@ -13,15 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from datetime import date, datetime
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import Column, MetaData, Table, insert
+from sqlalchemy.dialects import registry
 
 from starrocks import datatype
 from starrocks.dialect import StarRocksDialect
 
 _DIALECT = StarRocksDialect()
+
+registry.register("starrocks", "starrocks.dialect", "StarRocksDialect")
 
 
 def _sub_type_reprs(structured_type):
@@ -318,3 +323,106 @@ class TestMapNonStringKeys:
         result = _process(datatype.MAP(datatype.VARCHAR(10), datatype.INTEGER), '{"a":1}')
         assert list(result.keys()) == ["a"]
         assert isinstance(list(result.keys())[0], str)
+
+
+def _bind(type_obj, value):
+    """Call bind_processor and apply it to value."""
+    proc = type_obj.bind_processor(dialect=_DIALECT)
+    if proc is None:
+        return value
+    return proc(value)
+
+
+class TestStructuredTypeBindProcessor:
+    """bind_processor must JSON-encode Python values for parameter binding.
+
+    Without this, the DBAPI driver falls back to escaping lists/dicts as SQL
+    tuples (e.g. ``('a', 'b')``), which is invalid syntax for structured
+    literals.
+    """
+
+    def test_array_encodes_list_as_json(self):
+        assert _bind(datatype.ARRAY(datatype.VARCHAR(10)), ["a", "b"]) == '["a", "b"]'
+
+    def test_array_null_returns_none(self):
+        assert _bind(datatype.ARRAY(datatype.INTEGER), None) is None
+
+    def test_nested_array_encodes_as_json(self):
+        assert _bind(datatype.ARRAY(datatype.ARRAY(datatype.INTEGER)), [[1, 2], [3]]) == "[[1, 2], [3]]"
+
+    def test_map_encodes_dict_as_json(self):
+        assert _bind(datatype.MAP(datatype.VARCHAR(10), datatype.INTEGER), {"a": 1}) == '{"a": 1}'
+
+    def test_map_null_returns_none(self):
+        assert _bind(datatype.MAP(datatype.VARCHAR(10), datatype.INTEGER), None) is None
+
+    def test_struct_encodes_dict_as_json(self):
+        t = datatype.STRUCT(name=datatype.VARCHAR(10), age=datatype.INTEGER)
+        assert _bind(t, {"name": "Alice", "age": 30}) == '{"name": "Alice", "age": 30}'
+
+    def test_struct_null_returns_none(self):
+        t = datatype.STRUCT(name=datatype.VARCHAR(10))
+        assert _bind(t, None) is None
+
+    def test_decimal_values_are_encoded_via_default_str(self):
+        # json.dumps can't serialize Decimal natively; bind_processor must
+        # fall back to str() rather than raising.
+        result = _bind(datatype.ARRAY(datatype.DECIMAL(9, 3)), [Decimal("1.500")])
+        assert json.loads(result) == ["1.500"]
+
+
+def _compile_insert(table):
+    """Compile an INSERT statement for `table` against the StarRocks dialect."""
+    return str(insert(table).compile(dialect=_DIALECT))
+
+
+class TestStructuredTypeBindExpression:
+    """bind_expression must wrap bind params in a CAST the compiler can render.
+
+    The MySQL/MariaDB SQL compiler that StarRocksSQLCompiler inherits from
+    only knows how to CAST to a hardcoded set of types and silently drops
+    the cast (with a warning) for anything else. StarRocksSQLCompiler must
+    recognize StructuredType so this doesn't happen for ARRAY/MAP/STRUCT.
+    """
+
+    def test_array_casts_bind_param_directly(self):
+        table = Table("t", MetaData(), Column("fruits", datatype.ARRAY(datatype.VARCHAR(50))))
+
+        sql = _compile_insert(table)
+
+        assert "CAST(" in sql
+        assert "AS ARRAY<VARCHAR(50)>)" in sql
+        # ARRAY supports casting a JSON-encoded VARCHAR directly; no parse_json needed.
+        assert "parse_json" not in sql
+
+    def test_map_casts_via_parse_json(self):
+        table = Table(
+            "t",
+            MetaData(),
+            Column("kv", datatype.MAP(datatype.VARCHAR(10), datatype.INTEGER)),
+        )
+
+        sql = _compile_insert(table)
+
+        assert "CAST(parse_json(" in sql
+        assert "AS MAP<VARCHAR(10), INTEGER>)" in sql
+
+    def test_struct_casts_via_parse_json(self):
+        table = Table(
+            "t",
+            MetaData(),
+            Column("info", datatype.STRUCT(name=datatype.VARCHAR(10), age=datatype.INTEGER)),
+        )
+
+        sql = _compile_insert(table)
+
+        assert "CAST(parse_json(" in sql
+        assert "AS STRUCT<name VARCHAR(10), age INTEGER>)" in sql
+
+    def test_no_cast_is_skipped_warning(self, recwarn):
+        """Regression guard: casting a structured type must not warn/skip."""
+        table = Table("t", MetaData(), Column("fruits", datatype.ARRAY(datatype.INTEGER)))
+
+        _compile_insert(table)
+
+        assert not any("does not support CAST" in str(w.message) for w in recwarn.list)


### PR DESCRIPTION
## Why I'm doing:

`ARRAY`/`MAP`/`STRUCT` columns can't be used with normal SQLAlchemy bind parameters, only hand-written literal SQL. Four bugs, each minimally reproduced below:

**1. `ARRAY` can't bind a Python list**. No `bind_processor`, so pymysql escapes the list as a SQL tuple.
```python
t = sa.Table("t", sa.MetaData(), sa.Column("fruits", ARRAY(sa.types.VARCHAR(50))))
conn.execute(sa.insert(t), {"fruits": ["a", "b"]})
# pymysql.err.ProgrammingError: Unexpected input ')'
# -> VALUES (('a', 'b')) instead of an array literal
```

**2. `CAST(... AS ARRAY<...>)` silently dropped**. `visit_typeclause` only specialcases `Boolean`.
```python
sql = str(sa.insert(t).compile(dialect=StarRocksDialect()))
# SAWarning: Datatype ARRAY<VARCHAR(50)> does not support CAST on MySQL/MariaDb; the CAST will be skipped.
# sql has no CAST(...) at all
```

**3. `MAP`/`STRUCT` reject a direct `VARCHAR` cast** (StarRocks-side constraint, unlike `ARRAY`).
```sql
INSERT INTO t VALUES (1, CAST('{"a":1}' AS MAP<VARCHAR(20),INT>))
-- 1064: Invalid type cast from varchar to map<varchar(65533),varchar(65533)>
```

**4. `STRUCT` loses all fields on dialect adaptation** - `constructor_copy` can't match `field_tuples` to `STRUCT.__init__(self, *fields, **kwfields)`.
```python
s = STRUCT(name=VARCHAR(50), age=INTEGER)
s.dialect_impl(StarRocksDialect()).get_col_spec()  # "STRUCT<>" fields dropped
```
(This also broke the existing read-path test `TestStructResultProcessor`, already failing on `main`.)

## What I'm doing:

- `StructuredType.bind_processor`: JSON-encode Python values for binding.
- `StructuredType.bind_expression`: `CAST` the encoded value to the target type; `MAP`/`STRUCT` route through `PARSE_JSON` first (bug 3).
- `StarRocksSQLCompiler.visit_typeclause`: recognize `StructuredType` so the `CAST` isn't dropped (bug 2).
- `STRUCT.adapt()`: copy `__dict__` directly instead of via `constructor_copy` (bug 4).
- Unit tests (`test/unit/test_structured_type.py`) and live-DB integration tests (`test/integration/test_bind_processor.py`) for all four.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

