### PR TITLE
[BugFix] Throw std::bad_alloc when an aligned allocation fails

### DIFF
--- a/be/src/base/container/raw_container.h
+++ b/be/src/base/container/raw_container.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <new>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -102,7 +103,11 @@ public:
 
     pointer allocate(size_type n) {
         size_t size = (n * sizeof(value_type) < N) ? N : (n * sizeof(value_type));
-        return (pointer)BitUtil::safe_aligned_alloc(N, size);
+        auto* ptr = (pointer)BitUtil::safe_aligned_alloc(N, size);
+        // A null return is adopted as valid storage by the container; only std::bad_alloc
+        // reaches TRY_CATCH_ALLOC_SCOPE, which callers rely on for memory-limit errors.
+        if (UNLIKELY(ptr == nullptr)) throw std::bad_alloc();
+        return ptr;
     }
 
     void deallocate(pointer p, size_type) { free(p); }

--- a/be/test/base/raw_container_test.cpp
+++ b/be/test/base/raw_container_test.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <new>
+
 #include "common/memory/column_allocator.h"
 
 namespace starrocks {
@@ -74,4 +76,40 @@ TEST(TestRawContainer, rawStringPageIsPageAligned) {
         EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(s.data()) % kPageSize) << "unaligned for payload " << payload;
     }
 }
