### PR TITLE
[UT] Move three long-stable SQL-Tester cases off the PR sequential pass

### DIFF
--- a/test/sql/test_agg_function/R/test_approx_top_k
+++ b/test/sql/test_agg_function/R/test_approx_top_k
@@ -1056,7 +1056,7 @@ SELECT c_partition, APPROX_TOP_K(c_bool, 3, 10) OVER(PARTITION BY c_partition) F
 3	[{"item":null,"count":5}]
 3	[{"item":null,"count":5}]
 -- !result
--- name: test_approx_top_k_tpch @sequential
+-- name: test_approx_top_k_tpch @sequential @slow
 function: prepare_data("tpch", "${db[0]}")
 -- result:
 None

--- a/test/sql/test_agg_function/T/test_approx_top_k
+++ b/test/sql/test_agg_function/T/test_approx_top_k
@@ -333,7 +333,7 @@ SELECT c_partition, APPROX_TOP_K(c_bool) OVER(PARTITION BY c_partition) FROM t_b
 SELECT c_partition, APPROX_TOP_K(c_bool, 10) OVER(PARTITION BY c_partition) FROM t_bool ORDER BY c_partition;
 SELECT c_partition, APPROX_TOP_K(c_bool, 3, 10) OVER(PARTITION BY c_partition) FROM t_bool ORDER BY c_partition;
 
--- name: test_approx_top_k_tpch @sequential
+-- name: test_approx_top_k_tpch @sequential @slow
 function: prepare_data("tpch", "${db[0]}")
 SELECT APPROX_TOP_K(L_LINENUMBER) FROM lineitem;
 SELECT APPROX_TOP_K(L_LINENUMBER, 1) FROM lineitem;

