### PR TITLE
[BugFix] Fix compaction SIGFPE when a vector-index rowset reports negative data_disk_size

### DIFF
--- a/be/src/storage/compaction_utils.cpp
+++ b/be/src/storage/compaction_utils.cpp
@@ -14,6 +14,9 @@
 
 #include "storage/compaction_utils.h"
 
+#include <algorithm>
+#include <limits>
+
 #include "common/config_compaction_fwd.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
@@ -85,7 +88,24 @@ uint32_t CompactionUtils::get_segment_max_rows(int64_t max_segment_file_size, in
                                                int64_t input_rowsets_size) {
     // The range of config::max_segment_file_size is between [1, INT64_MAX]
     // If the configuration is wrong, the config::max_segment_file_size will be a negtive value.
-    // Using division instead multiplication can avoid the overflow
+    // Using division instead multiplication can avoid the overflow.
+    //
+    // Both statistics come from rowset metas and are summed as size_t by the callers, so a
+    // corrupted or negative value (e.g. a data_disk_size that went below zero) reaches here as
+    // a negative int64. A negative input_rowsets_size can make the divisor below zero, a
+    // negative input_row_num can make it undefined (input_row_num == -1), and input_row_num + 1
+    // can overflow; the first two raise SIGFPE and kill the process from a compaction thread.
+    // The two statistics are derived from the same rowset metas, so if either is out of range
+    // neither is trustworthy: drop both to zero, which makes the estimate degrade to
+    // max_segment_file_size (divisor 1) instead of crashing or deriving a number from a
+    // partially-corrupt pair.
+    if (input_row_num < 0 || input_rowsets_size < 0 || input_row_num >= std::numeric_limits<int64_t>::max()) {
+        LOG(WARNING) << "invalid compaction input statistics, fall back to max_segment_file_size as the segment row "
+                        "estimate. input_row_num="
+                     << input_row_num << ", input_rowsets_size=" << input_rowsets_size;
+        input_row_num = 0;
+        input_rowsets_size = 0;
+    }
     int64_t max_segment_rows = max_segment_file_size / (input_rowsets_size / (input_row_num + 1) + 1);
     if (max_segment_rows > INT32_MAX || max_segment_rows <= 0) {
         max_segment_rows = INT32_MAX;

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -117,8 +117,14 @@ public:
     void set_data_disk_size(size_t data_size) { _rowset_meta_pb->set_data_disk_size(data_size); }
 
     size_t index_disk_size() const { return _rowset_meta_pb->index_disk_size(); }
+    // Bytes of standalone index files (vector index .vi) counted inside index_disk_size but
+    // stored outside the segment files. 0 for rowsets written before this field existed.
+    int64_t standalone_index_size() const { return _rowset_meta_pb->standalone_index_size(); }
 
     void set_index_disk_size(int64_t index_disk_size) { _rowset_meta_pb->set_index_disk_size(index_disk_size); }
+    void set_standalone_index_size(int64_t standalone_index_size) {
+        _rowset_meta_pb->set_standalone_index_size(standalone_index_size);
+    }
 
     bool has_delete_predicate() const { return _rowset_meta_pb->has_delete_predicate(); }
 

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -38,6 +38,7 @@
 #include <butil/reader_writer.h>
 #include <fmt/format.h>
 
+#include <algorithm>
 #include <ctime>
 #include <memory>
 
@@ -159,6 +160,7 @@ StatusOr<RowsetSharedPtr> RowsetWriter::build() {
     _rowset_meta_pb->set_total_disk_size(_total_data_size + _total_index_size);
     _rowset_meta_pb->set_data_disk_size(_total_data_size);
     _rowset_meta_pb->set_index_disk_size(_total_index_size);
+    _rowset_meta_pb->set_standalone_index_size(_total_standalone_index_size);
     // TODO write zonemap to meta
     _rowset_meta_pb->set_empty(_num_rows_written == 0);
     _rowset_meta_pb->set_creation_time(time(nullptr));
@@ -315,10 +317,20 @@ Status RowsetWriter::_flush_segment(const SegmentPB& segment_pb, butil::IOBuf& d
     {
         std::lock_guard<std::mutex> l(_lock);
         // segment_pb.data_size() is full segment file bytes (column data + embedded index pages).
-        // Subtract embedded index so _total_data_size holds only column data bytes;
-        // invariant: data_disk_size + index_disk_size == total_disk_size == segment file size.
-        _total_data_size += segment_pb.data_size() - segment_pb.index_size();
+        // Subtract only the embedded index so _total_data_size holds the column data bytes:
+        // segment_pb.index_size() also counts standalone index files (vector index .vi) that
+        // are not inside the segment file, and subtracting those too would drive
+        // _total_data_size negative for segments whose .vi outweighs their data.
+        // standalone_index_size() defaults to 0 for messages from an older sender that does not
+        // set it (proto2), which reproduces the previous behaviour; clamp to index_size so a
+        // malformed message where standalone > embedded cannot inflate the data bytes instead.
+        // invariant: data_disk_size + index_disk_size == total_disk_size.
+        const uint64_t embedded_index_size =
+                segment_pb.index_size() -
+                std::min<uint64_t>(segment_pb.standalone_index_size(), segment_pb.index_size());
+        _total_data_size += segment_pb.data_size() - static_cast<int64_t>(embedded_index_size);
         _total_index_size += segment_pb.index_size();
+        _total_standalone_index_size += static_cast<int64_t>(segment_pb.index_size() - embedded_index_size);
         _num_rows_written += segment_pb.num_rows();
         _total_row_size += segment_pb.row_size();
         DCHECK(_segment_encryption_metas.size() == _num_segment);
@@ -773,6 +785,7 @@ Status HorizontalRowsetWriter::add_rowset(const RowsetSharedPtr& rowset) {
     _total_row_size += static_cast<int64_t>(rowset->total_row_size());
     _total_data_size += static_cast<int64_t>(rowset->rowset_meta()->data_disk_size());
     _total_index_size += static_cast<int64_t>(rowset->rowset_meta()->index_disk_size());
+    _total_standalone_index_size += rowset->rowset_meta()->standalone_index_size();
     DCHECK(_segment_encryption_metas.size() == _num_segment);
     RETURN_IF_UNLIKELY(_segment_encryption_metas.size() != _num_segment,
                        Status::InternalError(fmt::format("encryption_metas size {} != num segments {}",
@@ -934,6 +947,7 @@ Status HorizontalRowsetWriter::_final_merge() {
         _total_row_size = 0;
         _total_data_size = 0;
         _total_index_size = 0;
+        _total_standalone_index_size = 0;
 
         // If RowsetWriter has final merge, it will produce new partial rowset footers and append them to partial_rowset_footers array,
         // but this array already have old entries, should clear those entries before write new segments for final merge.
@@ -1105,6 +1119,7 @@ Status HorizontalRowsetWriter::_final_merge() {
         _total_row_size = 0;
         _total_data_size = 0;
         _total_index_size = 0;
+        _total_standalone_index_size = 0;
 
         // If RowsetWriter has final merge, it will produce new partial rowset footers and append them to partial_rowset_footers array,
         // but this array already have old entries, should clear those entries before write new segments for final merge.
@@ -1182,12 +1197,19 @@ Status HorizontalRowsetWriter::_flush_segment_writer(std::unique_ptr<SegmentWrit
             seg_info->set_partial_footer_size(footer_size);
         }
     }
+    // index_size counts the index pages embedded in the segment file plus any standalone
+    // index file (vector index .vi). Only the embedded part is inside segment_size, so only
+    // that part is subtracted to get the column data bytes; subtracting the standalone bytes
+    // as well makes data_disk_size negative once the .vi outweighs the data (small vectors,
+    // HNSW graph), which then poisons compaction scores and size estimates.
+    const uint64_t standalone_index_size = (*segment_writer)->standalone_index_size();
+    DCHECK_LE(standalone_index_size, index_size);
+    const uint64_t embedded_index_size = index_size - std::min(standalone_index_size, index_size);
     {
         std::lock_guard<std::mutex> l(_lock);
-        // segment_size is full segment file bytes; subtract index_size so
-        // _total_data_size holds only column data bytes.
-        _total_data_size += static_cast<int64_t>(segment_size) - static_cast<int64_t>(index_size);
+        _total_data_size += static_cast<int64_t>(segment_size) - static_cast<int64_t>(embedded_index_size);
         _total_index_size += static_cast<int64_t>(index_size);
+        _total_standalone_index_size += static_cast<int64_t>(index_size - embedded_index_size);
     }
 
     // check global_dict efficacy
@@ -1196,6 +1218,7 @@ Status HorizontalRowsetWriter::_flush_segment_writer(std::unique_ptr<SegmentWrit
     if (seg_info) {
         seg_info->set_data_size(segment_size);
         seg_info->set_index_size(index_size);
+        seg_info->set_standalone_index_size(standalone_index_size);
         seg_info->set_segment_id((*segment_writer)->segment_id());
         seg_info->set_path((*segment_writer)->segment_path());
         seg_info->set_encryption_meta((*segment_writer)->encryption_meta());
@@ -1365,6 +1388,7 @@ Status VerticalRowsetWriter::flush_columns() {
 
 Status VerticalRowsetWriter::final_flush() {
     int64_t total_segment_file_bytes = 0;
+    int64_t total_standalone_index_bytes = 0;
     for (auto& segment_writer : _segment_writers) {
         uint64_t segment_size = 0;
         uint64_t footer_position = 0;
@@ -1385,6 +1409,9 @@ Status VerticalRowsetWriter::final_flush() {
             partial_rowset_footer->set_size(segment_size - footer_position);
         }
         total_segment_file_bytes += static_cast<int64_t>(segment_size);
+        // Standalone index files (vector index .vi) are counted in _total_index_size but are
+        // not part of the segment files, so they must not be subtracted from the data bytes.
+        total_standalone_index_bytes += static_cast<int64_t>(segment_writer->standalone_index_size());
 
         // check global_dict efficacy
         _check_global_dict(segment_writer.get());
@@ -1395,7 +1422,8 @@ Status VerticalRowsetWriter::final_flush() {
         // _total_index_size was accumulated in _flush_columns() via finalize_columns().
         // Match horizontal RowsetWriter::flush: data_disk_size is column bytes only (segment file minus embedded index).
         std::lock_guard<std::mutex> l(_lock);
-        _total_data_size += total_segment_file_bytes - _total_index_size;
+        _total_data_size += total_segment_file_bytes - (_total_index_size - total_standalone_index_bytes);
+        _total_standalone_index_size += total_standalone_index_bytes;
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -213,6 +213,10 @@ protected:
     int64_t _total_row_size = 0;
     int64_t _total_data_size = 0;
     int64_t _total_index_size = 0;
+    // Bytes of standalone index files (vector index .vi); a subset of _total_index_size that
+    // is stored outside the segment files. Persisted so consumers starting from the segment
+    // file size can recover the embedded-only index bytes.
+    int64_t _total_standalone_index_size = 0;
     int64_t _num_rows_upt = 0;
     int64_t _total_update_row_size = 0;
 

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -491,6 +491,7 @@ Status SegmentWriter::finalize_columns(uint64_t* index_size) {
         uint64_t standalone_index_size = 0;
         RETURN_IF_ERROR(column_writer->write_vector_index(&standalone_index_size));
         *index_size += _wfile->size() - index_offset + standalone_index_size;
+        _standalone_index_size += standalone_index_size;
 
         // The footer's vector_index_storage_type is a segment-level flag: any column that
         // produced a standalone .vi file makes the whole segment STANDALONE. Only upgrade

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -161,6 +161,13 @@ public:
     // finalize() already reported them.
     uint64_t unreported_index_size() const { return _unreported_small_index_region_size; }
 
+    // Bytes of standalone index files (the vector index .vi) produced by finalize_columns().
+    // They are included in the index_size reported by finalize()/finalize_columns() but do
+    // NOT live in the segment file, so a caller that derives the column-data bytes as
+    // "segment file size - index_size" must add them back, or the result goes negative for
+    // segments whose .vi is larger than their data.
+    uint64_t standalone_index_size() const { return _standalone_index_size; }
+
     const DictColumnsValidMap& global_dict_columns_valid_info() { return _global_dict_columns_valid_info; }
 
     const std::string& segment_path() const;
@@ -250,6 +257,9 @@ private:
     // The horizontal path reports them through finalize()'s index_size and leaves this at zero,
     // so a caller adding both can never double count.
     uint64_t _unreported_small_index_region_size = 0;
+    // Accumulated size of standalone index files written by finalize_columns(); see
+    // standalone_index_size().
+    uint64_t _standalone_index_size = 0;
     std::vector<uint32_t> _column_indexes;
     bool _has_key = true;
     std::vector<uint32_t> _sort_column_indexes;

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -14,6 +14,8 @@
 
 #include "rowset_column_update_state.h"
 
+#include <algorithm>
+
 #include "base/phmap/phmap.h"
 #include "base/time/time.h"
 #include "base/utility/defer_op.h"
@@ -642,6 +644,7 @@ Status RowsetColumnUpdateState::_update_rowset_meta(const RowsetSegmentStat& sta
     rowset->rowset_meta()->set_total_disk_size(stat.total_data_size + stat.total_index_size);
     rowset->rowset_meta()->set_data_disk_size(stat.total_data_size);
     rowset->rowset_meta()->set_index_disk_size(stat.total_index_size);
+    rowset->rowset_meta()->set_standalone_index_size(stat.total_standalone_index_size);
     rowset->rowset_meta()->set_empty(stat.num_rows_written == 0);
     rowset->rowset_meta()->set_num_segments(stat.num_segment);
     if (stat.num_segment <= 1) {
@@ -698,8 +701,12 @@ Status RowsetColumnUpdateState::_insert_new_rows(const TabletSchemaCSPtr& tablet
             RETURN_IF_ERROR(writer->finalize(&segment_file_size, &index_size, &footer_position));
             // update statistic
             stat.num_segment++;
-            stat.total_data_size += static_cast<int64_t>(segment_file_size) - static_cast<int64_t>(index_size);
+            // index_size also counts standalone index files (vector index .vi) that are not in
+            // the segment file; subtract only the embedded part to get column data bytes.
+            const uint64_t embedded_index_size = index_size - std::min(writer->standalone_index_size(), index_size);
+            stat.total_data_size += static_cast<int64_t>(segment_file_size) - static_cast<int64_t>(embedded_index_size);
             stat.total_index_size += index_size;
+            stat.total_standalone_index_size += static_cast<int64_t>(index_size - embedded_index_size);
             stat.num_rows_written += static_cast<int64_t>(chunk_ptr->num_rows());
             stat.total_row_size += static_cast<int64_t>(chunk_ptr->bytes_usage());
             segid_to_chunk[segid] = std::move(chunk_ptr);

--- a/be/src/storage/rowset_column_update_state.h
+++ b/be/src/storage/rowset_column_update_state.h
@@ -47,6 +47,7 @@ struct RowsetSegmentStat {
     int64_t total_row_size = 0;
     int64_t total_data_size = 0;
     int64_t total_index_size = 0;
+    int64_t total_standalone_index_size = 0;
     int64_t num_segment = 0;
 };
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1769,14 +1769,19 @@ Status TabletUpdates::_apply_normal_rowset_commit(const EditVersionInfo& version
                 }
                 rowset->rowset_meta()->set_total_row_size(full_row_size);
                 const auto index_disk_size = rowset->rowset_meta()->index_disk_size();
-                // full_rowset_size is the segment file bytes (column data + embedded indexes).
-                // index_disk_size tracks additional index bytes recorded in RowsetMeta; these may
-                // be separately persisted (e.g. primary-key SSTable indexes) or otherwise accounted
-                // for outside the segment file.
-                // Canonical invariant: data_disk_size = segment_size - index_size,
-                //                      total_disk_size = segment_size (== data + index).
-                rowset->rowset_meta()->set_data_disk_size(std::max<int64_t>(0, full_rowset_size - index_disk_size));
-                rowset->rowset_meta()->set_total_disk_size(full_rowset_size);
+                // full_rowset_size is the segment (.dat) file bytes: column data + embedded indexes.
+                // index_disk_size counts all index bytes, including standalone index files (the
+                // vector index .vi) that live outside the segment files. Subtracting the full
+                // index_disk_size from the segment-file size would remove the standalone bytes that
+                // were never part of full_rowset_size and drive data_disk_size to zero for
+                // vector-index rowsets, so subtract only the embedded portion.
+                const auto standalone_index_size = rowset->rowset_meta()->standalone_index_size();
+                const auto embedded_index_size =
+                        index_disk_size - std::min<int64_t>(standalone_index_size, index_disk_size);
+                // Invariant: data_disk_size = segment_size - embedded_index_size,
+                //            total_disk_size = segment_size + standalone_index_size (== data + index).
+                rowset->rowset_meta()->set_data_disk_size(std::max<int64_t>(0, full_rowset_size - embedded_index_size));
+                rowset->rowset_meta()->set_total_disk_size(full_rowset_size + standalone_index_size);
                 rowset->set_schema(apply_tschema);
                 rowset->rowset_meta()->set_tablet_schema(apply_tschema);
                 (void)rowset->reload();

--- a/be/test/storage/compaction_utils_test.cpp
+++ b/be/test/storage/compaction_utils_test.cpp
@@ -16,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <limits>
 #include <vector>
 
 namespace starrocks {
@@ -78,6 +79,39 @@ TEST(CompactionUtilsTest, test_get_segment_max_rows) {
     max_segment_file_size = 0;
     segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 0, 0);
     ASSERT_EQ(2147483647, segment_max_rows);
+}
+
+// Corrupted statistics must never make the divisor zero (SIGFPE in a compaction thread).
+TEST(CompactionUtilsTest, test_get_segment_max_rows_negative_inputs) {
+    const int64_t max_segment_file_size = 1024 * 1024 * 1024;
+
+    // input_rowsets_size / (input_row_num + 1) == -1  =>  divisor 0 before the fix.
+    uint32_t segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 9, -10);
+    ASSERT_EQ(1073741824, segment_max_rows);
+    segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 41802, -41803);
+    ASSERT_EQ(1073741824, segment_max_rows);
+
+    // input_row_num + 1 == 0  =>  divisor 0 before the fix.
+    segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, -1, 100);
+    ASSERT_EQ(1073741824, segment_max_rows);
+
+    // INT64_MIN / -1 overflows (also SIGFPE) before the fix.
+    segment_max_rows =
+            CompactionUtils::get_segment_max_rows(max_segment_file_size, -2, std::numeric_limits<int64_t>::min());
+    ASSERT_EQ(1073741824, segment_max_rows);
+
+    // input_row_num + 1 must not overflow.
+    segment_max_rows =
+            CompactionUtils::get_segment_max_rows(max_segment_file_size, std::numeric_limits<int64_t>::max(), 100);
+    ASSERT_EQ(1073741824, segment_max_rows);
+
+    // A negative size with a sane row count degrades to the no-estimate answer, not a crash.
+    segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 100, -1);
+    ASSERT_EQ(1073741824, segment_max_rows);
+
+    // Sane inputs are unaffected.
+    segment_max_rows = CompactionUtils::get_segment_max_rows(max_segment_file_size, 10000, 100 * 10000);
+    ASSERT_EQ(10737418, segment_max_rows);
 }
 
 TEST(CompactionUtilsTest, test_split_column_into_groups) {

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -42,11 +42,13 @@
 #include "base/string/slice.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
+#include "base/utility/defer_op.h"
 #include "column/chunk_factory.h"
 #include "column/datum_tuple.h"
 #include "common/config_compaction_fwd.h"
 #include "common/config_exec_fwd.h"
 #include "common/config_storage_fwd.h"
+#include "common/config_vector_index_fwd.h"
 #include "exec/exec_env.h"
 #include "fs/fs_factory.h"
 #include "fs/fs_util.h"
@@ -1453,5 +1455,180 @@ TEST_F(RowsetTest, vertical_writer_dtor_skips_builtin_gin_index) {
 
     rowset_writer.reset();
     ASSERT_FALSE(fs::path_exist(segment_path));
+}
+
+namespace {
+
+constexpr int64_t kVectorIndexId = 100;
+
+// id(BIGINT key) + v(ARRAY<FLOAT>) with an HNSW vector index on v. The index is a standalone
+// .vi file next to the segment, not part of the segment file.
+std::shared_ptr<TabletSchema> create_vector_index_tablet_schema() {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(DUP_KEYS);
+    schema_pb.set_num_short_key_columns(1);
+    schema_pb.set_num_rows_per_row_block(1024);
+    schema_pb.set_next_column_unique_id(3);
+
+    auto* col0 = schema_pb.add_column();
+    col0->set_unique_id(0);
+    col0->set_name("id");
+    col0->set_type("BIGINT");
+    col0->set_is_key(true);
+    col0->set_is_nullable(false);
+    col0->set_length(8);
+    col0->set_index_length(8);
+    col0->set_aggregation("NONE");
+
+    auto* col1 = schema_pb.add_column();
+    col1->set_unique_id(1);
+    col1->set_name("v");
+    col1->set_type("ARRAY");
+    col1->set_is_key(false);
+    col1->set_is_nullable(false);
+    col1->set_length(24);
+    col1->set_aggregation("NONE");
+    auto* child = col1->add_children_columns();
+    child->set_unique_id(2);
+    child->set_name("element");
+    child->set_type("FLOAT");
+    child->set_is_key(false);
+    child->set_is_nullable(true);
+    child->set_length(4);
+    child->set_aggregation("NONE");
+
+    auto* idx = schema_pb.add_table_indices();
+    idx->set_index_id(kVectorIndexId);
+    idx->set_index_name("idx_v");
+    idx->set_index_type(IndexType::VECTOR);
+    idx->add_col_unique_id(1);
+    idx->set_index_properties(
+            R"({"common_properties":{"index_type":"hnsw","dim":"3","metric_type":"l2_distance","is_vector_normed":"false"},"index_properties":{"efconstruction":"40","m":"16"},"search_properties":{"efsearch":"40"}})");
+
+    return TabletSchema::create(schema_pb);
+}
+
+void append_vector_rows(Chunk* chunk, const std::vector<uint32_t>& column_indexes, size_t num_rows) {
+    for (size_t i = 0; i < num_rows; ++i) {
+        size_t c = 0;
+        for (uint32_t column_index : column_indexes) {
+            if (column_index == 0) {
+                chunk->columns()[c]->as_mutable_ptr()->append_datum(Datum(static_cast<int64_t>(i)));
+            } else {
+                DatumArray arr{Datum(static_cast<float>(i)), Datum(static_cast<float>(i + 1)),
+                               Datum(static_cast<float>(i + 2))};
+                chunk->columns()[c]->as_mutable_ptr()->append_datum(Datum(arr));
+            }
+            ++c;
+        }
+    }
+}
+
+// data_disk_size must be the column-data bytes of the segment files: the standalone .vi bytes
+// are part of index_disk_size, but subtracting them from the segment file size as well drives
+// data_disk_size below zero as soon as the .vi outweighs the data (small vectors + HNSW graph).
+// The negative value then wraps through size_t in compaction statistics, produces negative
+// compaction scores and finally a SIGFPE in CompactionUtils::get_segment_max_rows.
+void check_vector_index_rowset_sizes(const RowsetSharedPtr& rowset, const RowsetWriterContext& ctx,
+                                     int64_t expected_num_rows) {
+    const auto& meta = rowset->rowset_meta();
+    ASSERT_EQ(expected_num_rows, meta->num_rows());
+    ASSERT_GE(meta->num_segments(), 1);
+
+    int64_t segment_file_bytes = 0;
+    int64_t standalone_index_bytes = 0;
+    for (int64_t seg = 0; seg < meta->num_segments(); ++seg) {
+        std::string segment_path = Rowset::segment_file_path(ctx.rowset_path_prefix, ctx.rowset_id, seg);
+        ASSIGN_OR_ABORT(auto seg_size, FileSystem::Default()->get_file_size(segment_path));
+        segment_file_bytes += static_cast<int64_t>(seg_size);
+
+        std::string vi_path = IndexDescriptor::vector_index_file_path(ctx.rowset_path_prefix, ctx.rowset_id.to_string(),
+                                                                      seg, kVectorIndexId);
+        ASSERT_TRUE(fs::path_exist(vi_path)) << vi_path;
+        ASSIGN_OR_ABORT(auto vi_size, FileSystem::Default()->get_file_size(vi_path));
+        ASSERT_GT(vi_size, 0);
+        standalone_index_bytes += static_cast<int64_t>(vi_size);
+    }
+
+    const int64_t data = static_cast<int64_t>(meta->data_disk_size());
+    const int64_t index = static_cast<int64_t>(meta->index_disk_size());
+    const int64_t total = static_cast<int64_t>(meta->total_disk_size());
+    const int64_t standalone = meta->standalone_index_size();
+    ASSERT_GT(data, 0) << "data=" << data << " index=" << index << " total=" << total;
+    ASSERT_GE(index, standalone_index_bytes);
+    ASSERT_EQ(total, data + index);
+    // The persisted standalone_index_size must equal the on-disk .vi bytes, so a consumer that
+    // starts from the segment file size (e.g. the primary-key apply path) can recover the
+    // embedded-only index bytes.
+    ASSERT_EQ(standalone, standalone_index_bytes);
+    // column data + embedded index == segment file bytes; the .vi is outside the segment files.
+    ASSERT_EQ(segment_file_bytes, data + (index - standalone));
+}
+
+} // namespace
+
+TEST_F(RowsetTest, horizontal_writer_standalone_vector_index_not_subtracted_from_data_size) {
+    const int32_t saved_threshold = config::config_vector_index_default_build_threshold;
+    config::config_vector_index_default_build_threshold = 1;
+    DeferOp restore([&] { config::config_vector_index_default_build_threshold = saved_threshold; });
+
+    auto tablet_schema = create_vector_index_tablet_schema();
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(12345, tablet_schema, &writer_context);
+    writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.writer_type = kHorizontal;
+    writer_context.max_rows_per_segment = 4096;
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_OK(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer));
+
+    const size_t num_rows = 64;
+    std::vector<uint32_t> column_indexes{0, 1};
+    auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
+    auto chunk = ChunkFactory::new_chunk(schema, num_rows);
+    append_vector_rows(chunk.get(), column_indexes, num_rows);
+    ASSERT_OK(rowset_writer->add_chunk(*chunk));
+    ASSERT_OK(rowset_writer->flush());
+
+    RowsetSharedPtr rowset = rowset_writer->build().value();
+    check_vector_index_rowset_sizes(rowset, writer_context, num_rows);
+}
+
+TEST_F(RowsetTest, vertical_writer_standalone_vector_index_not_subtracted_from_data_size) {
+    const int32_t saved_threshold = config::config_vector_index_default_build_threshold;
+    config::config_vector_index_default_build_threshold = 1;
+    DeferOp restore([&] { config::config_vector_index_default_build_threshold = saved_threshold; });
+
+    auto tablet_schema = create_vector_index_tablet_schema();
+    RowsetWriterContext writer_context;
+    create_rowset_writer_context(12345, tablet_schema, &writer_context);
+    writer_context.rowset_id = StorageEngine::instance()->next_rowset_id();
+    writer_context.writer_type = kVertical;
+    writer_context.max_rows_per_segment = 4096;
+
+    std::unique_ptr<RowsetWriter> rowset_writer;
+    ASSERT_OK(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer));
+
+    const size_t num_rows = 64;
+    {
+        std::vector<uint32_t> column_indexes{0};
+        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
+        auto chunk = ChunkFactory::new_chunk(schema, num_rows);
+        append_vector_rows(chunk.get(), column_indexes, num_rows);
+        ASSERT_OK(rowset_writer->add_columns(*chunk, column_indexes, true));
+        ASSERT_OK(rowset_writer->flush_columns());
+    }
+    {
+        std::vector<uint32_t> column_indexes{1};
+        auto schema = ChunkHelper::convert_schema(tablet_schema, column_indexes);
+        auto chunk = ChunkFactory::new_chunk(schema, num_rows);
+        append_vector_rows(chunk.get(), column_indexes, num_rows);
+        ASSERT_OK(rowset_writer->add_columns(*chunk, column_indexes, false));
+        ASSERT_OK(rowset_writer->flush_columns());
+    }
+    ASSERT_OK(rowset_writer->final_flush());
+
+    RowsetSharedPtr rowset = rowset_writer->build().value();
+    check_vector_index_rowset_sizes(rowset, writer_context, num_rows);
 }
 } // namespace starrocks

--- a/gensrc/proto/data.proto
+++ b/gensrc/proto/data.proto
@@ -138,4 +138,7 @@ message SegmentPB {
     // for index
     optional int64 seg_index_data_size = 30;
     repeated SegmentIndexPB seg_indexes = 31;
+    // Bytes of standalone index files (e.g. the vector index .vi) that are counted in
+    // index_size but are not part of the segment file described by data_size.
+    optional int64 standalone_index_size = 32;
 };

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -182,6 +182,10 @@ message RowsetMetaPB {
     repeated bytes segment_encryption_metas = 64;
     repeated bytes delfile_encryption_metas = 65;
     repeated bytes updatefile_encryption_metas = 66;
+    // Bytes of standalone index files (e.g. the vector index .vi) that are part of
+    // index_disk_size but live outside the segment (.dat) files. Lets consumers that
+    // start from the segment file size recover the embedded-only index bytes.
+    optional int64 standalone_index_size = 67;
 }
 
 enum DataFileType {


### PR DESCRIPTION
## Why I'm doing:

```
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1789007916 (unix time) try "date -d @1789007916" if you are using GNU date ***
PC: @         0x21486d49 starrocks::CompactionUtils::get_segment_max_rows(long, long, long)
*** SIGFPE (@0x21486d49) received by PID 560765 (TID 0x7f8187ef96c0) LWP(562892) from PID 558394697; stack trace: ***
    @         0x336d1047 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7f8a490b5ed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @         0x336d0846 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f8a49059330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @         0x21486d49 starrocks::CompactionUtils::get_segment_max_rows(long, long, long)
    @         0x2269f9a1 starrocks::HorizontalCompactionTask::_horizontal_compact_data(starrocks::Statistics*)
    @         0x2269ef39 starrocks::HorizontalCompactionTask::run_impl()
    @         0x22697a28 starrocks::CompactionTask::run()
    @         0x1d681320 starrocks::BackgroundTask::start()
    @         0x226582a9 starrocks::CompactionManager::submit_compaction_task(starrocks::CompactionCandidate const&)::{lambda()#1}::operator()() const
    @         0x226652c0 void std::__invoke_impl<void, starrocks::CompactionManager::submit_compaction_task(starrocks::CompactionCandidate const&)::{lambda()#1}&>(std::__invoke_other, starrocks::CompactionManager::submit_compaction_task(starrocks::CompactionCandidate const&)::{lam@
    @         0x22664e88 std::enable_if<is_invocable_r_v<void, starrocks::CompactionManager::submit_compaction_task(starrocks::CompactionCandidate const&)::{lambda()#1}&>, void>::type std::__invoke_r<void, starrocks::CompactionManager::submit_compaction_task(starrocks::CompactionC@
    @         0x226648ea std::_Function_handler<void (), starrocks::CompactionManager::submit_compaction_task(starrocks::CompactionCandidate const&)::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @         0x1cf3b284 std::function<void ()>::operator()() const
    @         0x2eb17dac starrocks::FunctionRunnable::run()
    @         0x2eb11bb2 starrocks::ThreadPool::dispatch_thread()
    @         0x2eb32ea2 void std::__invoke_impl<void, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(std::__invoke_memfun_deref, void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2eb31840 std::__invoke_result<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>::type std::__invoke<void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&>(void (starrocks::ThreadPool::*&)(), starrocks::ThreadPool*&)
    @         0x2eb302b4 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::__call<void, , 0ul>(std::tuple<>&&, std::_Index_tuple<0ul>)
    @         0x2eb2e910 void std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>::operator()<, void>()
    @         0x2eb2cb96 void std::__invoke_impl<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::__invoke_other, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&)
    @         0x2eb2a499 std::enable_if<is_invocable_r_v<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>, void>::type std::__invoke_r<void, std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()>&>(std::_Bind<void (starrocks::ThreadPool:@
    @         0x2eb25d2f std::_Function_handler<void (), std::_Bind<void (starrocks::ThreadPool::*(starrocks::ThreadPool*))()> >::_M_invoke(std::_Any_data const&)
    @         0x1cf3b284 std::function<void ()>::operator()() const
    @         0x2eaf7fd3 starrocks::Thread::supervise_thread(void*)
    @         0x1cd95616 asan_thread_start(void*)
    @     0x7f8a490b0aa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x7f8a4913da64 __clone

```

The rowset writers derive data_disk_size as "segment file bytes - index_size",
but index_size also counts the standalone vector index (.vi) file, which lives
outside the segment file. For a table with an HNSW vector index the .vi can be
larger than the column data, so data_disk_size goes negative. Summed as size_t
in the compaction statistics it wraps to a huge value, and in
CompactionUtils::get_segment_max_rows the expression

    input_rowsets_size / (input_row_num + 1) + 1

becomes 0 whenever the negative size lands in (-2*(rows+1), -(rows+1)], dividing
max_segment_file_size by zero and killing the BE with SIGFPE from a compaction
thread. The same negative value also makes tablet_footprint() (data + index)
underflow, so the tablet size reported to the FE is garbage.

Fix the accounting on every path that writes rowset size metadata and guard the
divide:

- Track the standalone index bytes separately (SegmentWriter::standalone_index_size,
  SegmentPB.standalone_index_size, RowsetMetaPB.standalone_index_size) and subtract
  only the embedded index from the segment size in the horizontal writer, vertical
  writer, the flush-segment RPC path, the compaction link path, column-mode partial
  update, and the primary-key apply path (tablet_updates). data_disk_size now holds
  column data bytes only and stays non-negative; index_disk_size keeps counting the
  .vi; total_disk_size = data + index = column + all index = physical bytes.
- The primary-key apply path recomputes data/total from the on-disk segment file
  size, which excludes the .vi; it now reads the persisted standalone_index_size so
  it subtracts only the embedded index instead of clamping to zero for vector rowsets.
- Clamp negative/overflowing statistics to zero in get_segment_max_rows (with a
  warning) so rowsets persisted by an older BE degrade to max_segment_file_size
  instead of crashing.

standalone_index_size defaults to 0 for rowsets and messages written before this
change, which reproduces the previous behaviour, so old rowsets are safe and the
guard covers them until compaction rewrites them with correct sizes.

Add unit tests: CompactionUtilsTest.test_get_segment_max_rows_negative_inputs and
two RowsetTest cases asserting a standalone vector index is not subtracted from
data_disk_size and that RowsetMeta.standalone_index_size matches the .vi bytes.

Observability: get_segment_max_rows previously crashed silently; it now emits a
WARNING when it sees corrupted input statistics.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
