### PR TITLE
[BugFix] Fix list partition pruning of multi-value partitions containing NULL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -657,8 +657,9 @@ public class ListPartitionPruner implements PartitionPruner {
             case NE:
                 // SlotRef != Literal
                 matches.addAll(allPartitions);
-                // remove null partitions
-                matches.removeAll(nullPartitions);
+                // remove NULL-only partitions
+                matches.removeIf(id -> nullPartitions.contains(id)
+                        && (listPartitionInfo == null || listPartitionInfo.isSingleValuePartition(id)));
                 // remove partition matches literal
                 if (partitionValueMap.containsKey(literal)) {
                     if (listPartitionInfo == null) {
@@ -775,9 +776,10 @@ public class ListPartitionPruner implements PartitionPruner {
                 return Sets.newHashSet();
             }
 
-            // all partitions but remove null partitions
+            // all partitions but remove NULL-only partitions
             matches.addAll(allPartitions);
-            matches.removeAll(nullPartitions);
+            matches.removeIf(id -> nullPartitions.contains(id)
+                    && (listPartitionInfo == null || listPartitionInfo.isSingleValuePartition(id)));
         }
 
         for (int i = 1; i < inPredicate.getChildren().size(); ++i) {
@@ -824,7 +826,9 @@ public class ListPartitionPruner implements PartitionPruner {
         if (isNullPredicate.isNotNull()) {
             // is not null
             matches.addAll(allPartitions);
-            matches.removeAll(nullPartitions);
+            // all partitions but remove NULL-only partitions
+            matches.removeIf(id -> nullPartitions.contains(id)
+                    && (listPartitionInfo == null || listPartitionInfo.isSingleValuePartition(id)));
         } else {
             // is null
             matches.addAll(nullPartitions);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/ListPartitionPrunerTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HiveTable;
+import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.DateLiteral;
@@ -618,6 +619,53 @@ public class ListPartitionPrunerTest {
         conjuncts.add(new InPredicateOperator(true,
                 Lists.newArrayList(intColumn, ConstantOperator.createInt(1), ConstantOperator.createInt(2))));
         Assertions.assertEquals(Lists.newArrayList(0L, 3L, 6L), pruner.prune());
+    }
+
+    @Test
+    public void testNullRejectingPredicatesKeepMixedNullPartition() throws AnalysisException {
+        // city=beijing,null   0   (multi-value partition that merely contains NULL)
+        // city=shanghai       1
+        // city=null           2   (NULL-only partition)
+        ColumnRefOperator city = new ColumnRefOperator(1, VarcharType.VARCHAR, "city", true);
+        ConcurrentNavigableMap<LiteralExpr, Set<Long>> cityValues = new ConcurrentSkipListMap<>();
+        cityValues.put(new StringLiteral("beijing"), Sets.newHashSet(0L));
+        cityValues.put(new StringLiteral("shanghai"), Sets.newHashSet(1L));
+        Map<ColumnRefOperator, ConcurrentNavigableMap<LiteralExpr, Set<Long>>> valuesMap = Maps.newHashMap();
+        valuesMap.put(city, cityValues);
+        Map<ColumnRefOperator, Set<Long>> nullPartitions = Maps.newHashMap();
+        nullPartitions.put(city, Sets.newHashSet(0L, 2L));
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo();
+        listPartitionInfo.setValues(0L, Lists.newArrayList("beijing", "NULL"));
+        listPartitionInfo.setValues(1L, Lists.newArrayList("shanghai"));
+        listPartitionInfo.setValues(2L, Lists.newArrayList("NULL"));
+        List<ScalarOperator> predicates = Lists.newArrayList();
+        ListPartitionPruner mixedPruner =
+                new ListPartitionPruner(valuesMap, nullPartitions, predicates, null, listPartitionInfo);
+
+        // city is not null: only the NULL-only partition can go, the mixed one still holds beijing rows.
+        predicates.add(new IsNullPredicateOperator(true, city));
+        Assertions.assertEquals(Lists.newArrayList(0L, 1L), sorted(mixedPruner.prune()));
+
+        // city is null: both partitions holding NULL stay.
+        predicates.clear();
+        predicates.add(new IsNullPredicateOperator(false, city));
+        Assertions.assertEquals(Lists.newArrayList(0L, 2L), sorted(mixedPruner.prune()));
+
+        // city != 'shanghai': drops the single-value shanghai partition and the NULL-only one.
+        predicates.clear();
+        predicates.add(new BinaryPredicateOperator(BinaryType.NE, city, ConstantOperator.createVarchar("shanghai")));
+        Assertions.assertEquals(Lists.newArrayList(0L), sorted(mixedPruner.prune()));
+
+        // city not in ('shanghai'): same shape as !=.
+        predicates.clear();
+        predicates.add(new InPredicateOperator(true, city, ConstantOperator.createVarchar("shanghai")));
+        Assertions.assertEquals(Lists.newArrayList(0L), sorted(mixedPruner.prune()));
+    }
+
+    private static List<Long> sorted(List<Long> partitions) {
+        List<Long> copy = Lists.newArrayList(partitions);
+        copy.sort(null);
+        return copy;
     }
 
     @Test

--- a/test/sql/test_list_partition/R/test_list_partition_null_prune
+++ b/test/sql/test_list_partition/R/test_list_partition_null_prune
@@ -1,0 +1,134 @@
+-- name: test_list_partition_null_prune
+create database test_db_${uuid0};
+-- result:
+-- !result
+use test_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE fact (k INT NOT NULL, city VARCHAR(20)) ENGINE=OLAP
+DUPLICATE KEY(k)
+PARTITION BY LIST (city) (
+    PARTITION pmix VALUES IN ('beijing', NULL),
+    PARTITION psh VALUES IN ('shanghai')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO fact VALUES (1, NULL), (2, 'beijing'), (3, 'shanghai');
+-- result:
+-- !result
+CREATE TABLE dim (city VARCHAR(20)) ENGINE=OLAP
+DUPLICATE KEY(city) DISTRIBUTED BY HASH(city) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO dim VALUES ('beijing'), ('shanghai');
+-- result:
+-- !result
+function: assert_explain_contains("SELECT k FROM fact WHERE city IS NOT NULL", "partitions=2/2")
+-- result:
+None
+-- !result
+SELECT k, city FROM fact WHERE city IS NOT NULL ORDER BY k;
+-- result:
+2	beijing
+3	shanghai
+-- !result
+function: assert_explain_contains("SELECT k FROM fact WHERE city != 'shanghai'", "partitions=1/2")
+-- result:
+None
+-- !result
+SELECT k, city FROM fact WHERE city != 'shanghai' ORDER BY k;
+-- result:
+2	beijing
+-- !result
+function: assert_explain_contains("SELECT k FROM fact WHERE city NOT IN ('shanghai')", "partitions=1/2")
+-- result:
+None
+-- !result
+SELECT k, city FROM fact WHERE city NOT IN ('shanghai') ORDER BY k;
+-- result:
+2	beijing
+-- !result
+function: assert_explain_contains("SELECT f.k FROM fact f JOIN dim d ON f.city = d.city", "partitions=2/2")
+-- result:
+None
+-- !result
+SELECT f.k, f.city FROM fact f JOIN dim d ON f.city = d.city ORDER BY f.k;
+-- result:
+2	beijing
+3	shanghai
+-- !result
+function: assert_explain_contains("SELECT k FROM fact WHERE city IS NULL", "partitions=1/2")
+-- result:
+None
+-- !result
+SELECT k, city FROM fact WHERE city IS NULL ORDER BY k;
+-- result:
+1	None
+-- !result
+SELECT k, city FROM fact WHERE city <=> NULL ORDER BY k;
+-- result:
+1	None
+-- !result
+CREATE TABLE fact_null_only (k INT NOT NULL, city VARCHAR(20)) ENGINE=OLAP
+DUPLICATE KEY(k)
+PARTITION BY LIST (city) (
+    PARTITION pnull VALUES IN (NULL),
+    PARTITION psh VALUES IN ('shanghai')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO fact_null_only VALUES (1, NULL), (3, 'shanghai');
+-- result:
+-- !result
+function: assert_explain_contains("SELECT k FROM fact_null_only WHERE city IS NOT NULL", "partitions=1/2")
+-- result:
+None
+-- !result
+SELECT k, city FROM fact_null_only WHERE city IS NOT NULL ORDER BY k;
+-- result:
+3	shanghai
+-- !result
+function: assert_explain_contains("SELECT k FROM fact_null_only WHERE city != 'shanghai'", "EMPTYSET")
+-- result:
+None
+-- !result
+SELECT k, city FROM fact_null_only WHERE city != 'shanghai' ORDER BY k;
+-- result:
+-- !result
+CREATE TABLE fact_mc (id INT NOT NULL, city VARCHAR(20), k INT) ENGINE=OLAP
+DUPLICATE KEY(id)
+PARTITION BY LIST (city, k) (
+    PARTITION pmix VALUES IN (('beijing', '1'), (NULL, '2')),
+    PARTITION psh VALUES IN (('shanghai', '3'))
+)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO fact_mc VALUES (1, 'beijing', 1), (2, NULL, 2), (3, 'shanghai', 3);
+-- result:
+-- !result
+function: assert_explain_contains("SELECT id FROM fact_mc WHERE city IS NOT NULL", "partitions=2/2")
+-- result:
+None
+-- !result
+SELECT id, city, k FROM fact_mc WHERE city IS NOT NULL ORDER BY id;
+-- result:
+1	beijing	1
+3	shanghai	3
+-- !result
+function: assert_explain_contains("SELECT id FROM fact_mc WHERE city != 'shanghai'", "partitions=1/2")
+-- result:
+None
+-- !result
+SELECT id, city, k FROM fact_mc WHERE city != 'shanghai' ORDER BY id;
+-- result:
+1	beijing	1
+-- !result
+DROP database test_db_${uuid0} FORCE;
+-- result:
+-- !result

--- a/test/sql/test_list_partition/T/test_list_partition_null_prune
+++ b/test/sql/test_list_partition/T/test_list_partition_null_prune
@@ -1,0 +1,67 @@
+-- name: test_list_partition_null_prune
+create database test_db_${uuid0};
+use test_db_${uuid0};
+
+-- pmix holds NULL next to a real value
+CREATE TABLE fact (k INT NOT NULL, city VARCHAR(20)) ENGINE=OLAP
+DUPLICATE KEY(k)
+PARTITION BY LIST (city) (
+    PARTITION pmix VALUES IN ('beijing', NULL),
+    PARTITION psh VALUES IN ('shanghai')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO fact VALUES (1, NULL), (2, 'beijing'), (3, 'shanghai');
+CREATE TABLE dim (city VARCHAR(20)) ENGINE=OLAP
+DUPLICATE KEY(city) DISTRIBUTED BY HASH(city) BUCKETS 1 PROPERTIES ("replication_num" = "1");
+INSERT INTO dim VALUES ('beijing'), ('shanghai');
+
+-- null-rejecting predicates must keep pmix
+function: assert_explain_contains("SELECT k FROM fact WHERE city IS NOT NULL", "partitions=2/2")
+SELECT k, city FROM fact WHERE city IS NOT NULL ORDER BY k;
+function: assert_explain_contains("SELECT k FROM fact WHERE city != 'shanghai'", "partitions=1/2")
+SELECT k, city FROM fact WHERE city != 'shanghai' ORDER BY k;
+function: assert_explain_contains("SELECT k FROM fact WHERE city NOT IN ('shanghai')", "partitions=1/2")
+SELECT k, city FROM fact WHERE city NOT IN ('shanghai') ORDER BY k;
+
+-- the equi join derives city IS NOT NULL on the fact side
+function: assert_explain_contains("SELECT f.k FROM fact f JOIN dim d ON f.city = d.city", "partitions=2/2")
+SELECT f.k, f.city FROM fact f JOIN dim d ON f.city = d.city ORDER BY f.k;
+
+-- null-accepting predicates keep the partition holding NULL
+function: assert_explain_contains("SELECT k FROM fact WHERE city IS NULL", "partitions=1/2")
+SELECT k, city FROM fact WHERE city IS NULL ORDER BY k;
+SELECT k, city FROM fact WHERE city <=> NULL ORDER BY k;
+
+-- a NULL-only partition is still pruned by null-rejecting predicates
+CREATE TABLE fact_null_only (k INT NOT NULL, city VARCHAR(20)) ENGINE=OLAP
+DUPLICATE KEY(k)
+PARTITION BY LIST (city) (
+    PARTITION pnull VALUES IN (NULL),
+    PARTITION psh VALUES IN ('shanghai')
+)
+DISTRIBUTED BY HASH(k) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO fact_null_only VALUES (1, NULL), (3, 'shanghai');
+function: assert_explain_contains("SELECT k FROM fact_null_only WHERE city IS NOT NULL", "partitions=1/2")
+SELECT k, city FROM fact_null_only WHERE city IS NOT NULL ORDER BY k;
+function: assert_explain_contains("SELECT k FROM fact_null_only WHERE city != 'shanghai'", "EMPTYSET")
+SELECT k, city FROM fact_null_only WHERE city != 'shanghai' ORDER BY k;
+
+
+-- multi-column partition: one tuple carries NULL in the first column, the partition still has beijing rows
+CREATE TABLE fact_mc (id INT NOT NULL, city VARCHAR(20), k INT) ENGINE=OLAP
+DUPLICATE KEY(id)
+PARTITION BY LIST (city, k) (
+    PARTITION pmix VALUES IN (('beijing', '1'), (NULL, '2')),
+    PARTITION psh VALUES IN (('shanghai', '3'))
+)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+INSERT INTO fact_mc VALUES (1, 'beijing', 1), (2, NULL, 2), (3, 'shanghai', 3);
+function: assert_explain_contains("SELECT id FROM fact_mc WHERE city IS NOT NULL", "partitions=2/2")
+SELECT id, city, k FROM fact_mc WHERE city IS NOT NULL ORDER BY id;
+function: assert_explain_contains("SELECT id FROM fact_mc WHERE city != 'shanghai'", "partitions=1/2")
+SELECT id, city, k FROM fact_mc WHERE city != 'shanghai' ORDER BY id;
+
+DROP database test_db_${uuid0} FORCE;


### PR DESCRIPTION
## Why I'm doing:

`ListPartitionPruner` prunes `!=`, `NOT IN` and `IS NOT NULL` by `allPartitions - nullPartitions`, but `nullPartitions` holds every partition whose value list contains NULL. A multi-value partition like `VALUES IN ("beijing", NULL)` is dropped as a whole and its non-null rows are lost. An equi join derives `col IS NOT NULL` on the join key, so `JOIN ... ON f.city = d.city` hits it too.

```sql
CREATE TABLE fact (k INT, city VARCHAR(20))
PARTITION BY LIST (city) (
    PARTITION pmix VALUES IN ('beijing', NULL),
    PARTITION psh  VALUES IN ('shanghai'));
INSERT INTO fact VALUES (1, NULL), (2, 'beijing'), (3, 'shanghai');

SELECT k, city FROM fact WHERE city IS NOT NULL;   -- beijing is lost
SELECT k, city FROM fact WHERE city != 'shanghai'; -- empty
```
## What I'm doing:

Only drop NULL-only partitions for null-rejecting predicates: a partition is removed only if it is in nullPartitions and holds a single value (isSingleValuePartition), the same guard the literal removal already uses. External tables (no ListPartitionInfo) are unchanged since each partition holds one value. IS NULL and <=> NULL keep using the "contains NULL" set.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
