### PR TITLE
[Feature] Add WKB-backed GeoColumn and bounded inspection (Contract 2.2)

### DIFF
--- a/be/src/column/CMakeLists.txt
+++ b/be/src/column/CMakeLists.txt
@@ -65,6 +65,7 @@ ADD_BE_LIB(ColumnCore
         column_hash/column_hash.cpp
         adaptive_offsets.cpp
         serde/column_array_serde.cpp
+        geo_column.cpp
 )
 
 target_link_libraries(ColumnCore PRIVATE arrow streamvbyte)

--- a/be/src/column/geo_column.cpp
+++ b/be/src/column/geo_column.cpp
@@ -1,0 +1,226 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/geo_column.h"
+
+#include <stdexcept>
+
+namespace starrocks {
+namespace {
+
+[[noreturn]] void unsupported(const char* operation) {
+    throw std::runtime_error(std::string("GeoColumn does not support ") + operation);
+}
+
+} // namespace
+
+GeoColumn::GeoColumn(GeoColumnDescriptor descriptor, GeoWkbLimits limits)
+        : _descriptor(std::move(descriptor)), _limits(limits) {
+    if (_descriptor.storage.encoding != GEO_ENCODING_WKB)
+        throw std::invalid_argument("GeoColumn requires WKB encoding");
+}
+
+const GeoColumn& GeoColumn::_source(const Column& src) const {
+    // Column's copy API requires an identical physical type; do not introduce SQL type dispatch here.
+    const auto& geo = down_cast<const GeoColumn&>(src);
+    if (_descriptor != geo._descriptor) throw std::invalid_argument("GeoColumn descriptor mismatch");
+    return geo;
+}
+
+void GeoColumn::append_wkb(Slice wkb) {
+    clear_wkb_cache();
+    // BinaryColumn may reallocate its buffer. Own a copy when appending a slice from ourselves.
+    // External ingestion should use batch column copies once a GeoColumn exists.
+    const auto begin = reinterpret_cast<uintptr_t>(_data->get_string_begin());
+    const auto pointer = reinterpret_cast<uintptr_t>(wkb.data);
+    if (wkb.size != 0 && pointer >= begin && pointer - begin < _data->get_immutable_bytes().size()) {
+        const std::string copy(wkb.data, wkb.size);
+        _data->append(Slice(copy));
+    } else {
+        _data->append(wkb);
+    }
+}
+
+StatusOr<GeoWkbInfo> GeoColumn::inspect_wkb(size_t row) {
+    if (row >= size()) return Status::InvalidArgument("GeoColumn row out of range");
+    if (_cache && _cache->row == row) return _cache->info;
+    ASSIGN_OR_RETURN(auto info, inspect_geo_wkb(get_wkb(row), _limits));
+    _cache = CachedWkb{row, info};
+    return info;
+}
+
+void GeoColumn::append_wkb_batch(const Slice* values, size_t count) {
+    clear_wkb_cache();
+    (void)_data->append_strings(values, count);
+}
+
+void GeoColumn::resize(size_t count) {
+    clear_wkb_cache();
+    _data->resize(count);
+}
+
+void GeoColumn::assign(size_t count, size_t row) {
+    clear_wkb_cache();
+    _data->assign(count, row);
+}
+
+void GeoColumn::remove_first_n_values(size_t count) {
+    clear_wkb_cache();
+    _data->remove_first_n_values(count);
+}
+
+void GeoColumn::append(const Column& src, size_t offset, size_t count) {
+    if (&src == this) {
+        auto copy = clone();
+        append(*copy, offset, count);
+        return;
+    }
+    const auto& geo = _source(src);
+    clear_wkb_cache();
+    _data->append(*geo._data, offset, count);
+}
+
+void GeoColumn::append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t count) {
+    if (&src == this) {
+        auto copy = clone();
+        append_selective(*copy, indexes, from, count);
+        return;
+    }
+    const auto& geo = _source(src);
+    clear_wkb_cache();
+    _data->append_selective(*geo._data, indexes, from, count);
+}
+
+void GeoColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t count) {
+    if (&src == this) {
+        auto copy = clone();
+        append_value_multiple_times(*copy, index, count);
+        return;
+    }
+    const auto& geo = _source(src);
+    clear_wkb_cache();
+    _data->append_value_multiple_times(*geo._data, index, count);
+}
+
+void GeoColumn::append_value_multiple_times(const void* value, size_t count) {
+    // Own the source slice before the first append in case it aliases this column.
+    const auto slice = *static_cast<const Slice*>(value);
+    const std::string copy(slice.data, slice.size);
+    clear_wkb_cache();
+    const Slice owned(copy);
+    _data->append_value_multiple_times(&owned, count);
+}
+
+void GeoColumn::append_default(size_t count) {
+    clear_wkb_cache();
+    _data->append_default(count);
+}
+
+void GeoColumn::fill_default(const Filter& filter) {
+    clear_wkb_cache();
+    _data->fill_default(filter);
+}
+
+void GeoColumn::update_rows(const Column& src, const uint32_t* indexes) {
+    if (&src == this) {
+        auto copy = clone();
+        update_rows(*copy, indexes);
+        return;
+    }
+    const auto& geo = _source(src);
+    clear_wkb_cache();
+    _data->update_rows(*geo._data, indexes);
+}
+
+size_t GeoColumn::filter_range(const Filter& filter, size_t from, size_t to) {
+    clear_wkb_cache();
+    return _data->filter_range(filter, from, to);
+}
+
+MutableColumnPtr GeoColumn::clone_empty() const {
+    return create(_descriptor, _limits);
+}
+
+MutableColumnPtr GeoColumn::clone() const {
+    auto result = create(_descriptor, _limits);
+    result->_data->append(*_data, 0, size());
+    result->_delete_state = _delete_state;
+    return result;
+}
+
+void GeoColumn::swap_column(Column& rhs) {
+    auto& geo = down_cast<GeoColumn&>(rhs);
+    using std::swap;
+    swap(_descriptor, geo._descriptor);
+    swap(_limits, geo._limits);
+    swap(_data, geo._data);
+    swap(_delete_state, geo._delete_state);
+    clear_wkb_cache();
+    geo.clear_wkb_cache();
+}
+
+void GeoColumn::reset_column() {
+    Column::reset_column();
+    clear_wkb_cache();
+    _data->reset_column();
+}
+
+size_t GeoColumn::container_memory_usage() const {
+    return _data->memory_usage() + _descriptor.type.crs.capacity() + 1 + sizeof(_cache);
+}
+
+StatusOr<MutableColumnPtr> GeoColumn::upgrade_if_overflow() {
+    RETURN_IF_ERROR(capacity_limit_reached());
+    return MutableColumnPtr{};
+}
+
+std::string GeoColumn::debug_item(size_t row) const {
+    return fmt::format("geo[{} bytes]", get_wkb(row).size);
+}
+
+int GeoColumn::compare_at(size_t, size_t, const Column&, int) const {
+    unsupported("comparison");
+}
+int64_t GeoColumn::xor_checksum(uint32_t, uint32_t) const {
+    unsupported("checksum");
+}
+void GeoColumn::put_mysql_row_buffer(MysqlRowBuffer*, size_t, bool) const {
+    unsupported("public rendering");
+}
+uint32_t GeoColumn::max_one_element_serialize_size() const {
+    unsupported("serialization");
+}
+uint32_t GeoColumn::serialize(size_t, uint8_t*) const {
+    unsupported("serialization");
+}
+uint32_t GeoColumn::serialize_default(uint8_t*) const {
+    unsupported("serialization");
+}
+uint32_t GeoColumn::serialize_size(size_t) const {
+    unsupported("serialization");
+}
+void GeoColumn::serialize_batch(uint8_t*, Buffer<uint32_t>&, size_t, uint32_t) const {
+    unsupported("serialization");
+}
+const uint8_t* GeoColumn::deserialize_and_append(const uint8_t*) {
+    unsupported("deserialization");
+}
+void GeoColumn::deserialize_and_append_batch(Buffer<Slice>&, size_t) {
+    unsupported("deserialization");
+}
+void GeoColumn::deserialize_and_append_batch_nullable(Buffer<Slice>&, size_t, Buffer<uint8_t>&, bool&) {
+    unsupported("deserialization");
+}
+
+} // namespace starrocks

