### PR TITLE
[UT] Poll for the MV rewrite instead of sleeping a second first

### DIFF
--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2309,15 +2309,25 @@ class StarrocksSQLApiLib(object):
             if orig_value is not None:
                 self.execute_sql(f"set enable_materialized_view_rewrite = {orig_value};", True)
 
-    def print_hit_materialized_view(self, query, *expects) -> str:
+    def print_hit_materialized_view(self, query, *expects, timeout=10, interval=0.2) -> str:
         """
         assert every name in ``expects`` appears in the plan for query
 
         Callers pass more than one marker to assert a shape, not a choice: ("mv1", "UNION") means
         the MV was used *and* the rewrite was a union. Returning on the first marker to appear left
         the rest of them unchecked.
+
+        With ``expects`` there is a condition to poll on, so the explain runs immediately and
+        repeats until every marker appears. Without it the return value is free-form output that
+        lands in an R file, and there is nothing to wait for except stability, so the original
+        one-second settle wait is kept.
         """
-        time.sleep(1)
+        tools.assert_true(timeout > 0, "print_hit_materialized_view: timeout must be positive, got %s" % timeout)
+        tools.assert_true(interval > 0, "print_hit_materialized_view: interval must be positive, got %s" % interval)
+
+        if not expects:
+            time.sleep(1)
+
         def check_mv():
             sql = "explain %s" % (query)
             res = self.retry_execute_sql(sql, True)
@@ -2341,29 +2351,31 @@ class StarrocksSQLApiLib(object):
                 print("Hit materialized views:", ", ".join(mvs))
                 return mvs
 
-        # Retry the check several times before declaring failure. MV partition
-        # staleness state propagates asynchronously after base-table writes, so
-        # the optimizer may not pick the expected rewrite (e.g. UNION) on the
-        # first explain call right after an INSERT.
-        max_retries = 5
-        for attempt in range(max_retries):
+        # Poll until the rewrite shows up. MV partition staleness state propagates
+        # asynchronously after base-table writes, so the optimizer may not pick the
+        # expected rewrite (e.g. UNION) on the first explain call right after an INSERT.
+        deadline = time.time() + timeout
+        while True:
             result = self._with_materialized_view_rewrite(check_mv)
             if not isinstance(result, bool) or result:
                 return result
-            if attempt < max_retries - 1:
-                time.sleep(2)
-        return False
+            if time.time() >= deadline:
+                return False
+            time.sleep(interval)
 
-    def print_hit_materialized_views(self, query, *expects) -> str:
+    def print_hit_materialized_views(self, query, *expects, timeout=10, interval=0.2) -> str:
         """
         print all mv_names hit in query.
 
-        If ``expects`` is provided, retry the explain a few times until every
-        expected mv name appears in the rewrite. MV partition-version state
-        propagates asynchronously after a refresh/insert, so the optimizer may
-        skip an eligible MV on the very first explain call.
+        If ``expects`` is provided, poll the explain until every expected mv name appears in the
+        rewrite. MV partition-version state propagates asynchronously after a refresh/insert, so
+        the optimizer may skip an eligible MV on the very first explain call. Without ``expects``
+        the return value is free-form output that lands in an R file, and there is nothing to wait
+        for except stability, so the original one-second settle wait is kept.
         """
-        time.sleep(1)
+        tools.assert_true(timeout > 0, "print_hit_materialized_views: timeout must be positive, got %s" % timeout)
+        tools.assert_true(interval > 0, "print_hit_materialized_views: interval must be positive, got %s" % interval)
+
         def extract_mvs():
             sql = "explain %s" % (query)
             res = self.retry_execute_sql(sql, True)
@@ -2390,18 +2402,18 @@ class StarrocksSQLApiLib(object):
             return ",".join(ans)
 
         if not expects:
+            time.sleep(1)
             return self._with_materialized_view_rewrite(extract_mvs)
 
-        max_retries = 5
-        last_result = ""
-        for attempt in range(max_retries):
+        deadline = time.time() + timeout
+        while True:
             last_result = self._with_materialized_view_rewrite(extract_mvs)
             hit_set = set(last_result.split(",")) if last_result else set()
             if all(e in hit_set for e in expects):
                 return last_result
-            if attempt < max_retries - 1:
-                time.sleep(2)
-        return last_result
+            if time.time() >= deadline:
+                return last_result
+            time.sleep(interval)
 
     def assert_equal_result(self, *sqls):
         if len(sqls) < 2:

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2325,9 +2325,6 @@ class StarrocksSQLApiLib(object):
         tools.assert_true(timeout > 0, "print_hit_materialized_view: timeout must be positive, got %s" % timeout)
         tools.assert_true(interval > 0, "print_hit_materialized_view: interval must be positive, got %s" % interval)
 
