### PR TITLE
[BugFix] Compare JSON numbers above INT64_MAX without throwing

### DIFF
--- a/be/src/types/json_value.cpp
+++ b/be/src/types/json_value.cpp
@@ -234,6 +234,15 @@ static inline int cmpInt64(int64_t left, int64_t right) {
     return 0;
 }
 
+static inline int cmpUInt64(uint64_t left, uint64_t right) {
+    if (left < right) {
+        return -1;
+    } else if (left > right) {
+        return 1;
+    }
+    return 0;
+}
+
 static int sliceCompare(const vpack::Slice& left, const vpack::Slice& right) {
     if (left.isObject() && right.isObject()) {
         for (auto it : vpack::ObjectIterator(left)) {
@@ -270,8 +279,9 @@ static int sliceCompare(const vpack::Slice& left, const vpack::Slice& right) {
                 return left.getBool() - right.getBool();
             case vpack::ValueType::SmallInt:
             case vpack::ValueType::Int:
+                return cmpInt64(left.getIntUnchecked(), right.getIntUnchecked());
             case vpack::ValueType::UInt:
-                return cmpInt64(left.getInt(), right.getInt());
+                return cmpUInt64(left.getUIntUnchecked(), right.getUIntUnchecked());
             case vpack::ValueType::Double: {
                 return cmpDouble(left.getDouble(), right.getDouble());
             }
@@ -281,10 +291,9 @@ static int sliceCompare(const vpack::Slice& left, const vpack::Slice& right) {
                 // other types like illegal, none, min, max are considered equal
                 return 0;
             }
-        } else if (left.isInteger() && right.isInteger()) {
-            return cmpInt64(left.getInt(), right.getInt());
         } else {
-            return cmpDouble(left.getNumber<double>(), right.getNumber<double>());
+            // mixed number encodings (Int vs UInt, integer vs Double)
+            return cmpDouble(left.getNumericValue<double>(), right.getNumericValue<double>());
         }
     } else {
         if (left.type() == vpack::ValueType::MinKey) {

--- a/be/test/types/json_value_test.cpp
+++ b/be/test/types/json_value_test.cpp
@@ -173,6 +173,43 @@ TEST(JsonValueTest, CompareLargeIntegerArrays) {
     EXPECT_GT(neg_small.compare(neg_large), 0);
 }
 
+TEST(JsonValueTest, CompareUnsignedIntegersAboveInt64Max) {
+    // Numbers above INT64_MAX are stored as UInt. Comparing them used to call Slice::getInt(), which throws
+    // NumberOutOfRange, so the comparison escaped as an exception instead of returning an order. Bare scalars
+    // parse as strings, hence the arrays and objects.
+    auto v = [](const char* json) { return JsonValue::parse(json).value(); };
+    auto max_int64 = v("[9223372036854775807]");
+    auto two_pow_63 = v("[9223372036854775808]");
+    auto max_uint64 = v("[18446744073709551615]");
+    auto max_uint64_minus_1 = v("[18446744073709551614]");
+
+    // same encoding (UInt vs UInt): exact
+    EXPECT_GT(two_pow_63.compare(max_int64), 0);
+    EXPECT_LT(max_int64.compare(two_pow_63), 0);
+    EXPECT_GT(max_uint64.compare(max_uint64_minus_1), 0);
+    EXPECT_EQ(max_uint64.compare(v("[18446744073709551615]")), 0);
+    EXPECT_GT(v("[18446744073709551615]").compare(v("[1]")), 0);
+
+    // mixed encodings: negative Int vs large UInt, integer vs double
+    EXPECT_LT(v("[-1]").compare(max_uint64), 0);
+    EXPECT_LT(v("[-9223372036854775808]").compare(two_pow_63), 0);
+    EXPECT_GT(max_uint64.compare(v("[1.0e19]")), 0);
+    EXPECT_LT(two_pow_63.compare(v("[1.0e19]")), 0);
+    EXPECT_EQ(v("[10]").compare(v("[10.0]")), 0);
+
+    // nested inside objects, as produced by json_query on real documents
+    auto big_obj = v(R"({"a": 18446744073709551615})");
+    auto mid_obj = v(R"({"a": 9223372036854775808})");
+    EXPECT_GT(big_obj.compare(mid_obj), 0);
+    EXPECT_LT(mid_obj.compare(big_obj), 0);
+    EXPECT_EQ(big_obj.compare(v(R"({"a": 18446744073709551615})")), 0);
+
+    // the same values through the predicate operators
+    EXPECT_TRUE(big_obj > mid_obj);
+    EXPECT_FALSE(big_obj < mid_obj);
+    EXPECT_TRUE(big_obj == v(R"({"a": 18446744073709551615})"));
+}
+
 TEST(JsonValueTest, Hash) {
     JsonValue x = JsonValue::parse(R"({"a": 1, "b": 2})").value();
     JsonValue y = JsonValue::parse(R"({"b": 2, "a": 1})").value();


### PR DESCRIPTION
## Why I'm doing:

```
Built on a system without sched_getcpu() support. Performance may be impacted.terminate called after throwing an instance of 'arangodb::velocypack::Exception'
  what():  Number out of range
ovwfix-v6 RELEASE (build 387a1d6 distro ubuntu arch x86_64)
query_id:01a08a4b-d198-70d6-b0df-c02cf2d27602, fragment_instance:01a08a4b-d198-70d6-b0df-c02cf2d27603, plan_node_id:0
*** Aborted at 1789026619 (unix time) try "date -d @1789026619" if you are using GNU date ***
PC: @     0x7ff6c2c4cb2c pthread_kill
*** SIGABRT (@0x2e5cc) received by PID 189900 (TID 0x7ff516c626c0) LWP(190718) from PID 189900; stack trace: ***
    @     0x7ff6c2c4fed3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2)
    @          0xda92cc6 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7ff6c2bf3330 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4532f)
    @     0x7ff6c2c4cb2c pthread_kill
    @     0x7ff6c2bf327e gsignal
    @     0x7ff6c2bd68ff abort
    @          0x49646c2 __gnu_cxx::__verbose_terminate_handler() [clone .cold]
    @         0x11d0068a __cxxabiv1::__terminate(void (*)())
    @         0x11d006f5 std::terminate()
    @         0x11d00871 __cxa_throw
    @          0x9af8ee7 __wrap___cxa_throw
    @          0x4866561 arangodb::velocypack::Slice::getInt() const [clone .cold]
    @          0x9e74d66 starrocks::sliceCompare(arangodb::velocypack::Slice const&, arangodb::velocypack::Slice const&)
    @          0x9e7eaf1 starrocks::JsonValue::compare(starrocks::Slice const&, starrocks::Slice const&)
    @          0x88f60ff starrocks::Cow<starrocks::Column>::ImmutPtr<starrocks::Column> starrocks::UnpackConstColumnBinaryFunction<starrocks::BinaryPredFunc<std::greater<starrocks::JsonValue> > >::evaluate<(starrocks::LogicalType)54, (starrocks::LogicalType)54, (starrocks::Logical@
    @          0x88f633b starrocks::VectorizedBinaryPredicate<(starrocks::LogicalType)54, starrocks::BinaryPredFunc<std::greater<starrocks::JsonValue> > >::evaluate_checked(starrocks::ExprContext*, starrocks::Chunk*)
    @          0x8621959 starrocks::ExprContext::evaluate(starrocks::Expr*, starrocks::Chunk*, unsigned char*)
    @          0x862278f starrocks::ExprContext::evaluate(starrocks::Chunk*, unsigned char*)
    @          0x9611ef3 starrocks::ChunkPredicateEvaluator::eval_conjuncts(std::vector<starrocks::ExprContext*, std::allocator<starrocks::ExprContext*> > const&, starrocks::Chunk*, std::shared_ptr<std::vector<unsigned char, starrocks::ColumnAllocator<unsigned char> > >*, bool)
    @          0x55a3adf starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage(starrocks::RuntimeState*, starrocks::Chunk*)
    @          0x55a43cf starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @          0x5154b9d starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @          0x5011772 auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const [clone .isra.0]
    @          0x69572c0 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x9fd242d starrocks::ThreadPool::dispatch_thread()
    @          0x9fcac95 starrocks::Thread::supervise_thread(void*)
    @     0x7ff6c2c4aaa4 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x9caa3)
    @     0x7ff6c2cd7a64 __clone

```

`sliceCompare` compared every integer encoding through `Slice::getInt()`. velocypack stores non-negative integers as UInt, and `getInt()` throws `NumberOutOfRange` for a UInt above INT64_MAX, so comparing such a value (`json_query(j, '$.a') > ...` with a member like 18446744073709551615, or two documents containing one) threw an exception per row instead of returning an order. Nothing in the expression layer caught it: in a projection the query failed with "Internal error: Number out of range", and as an OLAP scan predicate the exception escaped the scan thread, which aborts the BE on main and hangs the query until `query_timeout` on branch-3.5.

Follow velocypack's own `NormalizedCompare::equalsNumbers` rules, extended to a three-way comparison: when both sides share an integer encoding compare them exactly with the unchecked accessors (Int and SmallInt as int64, UInt as uint64), and compare every other mix of number encodings as double via `getNumericValue<double>()`, which never throws for numbers. Parsed JSON stores non-negative integers as UInt and negative ones as Int, so the mixed-encoding case is a sign comparison that double represents exactly.

Verified on a branch-3.5 BE: 18446744073709551615 vs 9223372036854775808 now yields >, <, = correctly in projections and in a WHERE clause on an OLAP table, mixed negative/unsigned and integer/double comparisons are correct, and the BE stays up.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