--- a/test/sql/test_iceberg/R/test_iceberg_delete_partitioned
+++ b/test/sql/test_iceberg/R/test_iceberg_delete_partitioned
@@ -1,4 +1,4 @@
--- name: test_iceberg_delete_partitioned @sequential
+-- name: test_iceberg_delete_partitioned @sequential @slow
 create external catalog iceberg_del_part_${uuid0}
 PROPERTIES ( "type"  =  "iceberg",
     "iceberg.catalog.type"  =  "hive",

--- a/test/sql/test_iceberg/T/test_iceberg_delete_partitioned
+++ b/test/sql/test_iceberg/T/test_iceberg_delete_partitioned
@@ -1,4 +1,4 @@
--- name: test_iceberg_delete_partitioned @sequential
+-- name: test_iceberg_delete_partitioned @sequential @slow
 
 create external catalog iceberg_del_part_${uuid0}
 PROPERTIES ( "type"  =  "iceberg",

--- a/test/sql/test_join/R/test_join_linear_chained
+++ b/test/sql/test_join/R/test_join_linear_chained
@@ -1,4 +1,4 @@
--- name: test_join_linear_chained @sequential
+-- name: test_join_linear_chained @sequential @slow
 set enable_hash_join_range_direct_mapping_opt = false;
 -- result:
 -- !result

--- a/test/sql/test_join/R/test_join_one_key
+++ b/test/sql/test_join/R/test_join_one_key
@@ -1,4 +1,4 @@
--- name: test_join_one_key @sequential
+-- name: test_join_one_key @sequential @slow
 CREATE TABLE __row_util_base (
   k1 bigint NULL
 ) ENGINE=OLAP

--- a/test/sql/test_join/R/test_join_range_direct_mapping
+++ b/test/sql/test_join/R/test_join_range_direct_mapping
@@ -1,4 +1,4 @@
--- name: test_join_range_direct_mapping @sequential
+-- name: test_join_range_direct_mapping @sequential @slow
 CREATE TABLE __row_util_base (
   k1 bigint NULL
 ) ENGINE=OLAP

--- a/test/sql/test_join/T/test_join_linear_chained
+++ b/test/sql/test_join/T/test_join_linear_chained
@@ -1,4 +1,4 @@
--- name: test_join_linear_chained @sequential
+-- name: test_join_linear_chained @sequential @slow
 
 set enable_hash_join_range_direct_mapping_opt = false;
 set enable_partition_hash_join = false;

--- a/test/sql/test_join/T/test_join_one_key
+++ b/test/sql/test_join/T/test_join_one_key
@@ -1,4 +1,4 @@
--- name: test_join_one_key @sequential
+-- name: test_join_one_key @sequential @slow
 CREATE TABLE __row_util_base (
   k1 bigint NULL
 ) ENGINE=OLAP

--- a/test/sql/test_join/T/test_join_range_direct_mapping
+++ b/test/sql/test_join/T/test_join_range_direct_mapping
@@ -1,4 +1,4 @@
--- name: test_join_range_direct_mapping @sequential
+-- name: test_join_range_direct_mapping @sequential @slow
 
 CREATE TABLE __row_util_base (
   k1 bigint NULL

--- a/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/R/test_parse_and_rewrite_or_predicate
@@ -1,4 +1,4 @@
--- name: test_parse_and_rewrite_or_predicate @sequential
+-- name: test_parse_and_rewrite_or_predicate @sequential @slow
 set scan_or_to_union_limit = 1;
 -- result:
 -- !result

--- a/test/sql/test_scan/test_pushdown_or_predicate/T/test_parse_and_rewrite_or_predicate
+++ b/test/sql/test_scan/test_pushdown_or_predicate/T/test_parse_and_rewrite_or_predicate
@@ -1,4 +1,4 @@
--- name: test_parse_and_rewrite_or_predicate @sequential
+-- name: test_parse_and_rewrite_or_predicate @sequential @slow
 
 -- Setup configs.
 set scan_or_to_union_limit = 1;


### PR DESCRIPTION
## Why I'm doing:

**This PR doubles as a probe for StarRocks/ci-tool#5277** (`alter_scheduler_interval_millisecond` 10s → 1s), which just merged. It is test-only, so it triggers SQL-Tester on the cheapest build path. The tag change below is wanted on its own merits, so nothing here is throwaway.

Separately, these three cases burn 235s of serial wall clock on every PR while covering paths that have not changed in months.

## What I'm doing:

Tag three cases `@slow` in addition to `@sequential`:

| case | measured | why it is expensive |
|---|---|---|
| `test_join_linear_chained` | 110.7s | 45 self-joins over 2.56M rows, with `enable_hash_join_range_direct_mapping_opt` and `enable_partition_hash_join` deliberately off |
| `test_approx_top_k_tpch` | 70.4s | loads TPC-H SF1 (~1GB, serial stream loads) to run 6 queries |
| `test_join_one_key` | ~54s | 87 self-joins over 1.28M rows |
| `test_parse_and_rewrite_or_predicate` | 43.8s | 210 queries over two 1.28M-row tables, t2 an aggregate table loaded twice |
| `test_join_range_direct_mapping` | 36.0s | 56 self-joins, every one a `[broadcast]` join, 20 of them doubling both sides to 2.56M rows through a union-all CTE |
| `test_iceberg_delete_partitioned` | 17.6s | ~66 round trips to a Hive Metastore and OSS on tables of at most 15 rows |

Timings come from the `⌛️ Time spent` report of run 34445532823. That report only lists cases over 60s, which is why `test_join_one_key` is absent from it.

A note on `test_iceberg_delete_partitioned`, since it is the one case here whose cost is not CPU. Its 17.6s is almost entirely network wait: 8 tables, 12 inserts, 12 deletes and 22 selects, each against a Hive Metastore and OSS. An Iceberg delete rewrites data files and commits a new snapshot however few rows it removes, and the catalog is created with `enable_iceberg_metadata_cache=false`, so every select re-reads the metadata chain from object storage.

That makes it a poor fit for a pass that cannot overlap it with anything - it would be an ideal concurrent case, since the CPU sits idle. But running it concurrently is not on the table: `@sequential` and the disabled cache both arrived together in fd465b6c3e0 (#68594), "Fix unstable UT", across three iceberg delete cases. Undoing either without knowing what was failing would be trading a known cost for an unknown flake. Moving it to the weekly pass keeps that fix intact.

The delete coverage itself is not lost - `test_iceberg_delete_unpartitioned` and `test_iceberg_delete_partition_transform` stay in the per-PR pass, and this case still runs weekly. If reviewers would rather keep all three per-PR, dropping this one tag is fine by me; it is 17.6s of the 337s this PR moves.

One note on the fourth case. The view it reads to check predicate pushdown is stubbed out:

```sql
create view __pred_profile(idx, k, v) as
select 1, 2, 3;
-- TODO: use the real profile view
```

so 141 of its recorded assertions are the constant `1 2 3`, and the synchronous profile collection its 210 queries still pay for has no consumer. Restoring the real view is the fix worth making and belongs to whoever owns that TODO. Tagging keeps the cost off every PR in the meantime; it does not make the case verify less than it does today.

`ci-tool/bin/run-sql-tester.sh` already passes `!slow` on the per-PR sequential pass and picks these up again in the weekly `slow,sequential` pass, so no CI change is needed. `@sequential @slow` is established: nine cases already carry both.

### What to look for in this run

1. **`test_load_channel_profile` should drop from 65.4s to single digits.** It loads 12 rows total; nearly all of that time was waiting out 10s alter-scheduler ticks while building two sync MVs.
2. **The three cases above should disappear from the sequential report**, confirming the tags work.
3. **`test_add_column` and `test_schema_change_and_insert_concurrent`** are the only two cases that depend on observing an intermediate alter state. Both pin the job with an uncommitted transaction rather than relying on a slow scheduler, so a faster tick should not hurt them — but that is reasoning, not a measurement.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)