--- a/be/src/column/geo_column.h
+++ b/be/src/column/geo_column.h
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "column/binary_column.h"
+#include "types/geo_type_descriptor.h"
+#include "types/geo_wkb.h"
+
+namespace starrocks {
+
+// Standalone physical column; not a VARBINARY SQL type or a TypeDescriptor attachment.
+// The descriptor is immutable. Column-to-column copies require identical descriptors;
+// SQL assignment/coercion belongs to FE, not to these physical copy operations.
+// NULL is represented by NullableColumn. Empty bytes are only a default/null placeholder,
+// not an OGC EMPTY geometry. Payload ingestion preserves bytes without eager parsing.
+class GeoColumn final : public CowFactory<Column, GeoColumn> {
+public:
+    explicit GeoColumn(GeoColumnDescriptor descriptor, GeoWkbLimits limits = {});
+    DISALLOW_COPY(GeoColumn);
+
+    const GeoColumnDescriptor& descriptor() const { return _descriptor; }
+    Slice get_wkb(size_t row) const { return _data->get_slice(row); }
+    void append_wkb(Slice wkb);
+    // Batch ingestion from external buffers (must not alias this column).
+    void append_wkb_batch(const Slice* values, size_t count);
+    // Borrowed slices are read-only and follow Column lifetime rules: mutation may invalidate them.
+    // Inspection returns a pointer-free value. Only a mutable column can fill the cache:
+    // immutable shared columns never acquire mutable execution state through const access.
+    StatusOr<GeoWkbInfo> inspect_wkb(size_t row);
+    bool has_wkb_cache() const { return _cache.has_value(); }
+    void clear_wkb_cache() { _cache.reset(); }
+
+    size_t size() const override { return _data->size(); }
+    size_t capacity() const override { return _data->capacity(); }
+    size_t type_size() const override { return sizeof(Slice); }
+    size_t byte_size() const override { return _data->byte_size(); }
+    size_t byte_size(size_t from, size_t count) const override { return _data->byte_size(from, count); }
+    size_t byte_size(size_t row) const override { return _data->byte_size(row); }
+    void reserve(size_t count) override { _data->reserve(count); }
+    void reserve(size_t count, size_t bytes) { _data->reserve(count, bytes); }
+    void resize(size_t count) override;
+    void assign(size_t count, size_t row) override;
+    void remove_first_n_values(size_t count) override;
+    void append_datum(const Datum& datum) override { append_wkb(datum.get_slice()); }
+    using Column::append;
+    void append(const Column& src, size_t offset, size_t count) override;
+    void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t count) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t count) override;
+    void append_value_multiple_times(const void* value, size_t count) override;
+    bool append_nulls(size_t count) override { return false; }
+    size_t append_numbers(const void* data, size_t length) override { return size_t(-1); }
+    void append_default() override { append_default(1); }
+    void append_default(size_t count) override;
+    void fill_default(const Filter& filter) override;
+    void update_rows(const Column& src, const uint32_t* indexes) override;
+    size_t filter_range(const Filter& filter, size_t from, size_t to) override;
+    MutableColumnPtr clone_empty() const override;
+    MutableColumnPtr clone() const override;
+    void swap_column(Column& rhs) override;
+    void reset_column() override;
+
+    Datum get(size_t row) const override { return Datum(get_wkb(row)); }
+    std::string get_name() const override { return "geo"; }
+    std::string debug_item(size_t row) const override;
+    size_t container_memory_usage() const override;
+    size_t reference_memory_usage(size_t from, size_t count) const override { return 0; }
+    Status capacity_limit_reached() const override { return _data->capacity_limit_reached(); }
+    void check_or_die() const override { _data->check_or_die(); }
+    bool has_large_column() const override { return _data->has_large_column(); }
+    StatusOr<MutableColumnPtr> upgrade_if_overflow() override;
+    StatusOr<MutableColumnPtr> downgrade() override { return MutableColumnPtr{}; }
+
+    // No binary visitor fallback. Serde/public rendering are Contract 2.3;
+    // equality, ordering and geo keys remain unsupported.
+    Status accept(ColumnVisitor* visitor) const override { return Status::NotSupported("GeoColumn visitor"); }
+    Status accept_mutable(ColumnVisitorMutable* visitor) override { return Status::NotSupported("GeoColumn visitor"); }
+    int compare_at(size_t left, size_t right, const Column& rhs, int hint) const override;
+    int64_t xor_checksum(uint32_t from, uint32_t to) const override;
+    void put_mysql_row_buffer(MysqlRowBuffer* buf, size_t row, bool binary = false) const override;
+    uint32_t max_one_element_serialize_size() const override;
+    uint32_t serialize(size_t row, uint8_t* pos) const override;
+    uint32_t serialize_default(uint8_t* pos) const override;
+    uint32_t serialize_size(size_t row) const override;
+    void serialize_batch(uint8_t* dst, Buffer<uint32_t>& sizes, size_t count, uint32_t max_size) const override;
+    const uint8_t* deserialize_and_append(const uint8_t* pos) override;
+    void deserialize_and_append_batch(Buffer<Slice>& src, size_t count) override;
+    void deserialize_and_append_batch_nullable(Buffer<Slice>& src, size_t count, Buffer<uint8_t>& nulls,
+                                               bool& has_null) override;
+
+private:
+    const GeoColumn& _source(const Column& src) const;
+    struct CachedWkb {
+        size_t row;
+        GeoWkbInfo info;
+    };
+    GeoColumnDescriptor _descriptor;
+    GeoWkbLimits _limits;
+    // Exclusive ownership: no mutable BinaryColumn escape hatch or shared backing buffers.
+    std::unique_ptr<BinaryColumn> _data = std::make_unique<BinaryColumn>();
+    // One fixed-size entry; no heap allocation, geometry objects or source-buffer references.
+    std::optional<CachedWkb> _cache;
+};
+
+} // namespace starrocks