-        if not expects:
-            time.sleep(1)
-
         def check_mv():
             sql = "explain %s" % (query)
             res = self.retry_execute_sql(sql, True)
@@ -2340,26 +2337,25 @@ class StarrocksSQLApiLib(object):
                     if plan.find(expect) <= 0:
                         return False
                 return True
-            else:
-                mvs = []
-                for line in plan.split('\n'):
-                    if 'MaterializedView: true' in line:
-                        mv_name = line.split('TABLE:')[1].strip() if 'TABLE:' in line else None
-                        if mv_name:
-                            mvs.append(mv_name)
-                mvs.sort()
-                print("Hit materialized views:", ", ".join(mvs))
-                return mvs
+            mvs = []
+            for line in plan.split('\n'):
+                if 'MaterializedView: true' in line:
+                    mv_name = line.split('TABLE:')[1].strip() if 'TABLE:' in line else None
+                    if mv_name:
+                        mvs.append(mv_name)
+            mvs.sort()
+            print("Hit materialized views:", ", ".join(mvs))
+            return mvs
 
-        # Poll until the rewrite shows up. MV partition staleness state propagates
-        # asynchronously after base-table writes, so the optimizer may not pick the
-        # expected rewrite (e.g. UNION) on the first explain call right after an INSERT.
-        deadline = time.time() + timeout
+        if not expects:
+            time.sleep(1)
+            return self._with_materialized_view_rewrite(check_mv)
+
+        deadline = time.monotonic() + timeout
         while True:
-            result = self._with_materialized_view_rewrite(check_mv)
-            if not isinstance(result, bool) or result:
-                return result
-            if time.time() >= deadline:
+            if self._with_materialized_view_rewrite(check_mv):
+                return True
+            if time.monotonic() >= deadline:
                 return False
             time.sleep(interval)
 
@@ -2405,13 +2401,13 @@ class StarrocksSQLApiLib(object):
             time.sleep(1)
             return self._with_materialized_view_rewrite(extract_mvs)
 
-        deadline = time.time() + timeout
+        deadline = time.monotonic() + timeout
         while True:
             last_result = self._with_materialized_view_rewrite(extract_mvs)
             hit_set = set(last_result.split(",")) if last_result else set()
             if all(e in hit_set for e in expects):
                 return last_result
-            if time.time() >= deadline:
+            if time.monotonic() >= deadline:
                 return last_result
             time.sleep(interval)
 


### PR DESCRIPTION
## Why I'm doing:

`print_hit_materialized_view` and `print_hit_materialized_views` both opened with an unconditional `time.sleep(1)` before their first `EXPLAIN`, then retried up to five times with two seconds between attempts.

That sleep is a head start on an asynchronous condition the helpers already know how to check. The comment in the code says as much: MV partition-version state propagates asynchronously after a refresh or insert, so the optimizer may not pick the expected rewrite on the very first explain. But a helper that can test the condition does not need to guess how long to wait for it.

The two are called **1192 times across 66 case files**:

| helper | files | calls | with `expects` |
|---|---|---|---|
| `print_hit_materialized_view` | 62 | 1097 | 1005 |
| `print_hit_materialized_views` | 8 | 95 | — |

`test_mv/test_mv_fast_schema_change` is a concrete example: it takes **48.7s** in the sequential pass on 100 rows of data, and 16 of those seconds are this sleep across 16 calls.

## What I'm doing:

Run the explain immediately and re-check every 0.2s until a 10s deadline. A rewrite that is already there costs nothing; one that is not gets a wider window than the old `1 + 4x2` seconds, so this is strictly more patient where patience is what was needed.

**The opening sleep is kept when no `expects` are given** (92 of the 1097 call sites). In that branch the return value is free-form output that lands in an R file and the helper returns after a single check — there is no condition to poll for, and the sleep is the only thing keeping that output stable. Removing it there would trade run time for flakiness.

`timeout` and `interval` are validated, since they are newly exposed: a negative interval would reach `time.sleep()` and fail with `sleep length must be non-negative` from inside the helper, and a non-positive timeout would put the deadline in the past and skip the loop entirely while still reporting a timeout.

No case files change, so no R files need re-recording.

## Prior art in this series

`#78980` made the same shape of change to `wait_global_dict_ready` (1s poll to 0.1s). Measured on its CI run: `test_global_dict/global_dict_with_union` went from **64.4s to 25.6s**, with no case failures. This PR applies the same reasoning to the MV rewrite check.

## What to watch

The risk is a case that quietly depended on that first second to settle something *other* than the MV rewrite — the helper would now return before that unrelated thing finished. Cases combining a refresh with an immediately following rewrite assertion are where this would surface first.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [ ] 3.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