+
+// Both tests force a real aligned_alloc failure. The mem_alloc_error fail point cannot serve --
+// mem_hook's tracker-refusal branch is compiled out under BE_TEST -- and ASAN will not model a
+// failed allocation at all: it aborts with allocation-size-too-big, and allocator_may_return_null
+// is only settable through ASAN_OPTIONS at startup, which run-be-ut.sh overwrites. CI runs BE UT
+// in the Release configuration, where both tests execute.
+[[maybe_unused]] static constexpr size_t kUnsatisfiableSize = size_t{1} << 60; // 1 EiB, past the address space
+
+TEST(TestRawContainer, alignmentAllocatorThrowsWhenAllocationFails) {
+#if defined(ADDRESS_SANITIZER)
+    GTEST_SKIP() << "ASAN aborts on a refused aligned_alloc instead of returning null";
+#else
+    raw::AlignmentAllocator<char, 4096> allocator;
+    // Storing through a volatile keeps the compiler from eliding the allocation call outright,
+    // which would leave nothing for EXPECT_THROW to observe.
+    char* volatile allocated = nullptr;
+    EXPECT_THROW(allocated = allocator.allocate(kUnsatisfiableSize), std::bad_alloc);
+    EXPECT_EQ(nullptr, allocated);
+#endif
+}
+
+TEST(TestRawContainer, rawStringPageResizeThrowsInsteadOfAdoptingNullBuffer) {
+#if defined(ADDRESS_SANITIZER)
+    GTEST_SKIP() << "ASAN aborts on a refused aligned_alloc instead of returning null";
+#else
+    raw::RawStringPage s;
+    EXPECT_THROW(s.resize(kUnsatisfiableSize), std::bad_alloc);
+    EXPECT_TRUE(s.empty());
+
+    // A buffer that failed to grow must stay usable for the next chunk.
+    s.resize(8192);
+    EXPECT_EQ(8192u, s.size());
+    EXPECT_NE(nullptr, s.data());
+#endif
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

`AlignmentAllocator::allocate()` handed `std::aligned_alloc`'s result straight back without checking
it. An allocator has to report failure by throwing — `std::basic_string` is not allowed to inspect the
returned pointer — so a null return is adopted as the string's storage, and `resize()` then
value-initializes the appended characters, writing to address 0.

This became reachable in #77255, which changed `SerdeContext::serialize_buffer` from `raw::RawString`
to `raw::RawStringPage` so that O_DIRECT spill writes get the 4096-byte base alignment `pwritev`
requires for `iov_base`. The two types differ in the one layer that matters here:

- `RawString` allocates through `std::allocator` → `operator new`. When `mem_hook`'s
  `my_malloc()` refuses an allocation it returns `nullptr`, and `operator new` converts that into
  `std::bad_alloc`, which `TRY_CATCH_ALLOC_SCOPE` turns into `Status::MemoryLimitExceeded`.
- `RawStringPage` allocates through `std::aligned_alloc`. `my_aligned_alloc()` also returns
  `nullptr` on refusal, but there is no `operator new` above it to convert null into an exception,
  and `AlignmentAllocator` did not check it.

So under memory pressure a large spill stopped failing the query and started killing the process
instead. Observed on a shared-data cluster during a spilling aggregation: all CNs died within the
same second, `dmesg` reporting `segfault at 0 ... error 6` (a *write* to address 0):

```
*** SIGSEGV (@0x0) received by PID 7075 ... ***
    @      0x7249f1993fa (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1993f9)
    @          0xb5f120e starrocks::spill::ColumnarSerde::serialize(...)
    @          0xb5dc37e starrocks::spill::UnorderedMemTable::finalize(...)
    @          0xb5d2b02 starrocks::spill::PartitionedSpillerWriter::spill_partition(...)
    @          0xb5d602e starrocks::spill::PartitionedSpillerWriter::yieldable_flush_task(...)
```

and, on a separate run, the restore side:

```
*** SIGSEGV (@0x0) received by PID 53592 ... ***
    @      0x775581995ba (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1995b9)
    @          0xb5f2418 starrocks::spill::ColumnarSerde::deserialize(...)
    @          0xb5b12bd starrocks::spill::BufferedInputStream::prefetch(...)
    @          0x9f99a9b starrocks::pipeline::SpillableHashJoinProbeOperator::_load_partition_build_side(...)
```

Both faults are inside the `resize()` at `serde.cpp:129` and `serde.cpp:189` respectively, not at the
writes that follow them: growing a `basic_string` must value-initialize the new characters, so the
`memset` over the adopted null buffer happens before any of the serde's own stores. That is also why
`BlockReader::read_fully` (a virtual call, hence not inlinable) never appears on the restore-side
stack. A `data() == nullptr` check after `resize()` would be unreachable.

Note the buffer type change is unconditional, so running with `spill_enable_direct_io = false` (the
default) does not avoid this.

## What I'm doing:

Throw `std::bad_alloc` when the aligned allocation fails.

This restores exactly the contract that held before #77255, so no call site gains new exposure —
every caller already had to tolerate a throwing `resize()` of this same buffer. `load_chunk_spiller.cpp`,
the one caller not wrapped in `TRY_CATCH_ALLOC_SCOPE`, already allocates through `operator new` two
lines earlier via `chunk.clone_empty()`.

The check goes in `AlignmentAllocator` rather than in `BitUtil::safe_aligned_alloc` on purpose:
`state_combinator.h` deliberately inspects that helper's null return and reports
`Status::MemoryAllocFailed`, and throwing from the helper would make that check dead code.

Verification, with the production `AlignmentAllocator` / `RawAllocator` / `RawStringPage` extracted
verbatim and only libc's `aligned_alloc` (the function `mem_hook` interposes) stubbed to refuse, on
gcc 13.3 / libstdc++ and on clang / libc++:

| | `serialize` (`serde.cpp:129`) | `deserialize` (`serde.cpp:189`) |
|---|---|---|
| before | SIGSEGV, `si_addr = 0x0` | SIGSEGV, `si_addr = 0x0` |
| after | `std::bad_alloc` → `MemoryLimitExceeded` | `std::bad_alloc` → `MemoryLimitExceeded` |

The two added unit tests were confirmed to fail against the unfixed allocator and pass against the
fixed one through the same harness. Note they force a genuine allocation failure rather than using the
`mem_alloc_error` fail point, because `IS_BAD_ALLOC_CATCHED()` is compiled out under `BE_TEST`, and
they store the result through a `volatile` so the allocation call is not elided outright — without
that, `EXPECT_THROW` silently observes nothing.

Fixes #issue: N/A — found while stress-testing spill locally; no public issue filed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
