### PR TITLE
[Tool] TEMP: touch BE source to measure gen_system_cov after ci-tool#5270

### DIFF
--- a/be/src/base/status.cpp
+++ b/be/src/base/status.cpp
@@ -366,3 +366,8 @@ bool Status::is_moved_from(const char* state) {
 }
 
 } // namespace starrocks
+
+// DO NOT MERGE -- temporary marker so the `be/!(test)**` paths filter fires and this
+// PR runs BE UT + the BE total coverage merge, to measure gen_system_cov after the
+// hardlink change in ci-tool#5270. Comment only: no coverable line is added, so the
+// incremental coverage report stays at 0/0. This PR will be closed, not merged.


### PR DESCRIPTION
> [!WARNING]
> **Temporary PR — DO NOT MERGE. It will be closed once the measurement is taken.**

## Why I'm doing:

[ci-tool#5270](https://github.com/StarRocks/ci-tool/pull/5270) replaced the per-BE `tar -I pigz -xf src_ori.tar.gz` in `gen_system_cov` with `cp -al`. ci-tool is pulled at runtime by `BE-REPORT`, so the change is already live — this PR only produces a run that exercises it.

Measured cost of what it replaced, from earlier BE-REPORT logs:

| | unpack | actual gcov |
|---|---|---|
| idle runner | 110s + 75s | 53s + 28s |
| under load | 184s + 145s | 118s + 73s |

## What I'm doing:

A comment-only change to `be/src/base/status.cpp`, purely to make CI run the coverage path. The gating is by **path**, not content: `dorny/paths-filter`'s `be: ['be/!(test)**', ...]` fires, which gates `be-ut`; BE UT then uploads `flag/be_ut_res`, which is the `size != '0'` condition that gates `Merge BE Total Coverage`. A comment adds no coverable line, so the incremental report stays at `0/0` and cannot trip cover-checker's `--threshold 80`.

### What the run has to show

Timing is the easy part and the least trustworthy — the previous measurement PR (#78919) was swamped by runner load, with every phase 65-165% slower. The checks that matter are the invariants:

| | expected |
|---|---|
| `Found N coverage files (.gcda)` per BE | **1550** (1551 / 1550 / 1550 on the last three runs) |
| `Processed N .gcov files` per BE | **39349 (119640 total, 80291 skipped)** |
| `Setting ut_build_Release/ut_filtered.info as base report` | present |
| `Adding build_Release_gcov/system_*_filtered.info` | 6 of them |
| `BE Incremental Coverage Report` comment | posted, `0 / 0` |

A truncated or cross-contaminated src tree would still finish green with *different* numbers, which is why the counts are checked and not just the clock.

Timing, for reference: the per-BE phase was 5m30s idle, and the whole job 9m43s after ci-tool#5261. Expectation is ~2min and ~6min.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
