### PR TITLE
[UT] Poll for the global dict at 0.1s instead of 1s

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2665,22 +2665,26 @@ class StarrocksSQLApiLib(object):
         tools.assert_equal(expect_status, status, "wait alter table finish error")
         time.sleep(0.5)
 
-    def wait_global_dict_ready(self, column_name, table_name):
+    def wait_global_dict_ready(self, column_name, table_name, timeout=60, interval=0.1):
         """
         wait global dict ready
+
+        The first EXPLAIN only asks the FE for a dictionary it does not have yet; CacheDictManager
+        loads it asynchronously from the BE, so the plan gains its Decode node one poll later. That
+        load takes tens of milliseconds for the row counts these cases use, hence the 0.1s interval:
+        polling once a second spent ~0.9s of pure sleep per call, and this helper is called 89 times
+        across the suite (42 of them in test_global_dict/global_dict_with_union alone).
         """
-        status = ""
-        count = 0
-        while True:
-            if count > 60:
-                tools.assert_true(False, "acquire dictionary timeout for 60s")
-            sql = "explain costs select distinct %s from %s" % (column_name, table_name)
+        sql = "explain costs select distinct %s from %s" % (column_name, table_name)
+        deadline = time.time() + timeout
+        while time.time() < deadline:
             res = self.execute_sql(sql, True)
             if not res["status"]:
                 tools.assert_true(False, "acquire dictionary error")
             if str(res["result"]).find("Decode") > 0:
                 return ""
-            time.sleep(1)
+            time.sleep(interval)
+        tools.assert_true(False, "acquire dictionary timeout for %ss" % timeout)
     
     def wait_plan_contains(self, query, *expects):
         """

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2678,8 +2678,8 @@ class StarrocksSQLApiLib(object):
         tools.assert_true(interval > 0, "wait_global_dict_ready: interval must be positive, got %s" % interval)
 
         sql = "explain costs select distinct %s from %s" % (column_name, table_name)
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
             res = self.execute_sql(sql, True)
             if not res["status"]:
                 tools.assert_true(False, "acquire dictionary error")

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2667,14 +2667,16 @@ class StarrocksSQLApiLib(object):
 
     def wait_global_dict_ready(self, column_name, table_name, timeout=60, interval=0.1):
         """
-        wait global dict ready
+        wait until the global dict for table_name:column_name is collected
 
         The first EXPLAIN only asks the FE for a dictionary it does not have yet; CacheDictManager
-        loads it asynchronously from the BE, so the plan gains its Decode node one poll later. That
-        load takes tens of milliseconds for the row counts these cases use, hence the 0.1s interval:
-        polling once a second spent ~0.9s of pure sleep per call, and this helper is called 89 times
-        across the suite (42 of them in test_global_dict/global_dict_with_union alone).
+        loads it asynchronously from the BE, so the plan gains its Decode node a poll later rather
+        than on the first call. Poll rather than sleep between checks: the load finishes long
+        before a whole second has passed.
         """
+        tools.assert_true(timeout > 0, "wait_global_dict_ready: timeout must be positive, got %s" % timeout)
+        tools.assert_true(interval > 0, "wait_global_dict_ready: interval must be positive, got %s" % interval)
+
         sql = "explain costs select distinct %s from %s" % (column_name, table_name)
         deadline = time.time() + timeout
         while time.time() < deadline:


### PR DESCRIPTION
## Why I'm doing:

`wait_global_dict_ready` spends nearly all of its time asleep.

The first `EXPLAIN` only asks the FE for a dictionary it does not have yet. `CacheDictManager` loads it asynchronously from the BE (`CompletableFuture.supplyAsync` in its cache loader), so the plan gains its `Decode` node one poll later. That load takes tens of milliseconds at the row counts these cases use — but the helper then slept a full second before looking again.

It is called **89 times across 23 case files**:

| case | calls |
|---|---|
| `test_global_dict/global_dict_with_union` | 42 |
| `test_global_dict/global_dict_on_lake` | 9 |
| `test_global_dict/dict_lake_period_version` | 6 |
| `test_low_cardinality/test_low_cardinality_array` | 4 |
| 19 others | 28 |

`global_dict_with_union` takes **64.4s** in the sequential pass of a recent PR run while querying tables of a few rows each; 42 of those seconds are this sleep. It is currently the slowest case in that pass.

## What I'm doing:

Poll at 0.1s instead of 1s, with `timeout` and `interval` as optional keyword arguments so an individual case can widen them if it ever needs to. All 89 call sites pass two positional arguments, so they are unaffected.

Two fixes came along with it:

- **The timeout never fired.** `count` was initialised to 0 and never incremented, so `if count > 60` was dead code. A dictionary that never arrived spun forever until the framework's own case timeout, which then reported a generic timeout rather than `acquire dictionary timeout`. Replaced with a deadline check.
- The constant SQL string was rebuilt on every iteration; hoisted out of the loop.

No case file changes, so no R files need re-recording.

## What to watch

The 0.1s interval is reasoned from the async load being tens of milliseconds, not measured per call. If it turns out to need longer, the loop simply spins a few more times and still returns the right answer — the failure mode is "saves less", not "fails".

The real risk is the opposite direction: a case that quietly depended on that 1s sleep to also wait out some *other* async action. `test_materialized_view/test_sync_materialized_view_rewrite` and `test_skew_join/test_skew_join_v2_derived_dict` are the two call sites where such coupling is most plausible.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
