### PR TITLE
[BugFix] Bound only the pinned prefix of a multi-column RANGE partition in BE prune key ranges

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -145,6 +145,7 @@ import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.LiteralExprFactory;
+import com.starrocks.sql.ast.expression.MaxLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.TimestampArithmeticExpr;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -1208,6 +1209,16 @@ public class PlanFragmentBuilder {
             }
         }
     
+        /**
+         * A RANGE partition is an interval in the lexicographic order of the partition key tuple, so its
+         * endpoints bound the columns one at a time: the leading column lies within
+         * [lower[0], upper[0]], and column i is bounded by its own endpoint values only while every
+         * column before it is pinned to a single value (lower[j] == upper[j] for all j < i). Inside
+         * p = [(10, 10), (20, 20)) the second column can take any value at all - (11, 0) and (19, 25)
+         * both belong to p - and describing it as [10, 20] lets BE prune tablets that hold matching
+         * rows. The walk therefore stops at the first column that spans an interval; the columns
+         * behind it get no range, whether or not a predicate refers to them.
+         */
         private List<TKeyRange> computeRangePartitionKeyRanges(PartitionInfo partitionInfo, Partition partition,
                                                                List<Column> partitionCols,
                                                                Collection<Column> usedPartitionCols, long limit) {
@@ -1218,52 +1229,80 @@ public class PlanFragmentBuilder {
             }
 
             boolean isNullPartition = keyRange.lowerEndpoint().isMinValue();
-            long partitionValues = 1;
             List<TKeyRange> result = Lists.newArrayList();
     
             for (int i = 0; i < partitionCols.size(); i++) {
                 Column col = partitionCols.get(i);
-                if (!usedPartitionCols.contains(col)) {
-                    continue;
-                }
-    
-                TKeyRange kr = new TKeyRange();
-                long rangeSize;
-
-                if (col.getType().isDate()) {
-                    LiteralExpr lowerExpr = keyRange.lowerEndpoint().getKeys().get(i);
-                    LiteralExpr upperExpr = keyRange.upperEndpoint().getKeys().get(i);
-                    if (!(lowerExpr instanceof DateLiteral lower) || !(upperExpr instanceof DateLiteral upper)) {
-                        continue;
-                    }
-                    kr.setBegin_key(lower.getYear() * 10000 + lower.getMonth() * 100 + lower.getDay());
-                    kr.setEnd_key(upper.getYear() * 10000 + upper.getMonth() * 100 + upper.getDay());
-                    rangeSize = upper.toLocalDateTime().toLocalDate().toEpochDay()
-                            - lower.toLocalDateTime().toLocalDate().toEpochDay();
-                } else if (col.getType().isIntegerType()) {
-                    long lowerVal = keyRange.lowerEndpoint().getKeys().get(i).getLongValue();
-                    long upperVal = keyRange.upperEndpoint().getKeys().get(i).getLongValue();
-                    kr.setBegin_key(lowerVal);
-                    kr.setEnd_key(upperVal);
-                    rangeSize = upperVal - lowerVal;
-                } else {
-                    continue;
-                }
-
-                if (rangeSize <= 0 || wouldOverflowOrExceedLimit(partitionValues, rangeSize, limit)) {
+                LiteralExpr lowerExpr = keyRange.lowerEndpoint().getKeys().get(i);
+                LiteralExpr upperExpr = keyRange.upperEndpoint().getKeys().get(i);
+                if (lowerExpr instanceof MaxLiteral || upperExpr instanceof MaxLiteral) {
+                    // An open endpoint bounds nothing, here or in any column after it.
                     break;
                 }
-                partitionValues *= rangeSize;
-    
-                kr.setColumn_type(TypeSerializer.toThrift(col.getType().getPrimitiveType()));
-                // BE indexes the tuple's slots by col_name, which is the column id, so name the range by
-                // the id as well: a renamed partition column would otherwise be skipped and its
-                // scan ranges never pruned.
-                kr.setColumn_name(col.getColumnId().getId());
-                if (isNullPartition) {
-                    kr.setHas_null(true);
+
+                // A column is pinned when both endpoints agree on it, so the interval is carried by the
+                // columns after it. The NULL partition's lower endpoint is the type minimum standing in
+                // for NULL, and NULL is a value of its own: a leading key that may be NULL pins nothing.
+                boolean pinned = !isNullPartition && PartitionKey.compareLiteralExpr(lowerExpr, upperExpr) == 0;
+
+                long beginKey;
+                long endKey;
+                if (col.getType().isDate() && lowerExpr instanceof DateLiteral lower
+                        && upperExpr instanceof DateLiteral upper) {
+                    beginKey = lower.getYear() * 10000 + lower.getMonth() * 100 + lower.getDay();
+                    endKey = upper.getYear() * 10000 + upper.getMonth() * 100 + upper.getDay();
+                    if (!pinned) {
+                        long width = upper.toLocalDateTime().toLocalDate().toEpochDay()
+                                - lower.toLocalDateTime().toLocalDate().toEpochDay();
+                        if (width < 0 || width > limit) {
+                            break;
+                        }
+                    }
+                } else if (col.getType().isIntegerType()) {
+                    beginKey = lowerExpr.getLongValue();
+                    endKey = upperExpr.getLongValue();
+                    // BE materializes the range as `for (int64_t v = begin; v <= end; v++)`, which
+                    // never terminates once the end is the int64 maximum, so a BIGINT partition that
+                    // reaches it cannot be described here at all - pinned or not.
+                    if (endKey == Long.MAX_VALUE) {
+                        if (pinned) {
+                            continue;
+                        }
+                        break;
+                    }
+                    // BE enumerates [begin, end] inclusively; the half-open width is what the values
+                    // limit has always been compared against. A negative width is a long overflow.
+                    long width = endKey - beginKey;
+                    if (!pinned && (width < 0 || width > limit)) {
+                        break;
+                    }
+                } else if (pinned) {
+                    // A pinned column of a type BE cannot enumerate sends nothing, but the columns
+                    // behind it are still bounded.
+                    continue;
+                } else {
+                    break;
                 }
-                result.add(kr);
+
+                if (usedPartitionCols.contains(col)) {
+                    TKeyRange kr = new TKeyRange();
+                    kr.setBegin_key(beginKey);
+                    kr.setEnd_key(endKey);
+                    kr.setColumn_type(TypeSerializer.toThrift(col.getType().getPrimitiveType()));
+                    // BE indexes the tuple's slots by col_name, which is the column id, so name the range by
+                    // the id as well: a renamed partition column would otherwise be skipped and its
+                    // scan ranges never pruned.
+                    kr.setColumn_name(col.getColumnId().getId());
+                    if (isNullPartition) {
+                        kr.setHas_null(true);
+                    }
+                    result.add(kr);
+                }
+
+                if (!pinned) {
+                    // This column spans an interval, so the columns after it are unbounded.
+                    break;
+                }
             }
 
             return result;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MultiColumnRangePartitionKeyRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MultiColumnRangePartitionKeyRangeTest.java
@@ -1,0 +1,198 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.thrift.TKeyRange;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+/**
+ * The key ranges FE hands to BE for dynamic partition pruning must describe a superset of the values
+ * that can live in the partition, because BE drops a tablet outright when the partition conjuncts
+ * evaluate to false over the whole range.
+ * <p>
+ * A multi-column RANGE partition is an interval in the lexicographic order of the key tuple, so only
+ * the leading column is bounded by the endpoints. p1 = [(10,10), (20,20)) holds (11, 0) and (19, 25):
+ * id2 has no bound of its own until every column before it is pinned to a single value.
+ */
+public class MultiColumnRangePartitionKeyRangeTest {
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test_mcr").useDatabase("test_mcr")
+                .withTable("create table t2r(id1 int not null, id2 int not null, name varchar(25) not null)"
+                        + " duplicate key(id1) partition by range(id1, id2) ("
+                        + "  partition p0 values [('0', '0'), ('10', '10')),"
+                        + "  partition p1 values [('10', '10'), ('20', '20')),"
+                        + "  partition p2 values [('20', '20'), ('30', '30')))"
+                        + " distributed by hash(name) buckets 2 properties('replication_num' = '1');")
+                .withTable("create table t2r_fixed(id1 int not null, id2 int not null, name varchar(25) not null)"
+                        + " duplicate key(id1) partition by range(id1, id2) ("
+                        + "  partition p0 values [('5', '0'), ('5', '10')),"
+                        + "  partition p1 values [('5', '10'), ('5', '20')),"
+                        + "  partition p2 values [('6', '0'), ('7', '0')))"
+                        + " distributed by hash(name) buckets 2 properties('replication_num' = '1');")
+                .withTable("create table t1r_max(id1 int not null, name varchar(25) not null)"
+                        + " duplicate key(id1) partition by range(id1) ("
+                        + "  partition p0 values [('-200'), ('-100')),"
+                        + "  partition p1 values [('-100'), (maxvalue)))"
+                        + " distributed by hash(name) buckets 2 properties('replication_num' = '1');")
+                .withTable("create table t2r_null(id1 tinyint null, id2 tinyint not null, v int)"
+                        + " duplicate key(id1) partition by range(id1, id2) ("
+                        + "  partition p0 values less than ('-128', '10'),"
+                        + "  partition p1 values less than ('50', '0'))"
+                        + " distributed by hash(v) buckets 2 properties('replication_num' = '1');")
+                .withTable("create table t2r_bigmax(id1 bigint not null, id2 int not null, v int)"
+                        + " duplicate key(id1, id2) partition by range(id1, id2) ("
+                        + "  partition p0 values [('9223372036854775806', '0'), ('9223372036854775807', '0')),"
+                        + "  partition p1 values [('9223372036854775807', '0'), ('9223372036854775807', '100')))"
+                        + " distributed by hash(v) buckets 1 properties('replication_num' = '1');")
+                .withTable("create table t2r_nulltrail(id1 tinyint not null, id2 tinyint null, v int)"
+                        + " duplicate key(id1, id2) partition by range(id1, id2) ("
+                        + "  partition p0 values less than ('5'),"
+                        + "  partition p1 values less than ('5', '10'))"
+                        + " distributed by hash(v) buckets 2 properties('replication_num' = '1');")
+                .withTable("create table t2r_dt(ts datetime not null, id int not null, v int)"
+                        + " duplicate key(ts) partition by range(ts, id) ("
+                        + "  partition p0 values [('2024-01-01 00:00:00', '0'), ('2024-01-01 00:00:00', '100')),"
+                        + "  partition p1 values [('2024-01-02 00:00:00', '0'), ('2024-01-02 00:00:00', '100')))"
+                        + " distributed by hash(v) buckets 2 properties('replication_num' = '1');");
+    }
+
+    @Test
+    public void testNullPartitionPinsNothing() throws Exception {
+        // p0 = [(MIN, MIN), (-128, 10)) is the NULL partition: (NULL, 100) lands in it because NULL
+        // sorts below every id1, so id2 is unbounded there even though both endpoints read -128 on id1.
+        Assertions.assertEquals(List.of(),
+                keyRanges("t2r_null", "select v from test_mcr.t2r_null where id2 = 100"));
+        Assertions.assertEquals(List.of("p0:id1:-128--128:null", "p1:id1:-128-50"),
+                keyRanges("t2r_null", "select v from test_mcr.t2r_null where id1 <> 3 and id2 = 100"));
+    }
+
+    @Test
+    public void testPinnedPrefixAtTheIntegerMaximumSendsNoRange() throws Exception {
+        // BE materializes an integer range as `for (int64_t v = begin; v <= end; v++)`, which never
+        // terminates when end is the int64 maximum, so such a range must not be sent - pinned or not.
+        // p1 pins id1 to 9223372036854775807; id2 stays bounded because the prefix is still pinned.
+        Assertions.assertEquals(List.of("p1:id2:0-100"),
+                keyRanges("t2r_bigmax", "select v from test_mcr.t2r_bigmax where id1 > 0 and id2 < 5"));
+        Assertions.assertEquals(List.of(),
+                keyRanges("t2r_bigmax", "select v from test_mcr.t2r_bigmax where id1 <> 0"));
+    }
+
+    @Test
+    public void testNullableTrailingColumnBehindAPinnedPrefix() throws Exception {
+        // p1 = [(5, -128), (5, 10)) cannot hold (5, NULL): BE orders NULL below the type minimum, so
+        // such a row lands in p0 = [(MIN, MIN), (5, -128)) instead. p1's id2 range is therefore
+        // exact without a NULL of its own, while p0 is the one that carries has_null.
+        // p0's own leading column spans [MIN, 5] and is not pinned, so p0 sends nothing at all.
+        Assertions.assertEquals(List.of("p1:id2:-128-10"),
+                keyRanges("t2r_nulltrail", "select v from test_mcr.t2r_nulltrail where id2 <> 3"));
+    }
+
+    @Test
+    public void testPinnedLeadingColumnOfAnUnsupportedTypeStillBoundsTheTrailingColumn() throws Exception {
+        // BE cannot enumerate a DATETIME, so ts gets no range of its own, but each partition pins it
+        // and id stays bounded.
+        Assertions.assertEquals(List.of("p0:id:0-100", "p1:id:0-100"),
+                keyRanges("t2r_dt", "select v from test_mcr.t2r_dt where id > 500"));
+        Assertions.assertEquals(List.of("p0:id:0-100", "p1:id:0-100"),
+                keyRanges("t2r_dt", "select v from test_mcr.t2r_dt where ts <> '2024-01-05 00:00:00' and id > 500"));
+    }
+
+    @Test
+    public void testOpenUpperBoundGetsNoRange() throws Exception {
+        // MaxLiteral reads as 0 through getLongValue(), so a partition [-100, MAXVALUE) used to be
+        // described as [-100, 0] and `id1 > 0` pruned every tablet of it. FE itself drops p0 here,
+        // so p1 is the only partition left and it must carry no range.
+        Assertions.assertEquals(List.of(),
+                keyRanges("t1r_max", "select name from test_mcr.t1r_max where id1 > 0"));
+        // `<>` keeps both partitions in the plan: the bounded one is described, the open one is not.
+        Assertions.assertEquals(List.of("p0:id1:-200--100"),
+                keyRanges("t1r_max", "select name from test_mcr.t1r_max where id1 <> -150"));
+    }
+
+    @Test
+    public void testTrailingColumnGetsNoRangeWhenLeadingColumnIsNotFixed() throws Exception {
+        // Before the fix p1 was described as id2 in [10, 20], and `id2 <= 8` pruned the tablet that
+        // holds (11, 0) and (11, 1).
+        Assertions.assertEquals(List.of(), keyRanges("t2r", "select name from test_mcr.t2r where id2 <= 8"),
+                "id2 is unbounded inside every partition of t2r, so no range may be sent for it");
+        Assertions.assertEquals(List.of(), keyRanges("t2r", "select name from test_mcr.t2r where id2 = 25"));
+    }
+
+    @Test
+    public void testLeadingColumnKeepsItsRange() throws Exception {
+        // `<>` is not something FE prunes range partitions by, so all three reach the plan.
+        Assertions.assertEquals(List.of("p0:id1:0-10", "p1:id1:10-20", "p2:id1:20-30"),
+                keyRanges("t2r", "select name from test_mcr.t2r where id1 <> 11"));
+        // FE keeps only p1 for id1 = 11; of the two predicate columns only the leading one is bounded.
+        Assertions.assertEquals(List.of("p1:id1:10-20"),
+                keyRanges("t2r", "select name from test_mcr.t2r where id1 = 11 and id2 <= 8"));
+    }
+
+    @Test
+    public void testTrailingColumnIsBoundedOnlyBehindAFixedPrefix() throws Exception {
+        // p0 and p1 pin id1 to 5, so their id2 bounds are exact; p2 spans id1 in [6, 7] and says
+        // nothing about id2. id1 is not in the predicate, so it gets no range of its own.
+        Assertions.assertEquals(List.of("p0:id2:0-10", "p1:id2:10-20"),
+                keyRanges("t2r_fixed", "select name from test_mcr.t2r_fixed where id2 <= 8"));
+        // With id1 pinned FE can prune by id2 too and keeps only p0; it pins id1, so id2 is bounded.
+        Assertions.assertEquals(List.of("p0:id1:5-5", "p0:id2:0-10"),
+                keyRanges("t2r_fixed", "select name from test_mcr.t2r_fixed where id1 = 5 and id2 <= 8"));
+        Assertions.assertEquals(List.of("p0:id1:5-5", "p0:id2:0-10", "p1:id1:5-5", "p1:id2:10-20"),
+                keyRanges("t2r_fixed", "select name from test_mcr.t2r_fixed where id1 = 5 and id2 <> 8"));
+        // p2 spans id1 in [6, 7], so nothing is said about id2 there.
+        Assertions.assertEquals(List.of("p2:id1:6-7"),
+                keyRanges("t2r_fixed", "select name from test_mcr.t2r_fixed where id1 = 6 and id2 <= 8"));
+    }
+
+    /** Every TKeyRange in the plan as "partition:column:begin-end[:null]", deduplicated and sorted. */
+    private static List<String> keyRanges(String table, String sql) throws Exception {
+        OlapTable olapTable = (OlapTable) starRocksAssert.getTable("test_mcr", table);
+        List<String> ranges = Lists.newArrayList();
+        for (Pair<Long, TKeyRange> range : ScanRangeKeyRanges.collect(connectContext, sql)) {
+            // The scan range names the physical partition; report the logical one it belongs to.
+            PhysicalPartition physical = olapTable.getPhysicalPartition(range.first);
+            String partition = olapTable.getPartition(physical.getParentId()).getName();
+            TKeyRange keyRange = range.second;
+            Assertions.assertTrue(keyRange.isSetBegin_key() && keyRange.isSetEnd_key(),
+                    "a RANGE partition column range carries begin/end keys");
+            ranges.add(partition + ":" + keyRange.getColumn_name() + ":" + keyRange.getBegin_key() + "-"
+                    + keyRange.getEnd_key() + (keyRange.isHas_null() ? ":null" : ""));
+        }
+        // Each bucket repeats its partition's ranges; the claim is about the set.
+        return ranges.stream().distinct().sorted().toList();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PartitionKeyRangeColumnIdTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PartitionKeyRangeColumnIdTest.java
@@ -19,10 +19,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.plan.ExecPlan;
-import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TKeyRange;
-import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -74,20 +71,9 @@ public class PartitionKeyRangeColumnIdTest {
     }
 
     private static List<String> rangeColumnNames(String sql) throws Exception {
-        connectContext.setQueryId(UUIDUtil.genUUID());
-        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
-        Pair<String, ExecPlan> plan = UtFrameUtils.getPlanAndFragment(connectContext, sql);
         List<String> names = Lists.newArrayList();
-        for (ScanNode scanNode : plan.second.getScanNodes()) {
-            for (TScanRangeLocations locations : scanNode.getScanRangeLocations(0)) {
-                TInternalScanRange range = locations.getScan_range().getInternal_scan_range();
-                if (range == null || range.getPartition_column_ranges() == null) {
-                    continue;
-                }
-                for (TKeyRange keyRange : range.getPartition_column_ranges()) {
-                    names.add(keyRange.getColumn_name());
-                }
-            }
+        for (Pair<Long, TKeyRange> range : ScanRangeKeyRanges.collect(connectContext, sql)) {
+            names.add(range.second.getColumn_name());
         }
         Assertions.assertFalse(names.isEmpty(), "the plan must carry partition column ranges at all");
         return names;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/ScanRangeKeyRanges.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/ScanRangeKeyRanges.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TInternalScanRange;
+import com.starrocks.thrift.TKeyRange;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.utframe.UtFrameUtils;
+
+import java.util.List;
+
+/**
+ * Plans a statement and collects the partition column ranges FE attaches to every OLAP scan range,
+ * paired with the physical partition id the scan range belongs to. Shared by the tests that pin down
+ * what dynamic partition pruning hands to BE.
+ */
+final class ScanRangeKeyRanges {
+    private ScanRangeKeyRanges() {
+    }
+
+    /** Every (physical partition id, key range) pair in the plan, in scan range order. */
+    static List<Pair<Long, TKeyRange>> collect(ConnectContext connectContext, String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        Pair<String, ExecPlan> plan = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        List<Pair<Long, TKeyRange>> ranges = Lists.newArrayList();
+        for (ScanNode scanNode : plan.second.getScanNodes()) {
+            for (TScanRangeLocations locations : scanNode.getScanRangeLocations(0)) {
+                TInternalScanRange range = locations.getScan_range().getInternal_scan_range();
+                if (range == null || range.getPartition_column_ranges() == null) {
+                    continue;
+                }
+                for (TKeyRange keyRange : range.getPartition_column_ranges()) {
+                    ranges.add(Pair.create(range.getPartition_id(), keyRange));
+                }
+            }
+        }
+        return ranges;
+    }
+}

--- a/test/sql/test_dynamic_partition_prune/R/test_dynamic_partition_be_prune
+++ b/test/sql/test_dynamic_partition_prune/R/test_dynamic_partition_be_prune
@@ -719,3 +719,192 @@ drop table t_null_combined force;
 drop database test_dyn_prune_${uuid0} force;
 -- result:
 -- !result
+-- name: test_range_partition_prune_multi_column
+create database test_dyn_prune_${uuid0};
+-- result:
+-- !result
+use test_dyn_prune_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_range_multi (
+    id1 INT NOT NULL,
+    id2 INT NOT NULL,
+    name VARCHAR(25) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1, id2) (
+    PARTITION p0 VALUES [("0", "0"), ("10", "10")),
+    PARTITION p1 VALUES [("10", "10"), ("20", "20")),
+    PARTITION p2 VALUES [("20", "20"), ("30", "30"))
+)
+DISTRIBUTED BY HASH(name) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_range_multi VALUES (11, 0, 'a'), (11, 1, 'b'), (5, 9, 'c'), (25, 3, 'd'), (10, 10, 'e'), (19, 25, 'f'), (3, 3, 'g');
+-- result:
+-- !result
+SELECT name FROM t_range_multi WHERE id2 <= 8 ORDER BY name;
+-- result:
+a
+b
+d
+g
+-- !result
+SELECT name FROM t_range_multi WHERE id2 = 25 ORDER BY name;
+-- result:
+f
+-- !result
+SELECT count(*) FROM t_range_multi WHERE id2 > 8;
+-- result:
+3
+-- !result
+SELECT name FROM t_range_multi WHERE id1 <= 8 ORDER BY name;
+-- result:
+c
+g
+-- !result
+SELECT name FROM t_range_multi WHERE id1 = 11 AND id2 <= 8 ORDER BY name;
+-- result:
+a
+b
+-- !result
+SELECT count(*) FROM t_range_multi;
+-- result:
+7
+-- !result
+drop table t_range_multi force;
+-- result:
+-- !result
+drop database test_dyn_prune_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_range_partition_prune_multi_column_pinned_prefix
+create database test_dyn_prune_${uuid0};
+-- result:
+-- !result
+use test_dyn_prune_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_range_multi_fixed (
+    id1 INT NOT NULL,
+    id2 INT NOT NULL,
+    name VARCHAR(25) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1, id2) (
+    PARTITION p0 VALUES [("5", "0"), ("5", "10")),
+    PARTITION p1 VALUES [("5", "10"), ("5", "20")),
+    PARTITION p2 VALUES [("6", "0"), ("7", "0"))
+)
+DISTRIBUTED BY HASH(name) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_range_multi_fixed VALUES (5, 3, 'a'), (5, 15, 'b'), (6, 15, 'c'), (6, 3, 'd');
+-- result:
+-- !result
+SELECT name FROM t_range_multi_fixed WHERE id2 <= 8 ORDER BY name;
+-- result:
+a
+d
+-- !result
+SELECT name FROM t_range_multi_fixed WHERE id2 > 8 ORDER BY name;
+-- result:
+b
+c
+-- !result
+SELECT name FROM t_range_multi_fixed WHERE id1 = 5 AND id2 > 8 ORDER BY name;
+-- result:
+b
+-- !result
+drop table t_range_multi_fixed force;
+-- result:
+-- !result
+drop database test_dyn_prune_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_range_partition_prune_multi_column_null_partition @native
+create database test_dyn_prune_${uuid0};
+-- result:
+-- !result
+use test_dyn_prune_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_range_multi_null (
+    id1 TINYINT NULL,
+    id2 TINYINT NOT NULL,
+    v INT
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1, id2) (
+    PARTITION p0 VALUES LESS THAN ("-128", "10"),
+    PARTITION p1 VALUES LESS THAN ("50", "0")
+)
+DISTRIBUTED BY HASH(v) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_range_multi_null VALUES (NULL, 100, 1), (-100, 5, 2), (20, 3, 3);
+-- result:
+-- !result
+SELECT v FROM t_range_multi_null WHERE id2 = 100;
+-- result:
+1
+-- !result
+SELECT v FROM t_range_multi_null WHERE id2 <= 5 ORDER BY v;
+-- result:
+2
+3
+-- !result
+SELECT count(*) FROM t_range_multi_null;
+-- result:
+3
+-- !result
+drop table t_range_multi_null force;
+-- result:
+-- !result
+drop database test_dyn_prune_${uuid0} force;
+-- result:
+-- !result
+
+-- name: test_range_partition_prune_open_upper_bound
+create database test_dyn_prune_${uuid0};
+-- result:
+-- !result
+use test_dyn_prune_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t_range_maxvalue (
+    id1 INT NOT NULL,
+    name VARCHAR(25) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1) (
+    PARTITION p0 VALUES [("-200"), ("-100")),
+    PARTITION p1 VALUES [("-100"), (MAXVALUE))
+)
+DISTRIBUTED BY HASH(name) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_range_maxvalue VALUES (-150, 'a'), (-50, 'b'), (50, 'c');
+-- result:
+-- !result
+SELECT name FROM t_range_maxvalue WHERE id1 > 0 ORDER BY name;
+-- result:
+c
+-- !result
+SELECT name FROM t_range_maxvalue WHERE id1 > -60 ORDER BY name;
+-- result:
+b
+c
+-- !result
+drop table t_range_maxvalue force;
+-- result:
+-- !result
+drop database test_dyn_prune_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_dynamic_partition_prune/T/test_dynamic_partition_be_prune
+++ b/test/sql/test_dynamic_partition_prune/T/test_dynamic_partition_be_prune
@@ -544,3 +544,111 @@ SELECT COUNT(*) FROM t_null_combined WHERE dt IS NOT NULL AND category = 1;
 
 drop table t_null_combined force;
 drop database test_dyn_prune_${uuid0} force;
+
+-- name: test_range_partition_prune_multi_column
+create database test_dyn_prune_${uuid0};
+use test_dyn_prune_${uuid0};
+CREATE TABLE t_range_multi (
+    id1 INT NOT NULL,
+    id2 INT NOT NULL,
+    name VARCHAR(25) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1, id2) (
+    PARTITION p0 VALUES [("0", "0"), ("10", "10")),
+    PARTITION p1 VALUES [("10", "10"), ("20", "20")),
+    PARTITION p2 VALUES [("20", "20"), ("30", "30"))
+)
+DISTRIBUTED BY HASH(name) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_range_multi VALUES (11, 0, 'a'), (11, 1, 'b'), (5, 9, 'c'), (25, 3, 'd'), (10, 10, 'e'), (19, 25, 'f'), (3, 3, 'g');
+
+-- p1 = [(10,10), (20,20)) holds (11,0), (11,1) and (19,25): id2 is unbounded inside a multi-column range
+SELECT name FROM t_range_multi WHERE id2 <= 8 ORDER BY name;
+SELECT name FROM t_range_multi WHERE id2 = 25 ORDER BY name;
+SELECT count(*) FROM t_range_multi WHERE id2 > 8;
+SELECT name FROM t_range_multi WHERE id1 <= 8 ORDER BY name;
+SELECT name FROM t_range_multi WHERE id1 = 11 AND id2 <= 8 ORDER BY name;
+SELECT count(*) FROM t_range_multi;
+
+drop table t_range_multi force;
+drop database test_dyn_prune_${uuid0} force;
+
+-- name: test_range_partition_prune_multi_column_pinned_prefix
+create database test_dyn_prune_${uuid0};
+use test_dyn_prune_${uuid0};
+-- a leading column pinned to one value makes the trailing column's bound exact
+CREATE TABLE t_range_multi_fixed (
+    id1 INT NOT NULL,
+    id2 INT NOT NULL,
+    name VARCHAR(25) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1, id2) (
+    PARTITION p0 VALUES [("5", "0"), ("5", "10")),
+    PARTITION p1 VALUES [("5", "10"), ("5", "20")),
+    PARTITION p2 VALUES [("6", "0"), ("7", "0"))
+)
+DISTRIBUTED BY HASH(name) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_range_multi_fixed VALUES (5, 3, 'a'), (5, 15, 'b'), (6, 15, 'c'), (6, 3, 'd');
+
+SELECT name FROM t_range_multi_fixed WHERE id2 <= 8 ORDER BY name;
+SELECT name FROM t_range_multi_fixed WHERE id2 > 8 ORDER BY name;
+SELECT name FROM t_range_multi_fixed WHERE id1 = 5 AND id2 > 8 ORDER BY name;
+
+drop table t_range_multi_fixed force;
+drop database test_dyn_prune_${uuid0} force;
+
+-- name: test_range_partition_prune_multi_column_null_partition @native
+create database test_dyn_prune_${uuid0};
+use test_dyn_prune_${uuid0};
+-- the NULL partition's lower bound is the type minimum standing in for NULL; (NULL, 100) lands in
+-- p0 = [(MIN, MIN), (-128, 10)) although id2 = 100 is outside its id2 endpoints
+CREATE TABLE t_range_multi_null (
+    id1 TINYINT NULL,
+    id2 TINYINT NOT NULL,
+    v INT
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1, id2) (
+    PARTITION p0 VALUES LESS THAN ("-128", "10"),
+    PARTITION p1 VALUES LESS THAN ("50", "0")
+)
+DISTRIBUTED BY HASH(v) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_range_multi_null VALUES (NULL, 100, 1), (-100, 5, 2), (20, 3, 3);
+
+SELECT v FROM t_range_multi_null WHERE id2 = 100;
+SELECT v FROM t_range_multi_null WHERE id2 <= 5 ORDER BY v;
+SELECT count(*) FROM t_range_multi_null;
+
+drop table t_range_multi_null force;
+drop database test_dyn_prune_${uuid0} force;
+
+-- name: test_range_partition_prune_open_upper_bound
+create database test_dyn_prune_${uuid0};
+use test_dyn_prune_${uuid0};
+-- an open upper bound is not a bound: [(-100), MAXVALUE) must not be read as [-100, 0]
+CREATE TABLE t_range_maxvalue (
+    id1 INT NOT NULL,
+    name VARCHAR(25) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(id1)
+PARTITION BY RANGE(id1) (
+    PARTITION p0 VALUES [("-200"), ("-100")),
+    PARTITION p1 VALUES [("-100"), (MAXVALUE))
+)
+DISTRIBUTED BY HASH(name) BUCKETS 2
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_range_maxvalue VALUES (-150, 'a'), (-50, 'b'), (50, 'c');
+
+SELECT name FROM t_range_maxvalue WHERE id1 > 0 ORDER BY name;
+SELECT name FROM t_range_maxvalue WHERE id1 > -60 ORDER BY name;
+
+drop table t_range_maxvalue force;
+drop database test_dyn_prune_${uuid0} force;


### PR DESCRIPTION


The key ranges FE hands to BE for dynamic partition pruning must cover every value a partition can hold, because BE drops a tablet outright once the partition conjuncts are false over the whole range.

computeRangePartitionKeyRanges read the endpoints column by column, so a multi-column RANGE partition p1 = [(10, 10), (20, 20)) was described as id2 in [10, 20]. The endpoints are a lexicographic interval over the key tuple: only the leading column is bounded, and column i has a bound of its own only while every column before it is pinned to one value. p1 holds (11, 0), (11, 1) and (19, 25), and `WHERE id2 <= 8` or `WHERE id2 = 25` silently lost those rows while EXPLAIN still showed partitions=3/3. No session variable disables this path.

Walk the columns in order and stop at the first one that spans an interval; columns behind it get no range whether or not a predicate refers to them. A pinned column contributes a single value, so a leading column fixed to 5 still lets the trailing column's bound through, and a pinned column of a type BE cannot enumerate (DATETIME, LARGEINT) is skipped rather than ending the walk. The NULL partition's lower endpoint is the type minimum standing in for NULL, so a leading column whose upper key equals that minimum is not pinned: (NULL, 100) lands in [(MIN, MIN), (-128, 10)) with id2 unbounded.

MaxLiteral reads as 0 through getLongValue(), so a single-column partition [(-100), MAXVALUE) was described as [-100, 0] and `WHERE id1 > 0` pruned every tablet of it. An open endpoint now ends the walk as well.

Observability: planner-only change; the existing partition-prune EXPLAIN output and scan range counters are unchanged.

Verified with the new FE unit tests (each fails on the old code: id2 ranges [0-10]/[10-20]/[20-30] and [-100, 0] were emitted, the NULL partition's trailing column was bounded, a pinned DATETIME prefix lost its trailing bound) and by replaying the new SQLTest cases against a cluster with and without the fix (rows were lost before, all match after).

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
