### PR TITLE
[Doc] Document that GIN NOT MATCH predicates exclude NULL rows

### DIFF
--- a/docs/en/table_design/indexes/inverted_index.md
+++ b/docs/en/table_design/indexes/inverted_index.md
@@ -105,6 +105,9 @@ When a full-text inverted index column is enabled with tokenization (`parser` = 
 - `<col_name> (NOT) MATCH_ALL 'keyword1, keyword2'`
 
 Here, keyword must be a string literal; expressions are not supported.
+
+For a nullable indexed column, rows whose value is `NULL` are not returned by `NOT MATCH`, `NOT MATCH_ANY`, or `NOT MATCH_ALL`.
+
 1. Create a table and insert a few rows of test data.
 
       ```SQL

--- a/docs/ja/table_design/indexes/inverted_index.md
+++ b/docs/ja/table_design/indexes/inverted_index.md
@@ -108,6 +108,8 @@ ALTER TABLE t DROP index idx;
 
 ここで、キーワードは文字列リテラルである必要があります。式はサポートされていません。
 
+NULL を許可するインデックス列では、値が `NULL` の行は `NOT MATCH`、`NOT MATCH_ANY`、`NOT MATCH_ALL` の結果に含まれません。
+
 1. テーブルを作成し、テストデータを数行挿入します。
 
    ```SQL

--- a/docs/zh/table_design/indexes/inverted_index.md
+++ b/docs/zh/table_design/indexes/inverted_index.md
@@ -105,6 +105,9 @@ ALTER TABLE t DROP index idx;
 - `<col_name> (NOT) MATCH_ALL 'keyword1, keyword2'`
 
 其中，keyword 必须为字符串字面量，不支持表达式。
+
+对于可为空的索引列，值为 `NULL` 的行不会出现在 `NOT MATCH`、`NOT MATCH_ANY` 和 `NOT MATCH_ALL` 的查询结果中。
+
 1. 创建一个表并插入几行测试数据。
 
       ```SQL


### PR DESCRIPTION
## Why I'm doing:

[#75578](https://github.com/StarRocks/starrocks/pull/75578) made the inverted index iterator subtract the null bitmap from the row bitmap, so rows whose indexed column is `NULL` are no longer returned by `NOT MATCH`, `NOT MATCH_ANY`, or `NOT MATCH_ALL`. The full-text inverted index guide still lists the `(NOT) MATCH` formats without that behavior.

## What I'm doing:

Add a note to the English, Chinese, and Japanese versions of `docs/*/table_design/indexes/inverted_index.md` stating that rows with a `NULL` value in a nullable indexed column are not returned by `NOT MATCH`, `NOT MATCH_ANY`, or `NOT MATCH_ALL`.

Fixes #75737

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

> Verified the fix is present on `branch-4.1`; the builtin inverted index iterator does not exist on `branch-4.0`/`branch-3.5`, so those branches are unaffected.