### PR TITLE
[BugFix] Fix read overflow in convert_hash_set_to_chunk

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -1148,6 +1148,12 @@ const uint8_t* BinaryColumnBase<T>::deserialize_and_append(const uint8_t* pos) {
 
 template <typename T>
 void BinaryColumnBase<T>::deserialize_and_append_batch(Buffer<Slice>& srcs, size_t chunk_size) {
+    // Callers hand down a full-size slice buffer and a row count, and the entries past that count
+    // may still be default constructed -- Slice() points its data at a 1-byte "" literal. Bail out
+    // before the reserve heuristic peeks at srcs[0], which would read past that literal.
+    if (chunk_size == 0) {
+        return;
+    }
     // max size of one string is 2^32, so use uint32_t not T
     uint32_t string_size = *((uint32_t*)srcs[0].data);
     get_bytes().reserve(chunk_size * string_size * 2);
@@ -1212,6 +1218,11 @@ void BinaryColumnBase<T>::serialize_batch_with_null_masks(uint8_t* dst, Buffer<u
 template <typename T>
 void BinaryColumnBase<T>::deserialize_and_append_batch_nullable(Buffer<Slice>& srcs, size_t chunk_size,
                                                                 Buffer<uint8_t>& is_nulls, bool& has_null) {
+    // See deserialize_and_append_batch(): srcs[0] is only guaranteed to be a real key when there
+    // is at least one row to append.
+    if (chunk_size == 0) {
+        return;
+    }
     const uint32_t string_size = *((bool*)srcs[0].data) // is null
                                          ? 4
                                          : *((uint32_t*)(srcs[0].data + sizeof(bool))); // first string size

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -1873,7 +1873,11 @@ void Aggregator::convert_hash_set_to_chunk(int32_t chunk_size, ChunkPtr* chunk) 
             ++it;
         }
 
-        {
+        // A streaming DISTINCT aggregation re-drains the hash set every time the sink re-arms
+        // streaming_all_states, so this can run right after reset_state() emptied it. results is
+        // then a buffer of default constructed keys with nothing to deserialize out of it; mirror
+        // the read_index > 0 guard convert_hash_map_to_chunk() already has.
+        if (read_index > 0) {
             SCOPED_TIMER(_agg_stat->group_by_append_timer);
             hash_set.insert_keys_to_columns(hash_set.results, group_by_columns, read_index);
         }

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -750,4 +750,40 @@ PARALLEL_TEST(BinaryColumnTest, test_append_cross_type_large_to_binary_unsupport
     ASSERT_DEATH_IF_SUPPORTED(dst->append(*src, 0, 1), "incompatible column type");
 }
 
+
+// Regression test for the ASAN global-buffer-overflow reported as StarRocksTest#12188:
+//   BinaryColumnBase<uint32_t>::deserialize_and_append_batch_nullable() <- NullableColumn::
+//   deserialize_and_append_batch() <- AggHashSetOfSerializedKey::insert_keys_to_columns() <-
+//   Aggregator::convert_hash_set_to_chunk().
+//
+// convert_hash_set_to_chunk() sizes `hash_set.results` to the whole chunk size and then fills only
+// the first `read_index` entries. A streaming DISTINCT aggregation that AggregateDistinctStreaming
+// SourceOperator::_output_chunk_from_hash_set() has just reset drains a brand new, empty hash set,
+// so read_index is 0 and every Slice in the buffer is still default constructed -- Slice() points
+// its data at the 1-byte "" literal. Both deserialize_and_append_batch overloads peeked at srcs[0]
+// to size a reserve() before consulting chunk_size, reading 4 bytes off the end of that literal.
+//
+// Deserializing zero rows must not touch srcs[0] at all.
+// NOLINTNEXTLINE
+PARALLEL_TEST(BinaryColumnTest, test_deserialize_and_append_batch_zero_chunk_size) {
+    // Exactly what Aggregator::convert_hash_set_to_chunk() hands down when the hash set is empty:
+    // a full-size buffer of default constructed slices, and a row count of 0.
+    Buffer<Slice> srcs(4096);
+    ASSERT_EQ(0u, srcs[0].size);
+
+    auto column = BinaryColumn::create();
+    column->deserialize_and_append_batch(srcs, 0);
+    ASSERT_EQ(0u, column->size());
+
+    auto large_column = LargeBinaryColumn::create();
+    large_column->deserialize_and_append_batch(srcs, 0);
+    ASSERT_EQ(0u, large_column->size());
+
+    // The nullable wrapper is the path the crash actually took.
+    auto nullable_column = NullableColumn::create(BinaryColumn::create(), NullColumn::create());
+    nullable_column->deserialize_and_append_batch(srcs, 0);
+    ASSERT_EQ(0u, nullable_column->size());
+    ASSERT_FALSE(nullable_column->has_null());
+}
+
 } // namespace starrocks

--- a/be/test/column/binary_column_test.cpp
+++ b/be/test/column/binary_column_test.cpp
@@ -750,7 +750,6 @@ PARALLEL_TEST(BinaryColumnTest, test_append_cross_type_large_to_binary_unsupport
     ASSERT_DEATH_IF_SUPPORTED(dst->append(*src, 0, 1), "incompatible column type");
 }
 
-
 // Regression test for the ASAN global-buffer-overflow reported as StarRocksTest#12188:
 //   BinaryColumnBase<uint32_t>::deserialize_and_append_batch_nullable() <- NullableColumn::
 //   deserialize_and_append_batch() <- AggHashSetOfSerializedKey::insert_keys_to_columns() <-

--- a/test/sql/test_agg/R/test_streaming_agg
+++ b/test/sql/test_agg/R/test_streaming_agg
@@ -58,6 +58,42 @@ select c0, sum(c1) from t1 group by c0 order by 2 desc limit 10;
 9	4087
 10	4086
 -- !result
+create table t2 (
+    c0 INT,
+    c1 VARCHAR(64) NULL,
+    c2 VARCHAR(64) NULL,
+    c3 VARCHAR(64) NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t2 SELECT generate_series, concat('aaaaaaaaaaaaaaaa_', generate_series % 97), concat('bbbbbbbbbbbbbbbb_', generate_series % 89), concat('cccccccccccccccc_', generate_series % 83) FROM TABLE(generate_series(1, 40960));
+-- result:
+-- !result
+insert into t2 values (40961, null, null, null);
+-- result:
+-- !result
+set enable_spill = true;
+-- result:
+-- !result
+set spill_mode = "random";
+-- result:
+-- !result
+set spill_rand_ratio = 1.0;
+-- result:
+-- !result
+select count(*) from (select distinct c1, c2, c3 from t2) t;
+-- result:
+40961
+-- !result
+set spill_rand_ratio = 0.1;
+-- result:
+-- !result
+set spill_mode = "auto";
+-- result:
+-- !result
+set enable_spill = false;
+-- result:
+-- !result
 CLEANUP {
     admin disable failpoint 'force_reset_aggregator_after_agg_streaming_sink_finish';
 } END CLEANUP

--- a/test/sql/test_agg/T/test_streaming_agg
+++ b/test/sql/test_agg/T/test_streaming_agg
@@ -24,6 +24,29 @@ create table t1 (
 insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096)) union all select null,null;
 select c0, sum(c1) from t1 group by c0 order by 2 desc limit 10;
 
+-- StarRocksTest#12188: a streaming DISTINCT aggregation that gets pushed into LIMITED_MEM mode
+-- force-streams every chunk and keeps re-arming streaming_all_states, so the source operator
+-- drains a hash set that reset_state() has just emptied. convert_hash_set_to_chunk() must not
+-- hand a row count of 0 down to insert_keys_to_columns(): the key buffer is still default
+-- constructed there, and the nullable string key column read past the "" literal Slice() uses.
+-- spill_mode=random with ratio 1.0 latches LIMITED_MEM on the first chunk, deterministically.
+create table t2 (
+    c0 INT,
+    c1 VARCHAR(64) NULL,
+    c2 VARCHAR(64) NULL,
+    c3 VARCHAR(64) NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- 97, 89 and 83 are pairwise coprime, so every generate_series value yields a distinct triple
+insert into t2 SELECT generate_series, concat('aaaaaaaaaaaaaaaa_', generate_series % 97), concat('bbbbbbbbbbbbbbbb_', generate_series % 89), concat('cccccccccccccccc_', generate_series % 83) FROM TABLE(generate_series(1, 40960));
+insert into t2 values (40961, null, null, null);
+set enable_spill = true;
+set spill_mode = "random";
+set spill_rand_ratio = 1.0;
+select count(*) from (select distinct c1, c2, c3 from t2) t;
+set spill_rand_ratio = 0.1;
+set spill_mode = "auto";
+set enable_spill = false;
+
 CLEANUP {
     admin disable failpoint 'force_reset_aggregator_after_agg_streaming_sink_finish';
 } END CLEANUP


### PR DESCRIPTION
## Why I'm doing:

The `main-asan` nightly aborts the BE with a `global-buffer-overflow` while a streaming DISTINCT aggregation drains its hash set (StarRocks/StarRocksTest#12188):

```
==6211==ERROR: AddressSanitizer: global-buffer-overflow ... READ of size 4
    #0  BinaryColumnBase<unsigned int>::deserialize_and_append_batch_nullable  be/src/column/binary_column.cpp:1216
    #1  NullableColumn::deserialize_and_append_batch                           be/src/column/nullable_column.cpp:340
    #2  AggHashSetOfSerializedKey<...>::insert_keys_to_columns                 be/src/exec/aggregate/agg_hash_set.h:651
    #3  Aggregator::convert_hash_set_to_chunk                                  be/src/exec/aggregator.cpp:1878
    #11 AggregateDistinctStreamingSourceOperator::_output_chunk_from_hash_set  .../aggregate_distinct_streaming_source_operator.cpp:87

0x0000128abac1 is located 0 bytes after global variable '*.LC7' ... of size 1
  '*.LC7' is ascii string ''
```

Root cause, in three parts:

1. `convert_hash_set_to_chunk()` sizes `hash_set.results` to the whole chunk size, fills only the first `read_index` entries, and then calls `insert_keys_to_columns()` unconditionally. `convert_hash_map_to_chunk()` has guarded exactly this with `if (read_index > 0)` since #37238, and so do the INTERSECT/EXCEPT and agg-runtime-filter call sites — the hash-set path is the only one that never got the guard.

2. `AggregateDistinctStreamingSinkOperator` latches LIMITED_MEM, force-streams every chunk and keeps re-arming `streaming_all_states`. `_output_chunk_from_hash_set()` drains the set, `reset_state()` then installs a **fresh, empty** hash set, and the next drain therefore runs with `read_index == 0` over a `results` buffer of default-constructed slices. `Slice()` points its `data` at a 1-byte `""` literal.

3. Both `BinaryColumnBase::deserialize_and_append_batch` overloads peek at `srcs[0]` to size a `reserve()` **before** consulting `chunk_size`, so the peek reads 4 bytes past that literal. The generic `ColumnFactory` implementation they delegate to is already correct for a row count of 0.

In a release build the peeked value only scales a `reserve(0)`, so the read does no damage in practice — but it is UB, and it aborts every ASAN build.

## What I'm doing:

- `Aggregator::convert_hash_set_to_chunk()`: skip `insert_keys_to_columns()` when `read_index == 0`, mirroring `convert_hash_map_to_chunk()`. All `insert_keys_to_columns()` implementations are already no-ops at a row count of 0, so the output chunk is unchanged.
- `BinaryColumnBase::deserialize_and_append_batch{,_nullable}()`: return early when `chunk_size == 0`, so no caller can reach the `srcs[0]` peek with an unfilled buffer. This also covers `AggHashSetOfSerializedKeyFixedSize`, which hands down a `tmp_slices` buffer that is only `reserve()`d.

### Verification

**Reproduced first** on a 3-node ASAN cluster at the reported commit (`main-99486d2`). `spill_mode=random` with `spill_rand_ratio=1.0` makes `PipelineDriver::_adjust_memory_usage()` latch LIMITED_MEM on the first chunk, which makes the crash deterministic:

```sql
SET enable_spill = true; SET spill_mode = "random"; SET spill_rand_ratio = 1.0;
SELECT count(*) FROM (SELECT DISTINCT v1, v2, v3 FROM t) x;  -- 3 nullable varchar keys
```

| | before | after |
|---|---|---|
| that query | crashed the BE on the **first** run, same stack as the report | 5/5 pass, plus 8-way concurrent, NULL keys, and 2/3/4-column variants |
| new ASAN records | — | none; no BE restarted |
| same query with `enable_spill=false` | 5/5 pass (control — confirms the LIMITED_MEM path is required) | 5/5 pass |

**Unit test negative control**: with the `binary_column.cpp` guards reverted, the new test reproduces the same signature (`global-buffer-overflow`, `READ of size 4`, `0 bytes after global ... of size 1`); with them restored, `BinaryColumnTest*` + `NullableColumnTest*` are 39/39 green.

Fixes StarRocks/StarRocksTest#12188

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
