### PR TITLE
[BugFix] Bind prepared parameters by column instead of AND-tree position

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/PrepareStmtPlanner.java
@@ -22,24 +22,46 @@ import com.starrocks.sql.analyzer.ResolvedAIFunctionDetector;
 import com.starrocks.sql.ast.ExecuteStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.CompoundPredicate;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.ast.expression.NullLiteral;
+import com.starrocks.sql.ast.expression.Parameter;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
-import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.OptDistributionPruner;
 import com.starrocks.sql.optimizer.rewrite.OptOlapPartitionPruner;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.thrift.TResultSinkType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 
 public class PrepareStmtPlanner {
+    private static final Logger LOG = LogManager.getLogger(PrepareStmtPlanner.class);
 
     public static ExecPlan plan(ExecuteStmt executeStmt, StatementBase stmt, ConnectContext session) {
         try {
@@ -56,15 +78,18 @@ public class PrepareStmtPlanner {
 
             PrepareStmtContext prepareStmtContext = session.getPreparedStmt(executeStmt.getStmtName());
             if (!prepareStmtContext.isCached()) {
-                return planAndCacheExecPlan(stmt, session, prepareStmtContext);
+                return planAndCacheExecPlan(executeStmt, stmt, session, prepareStmtContext);
             } else {
                 if (prepareStmtContext.needReAnalyze(queryStmt, session)) {
-                    return planAndCacheExecPlan(stmt, session, prepareStmtContext);
+                    return planAndCacheExecPlan(executeStmt, stmt, session, prepareStmtContext);
                 } else {
                     ExecPlan execPlan = prepareStmtContext.getExecPlan();
 
-                    // use cache and rebuild physical plan
-                    rePlan(executeStmt, execPlan.getLogicalPlan(), execPlan.getPhysicalPlan());
+                    // a rejected rebind leaves the cached predicate untouched; the full planning below then
+                    // decides whether to replace the cached plan or drop it
+                    if (!tryRebind(executeStmt, queryStmt, execPlan)) {
+                        return planAndCacheExecPlan(executeStmt, stmt, session, prepareStmtContext);
+                    }
 
                     TResultSinkType resultSinkType = session instanceof HttpConnectContext ? TResultSinkType.HTTP_PROTOCAL :
                             TResultSinkType.MYSQL_PROTOCAL;
@@ -89,29 +114,189 @@ public class PrepareStmtPlanner {
         }
     }
 
-    private static ExecPlan planAndCacheExecPlan(StatementBase stmt, ConnectContext session,
+    private static ExecPlan planAndCacheExecPlan(ExecuteStmt executeStmt, StatementBase stmt, ConnectContext session,
                                                  PrepareStmtContext prepareStmtContext) {
         ExecPlan execPlan = StatementPlanner.plan(stmt, session);
         if (execPlan == null) {
             return null;
         }
 
+        QueryStatement queryStmt = (QueryStatement) stmt;
+        if (!isRebindable(executeStmt, queryStmt, execPlan)) {
+            // reset, not just skip: the needReAnalyze() call site arrives holding a plan built against the old schema
+            prepareStmtContext.reset();
+            return execPlan;
+        }
+
         prepareStmtContext.setExecPlan(execPlan);
-        prepareStmtContext.updateLastSchemaUpdateTime((QueryStatement) stmt, session);
+        prepareStmtContext.updateLastSchemaUpdateTime(queryStmt, session);
         prepareStmtContext.cachePlan(execPlan);
         return execPlan;
     }
 
-    private static void rePlan(ExecuteStmt executeStmt,
-                               LogicalPlan logicalPlan,
-                               OptExpression optimizedPlan) {
-
-        Operator operator = logicalPlan.getRoot().getInputs().get(0).getOp();
-        if (operator instanceof LogicalFilterOperator) {
-            ScalarOperator.updateLiteralPredicates(operator.getPredicate(), executeStmt.getParamsExpr());
+    // decided once, when the plan is cached, so the hit path never meets a shape whose constants it cannot locate
+    private static boolean isRebindable(ExecuteStmt executeStmt, QueryStatement queryStmt, ExecPlan execPlan) {
+        LogicalFilterOperator filter = rebindableFilter(execPlan.getLogicalPlan());
+        if (filter == null) {
+            return rejectCaching(executeStmt, "logical plan is not a filter over an olap scan");
+        }
+        if (!(execPlan.getPhysicalPlan().getOp() instanceof PhysicalOlapScanOperator)) {
+            return rejectCaching(executeStmt, "physical plan root is not an olap scan");
         }
 
-        rePlanOptimizedPlan(logicalPlan, optimizedPlan);
+        Map<String, Integer> slotByColumn = paramSlotByColumn(queryStmt);
+        if (slotByColumn == null) {
+            return rejectCaching(executeStmt, "where clause is not a conjunction of column = parameter");
+        }
+
+        int paramCount = executeStmt.getParamsExpr().size();
+        Set<Integer> boundSlots = new HashSet<>();
+        for (ScalarOperator conjunct : Utils.extractConjuncts(filter.getPredicate())) {
+            ColumnRefOperator column = equalityColumn(conjunct);
+            if (column == null) {
+                return rejectCaching(executeStmt, "predicate is not a conjunction of column = constant");
+            }
+            Integer slot = slotByColumn.get(column.getName());
+            if (slot == null || slot >= paramCount || !boundSlots.add(slot)) {
+                return rejectCaching(executeStmt, "predicate column " + column.getName() + " has no unique parameter");
+            }
+        }
+
+        // a parameter outside the predicate, in the select list say, would keep the value it had when the plan was built
+        if (boundSlots.size() != paramCount) {
+            return rejectCaching(executeStmt, "only " + boundSlots.size() + " of " + paramCount
+                    + " parameters appear in the predicate");
+        }
+        return true;
+    }
+
+    // replace the cached predicate constants with this EXECUTE's parameters, located by column name, not by tree position
+    private static boolean tryRebind(ExecuteStmt executeStmt, QueryStatement queryStmt, ExecPlan execPlan) {
+        LogicalPlan logicalPlan = execPlan.getLogicalPlan();
+        LogicalFilterOperator filter = rebindableFilter(logicalPlan);
+        Map<String, Integer> slotByColumn = filter == null ? null : paramSlotByColumn(queryStmt);
+        if (slotByColumn == null) {
+            return rejectRebind(executeStmt, "cached plan no longer has a rebindable shape");
+        }
+
+        List<Expr> params = executeStmt.getParamsExpr();
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(filter.getPredicate());
+        List<ConstantOperator> rebound = new ArrayList<>(conjuncts.size());
+        for (ScalarOperator conjunct : conjuncts) {
+            ColumnRefOperator column = equalityColumn(conjunct);
+            Integer slot = column == null ? null : slotByColumn.get(column.getName());
+            if (slot == null || slot >= params.size()) {
+                return rejectRebind(executeStmt, "no parameter matches predicate column");
+            }
+            if (!(params.get(slot) instanceof LiteralExpr)) {
+                return rejectRebind(executeStmt, "parameter " + slot + " is not a literal");
+            }
+            ConstantOperator adapted = rebindConstant(column, (LiteralExpr) params.get(slot));
+            if (adapted == null) {
+                return rejectRebind(executeStmt, "parameter " + slot + " would change the comparison for column "
+                        + column.getName());
+            }
+            rebound.add(adapted);
+        }
+
+        // every parameter is validated before the first write, so a rejected EXECUTE never leaves the tree half bound
+        for (int i = 0; i < conjuncts.size(); i++) {
+            conjuncts.get(i).setChild(1, rebound.get(i));
+        }
+        rePlanOptimizedPlan(logicalPlan, execPlan.getPhysicalPlan());
+        return true;
+    }
+
+    // run the real cast rule instead of predicting it: only a parameter it leaves the column uncast for keeps the
+    // cached comparison semantics (a DOUBLE bound onto a VARCHAR key makes planning compare numerically instead)
+    private static ConstantOperator rebindConstant(ColumnRefOperator column, LiteralExpr literal) {
+        // same construction as SqlToScalarOperatorTranslator.visitLiteral, so the value matches what planning builds
+        ConstantOperator value = literal instanceof NullLiteral
+                ? ConstantOperator.createNull(literal.getType())
+                : ConstantOperator.createObject(literal.getRealObjectValue(), literal.getType());
+
+        // a rule may write through to what it is handed (ReduceCastRule setTypes a cast child in place) and this
+        // reference belongs to the cached tree, so the candidate gets a copy
+        ColumnRefOperator candidateColumn = (ColumnRefOperator) column.clone();
+        ScalarOperator rewritten;
+        try {
+            rewritten = new ScalarOperatorRewriter().rewrite(
+                    new BinaryPredicateOperator(BinaryType.EQ, candidateColumn, value),
+                    ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+        } catch (StarRocksPlannerException e) {
+            // let full planning raise it, from the path that can name the statement
+            return null;
+        }
+
+        if (!(rewritten instanceof BinaryPredicateOperator)
+                || ((BinaryPredicateOperator) rewritten).getBinaryType() != BinaryType.EQ
+                || !(rewritten.getChild(1) instanceof ConstantOperator)) {
+            return null;
+        }
+        // identity, not equality: a cast wraps the reference in a new operator, an untouched column stays this object
+        return rewritten.getChild(0) == candidateColumn ? (ConstantOperator) rewritten.getChild(1) : null;
+    }
+
+    // the exact shape rePlanOptimizedPlan walks unguarded: project -> filter -> project -> olap scan
+    private static LogicalFilterOperator rebindableFilter(LogicalPlan logicalPlan) {
+        OptExpression root = logicalPlan.getRoot();
+        if (root.getInputs().isEmpty() || !(root.inputAt(0).getOp() instanceof LogicalFilterOperator)) {
+            return null;
+        }
+        OptExpression filter = root.inputAt(0);
+        if (filter.getInputs().isEmpty() || filter.inputAt(0).getInputs().isEmpty()
+                || !(filter.inputAt(0).inputAt(0).getOp() instanceof LogicalOlapScanOperator)) {
+            return null;
+        }
+        return (LogicalFilterOperator) filter.getOp();
+    }
+
+    private static ColumnRefOperator equalityColumn(ScalarOperator conjunct) {
+        if (!(conjunct instanceof BinaryPredicateOperator)
+                || ((BinaryPredicateOperator) conjunct).getBinaryType() != BinaryType.EQ) {
+            return null;
+        }
+        if (!(conjunct.getChild(0) instanceof ColumnRefOperator) || !(conjunct.getChild(1) instanceof ConstantOperator)) {
+            return null;
+        }
+        return (ColumnRefOperator) conjunct.getChild(0);
+    }
+
+    private static Map<String, Integer> paramSlotByColumn(QueryStatement queryStmt) {
+        Map<String, Integer> slotByColumn = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Expr predicate = ((SelectRelation) queryStmt.getQueryRelation()).getPredicate();
+        return collectParamSlots(predicate, slotByColumn) ? slotByColumn : null;
+    }
+
+    private static boolean collectParamSlots(Expr predicate, Map<String, Integer> slotByColumn) {
+        if (predicate instanceof CompoundPredicate) {
+            CompoundPredicate compound = (CompoundPredicate) predicate;
+            return compound.getOp() == CompoundPredicate.Operator.AND
+                    && collectParamSlots(compound.getChild(0), slotByColumn)
+                    && collectParamSlots(compound.getChild(1), slotByColumn);
+        }
+        if (!(predicate instanceof BinaryPredicate) || ((BinaryPredicate) predicate).getOp() != BinaryType.EQ) {
+            return false;
+        }
+        Expr left = predicate.getChild(0);
+        Expr right = predicate.getChild(1);
+        SlotRef column = left instanceof SlotRef ? (SlotRef) left : (right instanceof SlotRef ? (SlotRef) right : null);
+        Expr parameter = left instanceof SlotRef ? right : left;
+        if (column == null || !(parameter instanceof Parameter)) {
+            return false;
+        }
+        return slotByColumn.put(column.getColumnName(), ((Parameter) parameter).getSlotId()) == null;
+    }
+
+    // the repo has no plan-cache hit-rate metric, so a debug line is all a user has to explain a point query gone slow
+    private static boolean rejectCaching(ExecuteStmt executeStmt, String reason) {
+        LOG.debug("prepared statement {}: plan not cached for parameter rebinding, {}", executeStmt.getStmtName(), reason);
+        return false;
+    }
+
+    private static boolean rejectRebind(ExecuteStmt executeStmt, String reason) {
+        LOG.debug("prepared statement {}: falling back to full planning, {}", executeStmt.getStmtName(), reason);
+        return false;
     }
 
     private static void rePlanOptimizedPlan(LogicalPlan logicalPlan, OptExpression optimizedPlan) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -18,8 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Config;
 import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.type.BooleanType;
@@ -408,29 +406,6 @@ public abstract class ScalarOperator implements Cloneable {
                     && binaryPredicate.getChild(0).isColumnRef() && binaryPredicate.getChild(1).isConstantRef();
         }
         return false;
-    }
-
-    public static void updateLiteralPredicates(ScalarOperator predicate, List<Expr> exprs) {
-        if (predicate instanceof CompoundPredicateOperator) {
-            updateCompoundLiteralPredicate((CompoundPredicateOperator) predicate, exprs);
-        } else {
-            updateSingleLiteralPredicate(predicate, exprs.get(0));
-        }
-    }
-
-    private static void updateCompoundLiteralPredicate(CompoundPredicateOperator compoundPredicate, List<Expr> exprs) {
-        for (int i = 0; i < compoundPredicate.getChildren().size(); i++) {
-            updateSingleLiteralPredicate(compoundPredicate.getChild(i), exprs.get(i));
-        }
-    }
-
-    private static void updateSingleLiteralPredicate(ScalarOperator predicate, Expr expr) {
-        Object realObjectValue = ((LiteralExpr) expr).getRealObjectValue();
-        Optional<ConstantOperator> constantOperator =
-                new ConstantOperator(realObjectValue, expr.getType()).castTo(predicate.getChild(1).getType());
-        if (constantOperator.isPresent()) {
-            predicate.setChild(1, constantOperator.get());
-        }
     }
 
     public Stream<ScalarOperator> asStream() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PrepareStmtPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PrepareStmtPlannerTest.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.PrepareStmtContext;
+import com.starrocks.sql.OptimisticVersion;
 import com.starrocks.sql.PrepareStmtPlanner;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.ExecuteStmt;
@@ -471,7 +472,8 @@ public class PrepareStmtPlannerTest extends PlanTestBase {
         Assertions.assertTrue(prepared.context().isCached());
 
         OlapTable table = getOlapTable("pq_stale");
-        table.lastSchemaUpdateTime.set(System.currentTimeMillis() + 3600_000L);
+        // stamp it the way production does: OptimisticVersion compares this field against its own nanoTime clock
+        table.lastSchemaUpdateTime.set(OptimisticVersion.generate());
         long oldLimit = connectContext.getSessionVariable().getSqlSelectLimit();
         connectContext.getSessionVariable().setSqlSelectLimit(100);
         try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PrepareStmtPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PrepareStmtPlannerTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.PrepareStmtContext;
@@ -22,25 +23,46 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.ast.ExecuteStmt;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.expression.DateLiteral;
+import com.starrocks.sql.ast.expression.DecimalLiteral;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.FloatLiteral;
 import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.AIModelConfigs;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalAIProjectOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
 import com.starrocks.utframe.UtFrameUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 public class PrepareStmtPlannerTest extends PlanTestBase {
     private static final AtomicInteger NEXT_STMT_ID = new AtomicInteger();
@@ -56,6 +78,117 @@ public class PrepareStmtPlannerTest extends PlanTestBase {
         Config.ai_default_chat_endpoint = "https://unit.test.example/v1/chat/completions";
         Config.ai_default_chat_model = "unit-test-model";
         Config.ai_default_chat_provider = AIModelConfigs.OPENAI_COMPATIBLE_PROVIDER;
+
+        starRocksAssert.withTable("CREATE TABLE `pq_dup3` (\n" +
+                "  `k1` int NOT NULL,\n" +
+                "  `k2` int NOT NULL,\n" +
+                "  `k3` int NOT NULL,\n" +
+                "  `v` string NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_pk3` (\n" +
+                "  `k1` int NOT NULL,\n" +
+                "  `k2` int NOT NULL,\n" +
+                "  `k3` int NOT NULL,\n" +
+                "  `v` string NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`k1`, `k2`, `k3`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_dup2` (\n" +
+                "  `k1` int NOT NULL,\n" +
+                "  `k2` int NOT NULL,\n" +
+                "  `v` string NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_dup4` (\n" +
+                "  `k1` int NOT NULL,\n" +
+                "  `k2` int NOT NULL,\n" +
+                "  `k3` int NOT NULL,\n" +
+                "  `k4` int NOT NULL,\n" +
+                "  `v` string NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_varchar` (\n" +
+                "  `k1` varchar(32) NOT NULL,\n" +
+                "  `v` string NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_str` (\n" +
+                "  `k` varchar(10) NOT NULL,\n" +
+                "  `v` varchar(20) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_strdt` (\n" +
+                "  `k` varchar(20) NOT NULL,\n" +
+                "  `v` varchar(20) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_dec` (\n" +
+                "  `k` decimal(10,2) NOT NULL,\n" +
+                "  `v` varchar(20) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_date` (\n" +
+                "  `k` date NOT NULL,\n" +
+                "  `v` varchar(20) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_datetime` (\n" +
+                "  `k` datetime NOT NULL,\n" +
+                "  `v` varchar(20) NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k`)\n" +
+                "DISTRIBUTED BY HASH(`k`) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_stale` (\n" +
+                "  `k1` int NOT NULL,\n" +
+                "  `k2` int NOT NULL,\n" +
+                "  `k3` int NOT NULL,\n" +
+                "  `v` string NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`, `k3`)\n" +
+                "DISTRIBUTED BY HASH(`k1`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE `pq_part` (\n" +
+                "  `k1` int NOT NULL,\n" +
+                "  `k2` int NOT NULL,\n" +
+                "  `v` string NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`k1`, `k2`)\n" +
+                "PARTITION BY RANGE(`k1`) (\n" +
+                "  PARTITION p1 VALUES [(\"1\"), (\"10\")),\n" +
+                "  PARTITION p2 VALUES [(\"10\"), (\"20\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
     }
 
     @AfterAll
@@ -104,6 +237,306 @@ public class PrepareStmtPlannerTest extends PlanTestBase {
                 () -> Assertions.assertEquals(2, scanPredicateValue(second)));
     }
 
+    @Test
+    public void testComparisonSemanticsHoldAcrossKeyAndParameterTypes() throws Exception {
+        assertCachedPlanMatchesFreshPlan("select v from pq_dec where k = ?",
+                () -> List.of(new DecimalLiteral("1.00")),
+                () -> List.of(new DecimalLiteral("1.005")),
+                () -> List.of(intLit(1)),
+                () -> List.of(new StringLiteral("1.00")),
+                () -> List.of(doubleLit(1.0)));
+        assertCachedPlanMatchesFreshPlan("select v from pq_date where k = ?",
+                () -> List.of(new DateLiteral(2020, 1, 1)),
+                () -> List.of(new DateLiteral(2020, 1, 2, 3, 4, 5, 0)),
+                () -> List.of(new StringLiteral("2020-01-03")),
+                () -> List.of(intLit(20200104)));
+        assertCachedPlanMatchesFreshPlan("select v from pq_datetime where k = ?",
+                () -> List.of(new DateLiteral(2020, 1, 1, 2, 3, 4, 0)),
+                () -> List.of(new DateLiteral(2020, 1, 2)),
+                () -> List.of(new StringLiteral("2020-01-03 01:02:03")));
+    }
+
+    @Test
+    public void testDateParameterOnVarcharKeyDoesNotKeepStringComparison() throws Exception {
+        assertCachedPlanMatchesFreshPlan("select v from pq_strdt where k = ?",
+                () -> List.of(new StringLiteral("2020-01-02")),
+                () -> List.of(new DateLiteral(2020, 1, 2)),
+                () -> List.of(new StringLiteral("2020-01-02")),
+                () -> List.of(new DateLiteral(2020, 1, 2, 3, 4, 5, 0)));
+    }
+
+    @Test
+    public void testFloatingParameterOnVarcharKeyDoesNotKeepStringComparison() throws Exception {
+        assertCachedPlanMatchesFreshPlan("select v from pq_str where k = ?",
+                () -> List.of(new StringLiteral("1")),
+                () -> List.of(doubleLit(1.0)),
+                () -> List.of(new StringLiteral("1")));
+    }
+
+    @Test
+    public void testExactNumericParameterOnVarcharKeyStillRebinds() throws Exception {
+        assertCachedPlanMatchesFreshPlan("select v from pq_str where k = ?",
+                () -> List.of(new StringLiteral("1")),
+                () -> List.of(intLit(1)),
+                () -> List.of(new DecimalLiteral("1")));
+    }
+
+    // the common JDBC shape: numeric key columns, every parameter sent as a string. Planning folds the string into
+    // the column type and casts nothing, so these must keep hitting the cache
+    @Test
+    public void testStringParameterOnIntegerKeyStillRebinds() throws Exception {
+        String sql = "select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?";
+        PreparedQuery prepared = prepare(sql);
+        ExecPlan first = execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+        List<Expr> strings = List.of(new StringLiteral("4"), new StringLiteral("5"), new StringLiteral("6"));
+        ExecPlan second = execute(prepared, strings);
+        Map<String, String> fresh = scanBindings(execute(prepare(sql),
+                List.of(new StringLiteral("4"), new StringLiteral("5"), new StringLiteral("6"))));
+
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(prepared.context().isCached()),
+                () -> Assertions.assertSame(first.getPhysicalPlan(), second.getPhysicalPlan()),
+                () -> Assertions.assertEquals(Map.of("k1", "4", "k2", "5", "k3", "6"), scanBindings(second)),
+                () -> Assertions.assertEquals(fresh, scanBindings(second)));
+    }
+
+    @Test
+    public void testThreeKeyPointQueryRebindsEveryParameter() throws Exception {
+        for (String table : List.of("pq_dup3", "pq_pk3")) {
+            assertCachedPlanMatchesFreshPlan("select v from " + table + " where k1 = ? and k2 = ? and k3 = ?",
+                    () -> List.of(intLit(1), intLit(2), intLit(3)),
+                    () -> List.of(intLit(4), intLit(5), intLit(6)),
+                    () -> List.of(intLit(1), intLit(2), intLit(3)),
+                    () -> List.of(intLit(7), intLit(8), intLit(9)));
+        }
+    }
+
+    @Test
+    public void testFourKeysBoundWhenPredicateOrderDiffersFromKeyOrder() throws Exception {
+        assertCachedPlanMatchesFreshPlan("select v from pq_dup4 where k3 = ? and k1 = ? and k4 = ? and k2 = ?",
+                () -> List.of(intLit(3), intLit(1), intLit(4), intLit(2)),
+                () -> List.of(intLit(30), intLit(10), intLit(40), intLit(20)),
+                () -> List.of(intLit(3), intLit(1), intLit(4), intLit(2)));
+    }
+
+    @Test
+    public void testParameterOnTheLeftOfEqualityStillBindsByColumn() throws Exception {
+        assertCachedPlanMatchesFreshPlan("select v from pq_dup3 where ? = k1 and ? = k2 and ? = k3",
+                () -> List.of(intLit(1), intLit(2), intLit(3)),
+                () -> List.of(intLit(4), intLit(5), intLit(6)));
+    }
+
+    @Test
+    public void testFractionalParameterIsNotTruncatedOntoAnIntKey() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?");
+        execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+
+        List<Expr> fractional = List.of(doubleLit(1.9), intLit(2), intLit(3));
+        ExecPlan second = execute(prepared, fractional);
+        ExecPlan fresh = execute(prepare("select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?"),
+                List.of(doubleLit(1.9), intLit(2), intLit(3)));
+
+        Assertions.assertAll(
+                () -> Assertions.assertNotEquals("1", scanBindings(second).get("k1")),
+                () -> Assertions.assertEquals(scanBindings(fresh), scanBindings(second)));
+    }
+
+    @Test
+    public void testNullParameterDoesNotMatchTheStringNull() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_varchar where k1 = ?");
+        execute(prepared, new StringLiteral("abc"));
+
+        ExecPlan second = execute(prepared, new NullLiteral());
+        ExecPlan fresh = execute(prepare("select v from pq_varchar where k1 = ?"), List.of(new NullLiteral()));
+
+        Assertions.assertAll(
+                // k1 = NULL matches nothing, so planning folds the query away; the old code bound the string 'NULL'
+                () -> Assertions.assertFalse(second.getPhysicalPlan().getOp() instanceof PhysicalOlapScanOperator,
+                        "expected the NULL parameter to leave no scan"),
+                () -> Assertions.assertEquals(fresh.getExplainString(TExplainLevel.NORMAL),
+                        second.getExplainString(TExplainLevel.NORMAL)));
+    }
+
+    @Test
+    public void testRejectedRebindLeavesTheCachedPredicateUntouched() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?");
+        execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+        ExecPlan cachedPlan = prepared.context().getExecPlan();
+
+        execute(prepared, List.of(intLit(4), intLit(5), doubleLit(6.5)));
+
+        Assertions.assertEquals(Map.of("k1", "1", "k2", "2", "k3", "3"), logicalFilterBindings(cachedPlan));
+    }
+
+    @Test
+    public void testSelectLimitSessionVariableKeepsThePlanOutOfTheCache() throws Exception {
+        long oldLimit = connectContext.getSessionVariable().getSqlSelectLimit();
+        connectContext.getSessionVariable().setSqlSelectLimit(100);
+        try {
+            PreparedQuery prepared = prepare("select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?");
+            execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+            ExecPlan second = execute(prepared, List.of(intLit(4), intLit(5), intLit(6)));
+
+            Assertions.assertAll(
+                    () -> Assertions.assertFalse(prepared.context().isCached()),
+                    () -> Assertions.assertEquals(Map.of("k1", "4", "k2", "5", "k3", "6"), scanBindings(second)));
+        } finally {
+            connectContext.getSessionVariable().setSqlSelectLimit(oldLimit);
+        }
+    }
+
+    @Test
+    public void testWindowFunctionKeepsThePlanOutOfTheCache() throws Exception {
+        PreparedQuery prepared =
+                prepare("select v, row_number() over () from pq_dup3 where k1 = ? and k2 = ? and k3 = ?");
+        execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+        ExecPlan second = execute(prepared, List.of(intLit(4), intLit(5), intLit(6)));
+
+        Assertions.assertAll(
+                () -> Assertions.assertFalse(prepared.context().isCached()),
+                () -> Assertions.assertEquals(Map.of("k1", "4", "k2", "5", "k3", "6"), scanBindings(second)));
+    }
+
+    @Test
+    public void testAlwaysEmptyResultKeepsThePlanOutOfTheCache() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_varchar where k1 = ?");
+        ExecPlan first = execute(prepared, new NullLiteral());
+
+        Assertions.assertAll(
+                () -> Assertions.assertFalse(first.getPhysicalPlan().getOp() instanceof PhysicalOlapScanOperator),
+                () -> Assertions.assertFalse(prepared.context().isCached()));
+    }
+
+    @Test
+    public void testRejectedPlanIsReportedInTheDebugLog() throws Exception {
+        ReasonAppender appender = new ReasonAppender();
+        Logger planner = (Logger) LogManager.getLogger(PrepareStmtPlanner.class);
+        Level oldLevel = planner.getLevel();
+        appender.start();
+        planner.addAppender(appender);
+        Configurator.setLevel(PrepareStmtPlanner.class.getName(), Level.DEBUG);
+        try {
+            PreparedQuery prepared = prepare("select ?, v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?");
+            execute(prepared, List.of(intLit(7), intLit(1), intLit(2), intLit(3)));
+        } finally {
+            Configurator.setLevel(PrepareStmtPlanner.class.getName(), oldLevel);
+            planner.removeAppender(appender);
+            appender.stop();
+        }
+
+        Assertions.assertTrue(appender.messages.stream().anyMatch(m -> m.contains("parameters appear in the predicate")),
+                "expected a debug line naming the reason, got " + appender.messages);
+    }
+
+    @Test
+    public void testParameterInSelectListKeepsThePlanOutOfTheCache() throws Exception {
+        PreparedQuery prepared = prepare("select ?, v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?");
+        execute(prepared, List.of(intLit(7), intLit(1), intLit(2), intLit(3)));
+        ExecPlan second = execute(prepared, List.of(intLit(8), intLit(4), intLit(5), intLit(6)));
+
+        Assertions.assertAll(
+                () -> Assertions.assertFalse(prepared.context().isCached()),
+                () -> Assertions.assertTrue(planConstants(second).contains("8"),
+                        "select list parameter stuck at its first value: " + planConstants(second)),
+                () -> Assertions.assertEquals(Map.of("k1", "4", "k2", "5", "k3", "6"), scanBindings(second)));
+    }
+
+    @Test
+    public void testRepeatedEqualityOnOneColumnIsNotAPointQuery() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_dup3 where k1 = ? and k1 = ? and k2 = ? and k3 = ?");
+        execute(prepared, List.of(intLit(1), intLit(1), intLit(2), intLit(3)));
+        execute(prepared, List.of(intLit(4), intLit(4), intLit(5), intLit(6)));
+
+        Assertions.assertFalse(prepared.context().isCached());
+    }
+
+    @Test
+    public void testLimitInAndOrPredicatesAreNotPointQueries() throws Exception {
+        List<String> queries = List.of(
+                "select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ? limit 1",
+                "select v from pq_dup3 where k1 in (?) and k2 = ? and k3 = ?",
+                "select v from pq_dup3 where (k1 = ? or k2 = ?) and k3 = ?");
+        for (String query : queries) {
+            PreparedQuery prepared = prepare(query);
+            execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+            execute(prepared, List.of(intLit(4), intLit(5), intLit(6)));
+            Assertions.assertFalse(prepared.context().isCached(), query);
+        }
+    }
+
+    @Test
+    public void testSchemaChangeToAnUncacheablePlanClearsTheStaleCache() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_stale where k1 = ? and k2 = ? and k3 = ?");
+        execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+        Assertions.assertTrue(prepared.context().isCached());
+
+        OlapTable table = getOlapTable("pq_stale");
+        table.lastSchemaUpdateTime.set(System.currentTimeMillis() + 3600_000L);
+        long oldLimit = connectContext.getSessionVariable().getSqlSelectLimit();
+        connectContext.getSessionVariable().setSqlSelectLimit(100);
+        try {
+            execute(prepared, List.of(intLit(4), intLit(5), intLit(6)));
+        } finally {
+            connectContext.getSessionVariable().setSqlSelectLimit(oldLimit);
+        }
+
+        Assertions.assertAll(
+                () -> Assertions.assertFalse(prepared.context().isCached()),
+                () -> Assertions.assertNull(prepared.context().getExecPlan()));
+    }
+
+    @Test
+    public void testOneAndTwoKeyPointQueriesKeepUsingTheCache() throws Exception {
+        assertStaysCached("select v1 from tprimary where pk = ?",
+                List.of(bigint(1)), List.of(bigint(2)));
+        assertStaysCached("select v from pq_dup2 where k1 = ? and k2 = ?",
+                List.of(intLit(1), intLit(2)), List.of(intLit(4), intLit(5)));
+    }
+
+    @Test
+    public void testWiderIntegerParameterStillRebinds() throws Exception {
+        PreparedQuery prepared = prepare("select v1 from tprimary where pk = ?");
+        ExecPlan first = execute(prepared, bigint(1));
+        ExecPlan second = execute(prepared, intLit(2));
+
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(prepared.context().isCached()),
+                () -> Assertions.assertSame(first.getPhysicalPlan(), second.getPhysicalPlan()),
+                () -> Assertions.assertEquals(2, scanPredicateValue(second)));
+    }
+
+    @Test
+    public void testPartitionedPointQueryRebindsAcrossPartitions() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_part where k1 = ? and k2 = ?");
+        ExecPlan first = execute(prepared, List.of(intLit(5), intLit(1)));
+        ExecPlan second = execute(prepared, List.of(intLit(15), intLit(1)));
+        ExecPlan fresh = execute(prepare("select v from pq_part where k1 = ? and k2 = ?"),
+                List.of(intLit(15), intLit(1)));
+
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(prepared.context().isCached()),
+                () -> Assertions.assertSame(first.getPhysicalPlan(), second.getPhysicalPlan()),
+                () -> Assertions.assertEquals(Map.of("k1", "15", "k2", "1"), scanBindings(second)),
+                () -> Assertions.assertEquals(fresh.getExplainString(TExplainLevel.NORMAL),
+                        second.getExplainString(TExplainLevel.NORMAL)));
+    }
+
+    @Test
+    public void testFloatingPointParameterFallsBackToFullPlanning() throws Exception {
+        PreparedQuery prepared = prepare("select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?");
+        execute(prepared, List.of(intLit(1), intLit(2), intLit(3)));
+
+        ExecPlan withFloat = execute(prepared, List.of(floatLit(2.0), intLit(2), intLit(3)));
+        ExecPlan fresh = execute(prepare("select v from pq_dup3 where k1 = ? and k2 = ? and k3 = ?"),
+                List.of(floatLit(2.0), intLit(2), intLit(3)));
+        ExecPlan backToInts = execute(prepared, List.of(intLit(4), intLit(5), intLit(6)));
+
+        Assertions.assertAll(
+                () -> Assertions.assertEquals(scanBindings(fresh), scanBindings(withFloat)),
+                () -> Assertions.assertEquals(Map.of("k1", "4", "k2", "5", "k3", "6"), scanBindings(backToInts)),
+                () -> Assertions.assertTrue(prepared.context().isCached()));
+    }
+
     private static PreparedQuery prepare(String query) throws Exception {
         String name = "prepared_" + NEXT_STMT_ID.incrementAndGet();
         boolean oldEnablePrepare = connectContext.getSessionVariable().isEnablePrepareStmt();
@@ -120,11 +553,14 @@ public class PrepareStmtPlannerTest extends PlanTestBase {
     }
 
     private static ExecPlan execute(PreparedQuery prepared, Expr... values) {
+        return execute(prepared, List.of(values));
+    }
+
+    private static ExecPlan execute(PreparedQuery prepared, List<Expr> params) {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setThreadLocalInfo();
 
-        List<Expr> params = List.of(values);
         ExecuteStmt executeStmt = new ExecuteStmt(prepared.name(), params);
         Analyzer.analyze(executeStmt, connectContext);
         StatementBase assigned = prepared.statement().assignValues(params);
@@ -133,6 +569,18 @@ public class PrepareStmtPlannerTest extends PlanTestBase {
 
     private static IntLiteral bigint(long value) {
         return new IntLiteral(value, IntegerType.BIGINT);
+    }
+
+    private static IntLiteral intLit(long value) {
+        return new IntLiteral(value, IntegerType.INT);
+    }
+
+    private static FloatLiteral doubleLit(double value) {
+        return new FloatLiteral(value, FloatType.DOUBLE);
+    }
+
+    private static FloatLiteral floatLit(double value) {
+        return new FloatLiteral(value, FloatType.FLOAT);
     }
 
     private static long scanPredicateValue(ExecPlan plan) {
@@ -184,6 +632,109 @@ public class PrepareStmtPlannerTest extends PlanTestBase {
             }
         }
         return null;
+    }
+
+    private static void assertStaysCached(String sql, List<Expr> firstParams, List<Expr> secondParams)
+            throws Exception {
+        PreparedQuery prepared = prepare(sql);
+        ExecPlan first = execute(prepared, firstParams);
+        ExecPlan second = execute(prepared, secondParams);
+        ExecPlan freshPlan = execute(prepare(sql), secondParams);
+        Map<String, String> fresh = scanBindings(freshPlan);
+        Map<String, String> freshTypes = scanBindingTypes(freshPlan);
+
+        Assertions.assertAll(
+                () -> Assertions.assertTrue(prepared.context().isCached(), sql),
+                () -> Assertions.assertSame(first.getPhysicalPlan(), second.getPhysicalPlan(), sql),
+                () -> Assertions.assertEquals(fresh, scanBindings(second), sql),
+                () -> Assertions.assertEquals(freshTypes, scanBindingTypes(second), sql));
+    }
+
+    private static Map<String, String> logicalFilterBindings(ExecPlan plan) {
+        ScalarOperator predicate = plan.getLogicalPlan().getRoot().inputAt(0).getOp().getPredicate();
+        Map<String, String> bindings = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (ScalarOperator conjunct : Utils.extractConjuncts(predicate)) {
+            bindings.put(((ColumnRefOperator) conjunct.getChild(0)).getName(), conjunct.getChild(1).toString());
+        }
+        return bindings;
+    }
+
+
+    // every constant reachable from the physical tree, so a select-list parameter frozen at its first value shows up
+    private static Set<String> planConstants(ExecPlan plan) {
+        Set<String> constants = new LinkedHashSet<>();
+        List<OptExpression> pending = new ArrayList<>(List.of(plan.getPhysicalPlan()));
+        while (!pending.isEmpty()) {
+            OptExpression node = pending.remove(pending.size() - 1);
+            List<ScalarOperator> roots = new ArrayList<>();
+            if (node.getOp().getPredicate() != null) {
+                roots.add(node.getOp().getPredicate());
+            }
+            if (node.getOp().getProjection() != null) {
+                roots.addAll(node.getOp().getProjection().getColumnRefMap().values());
+            }
+            roots.stream().flatMap(ScalarOperator::asStream)
+                    .filter(ConstantOperator.class::isInstance)
+                    .forEach(constant -> constants.add(constant.toString()));
+            pending.addAll(node.getInputs());
+        }
+        return constants;
+    }
+
+    @SafeVarargs
+    private static void assertCachedPlanMatchesFreshPlan(String sql, Supplier<List<Expr>>... paramSets) throws Exception {
+        PreparedQuery cached = prepare(sql);
+        for (Supplier<List<Expr>> params : paramSets) {
+            ExecPlan fromCache = execute(cached, params.get());
+            ExecPlan fromScratch = execute(prepare(sql), params.get());
+            Assertions.assertAll(
+                    () -> Assertions.assertEquals(scanBindings(fromScratch), scanBindings(fromCache),
+                            sql + " bound with " + params.get()),
+                    () -> Assertions.assertEquals(scanBindingTypes(fromScratch), scanBindingTypes(fromCache),
+                            sql + " bound with " + params.get()));
+        }
+    }
+
+    // the invariant is that a rebound constant is the one full planning would build, so its type has to match too:
+    // 1 reads the same whether it is varchar(10) or varchar(1048576), and 1.00 whether decimal(4,2) or decimal(10,2)
+    private static Map<String, String> scanBindingTypes(ExecPlan plan) {
+        PhysicalOlapScanOperator scan =
+                findPhysicalOperator(plan.getPhysicalPlan(), PhysicalOlapScanOperator.class);
+        Map<String, String> types = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (ScalarOperator conjunct : Utils.extractConjuncts(scan.getPredicate())) {
+            Type type = conjunct.getChild(1).getType();
+            types.put(bindingKey(conjunct), type.getPrimitiveType() + "/" + type.toSql());
+        }
+        return types;
+    }
+
+    // the scan predicate as column name -> literal, so cached and freshly planned trees compare across differing ref ids
+    private static Map<String, String> scanBindings(ExecPlan plan) {
+        PhysicalOlapScanOperator scan =
+                findPhysicalOperator(plan.getPhysicalPlan(), PhysicalOlapScanOperator.class);
+        Map<String, String> bindings = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        for (ScalarOperator conjunct : Utils.extractConjuncts(scan.getPredicate())) {
+            bindings.put(bindingKey(conjunct), conjunct.getChild(1).toString());
+        }
+        return bindings;
+    }
+
+    private static String bindingKey(ScalarOperator conjunct) {
+        return conjunct.getChild(0) instanceof ColumnRefOperator
+                ? ((ColumnRefOperator) conjunct.getChild(0)).getName() : conjunct.getChild(0).toString();
+    }
+
+    private static class ReasonAppender extends AbstractAppender {
+        private final List<String> messages = new ArrayList<>();
+
+        ReasonAppender() {
+            super("prepare-stmt-planner-reasons", null, null);
+        }
+
+        @Override
+        public void append(LogEvent event) {
+            messages.add(event.getMessage().getFormattedMessage());
+        }
     }
 
     private record PreparedQuery(String name, PrepareStmt statement, PrepareStmtContext context) {


### PR DESCRIPTION
## Why I'm doing:

A cached prepared point-query plan can silently return the wrong rows. On a plan-cache hit,
`ScalarOperator.updateLiteralPredicates` walked the cached predicate exactly two levels deep: it iterated
the children of the top-level `AND` and took the parameter at the same index. `a AND b AND c` is a nested
binary tree, so with three key columns the constants sit one level lower. The loop then wrote parameter
*i* into whatever sat at position *i*, which for `i = 0` is the whole `k2 = ?` sub-predicate rather than a
constant — and the last parameter was never used at all. No error, no log, just the wrong row.

Reproduced on a `(k1, k2, k3)` table holding `(1,2,3,'a') (4,5,6,'b') (1,2,5,'c') (7,8,9,'d') (1,2,8,'e')`,
one connection, `mysql-connector` `cursor(prepared=True)`:

| EXECUTE | expected | before | after |
|---|---|---|---|
| (1,2,3) | a | a | a |
| (4,5,6) | b | **c** | b |
| (1,2,3) again | a | **(empty)** | a |
| (7,8,9) | d | **e** | d |

Affects any OLAP table with **three or more key columns** all matched by `= ?`, over the **binary
protocol**, from the second EXECUTE of a connection onwards; `PRIMARY KEY` and `DUPLICATE KEY` behave
identically. The defect dates back to #44266 (2024-04), when point-query plan caching was introduced.

Text-protocol `EXECUTE ... USING @v` never reaches this path — those parameters are `VariableExpr`, not
`LiteralExpr`, so `isPointQuery()` is false and nothing is cached. That is also why no SQL test could
have caught it, and why the regression tests here are FE unit tests.

## What I'm doing:

Rather than patch the tree walk, this replaces the hand-written binding with the primitives normal
planning already gets right, and moves the "can this plan be rebound at all?" decision from the hit path
to the moment the plan is cached.

* **Locate constants by column name, not by position.** The mapping comes from the analysed `WHERE`
  clause (`SlotRef` -> `Parameter.getSlotId()`), rebuilt per EXECUTE in O(key columns). Position-based
  binding silently depends on a global property — "no rewrite rule ever reorders `col = ?` conjuncts" —
  that nothing in the tree maintains. Name-based binding depends only on a local one.
* **Decide each parameter with the rule that decides it during planning.** A cached conjunct compares at
  the column's own type: its left side is a bare column reference, so the first planning added no cast
  there. Whether that still holds for a new parameter is `ImplicitCastRule`'s decision, so the candidate
  conjunct `column = <new constant>` is run through `ScalarOperatorRewriter` with the same
  `DEFAULT_REWRITE_RULES` the `WHERE` clause goes through, and the result is accepted only when the column
  comes back uncast. The rebound conjunct is then the one full planning would have built, type included —
  a stronger invariant than a round-trip value check, and one that needs no second copy of the coercion
  rules. The constant itself is built exactly as `SqlToScalarOperatorTranslator.visitLiteral` builds it,
  so a `NullLiteral` becomes a NULL constant rather than the string `'NULL'` that `getRealObjectValue()`
  returns.
* **Validate every parameter before writing any of them**, so a rejected EXECUTE cannot leave the cached
  tree half rebound.
* **Decide the plan shape once, when caching.** A plan is cached only when the logical side is
  `filter -> project -> olap scan`, the physical root is a `PhysicalOlapScanOperator`, every conjunct is
  `ColumnRef = Constant`, columns and parameter slots correspond one-to-one, and the mapping covers every
  parameter of the statement. Anything else calls `PrepareStmtContext.reset()` and is planned in full on
  each EXECUTE. `reset()` rather than "just don't cache" because one of the two call sites arrives holding
  a plan built against the previous schema.
* `ScalarOperator` loses three methods (`updateLiteralPredicates` and its two helpers). They had a single
  caller and no tests; sitting on an optimizer core class is part of why nobody questioned their
  tree-shape assumption.

### Behaviour changes

1. **Correctness.** Prepared point queries on tables with >= 3 key columns return the right rows on the
   second and later EXECUTE of a connection. This also fixes a hard failure, not only wrong rows: binding
   a `DATE` parameter onto a cached `VARCHAR` key-column comparison made fragment building throw
   `Cannot convert ColumnRefOperator to Expr`.
2. **Some statements stop using the cached plan and are planned in full on every EXECUTE.** This is
   deliberate — each case is one the old code got wrong rather than slow:
   - a parameter outside `WHERE` (e.g. `select ?, v from t where k = ?`): previously cached, and the
     select-list constant stayed frozen at its first value;
   - shapes the rebind cannot reach: a session whose `sql_select_limit` is non-default **at EXECUTE time** —
     checked on every EXECUTE, not only when the plan was cached, so `SET sql_select_limit` after the first
     EXECUTE also takes effect — or a window function in the select list. Both add an operator above the
     filter, and the old code then skipped rebinding entirely and reused the *previous* EXECUTE's parameter
     values (and, for a limit set after caching, ignored the limit altogether — a pre-existing gap the
     review surfaced);
   - a plan whose physical root is not an olap scan, e.g. a parameter bound to `NULL` on the first
     EXECUTE folds the query to an empty `VALUES`;
   - a parameter whose type would change how the comparison is performed. A `DOUBLE` parameter against a
     `VARCHAR` key column makes normal planning cast the column and compare numerically, where `'1'` and
     `'01'` are the same value; a `DATE` parameter against a `VARCHAR` key column makes it compare as
     `DATETIME`; a `VARCHAR` parameter against a `DECIMAL` key column makes it compare as strings. The
     common JDBC shape — numeric key columns with every parameter sent as a string — is unaffected,
     because planning folds the string into the column type and casts nothing;
   - any NULL parameter, since `FoldConstantsRule.visitBinaryPredicate` folds `col = NULL` to a constant,
     which is no longer a `column = constant` conjunct;
   - a parameter that cannot be rebound also drops the cached plan: the fallback re-plans, and if that
     plan is not itself rebindable the context is reset, so a later EXECUTE with a compatible parameter
     pays one more full planning before it can be cached again. An application that alternates parameter
     types on the same prepared statement will keep missing the cache.
3. **Correct results are preferred over cache hit rate**; the degradations above are the intended
   trade-off. One-key and two-key point queries, and semantically equivalent widenings such as an `INT`
   literal on a `BIGINT` key column, still hit the cache.

### Observability

Reviewed the existing signals on this path: **there were none.** The bug returned wrong rows with no
error, no log line and no metric; the repo has no plan-cache hit/miss counter for prepared statements
either. This PR adds one signal — a `DEBUG` line on `com.starrocks.sql.PrepareStmtPlanner` naming the
reason a plan was not cached or an EXECUTE fell back: plan shape, physical root, a non-default
`sql_select_limit`, a missing or duplicated parameter for a predicate column, parameters outside the
predicate, a non-literal parameter, or a parameter that would change the comparison for a column.
`DEBUG` rather than `INFO` because it fires per EXECUTE on a path whose whole purpose is low latency, and
it answers exactly one operator question — "why did my prepared point query get slower?" A hit-rate metric
remains missing; that is a pre-existing gap and out of scope here.

### Notes from reviewing the perimeter

- **Execution context.** `PrepareStmtPlanner.plan` runs on the per-connection query thread, serial per
  connection, inside the planning budget. Everything added is in-memory tree walking bounded by the number
  of key columns; no syscalls, no locks, no state shared beyond the per-connection `PrepareStmtContext`.
  The candidate conjunct handed to the rewriter uses a copy of the cached column reference, because a rule
  may write through to what it is given (`ReduceCastRule` calls `setType` on a cast child in place) and
  the cached tree outlives the call.
- **Consumers of the state written.** `PlanFragmentBuilder.visitPhysicalOlapScan` (predicate, selected
  partitions, selected tablets) and `OlapScanNode.computePointScanRangeLocations`, which merges the scan's
  `prunedPartitionPredicates` back into the conjuncts to extract the point key. Because the hit path
  re-installs the *full* predicate, a stale pruned partition predicate collides with the live conjunct and
  `RowStoreUtils.extractPointsLiteral` returns empty, disabling the short-circuit lookup and falling back
  to a normal scan. That costs performance, never correctness — verified end to end on a single-value
  range-partitioned table with the partition column in the primary key (6/6 correct both before and after
  this change). Not tightened here, to keep the behaviour-change list short.
- **Error branches.** Both rejection branches return a correct plan, log one debug line, and touch no
  metric. None of the three claims failure; they are performance outcomes, not errors.
- **Bounds.** Every added loop is over the conjuncts of a point-query predicate, i.e. the table's key
  columns, one pass per EXECUTE. Nothing iterates external or unbounded data.
- **Copied patterns.** The constant construction copies `visitLiteral` because the cached constants were
  produced by that exact call on the first EXECUTE. The pattern deliberately *not* copied is
  `ConstantOperator.castTo`, which truncates a floating-point source onto an integer target
  (`childString.split("\\.")[0]`); nor is `ImplicitCastRule`'s coercion table reimplemented — the rule is
  invoked instead.

### Testing

`PrepareStmtPlannerTest` goes from 3 to 27 cases. Every correctness case compares the rebound plan against
the plan a freshly prepared statement produces for the same parameters, by value *and* by constant type,
rather than asserting internal state. Coverage includes: three and four key columns, `? = col`, predicate
order differing from key order, a fractional parameter on an `INT` key, `NULL` versus the string `'NULL'`,
a failure on the last parameter leaving earlier conjuncts untouched, `sql_select_limit` (set before the
first EXECUTE, and set after the plan was cached), window functions, a physical root that is not a scan,
a parameter in the select list, entry rejections (`LIMIT`/`IN`/`OR`, repeated equality on one column),
stale-cache clearing after a schema bump, partitioned tables, and the type pairs above across
`VARCHAR`/`DECIMAL`/`DATE`/`DATETIME` key columns.

Verified against unmodified `main`: 13 of the new cases fail there. Also ran `PreparedStmtTest`,
`ConnectProcessorTest`, `ConnectProcessorExecuteTest`, `ShortCircuitTest`, `ImplicitCastRuleTest`,
`UtilsTest` and `optimizer.operator.scalar.*Test` — 180 pass, 0 fail. End to end over the binary protocol,
the three reproductions above return correct rows after the change and 5 wrong rows / 1 hard error before.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

The policy change is which prepared point-query plans stay eligible for the plan cache, described under
"Behaviour changes" above. No syntax, parameter or configuration changes.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