--- a/be/src/types/CMakeLists.txt
+++ b/be/src/types/CMakeLists.txt
@@ -39,6 +39,7 @@ ADD_BE_LIB(Types
     timestamp_value.cpp
     variant.cpp
     variant_value.cpp
+    geo_wkb.cpp
 )
 
 target_link_libraries(Types PRIVATE

--- a/be/src/types/geo_wkb.cpp
+++ b/be/src/types/geo_wkb.cpp
@@ -24,105 +24,113 @@ namespace {
 
 class WkbReader {
 public:
-    WkbReader(Slice bytes, const GeoWkbLimits& limits) : _bytes(bytes), _limits(limits) {}
+    WkbReader(Slice bytes, const GeoWkbLimits& limits);
 
-    StatusOr<GeoWkbInfo> read() {
-        if (_bytes.size > _limits.max_bytes) return Status::InvalidArgument("WKB payload limit exceeded");
-        RETURN_IF_ERROR(geometry(1, 0));
-        if (_offset != _bytes.size) return Status::InvalidArgument("Trailing WKB bytes");
-        return _info;
-    }
+    StatusOr<GeoWkbInfo> read();
 
 private:
     template <typename T>
-    StatusOr<T> number(bool little) {
-        if (sizeof(T) > _bytes.size - _offset) return Status::InvalidArgument("Truncated WKB");
-        T value;
-        memcpy(&value, _bytes.data + _offset, sizeof(T));
-        _offset += sizeof(T);
-        if (little != (std::endian::native == std::endian::little)) value = std::byteswap(value);
-        return value;
-    }
+    StatusOr<T> number(bool little);
 
-    Status components(uint32_t count) {
-        if (count > _limits.max_components - _info.components)
-            return Status::InvalidArgument("WKB component limit exceeded");
-        _info.components += count;
-        return Status::OK();
-    }
-
-    Status coordinates(uint32_t count, uint32_t width) {
-        if (count > _limits.max_coordinates - _info.coordinates)
-            return Status::InvalidArgument("WKB coordinate limit exceeded");
-        const size_t stride = width * sizeof(double);
-        if (count > (_bytes.size - _offset) / stride) return Status::InvalidArgument("Truncated WKB coordinates");
-        _info.coordinates += count;
-        _offset += size_t(count) * stride;
-        return Status::OK();
-    }
-
-    Status geometry(uint32_t depth, uint32_t expected_type) {
-        if (depth > std::min(_limits.max_depth, uint32_t(64)))
-            return Status::InvalidArgument("WKB nesting limit exceeded");
-        RETURN_IF_ERROR(components(1));
-        ASSIGN_OR_RETURN(auto order, number<uint8_t>(true));
-        if (order > 1) return Status::InvalidArgument("Invalid WKB byte order");
-        const bool little = order == 1;
-        ASSIGN_OR_RETURN(auto code, number<uint32_t>(little));
-        const uint32_t type = code % 1000;
-        const uint32_t dimension = code / 1000;
-        if (dimension > 3 || type < 1 || type > 7 || (expected_type != 0 && code != expected_type))
-            return Status::InvalidArgument("Unsupported WKB type or invalid MULTI child");
-        const GeoDimensionPB dimensions[] = {GEO_DIMENSION_XY, GEO_DIMENSION_XYZ, GEO_DIMENSION_XYM,
-                                             GEO_DIMENSION_XYZM};
-        if (depth == 1) {
-            _info.geometry_type = type;
-            _info.dimension = dimensions[dimension];
-        } else if (_info.dimension != dimensions[dimension]) {
-            _info.dimension = GEO_DIMENSION_MIXED;
-        }
-        const uint32_t width = 2 + (dimension == 3 ? 2 : dimension != 0);
-        if (type == 1) {
-            const size_t start = _offset;
-            RETURN_IF_ERROR(coordinates(1, width));
-            // An all-NaN XY tuple represents POINT EMPTY. Z/M do not change emptiness.
-            _offset = start;
-            ASSIGN_OR_RETURN(auto x, number<uint64_t>(little));
-            ASSIGN_OR_RETURN(auto y, number<uint64_t>(little));
-            _info.empty &= std::isnan(std::bit_cast<double>(x)) && std::isnan(std::bit_cast<double>(y));
-            _offset = start + width * sizeof(double);
-            return Status::OK();
-        }
-        ASSIGN_OR_RETURN(auto count, number<uint32_t>(little));
-        if (type == 2) {
-            RETURN_IF_ERROR(coordinates(count, width));
-            _info.empty &= count == 0;
-        } else if (type == 3) {
-            RETURN_IF_ERROR(components(count));
-            if (count > (_bytes.size - _offset) / sizeof(uint32_t))
-                return Status::InvalidArgument("Truncated WKB rings");
-            for (uint32_t i = 0; i < count; ++i) {
-                ASSIGN_OR_RETURN(auto points, number<uint32_t>(little));
-                RETURN_IF_ERROR(coordinates(points, width));
-                _info.empty &= points == 0;
-            }
-        } else {
-            // Every child has at least byte-order and type headers. Check before iterating.
-            if (count > _limits.max_components - _info.components)
-                return Status::InvalidArgument("WKB component limit exceeded");
-            if (count > (_bytes.size - _offset) / 5) return Status::InvalidArgument("Truncated WKB children");
-            for (uint32_t i = 0; i < count; ++i) {
-                RETURN_IF_ERROR(geometry(depth + 1, type == 7 ? 0 : dimension * 1000 + type - 3));
-            }
-        }
-        return Status::OK();
-    }
+    Status components(uint32_t count);
+    Status coordinates(uint32_t count, uint32_t width);
+    Status geometry(uint32_t depth, uint32_t expected_type);
 
     Slice _bytes;
     const GeoWkbLimits& _limits;
     size_t _offset = 0;
     GeoWkbInfo _info;
 };
+
+WkbReader::WkbReader(Slice bytes, const GeoWkbLimits& limits) : _bytes(bytes), _limits(limits) {}
+
+StatusOr<GeoWkbInfo> WkbReader::read() {
+    if (_bytes.size > _limits.max_bytes) return Status::InvalidArgument("WKB payload limit exceeded");
+    RETURN_IF_ERROR(geometry(1, 0));
+    if (_offset != _bytes.size) return Status::InvalidArgument("Trailing WKB bytes");
+    return _info;
+}
+
+template <typename T>
+StatusOr<T> WkbReader::number(bool little) {
+    if (sizeof(T) > _bytes.size - _offset) return Status::InvalidArgument("Truncated WKB");
+    T value;
+    memcpy(&value, _bytes.data + _offset, sizeof(T));
+    _offset += sizeof(T);
+    if (little != (std::endian::native == std::endian::little)) value = std::byteswap(value);
+    return value;
+}
+
+Status WkbReader::components(uint32_t count) {
+    if (count > _limits.max_components - _info.components)
+        return Status::InvalidArgument("WKB component limit exceeded");
+    _info.components += count;
+    return Status::OK();
+}
+
+Status WkbReader::coordinates(uint32_t count, uint32_t width) {
+    if (count > _limits.max_coordinates - _info.coordinates)
+        return Status::InvalidArgument("WKB coordinate limit exceeded");
+    const size_t stride = width * sizeof(double);
+    if (count > (_bytes.size - _offset) / stride) return Status::InvalidArgument("Truncated WKB coordinates");
+    _info.coordinates += count;
+    _offset += size_t(count) * stride;
+    return Status::OK();
+}
+
+Status WkbReader::geometry(uint32_t depth, uint32_t expected_type) {
+    if (depth > std::min(_limits.max_depth, uint32_t(64))) return Status::InvalidArgument("WKB nesting limit exceeded");
+    RETURN_IF_ERROR(components(1));
+    ASSIGN_OR_RETURN(auto order, number<uint8_t>(true));
+    if (order > 1) return Status::InvalidArgument("Invalid WKB byte order");
+    const bool little = order == 1;
+    ASSIGN_OR_RETURN(auto code, number<uint32_t>(little));
+    const uint32_t type = code % 1000;
+    const uint32_t dimension = code / 1000;
+    if (dimension > 3 || type < 1 || type > 7 || (expected_type != 0 && code != expected_type))
+        return Status::InvalidArgument("Unsupported WKB type or invalid MULTI child");
+    const GeoDimensionPB dimensions[] = {GEO_DIMENSION_XY, GEO_DIMENSION_XYZ, GEO_DIMENSION_XYM, GEO_DIMENSION_XYZM};
+    if (depth == 1) {
+        _info.geometry_type = type;
+        _info.dimension = dimensions[dimension];
+    } else if (_info.dimension != dimensions[dimension]) {
+        _info.dimension = GEO_DIMENSION_MIXED;
+    }
+    const uint32_t width = 2 + (dimension == 3 ? 2 : dimension != 0);
+    if (type == 1) {
+        const size_t start = _offset;
+        RETURN_IF_ERROR(coordinates(1, width));
+        // An all-NaN XY tuple represents POINT EMPTY. Z/M do not change emptiness.
+        _offset = start;
+        ASSIGN_OR_RETURN(auto x, number<uint64_t>(little));
+        ASSIGN_OR_RETURN(auto y, number<uint64_t>(little));
+        _info.empty &= std::isnan(std::bit_cast<double>(x)) && std::isnan(std::bit_cast<double>(y));
+        _offset = start + width * sizeof(double);
+        return Status::OK();
+    }
+    ASSIGN_OR_RETURN(auto count, number<uint32_t>(little));
+    if (type == 2) {
+        RETURN_IF_ERROR(coordinates(count, width));
+        _info.empty &= count == 0;
+    } else if (type == 3) {
+        RETURN_IF_ERROR(components(count));
+        if (count > (_bytes.size - _offset) / sizeof(uint32_t)) return Status::InvalidArgument("Truncated WKB rings");
+        for (uint32_t i = 0; i < count; ++i) {
+            ASSIGN_OR_RETURN(auto points, number<uint32_t>(little));
+            RETURN_IF_ERROR(coordinates(points, width));
+            _info.empty &= points == 0;
+        }
+    } else {
+        // Every child has at least byte-order and type headers. Check before iterating.
+        if (count > _limits.max_components - _info.components)
+            return Status::InvalidArgument("WKB component limit exceeded");
+        if (count > (_bytes.size - _offset) / 5) return Status::InvalidArgument("Truncated WKB children");
+        for (uint32_t i = 0; i < count; ++i) {
+            RETURN_IF_ERROR(geometry(depth + 1, type == 7 ? 0 : dimension * 1000 + type - 3));
+        }
+    }
+    return Status::OK();
+}
 
 } // namespace
 

--- a/be/src/types/geo_wkb.cpp
+++ b/be/src/types/geo_wkb.cpp
@@ -1,0 +1,133 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/geo_wkb.h"
+
+#include <algorithm>
+#include <bit>
+#include <cmath>
+#include <cstring>
+
+namespace starrocks {
+namespace {
+
+class WkbReader {
+public:
+    WkbReader(Slice bytes, const GeoWkbLimits& limits) : _bytes(bytes), _limits(limits) {}
+
+    StatusOr<GeoWkbInfo> read() {
+        if (_bytes.size > _limits.max_bytes) return Status::InvalidArgument("WKB payload limit exceeded");
+        RETURN_IF_ERROR(geometry(1, 0));
+        if (_offset != _bytes.size) return Status::InvalidArgument("Trailing WKB bytes");
+        return _info;
+    }
+
+private:
+    template <typename T>
+    StatusOr<T> number(bool little) {
+        if (sizeof(T) > _bytes.size - _offset) return Status::InvalidArgument("Truncated WKB");
+        T value;
+        memcpy(&value, _bytes.data + _offset, sizeof(T));
+        _offset += sizeof(T);
+        if (little != (std::endian::native == std::endian::little)) value = std::byteswap(value);
+        return value;
+    }
+
+    Status components(uint32_t count) {
+        if (count > _limits.max_components - _info.components)
+            return Status::InvalidArgument("WKB component limit exceeded");
+        _info.components += count;
+        return Status::OK();
+    }
+
+    Status coordinates(uint32_t count, uint32_t width) {
+        if (count > _limits.max_coordinates - _info.coordinates)
+            return Status::InvalidArgument("WKB coordinate limit exceeded");
+        const size_t stride = width * sizeof(double);
+        if (count > (_bytes.size - _offset) / stride) return Status::InvalidArgument("Truncated WKB coordinates");
+        _info.coordinates += count;
+        _offset += size_t(count) * stride;
+        return Status::OK();
+    }
+
+    Status geometry(uint32_t depth, uint32_t expected_type) {
+        if (depth > std::min(_limits.max_depth, uint32_t(64)))
+            return Status::InvalidArgument("WKB nesting limit exceeded");
+        RETURN_IF_ERROR(components(1));
+        ASSIGN_OR_RETURN(auto order, number<uint8_t>(true));
+        if (order > 1) return Status::InvalidArgument("Invalid WKB byte order");
+        const bool little = order == 1;
+        ASSIGN_OR_RETURN(auto code, number<uint32_t>(little));
+        const uint32_t type = code % 1000;
+        const uint32_t dimension = code / 1000;
+        if (dimension > 3 || type < 1 || type > 7 || (expected_type != 0 && code != expected_type))
+            return Status::InvalidArgument("Unsupported WKB type or invalid MULTI child");
+        const GeoDimensionPB dimensions[] = {GEO_DIMENSION_XY, GEO_DIMENSION_XYZ, GEO_DIMENSION_XYM,
+                                             GEO_DIMENSION_XYZM};
+        if (depth == 1) {
+            _info.geometry_type = type;
+            _info.dimension = dimensions[dimension];
+        } else if (_info.dimension != dimensions[dimension]) {
+            _info.dimension = GEO_DIMENSION_MIXED;
+        }
+        const uint32_t width = 2 + (dimension == 3 ? 2 : dimension != 0);
+        if (type == 1) {
+            const size_t start = _offset;
+            RETURN_IF_ERROR(coordinates(1, width));
+            // An all-NaN XY tuple represents POINT EMPTY. Z/M do not change emptiness.
+            _offset = start;
+            ASSIGN_OR_RETURN(auto x, number<uint64_t>(little));
+            ASSIGN_OR_RETURN(auto y, number<uint64_t>(little));
+            _info.empty &= std::isnan(std::bit_cast<double>(x)) && std::isnan(std::bit_cast<double>(y));
+            _offset = start + width * sizeof(double);
+            return Status::OK();
+        }
+        ASSIGN_OR_RETURN(auto count, number<uint32_t>(little));
+        if (type == 2) {
+            RETURN_IF_ERROR(coordinates(count, width));
+            _info.empty &= count == 0;
+        } else if (type == 3) {
+            RETURN_IF_ERROR(components(count));
+            if (count > (_bytes.size - _offset) / sizeof(uint32_t))
+                return Status::InvalidArgument("Truncated WKB rings");
+            for (uint32_t i = 0; i < count; ++i) {
+                ASSIGN_OR_RETURN(auto points, number<uint32_t>(little));
+                RETURN_IF_ERROR(coordinates(points, width));
+                _info.empty &= points == 0;
+            }
+        } else {
+            // Every child has at least byte-order and type headers. Check before iterating.
+            if (count > _limits.max_components - _info.components)
+                return Status::InvalidArgument("WKB component limit exceeded");
+            if (count > (_bytes.size - _offset) / 5) return Status::InvalidArgument("Truncated WKB children");
+            for (uint32_t i = 0; i < count; ++i) {
+                RETURN_IF_ERROR(geometry(depth + 1, type == 7 ? 0 : dimension * 1000 + type - 3));
+            }
+        }
+        return Status::OK();
+    }
+
+    Slice _bytes;
+    const GeoWkbLimits& _limits;
+    size_t _offset = 0;
+    GeoWkbInfo _info;
+};
+
+} // namespace
+
+StatusOr<GeoWkbInfo> inspect_geo_wkb(Slice wkb, const GeoWkbLimits& limits) {
+    return WkbReader(wkb, limits).read();
+}
+
+} // namespace starrocks

--- a/be/src/types/geo_wkb.h
+++ b/be/src/types/geo_wkb.h
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "base/string/slice.h"
+#include "common/statusor.h"
+#include "gen_cpp/types.pb.h"
+
+namespace starrocks {
+
+// Limits apply to one structural scan, independently of producer-validation metadata.
+struct GeoWkbLimits {
+    size_t max_bytes = 64 * 1024 * 1024;
+    uint32_t max_depth = 64;
+    uint32_t max_components = 1'000'000;
+    uint32_t max_coordinates = 1'000'000;
+};
+
+// No pointers into the input and no decoded coordinate arrays. Safe to retain by value.
+struct GeoWkbInfo {
+    uint32_t geometry_type = 0; // OGC 1..7, without ISO Z/M offsets.
+    GeoDimensionPB dimension = GEO_DIMENSION_UNKNOWN;
+    uint32_t components = 0;  // Geometries plus polygon rings.
+    uint32_t coordinates = 0; // Includes the NaN tuple representing POINT EMPTY.
+    bool empty = true;
+};
+
+// Read ISO WKB without normalizing it. Supports both byte orders and XY/Z/M/ZM.
+// This checks structure, not topology, CRS, coordinate ranges or compute capability.
+// EWKB flags/SRID are deliberately not accepted here: conversion belongs to SQL boundaries.
+// Allocation-free; recursion is capped at 64 even if a caller supplies a larger limit.
+StatusOr<GeoWkbInfo> inspect_geo_wkb(Slice wkb, const GeoWkbLimits& limits = {});
+
+} // namespace starrocks

--- a/be/test/column/CMakeLists.txt
+++ b/be/test/column/CMakeLists.txt
@@ -67,6 +67,7 @@ set(COLUMN_TEST_FILES
     variant_builder_test.cpp
     variant_encoder_test.cpp
     buffer_test.cpp
+    geo_column_test.cpp
 )
 
 if (USE_AVX2)

--- a/be/test/column/geo_column_test.cpp
+++ b/be/test/column/geo_column_test.cpp
@@ -1,0 +1,279 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/geo_column.h"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+#include "column/const_column.h"
+#include "column/nullable_column.h"
+
+namespace starrocks {
+namespace {
+
+GeoColumnDescriptor descriptor(GeoLogicalTypePB kind = GEO_LOGICAL_TYPE_GEOGRAPHY) {
+    GeoColumnDescriptor desc;
+    desc.type.logical_type = kind;
+    desc.type.coordinate_system =
+            kind == GEO_LOGICAL_TYPE_GEOGRAPHY ? GEO_COORDINATE_SYSTEM_SPHERICAL : GEO_COORDINATE_SYSTEM_CARTESIAN;
+    desc.type.edge_algorithm =
+            kind == GEO_LOGICAL_TYPE_GEOGRAPHY ? GEO_EDGE_ALGORITHM_SPHERICAL : GEO_EDGE_ALGORITHM_PLANAR;
+    desc.type.crs = "OGC:CRS84";
+    desc.storage.encoding = GEO_ENCODING_WKB;
+    return desc;
+}
+std::string point() {
+    // Little-endian POINT (1 2).
+    const unsigned char bytes[] = {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xf0, 0x3f, 0, 0, 0, 0, 0, 0, 0, 0x40};
+    return std::string(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+}
+std::string empty_collection() {
+    return std::string("\x01\x07\0\0\0\0\0\0\0", 9);
+}
+
+TEST(GeoColumnTest, RawBytesAndDistinctSemantics) {
+    const auto bytes = point();
+    for (auto kind : {GEO_LOGICAL_TYPE_GEOGRAPHY, GEO_LOGICAL_TYPE_GEOMETRY}) {
+        auto column = GeoColumn::create(descriptor(kind));
+        column->append_wkb(Slice(bytes));
+        EXPECT_EQ(bytes, column->get_wkb(0).to_string());
+        EXPECT_EQ(kind, column->descriptor().type.logical_type);
+        EXPECT_FALSE(column->is_binary());
+        EXPECT_FALSE(column->has_wkb_cache());
+        auto info = column->inspect_wkb(0);
+        ASSERT_TRUE(info.ok());
+        EXPECT_EQ(1, info->geometry_type);
+        EXPECT_FALSE(info->empty);
+        EXPECT_TRUE(column->has_wkb_cache());
+        EXPECT_EQ(GEO_VALIDATION_STATE_UNKNOWN, column->descriptor().storage.validation_state);
+    }
+}
+
+TEST(GeoColumnTest, BatchIngestionAndCopyOnWrite) {
+    auto column = GeoColumn::create(descriptor());
+    const auto p = point();
+    const auto e = empty_collection();
+    const Slice values[] = {Slice(p), Slice(e), Slice(p)};
+    column->append_wkb_batch(values, 3);
+    ASSERT_TRUE(column->inspect_wkb(0).ok());
+    ColumnPtr shared = column;
+    auto changed = Column::mutate(shared);
+    auto& changed_geo = static_cast<GeoColumn&>(*changed);
+    EXPECT_FALSE(changed_geo.has_wkb_cache());
+    changed_geo.append_wkb_batch(values, 3);
+    EXPECT_EQ(3, column->size());
+    EXPECT_EQ(6, changed_geo.size());
+    EXPECT_TRUE(column->has_wkb_cache());
+    EXPECT_EQ(e, changed_geo.get_wkb(4).to_string());
+    column->reserve(100, 8192); // Cached info owns no pointers to the reallocated bytes.
+    EXPECT_TRUE(column->inspect_wkb(0).ok());
+    column->append_wkb_batch(values, 3);
+    EXPECT_FALSE(column->has_wkb_cache());
+}
+
+TEST(GeoColumnTest, NullAndEmptyAreDifferent) {
+    auto geo = GeoColumn::create(descriptor());
+    geo->append_wkb(Slice(empty_collection()));
+    geo->append_default();
+    auto nulls = NullColumn::create();
+    nulls->append(0);
+    nulls->append(1);
+    auto nullable = NullableColumn::create(std::move(geo), std::move(nulls));
+    EXPECT_FALSE(nullable->is_null(0));
+    EXPECT_TRUE(nullable->is_null(1));
+    const auto& data = static_cast<const GeoColumn&>(*nullable->data_column());
+    EXPECT_EQ(empty_collection(), data.get_wkb(0).to_string());
+    EXPECT_EQ(0, data.get_wkb(1).size);
+    auto copy = nullable->clone_empty();
+    const uint32_t indexes[] = {1, 0};
+    copy->append_selective(*nullable, indexes, 0, 2);
+    EXPECT_TRUE(copy->is_null(0));
+    EXPECT_FALSE(copy->is_null(1));
+    EXPECT_EQ(empty_collection(), copy->get(1).get_slice().to_string());
+    EXPECT_EQ(descriptor(),
+              static_cast<const GeoColumn&>(*static_cast<const NullableColumn&>(*copy).data_column()).descriptor());
+}
+
+TEST(GeoColumnTest, CopyFilterReplicateAndConst) {
+    auto column = GeoColumn::create(descriptor());
+    column->append_wkb(Slice(point()));
+    column->append_wkb(Slice(empty_collection()));
+    auto selected = column->clone_empty();
+    const uint32_t indexes[] = {1, 0, 1};
+    selected->append_selective(*column, indexes, 0, 3);
+    EXPECT_EQ(empty_collection(), selected->get(0).get_slice().to_string());
+    EXPECT_EQ(point(), selected->get(1).get_slice().to_string());
+    Filter keep = {0, 1, 1};
+    selected->filter(keep);
+    EXPECT_EQ(2, selected->size());
+    EXPECT_EQ(point(), selected->get(0).get_slice().to_string());
+    Buffer<uint32_t> offsets = {0, 2, 3};
+    auto replicated = selected->replicate(offsets);
+    ASSERT_TRUE(replicated.ok());
+    EXPECT_EQ(3, (*replicated)->size());
+    EXPECT_EQ(point(), (*replicated)->get(1).get_slice().to_string());
+    EXPECT_EQ(empty_collection(), (*replicated)->get(2).get_slice().to_string());
+    EXPECT_EQ(descriptor(), static_cast<const GeoColumn&>(**replicated).descriptor());
+    auto one = GeoColumn::create(descriptor());
+    one->append_wkb(Slice(point()));
+    auto constant = ConstColumn::create(std::move(one), 5);
+    EXPECT_EQ(point(), constant->get(4).get_slice().to_string());
+    EXPECT_EQ(5, constant->size());
+}
+
+TEST(GeoColumnTest, CacheOwnershipCloneAndBufferLifetime) {
+    auto column = GeoColumn::create(descriptor());
+    {
+        auto bytes = point();
+        column->append_wkb(Slice(bytes));
+        bytes.assign(bytes.size(), 'x');
+    }
+    auto info = column->inspect_wkb(0);
+    ASSERT_TRUE(info.ok());
+    const auto usage = column->memory_usage();
+    EXPECT_GT(usage, column->byte_size());
+    EXPECT_TRUE(column->inspect_wkb(0).ok());
+    EXPECT_EQ(usage, column->memory_usage()); // fixed-size cache, no growth per lookup
+    auto copy = column->clone();
+    EXPECT_FALSE(static_cast<const GeoColumn&>(*copy).has_wkb_cache());
+    column->reset_column();
+    EXPECT_FALSE(column->has_wkb_cache());
+    EXPECT_EQ(point(), copy->get(0).get_slice().to_string());
+    copy.reset();
+    EXPECT_EQ(1, info->geometry_type); // no borrowed WKB pointers
+}
+
+TEST(GeoColumnTest, EveryMutationInvalidatesCache) {
+    auto column = GeoColumn::create(descriptor());
+    auto source = GeoColumn::create(descriptor());
+    source->append_wkb(Slice(empty_collection()));
+    auto prepare = [&] {
+        column->reset_column();
+        column->append_wkb(Slice(point()));
+        ASSERT_TRUE(column->inspect_wkb(0).ok());
+        ASSERT_TRUE(column->has_wkb_cache());
+    };
+    prepare();
+    column->append_wkb(Slice(point()));
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->append(*source);
+    EXPECT_FALSE(column->has_wkb_cache());
+    const uint32_t index[] = {0};
+    prepare();
+    column->append_selective(*source, index, 0, 1);
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->append_value_multiple_times(*source, 0, 2);
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->append_default();
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->resize(0);
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->assign(2, 0);
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->remove_first_n_values(1);
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->fill_default(Filter{1});
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->filter(Filter{0});
+    EXPECT_FALSE(column->has_wkb_cache());
+    prepare();
+    column->update_rows(*source, index);
+    EXPECT_FALSE(column->has_wkb_cache());
+    EXPECT_TRUE(column->inspect_wkb(0)->empty);
+    auto other = GeoColumn::create(descriptor(GEO_LOGICAL_TYPE_GEOMETRY));
+    other->append_wkb(Slice(empty_collection()));
+    ASSERT_TRUE(other->inspect_wkb(0).ok());
+    column->swap_column(*other);
+    EXPECT_FALSE(column->has_wkb_cache());
+    EXPECT_FALSE(other->has_wkb_cache());
+    EXPECT_EQ(GEO_LOGICAL_TYPE_GEOMETRY, column->descriptor().type.logical_type);
+}
+
+TEST(GeoColumnTest, SelfAppendAndIndependentClone) {
+    auto column = GeoColumn::create(descriptor());
+    column->append_wkb(Slice(point()));
+    column->append_wkb(column->get_wkb(0));
+    column->append(*column);
+    EXPECT_EQ(4, column->size());
+    const uint32_t indexes[] = {3, 0};
+    column->append_selective(*column, indexes, 0, 2);
+    EXPECT_EQ(6, column->size());
+    column->append_value_multiple_times(*column, 0, 2);
+    auto slice = column->get_wkb(0);
+    column->append_value_multiple_times(&slice, 2);
+    EXPECT_EQ(10, column->size());
+    for (size_t i = 0; i < column->size(); ++i) EXPECT_EQ(point(), column->get_wkb(i).to_string());
+    auto copy = column->clone();
+    column->reset_column();
+    EXPECT_EQ(10, copy->size());
+}
+
+TEST(GeoColumnTest, CopyRejectsDescriptorChangesWithoutSqlCoercion) {
+    auto column = GeoColumn::create(descriptor());
+    auto other = GeoColumn::create(descriptor(GEO_LOGICAL_TYPE_GEOMETRY));
+    other->append_wkb(Slice(point()));
+    EXPECT_THROW(column->append(*other), std::invalid_argument);
+    EXPECT_EQ(0, column->size());
+    auto different = descriptor();
+    different.storage.dimension = GEO_DIMENSION_XYZ;
+    other = GeoColumn::create(different);
+    other->append_wkb(Slice(point()));
+    EXPECT_THROW(column->append(*other), std::invalid_argument);
+    EXPECT_EQ(0, column->size());
+    different.storage.encoding = GEO_ENCODING_UNKNOWN;
+    EXPECT_THROW(GeoColumn::create(different), std::invalid_argument);
+}
+
+TEST(GeoColumnTest, BoundedInspectionDoesNotTrustProducerFlag) {
+    auto desc = descriptor();
+    desc.storage.validation_state = GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED;
+    GeoWkbLimits limits;
+    limits.max_bytes = 20;
+    auto column = GeoColumn::create(desc, limits);
+    column->append_wkb(Slice(point()));
+    EXPECT_FALSE(column->inspect_wkb(0).ok());
+    EXPECT_FALSE(column->has_wkb_cache());
+    column->reset_column();
+    column->append_wkb(Slice("invalid"));
+    EXPECT_FALSE(column->inspect_wkb(0).ok());
+    EXPECT_FALSE(column->inspect_wkb(1).ok());
+    EXPECT_EQ("invalid", column->get_wkb(0).to_string());
+}
+
+TEST(GeoColumnTest, UnsupportedPathsDoNotFallBackToBinary) {
+    auto column = GeoColumn::create(descriptor());
+    column->append_wkb(Slice(point()));
+    ColumnVisitor visitor;
+    ColumnVisitorMutable mutable_visitor;
+    EXPECT_TRUE(column->accept(&visitor).is_not_supported());
+    EXPECT_TRUE(column->accept_mutable(&mutable_visitor).is_not_supported());
+    EXPECT_THROW(column->compare_at(0, 0, *column, 1), std::runtime_error);
+    EXPECT_THROW(column->serialize_size(0), std::runtime_error);
+    EXPECT_THROW(column->deserialize_and_append(nullptr), std::runtime_error);
+    EXPECT_THROW(column->put_mysql_row_buffer(nullptr, 0), std::runtime_error);
+    EXPECT_FALSE(column->append_strings(nullptr, 0));
+}
+
+} // namespace
+} // namespace starrocks

--- a/be/test/types/CMakeLists.txt
+++ b/be/test/types/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TYPES_TEST_FILES
     timestamp_value_test.cpp
     type_info_test.cpp
     variant_value_test.cpp
+    geo_wkb_test.cpp
 )
 
 set(TYPES_TEST_LINK_LIBS

--- a/be/test/types/geo_wkb_test.cpp
+++ b/be/test/types/geo_wkb_test.cpp
@@ -1,0 +1,212 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "types/geo_wkb.h"
+
+#include <gtest/gtest.h>
+
+#include <bit>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace starrocks {
+namespace {
+
+void u32(std::string& out, uint32_t value, bool little) {
+    for (int i = 0; i < 4; ++i) out.push_back(char(value >> (8 * (little ? i : 3 - i))));
+}
+void f64(std::string& out, double value, bool little) {
+    auto bits = std::bit_cast<uint64_t>(value);
+    for (int i = 0; i < 8; ++i) out.push_back(char(bits >> (8 * (little ? i : 7 - i))));
+}
+std::string header(uint32_t type, bool little) {
+    std::string out(1, char(little));
+    u32(out, type, little);
+    return out;
+}
+std::string shape(uint32_t type, uint32_t dimension, bool little, bool empty = false) {
+    auto out = header(type + dimension * 1000, little);
+    auto tuple = [&] {
+        const uint32_t width = 2 + (dimension == 3 ? 2 : dimension != 0);
+        for (uint32_t i = 0; i < width; ++i)
+            f64(out, empty ? std::numeric_limits<double>::quiet_NaN() : double(i + 1), little);
+    };
+    if (type == 1) {
+        tuple();
+    } else if (type == 2) {
+        u32(out, empty ? 0 : 2, little);
+        if (!empty) {
+            tuple();
+            tuple();
+        }
+    } else if (type == 3) {
+        u32(out, empty ? 0 : 1, little);
+        if (!empty) {
+            u32(out, 4, little);
+            for (int i = 0; i < 4; ++i) tuple();
+        }
+    } else {
+        u32(out, empty ? 0 : 1, little);
+        if (!empty) out += shape(type == 7 ? 6 : type - 3, dimension, !little);
+    }
+    return out;
+}
+
+TEST(GeoWkbTest, AllFamiliesDimensionsAndByteOrders) {
+    const GeoDimensionPB dims[] = {GEO_DIMENSION_XY, GEO_DIMENSION_XYZ, GEO_DIMENSION_XYM, GEO_DIMENSION_XYZM};
+    for (bool little : {false, true}) {
+        for (uint32_t dimension = 0; dimension < 4; ++dimension) {
+            for (uint32_t type = 1; type <= 7; ++type) {
+                for (bool empty : {false, true}) {
+                    auto bytes = shape(type, dimension, little, empty);
+                    const auto original = bytes;
+                    auto result = inspect_geo_wkb(Slice(bytes));
+                    ASSERT_TRUE(result.ok()) << result.status();
+                    EXPECT_EQ(type, result->geometry_type);
+                    EXPECT_EQ(dims[dimension], result->dimension);
+                    EXPECT_EQ(empty, result->empty);
+                    EXPECT_EQ(original, bytes);
+                }
+            }
+        }
+    }
+}
+
+TEST(GeoWkbTest, EveryTruncationIsRejected) {
+    for (uint32_t type = 1; type <= 7; ++type) {
+        for (bool little : {false, true}) {
+            auto bytes = shape(type, 3, little);
+            for (size_t end = 0; end < bytes.size(); ++end)
+                EXPECT_FALSE(inspect_geo_wkb(Slice(bytes.data(), end)).ok()) << type << " " << end;
+        }
+    }
+    EXPECT_FALSE(inspect_geo_wkb(Slice()).ok());
+}
+
+TEST(GeoWkbTest, CountAndPayloadBudgets) {
+    auto point = shape(1, 0, true);
+    GeoWkbLimits limits;
+    limits.max_bytes = point.size() - 1;
+    EXPECT_FALSE(inspect_geo_wkb(Slice(point), limits).ok());
+    limits.max_bytes = point.size();
+    EXPECT_TRUE(inspect_geo_wkb(Slice(point), limits).ok());
+    limits.max_coordinates = 0;
+    EXPECT_FALSE(inspect_geo_wkb(Slice(point), limits).ok());
+    limits.max_coordinates = 1;
+    EXPECT_TRUE(inspect_geo_wkb(Slice(point), limits).ok());
+    limits.max_components = 0;
+    EXPECT_FALSE(inspect_geo_wkb(Slice(point), limits).ok());
+    for (uint32_t type = 2; type <= 7; ++type) {
+        auto bytes = header(type, true);
+        u32(bytes, UINT32_MAX, true);
+        EXPECT_FALSE(inspect_geo_wkb(Slice(bytes)).ok());
+    }
+    auto line = shape(2, 3, true);
+    limits = {};
+    limits.max_coordinates = 1;
+    EXPECT_FALSE(inspect_geo_wkb(Slice(line), limits).ok());
+    auto polygon = shape(3, 0, true);
+    limits = {};
+    limits.max_components = 1; // The ring also consumes work.
+    EXPECT_FALSE(inspect_geo_wkb(Slice(polygon), limits).ok());
+    limits.max_components = 2;
+    EXPECT_TRUE(inspect_geo_wkb(Slice(polygon), limits).ok());
+}
+
+TEST(GeoWkbTest, NestingLimitAndHardStackBound) {
+    auto bytes = shape(1, 0, true);
+    for (uint32_t depth = 2; depth <= 65; ++depth) {
+        auto outer = header(7, true);
+        u32(outer, 1, true);
+        bytes = outer + bytes;
+        GeoWkbLimits limits;
+        limits.max_depth = depth;
+        EXPECT_EQ(depth <= 64, inspect_geo_wkb(Slice(bytes), limits).ok());
+        limits.max_depth = depth - 1;
+        EXPECT_FALSE(inspect_geo_wkb(Slice(bytes), limits).ok());
+    }
+    GeoWkbLimits limits;
+    limits.max_depth = UINT32_MAX;
+    EXPECT_FALSE(inspect_geo_wkb(Slice(bytes), limits).ok());
+}
+
+TEST(GeoWkbTest, InvalidHeadersChildrenAndTrailingBytes) {
+    auto point = shape(1, 0, true);
+    point[0] = 2;
+    EXPECT_FALSE(inspect_geo_wkb(Slice(point)).ok());
+    for (uint32_t code : {0u, 8u, 4001u, 0x80000001u, 0x20000001u}) {
+        auto bytes = header(code, true);
+        EXPECT_FALSE(inspect_geo_wkb(Slice(bytes)).ok());
+    }
+    auto multi = header(4, true);
+    u32(multi, 1, true);
+    EXPECT_FALSE(inspect_geo_wkb(Slice(multi + shape(2, 0, true))).ok());
+    EXPECT_FALSE(inspect_geo_wkb(Slice(multi + shape(1, 1, true))).ok());
+    auto bytes = shape(1, 0, true) + "x";
+    EXPECT_FALSE(inspect_geo_wkb(Slice(bytes)).ok());
+}
+
+TEST(GeoWkbTest, EmptyChildrenAndMixedCollection) {
+    auto collection = header(7, true);
+    u32(collection, 2, true);
+    auto bytes = collection + shape(1, 0, false, true) + shape(3, 0, true, true);
+    auto info = inspect_geo_wkb(Slice(bytes));
+    ASSERT_TRUE(info.ok());
+    EXPECT_TRUE(info->empty);
+    EXPECT_EQ(3, info->components);
+    bytes = collection + shape(1, 0, false) + shape(2, 2, true);
+    info = inspect_geo_wkb(Slice(bytes));
+    ASSERT_TRUE(info.ok());
+    EXPECT_FALSE(info->empty);
+    EXPECT_EQ(GEO_DIMENSION_MIXED, info->dimension);
+    EXPECT_EQ(3, info->coordinates);
+}
+
+TEST(GeoWkbTest, ResultOutlivesInput) {
+    auto info = [] {
+        auto bytes = shape(3, 1, false);
+        return inspect_geo_wkb(Slice(bytes));
+    }();
+    ASSERT_TRUE(info.ok());
+    EXPECT_EQ(3, info->geometry_type);
+    EXPECT_EQ(4, info->coordinates);
+    EXPECT_EQ(GEO_DIMENSION_XYZ, info->dimension);
+}
+
+TEST(GeoWkbTest, HostileBuffersStayWithinBudgets) {
+    GeoWkbLimits limits;
+    limits.max_bytes = 256;
+    limits.max_components = 32;
+    limits.max_coordinates = 32;
+    limits.max_depth = 8;
+    uint32_t state = 0x9e3779b9;
+    for (size_t attempt = 0; attempt < 4096; ++attempt) {
+        auto bytes = shape(1 + attempt % 7, attempt % 4, attempt % 2);
+        for (size_t i = attempt % 3; i < bytes.size(); i += 7) {
+            state = state * 1664525 + 1013904223;
+            bytes[i] = char(state >> 24);
+        }
+        auto info = inspect_geo_wkb(Slice(bytes), limits);
+        if (info.ok()) {
+            EXPECT_LE(info->components, limits.max_components);
+            EXPECT_LE(info->coordinates, limits.max_coordinates);
+            EXPECT_GE(info->geometry_type, 1);
+            EXPECT_LE(info->geometry_type, 7);
+        }
+    }
+}
+
+} // namespace
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

Part of #78693 (Milestone 2, Contract 2.2), following the merged descriptor-only Contract 2.1 (#78916).

Provide a standalone WKB-backed column foundation before native type activation and transport integration. Keep existing column and spatial behavior unchanged, and put bounded WKB inspection at the point where it is requested.

## What I'm doing:

- Add `GeoColumn`, which owns a binary payload together with its `GeoColumnDescriptor`. Raw ingestion preserves WKB bytes without eager parsing or normalization; the supplied descriptor keeps GEOGRAPHY and GEOMETRY semantics distinct.
- Reuse binary batch operations and normal nullable/constant wrappers. Physical column copies require identical descriptors; they do not implement SQL assignment or UNION ALL type resolution.
- Add on-demand structural WKB inspection for all seven OGC geometry families, both byte orders, and ISO XY/Z/M/ZM encodings, including EMPTY and nested collections.
- Bound inspection by payload bytes, nesting depth, component count, and coordinate count. Reject malformed/truncated payloads, invalid child types or dimensions, unsupported encodings, and trailing bytes. This is structural inspection, not topology, CRS, or coordinate-range validation.
- Keep a single pointer-free inspection result per column, invalidate it on mutation, and exclude it from clones. Account for descriptor/cache memory through the existing column memory API.
- Leave existing source order intact; the four existing CMake files only gain one source entry each. No Thrift/protobuf schema changes.

### Scope and follow-up

This is a standalone column/inspection foundation, not native SQL type support. It does not register primitive types, attach native TypeDescriptors, activate Iceberg reads, add GEOS/S2 objects, or implement exchange/spill serde, SQL functions, assignment/UNION ALL helpers, or native-table persistence. Those require their own callers and integration tests in subsequent slices.

No existing query/profile/logging path changes. Inspection errors use Status diagnostics, and memory is exposed through the column memory API; no new operational counters are introduced.

### Validation

- Added 18 focused tests: 10 GeoColumn and 8 WKB inspection tests.
- 39/39 passed under ASAN with leak detection: the 18 new tests, 14 existing geo descriptor tests, and 7 binary/nullable/constant support tests.
- The same 39/39 passed with ASAN + NDEBUG.
- Passed the full BE module-boundary check, generated BE AGENTS consistency check, changed-schema compatibility check, and `git diff --check`.
- Formatted the six new C++ files with clang-format 10.

The focused executable compiles the new sources/tests and generated schema sources against existing read-only ASAN support libraries. This is not a full BE/FE build or a complete column/types test-suite run. The NDEBUG run is ASAN at -O0, not an optimized Release build. No end-to-end SQL integration is claimed.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

The new standalone implementation is not connected to existing SQL or execution paths.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

User documentation is deferred until a user-facing integration is introduced.

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Not applicable: new foundation targeting main, no backport requested.
