### PR TITLE
[BugFix] Verify block checksums on PK index sstable reads (backport #77479)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1479,6 +1479,13 @@ CONF_mBool(lake_enable_orphan_delvec_cleanup_on_compaction, "false");
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
+// Verify sstable block checksums on cloud-native PK index reads (open, point lookup,
+// and compaction merge), so corrupted bytes (usually a bad local cache copy) fail
+// deterministically as Corruption — and get healed by the drop-corrupted-cache
+// fallback — instead of being misparsed or silently returning wrong index values.
+// Mutable so the verification can be switched off quickly if the crc32c overhead
+// ever becomes a concern on a hot read path.
+CONF_mBool(lake_pk_index_sst_verify_checksum, "true");
 CONF_mBool(enable_strict_delvec_crc_check, "true");
 // When true, a shared-data del file (.del) read back during publish or primary-key index rebuild is
 // verified against the CRC32C recorded in its metadata, and a mismatch fails the operation with

--- a/be/src/storage/lake/lake_persistent_index.cpp
+++ b/be/src/storage/lake/lake_persistent_index.cpp
@@ -574,6 +574,9 @@ Status LakePersistentIndex::prepare_merging_iterator(
     sstable::ReadOptions read_options;
     // No need to cache input sst's blocks.
     read_options.fill_cache = false;
+    // Catch corrupted data blocks as Corruption instead of merging garbage into the
+    // compaction output.
+    read_options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
     std::vector<sstable::Iterator*> iters;
     DeferOp free_iters([&] {
         for (sstable::Iterator* iter : iters) {

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.cpp
@@ -115,6 +115,9 @@ Status LakePersistentIndexParallelCompactTask::do_run() {
 
     sstable::ReadOptions read_options;
     read_options.fill_cache = false;
+    // Catch corrupted data blocks as Corruption instead of merging garbage into the
+    // compaction output.
+    read_options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
 
     bool contain_shared_sstables = false;
     // Open each sstable and create iterator

--- a/be/src/storage/lake/persistent_index_sstable.cpp
+++ b/be/src/storage/lake/persistent_index_sstable.cpp
@@ -74,6 +74,10 @@ Status PersistentIndexSstable::init(std::unique_ptr<RandomAccessFile> rf, const 
         options.filter_policy = _filter_policy.get();
     }
     options.block_cache = cache;
+    // Verify block checksums when reading the index/meta blocks, so corrupted bytes
+    // (usually from the local cache) fail deterministically as Corruption instead of
+    // being misparsed, and can be healed by the drop-cache-and-retry below.
+    options.paranoid_checks = config::lake_pk_index_sst_verify_checksum;
     std::unique_ptr<sstable::Table> table;
     auto open_st = sstable::Table::Open(options, rf.get(), sstable_pb.filesize(), table);
     TEST_SYNC_POINT_CALLBACK("PersistentIndexSstable::init:table_open_error", &open_st);
@@ -160,6 +164,9 @@ Status PersistentIndexSstable::multi_get(const Slice* keys, const KeyIndexSet& k
     sstable::ReadIOStat stat;
     sstable::ReadOptions options;
     options.stat = &stat;
+    // Catch corrupted data blocks as Corruption (instead of silently returning wrong
+    // index values) so the drop-cache-and-retry below can heal a bad local cache.
+    options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
     std::unique_ptr<RandomAccessFile> rf;
     if (config::enable_pk_index_parallel_execution) {
         RandomAccessFileOptions opts;

--- a/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_unsort_sst_writer.cpp
@@ -269,8 +269,15 @@ Status PkTabletUnsortSSTWriter::merge_intermediates_into(sstable::TableBuilder* 
             ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, sst.location));
         }
         std::unique_ptr<sstable::Table> table;
-        RETURN_IF_ERROR(sstable::Table::Open(sstable::Options{}, rf.get(), sst.size, table));
-        auto* iter = table->NewIterator(sstable::ReadOptions{});
+        // Verify block checksums when re-reading the intermediate ssts this load just
+        // wrote: corrupted bytes (usually a bad local cache copy) must fail as
+        // Corruption instead of being silently merged into a wrong dedup result.
+        sstable::Options open_options;
+        open_options.paranoid_checks = config::lake_pk_index_sst_verify_checksum;
+        RETURN_IF_ERROR(sstable::Table::Open(open_options, rf.get(), sst.size, table));
+        sstable::ReadOptions read_options;
+        read_options.verify_checksums = config::lake_pk_index_sst_verify_checksum;
+        auto* iter = table->NewIterator(read_options);
         iter_holders.emplace_back(iter);
         child_iters.push_back(iter);
         rfs.push_back(std::move(rf));

--- a/be/test/storage/lake/persistent_index_sstable_test.cpp
+++ b/be/test/storage/lake/persistent_index_sstable_test.cpp
@@ -805,6 +805,52 @@ TEST_F(PersistentIndexSstableTest, test_multiget_retry_after_clear_corrupted_cac
 }
 #endif // USE_STAROS && !BUILD_FORMAT_LIB
 
+// Flip a few bytes inside the first data block (data blocks start at file offset 0),
+// keeping the file tail (filter/index blocks and footer) intact so Table::Open still
+// succeeds and the corruption is only hit when the data block itself is read.
+static void corrupt_sst_data_block(const std::string& path) {
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    ASSIGN_OR_ABORT(auto file_size, rf->get_size());
+    std::string content(file_size, '\0');
+    ASSERT_OK(rf->read_at_fully(0, content.data(), file_size));
+    for (size_t i = 16; i < 24 && i < content.size(); i++) {
+        content[i] ^= 0xff;
+    }
+    WritableFileOptions opts;
+    opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ABORT(auto wf, FileSystem::Default()->new_writable_file(opts, path));
+    ASSERT_OK(wf->append(Slice(content)));
+    ASSERT_OK(wf->close());
+}
+
+// A data block whose bytes were tampered with must surface as Corruption via the block
+// checksum, not be misparsed (the "bad block type" failure mode) or silently return
+// wrong index values.
+TEST_F(PersistentIndexSstableTest, test_multiget_detects_corrupted_data_block) {
+    bool old_verify = config::lake_pk_index_sst_verify_checksum;
+    config::lake_pk_index_sst_verify_checksum = true;
+    const std::string path = lake::join_path(kTestDir, "multiget_corrupted_block.sst");
+    uint64_t filesize = 0;
+    build_test_sst(path, &filesize);
+    corrupt_sst_data_block(path);
+
+    auto sst = std::make_unique<PersistentIndexSstable>();
+    ASSIGN_OR_ABORT(auto rf, fs::new_random_access_file(path));
+    PersistentIndexSstablePB sstable_pb;
+    sstable_pb.set_filename("multiget_corrupted_block.sst");
+    sstable_pb.set_filesize(filesize);
+    ASSERT_OK(sst->init(std::move(rf), sstable_pb, nullptr));
+
+    std::string key_str = fmt::format("key_{:04d}", 0);
+    Slice key(key_str);
+    KeyIndexSet key_indexes{0};
+    std::vector<IndexValue> values(1, IndexValue(NullIndexValue));
+    KeyIndexSet found;
+    auto st = sst->multi_get(&key, key_indexes, -1, values.data(), &found);
+    ASSERT_TRUE(st.is_corruption()) << st;
+    config::lake_pk_index_sst_verify_checksum = old_verify;
+}
+
 // Tombstones are stored as (rssid=UINT32_MAX, rowid=UINT32_MAX) so that the
 // 64-bit packed value equals NullIndexValue on the way out. When the owning
 // sstable has a non-zero rssid_offset (child-tablet contribution after a

--- a/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/en/administration/configuration/BE_parameters/shared_lake_other.md
@@ -490,6 +490,15 @@ This topic introduces the following types of BE configurations:
 - Description: Whether to allow the system to clear the corrupted data cache in a shared-data cluster.
 - Introduced in: v3.4
 
+### lake_pk_index_sst_verify_checksum
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to verify sstable block checksums when reading the cloud-native Primary Key index (point lookups and compaction merges) in a shared-data cluster. When enabled, corrupted bytes (usually from a corrupted local cache copy) deterministically fail as a Corruption error and trigger the corrupted-cache cleanup, instead of being misparsed or silently returning wrong index values. Note that the automatic cleanup of the corrupted cache additionally requires `lake_clear_corrupted_cache_data` to be enabled.
+- Introduced in: v4.1
+
 ### lake_clear_corrupted_cache_meta
 
 - Default: true

--- a/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/ja/administration/configuration/BE_parameters/shared_lake_other.md
@@ -481,6 +481,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 説明: 共有データクラスタにおいて、システムが破損したデータキャッシュをクリアすることを許可するかどうか。
 - 導入バージョン: v3.4
 
+### lake_pk_index_sst_verify_checksum
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: 共有データクラスタにおいて、クラウドネイティブ主キーインデックスの sstable を読み取る際（ポイントルックアップおよび Compaction マージ）にブロックの Checksum を検証するかどうか。有効にすると、破損したバイト列（通常は破損したローカルキャッシュのコピーに起因）は Corruption エラーとして確定的に失敗し、破損キャッシュのクリーンアップがトリガーされます。誤って解析されたり、誤ったインデックス値が静かに返されたりすることを防ぎます。なお、破損キャッシュの自動クリーンアップには `lake_clear_corrupted_cache_data` の有効化も必要です。
+- 導入バージョン: v4.1
+
 ### lake_clear_corrupted_cache_meta
 
 - デフォルト: true

--- a/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
+++ b/docs/zh/administration/configuration/BE_parameters/shared_lake_other.md
@@ -487,6 +487,15 @@ SELECT * FROM information_schema.be_configs [WHERE NAME LIKE "%<name_pattern>%"]
 - 描述：存算分离集群下，是否允许自动清理损坏的数据缓存。
 - 引入版本：v3.4
 
+### lake_pk_index_sst_verify_checksum
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：存算分离集群下，读取云原生主键索引 sstable（点查与 Compaction 归并）时是否校验数据块 Checksum。开启后，损坏的字节（通常来自损坏的本地缓存副本）会确定性地报 Corruption 错误并触发损坏缓存清理，而不是被错误解析或静默返回错误的索引值。注意：自动清理损坏缓存还需同时开启 `lake_clear_corrupted_cache_data`。
+- 引入版本：v4.1
+
 ### lake_clear_corrupted_cache_meta
 
 - 默认值：true


### PR DESCRIPTION
## Why I'm doing:

Backport #77479 to branch-4.1. The mergify auto-backport (#78944) hit conflicts and was closed.

PK index sstable block reads never verified the crc32c trailer that `TableBuilder` has always written, so corrupted bytes — usually a bad local cache copy — surfaced as the confusing "bad block type" error, or worse, were silently parsed as legal index entries: `multi_get` could return wrong index values and compaction could merge garbage into its output sstable. branch-4.1 already carries the drop-cache self-healing hooks (#77997), but without a deterministic Corruption signal they cannot fire on misparsed blocks.

## What I'm doing:

- Cherry-pick of #77479: turn on checksum verification on the PK index sstable read paths, all gated by the mutable BE config `lake_pk_index_sst_verify_checksum` (default `true`):
  - `PersistentIndexSstable::init`: `paranoid_checks` on `Table::Open`.
  - `PersistentIndexSstable::multi_get`: `verify_checksums` on data block reads.
  - Compaction merge readers (`LakePersistentIndex::prepare_merging_iterator` serial + `LakePersistentIndexParallelCompactTask::do_run` parallel): `verify_checksums`.
  - `PkTabletUnsortSSTWriter::merge_intermediates_into`: `paranoid_checks` + `verify_checksums` on intermediate sst re-reads.
  - UT: corrupted-data-block detection test for `multi_get`.
- Conflict adaptations for branch-4.1:
  - `common/config_fwd_headers_manifest.json` / `common/config_primary_key_fwd.h` dropped — the fwd-header split only exists on main; the config lands in `common/config.h`, which applied cleanly.
  - The `sample_data_keys` instrumentation and its UT dropped — the tablet-split sampling path does not exist on branch-4.1.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4