### PR TITLE
[Feature] Integrate native geo types in FE (Contract 2.4)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -656,6 +656,11 @@ public class TypeManager {
             return t1;
         }
 
+        // Unequal geo types have no implicit common type; preserve the identity/null shortcuts above.
+        if (t1.isGeoType() || t2.isGeoType()) {
+            return InvalidType.INVALID;
+        }
+
         boolean t1IsHLL = t1.getType() == PrimitiveType.HLL;
         boolean t2IsHLL = t2.getType() == PrimitiveType.HLL;
         if (t1IsHLL || t2IsHLL) {

--- a/fe/fe-core/src/main/java/com/starrocks/type/GeoTypeSerde.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/GeoTypeSerde.java
@@ -14,12 +14,10 @@
 
 package com.starrocks.type;
 
-import com.starrocks.proto.GeoColumnDescPB;
 import com.starrocks.proto.GeoCoordinateSystemPB;
 import com.starrocks.proto.GeoEdgeAlgorithmPB;
 import com.starrocks.proto.GeoLogicalTypePB;
 import com.starrocks.proto.GeoTypeDescPB;
-import com.starrocks.thrift.TGeoColumnDesc;
 import com.starrocks.thrift.TGeoCoordinateSystem;
 import com.starrocks.thrift.TGeoEdgeAlgorithm;
 import com.starrocks.thrift.TGeoLogicalType;
@@ -30,7 +28,7 @@ final class GeoTypeSerde {
     private GeoTypeSerde() {
     }
 
-    static TGeoColumnDesc toThrift(GeoTypeDescriptor descriptor) {
+    static TGeoTypeDesc toThrift(GeoTypeDescriptor descriptor) {
         TGeoTypeDesc semantic = new TGeoTypeDesc();
         semantic.setLogical_type(TGeoLogicalType.valueOf(descriptor.logicalType().name()));
         semantic.setCoordinate_system(TGeoCoordinateSystem.valueOf(descriptor.coordinateSystem().name()));
@@ -39,10 +37,10 @@ final class GeoTypeSerde {
         if (descriptor.srid() != null) {
             semantic.setSrid(descriptor.srid());
         }
-        return new TGeoColumnDesc().setType(semantic);
+        return semantic;
     }
 
-    static GeoColumnDescPB toProtobuf(GeoTypeDescriptor descriptor) {
+    static GeoTypeDescPB toProtobuf(GeoTypeDescriptor descriptor) {
         GeoTypeDescPB semantic = new GeoTypeDescPB();
         semantic.logicalType = GeoLogicalTypePB.valueOf("GEO_LOGICAL_TYPE_" + descriptor.logicalType().name());
         semantic.coordinateSystem =
@@ -50,13 +48,10 @@ final class GeoTypeSerde {
         semantic.edgeAlgorithm = GeoEdgeAlgorithmPB.valueOf("GEO_EDGE_ALGORITHM_" + descriptor.edgeAlgorithm().name());
         semantic.crs = descriptor.crs();
         semantic.srid = descriptor.srid();
-        GeoColumnDescPB result = new GeoColumnDescPB();
-        result.type = semantic;
-        return result;
+        return semantic;
     }
 
-    static GeoTypeDescriptor fromThrift(TGeoColumnDesc descriptor) {
-        TGeoTypeDesc semantic = descriptor.isSetType() ? descriptor.type : new TGeoTypeDesc();
+    static GeoTypeDescriptor fromThrift(TGeoTypeDesc semantic) {
         return new GeoTypeDescriptor(
                 fromWire(semantic.logical_type, GeoTypeDescriptor.LogicalType.class, ""),
                 fromWire(semantic.coordinate_system, GeoTypeDescriptor.CoordinateSystem.class, ""),
@@ -64,8 +59,7 @@ final class GeoTypeSerde {
                 semantic.crs == null ? "" : semantic.crs, semantic.isSetSrid() ? semantic.srid : null);
     }
 
-    static GeoTypeDescriptor fromProtobuf(GeoColumnDescPB descriptor) {
-        GeoTypeDescPB semantic = descriptor.type == null ? new GeoTypeDescPB() : descriptor.type;
+    static GeoTypeDescriptor fromProtobuf(GeoTypeDescPB semantic) {
         return new GeoTypeDescriptor(
                 fromWire(semantic.logicalType, GeoTypeDescriptor.LogicalType.class, "GEO_LOGICAL_TYPE_"),
                 fromWire(semantic.coordinateSystem, GeoTypeDescriptor.CoordinateSystem.class, "GEO_COORDINATE_SYSTEM_"),

--- a/fe/fe-core/src/main/java/com/starrocks/type/GeoTypeSerde.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/GeoTypeSerde.java
@@ -16,86 +16,61 @@ package com.starrocks.type;
 
 import com.starrocks.proto.GeoColumnDescPB;
 import com.starrocks.proto.GeoCoordinateSystemPB;
-import com.starrocks.proto.GeoDimensionPB;
 import com.starrocks.proto.GeoEdgeAlgorithmPB;
-import com.starrocks.proto.GeoEncodingPB;
 import com.starrocks.proto.GeoLogicalTypePB;
-import com.starrocks.proto.GeoStorageDescPB;
 import com.starrocks.proto.GeoTypeDescPB;
-import com.starrocks.proto.GeoValidationStatePB;
 import com.starrocks.thrift.TGeoColumnDesc;
 import com.starrocks.thrift.TGeoCoordinateSystem;
-import com.starrocks.thrift.TGeoDimension;
 import com.starrocks.thrift.TGeoEdgeAlgorithm;
-import com.starrocks.thrift.TGeoEncoding;
 import com.starrocks.thrift.TGeoLogicalType;
-import com.starrocks.thrift.TGeoStorageDesc;
 import com.starrocks.thrift.TGeoTypeDesc;
-import com.starrocks.thrift.TGeoValidationState;
 
 /** Wire conversion only; native primitive consistency belongs to ScalarType construction. */
 final class GeoTypeSerde {
     private GeoTypeSerde() {
     }
 
-    static TGeoColumnDesc toThrift(GeoColumnDescriptor descriptor) {
+    static TGeoColumnDesc toThrift(GeoTypeDescriptor descriptor) {
         TGeoTypeDesc semantic = new TGeoTypeDesc();
-        TGeoStorageDesc storage = new TGeoStorageDesc();
         semantic.setLogical_type(TGeoLogicalType.valueOf(descriptor.logicalType().name()));
         semantic.setCoordinate_system(TGeoCoordinateSystem.valueOf(descriptor.coordinateSystem().name()));
         semantic.setEdge_algorithm(TGeoEdgeAlgorithm.valueOf(descriptor.edgeAlgorithm().name()));
-        storage.setEncoding(TGeoEncoding.valueOf(descriptor.encoding().name()));
-        storage.setDimension(TGeoDimension.valueOf(descriptor.dimension().name()));
-        storage.setValidation_state(TGeoValidationState.valueOf(descriptor.validationState().name()));
         semantic.setCrs(descriptor.crs());
         if (descriptor.srid() != null) {
             semantic.setSrid(descriptor.srid());
         }
-        return new TGeoColumnDesc().setType(semantic).setStorage(storage);
+        return new TGeoColumnDesc().setType(semantic);
     }
 
-    static GeoColumnDescPB toProtobuf(GeoColumnDescriptor descriptor) {
+    static GeoColumnDescPB toProtobuf(GeoTypeDescriptor descriptor) {
         GeoTypeDescPB semantic = new GeoTypeDescPB();
-        GeoStorageDescPB storage = new GeoStorageDescPB();
         semantic.logicalType = GeoLogicalTypePB.valueOf("GEO_LOGICAL_TYPE_" + descriptor.logicalType().name());
         semantic.coordinateSystem =
                 GeoCoordinateSystemPB.valueOf("GEO_COORDINATE_SYSTEM_" + descriptor.coordinateSystem().name());
         semantic.edgeAlgorithm = GeoEdgeAlgorithmPB.valueOf("GEO_EDGE_ALGORITHM_" + descriptor.edgeAlgorithm().name());
-        storage.encoding = GeoEncodingPB.valueOf("GEO_ENCODING_" + descriptor.encoding().name());
-        storage.dimension = GeoDimensionPB.valueOf("GEO_DIMENSION_" + descriptor.dimension().name());
-        storage.validationState = GeoValidationStatePB.valueOf("GEO_VALIDATION_STATE_" + descriptor.validationState().name());
         semantic.crs = descriptor.crs();
         semantic.srid = descriptor.srid();
         GeoColumnDescPB result = new GeoColumnDescPB();
         result.type = semantic;
-        result.storage = storage;
         return result;
     }
 
-    static GeoColumnDescriptor fromThrift(TGeoColumnDesc descriptor) {
+    static GeoTypeDescriptor fromThrift(TGeoColumnDesc descriptor) {
         TGeoTypeDesc semantic = descriptor.isSetType() ? descriptor.type : new TGeoTypeDesc();
-        TGeoStorageDesc storage = descriptor.isSetStorage() ? descriptor.storage : new TGeoStorageDesc();
-        return new GeoColumnDescriptor(
-                fromWire(semantic.logical_type, GeoColumnDescriptor.LogicalType.class, ""),
-                fromWire(semantic.coordinate_system, GeoColumnDescriptor.CoordinateSystem.class, ""),
-                fromWire(semantic.edge_algorithm, GeoColumnDescriptor.EdgeAlgorithm.class, ""),
-                semantic.crs == null ? "" : semantic.crs, semantic.isSetSrid() ? semantic.srid : null,
-                fromWire(storage.encoding, GeoColumnDescriptor.Encoding.class, ""),
-                fromWire(storage.dimension, GeoColumnDescriptor.Dimension.class, ""),
-                fromWire(storage.validation_state, GeoColumnDescriptor.ValidationState.class, ""));
+        return new GeoTypeDescriptor(
+                fromWire(semantic.logical_type, GeoTypeDescriptor.LogicalType.class, ""),
+                fromWire(semantic.coordinate_system, GeoTypeDescriptor.CoordinateSystem.class, ""),
+                fromWire(semantic.edge_algorithm, GeoTypeDescriptor.EdgeAlgorithm.class, ""),
+                semantic.crs == null ? "" : semantic.crs, semantic.isSetSrid() ? semantic.srid : null);
     }
 
-    static GeoColumnDescriptor fromProtobuf(GeoColumnDescPB descriptor) {
+    static GeoTypeDescriptor fromProtobuf(GeoColumnDescPB descriptor) {
         GeoTypeDescPB semantic = descriptor.type == null ? new GeoTypeDescPB() : descriptor.type;
-        GeoStorageDescPB storage = descriptor.storage == null ? new GeoStorageDescPB() : descriptor.storage;
-        return new GeoColumnDescriptor(
-                fromWire(semantic.logicalType, GeoColumnDescriptor.LogicalType.class, "GEO_LOGICAL_TYPE_"),
-                fromWire(semantic.coordinateSystem, GeoColumnDescriptor.CoordinateSystem.class, "GEO_COORDINATE_SYSTEM_"),
-                fromWire(semantic.edgeAlgorithm, GeoColumnDescriptor.EdgeAlgorithm.class, "GEO_EDGE_ALGORITHM_"),
-                semantic.crs == null ? "" : semantic.crs, semantic.srid,
-                fromWire(storage.encoding, GeoColumnDescriptor.Encoding.class, "GEO_ENCODING_"),
-                fromWire(storage.dimension, GeoColumnDescriptor.Dimension.class, "GEO_DIMENSION_"),
-                fromWire(storage.validationState, GeoColumnDescriptor.ValidationState.class, "GEO_VALIDATION_STATE_"));
+        return new GeoTypeDescriptor(
+                fromWire(semantic.logicalType, GeoTypeDescriptor.LogicalType.class, "GEO_LOGICAL_TYPE_"),
+                fromWire(semantic.coordinateSystem, GeoTypeDescriptor.CoordinateSystem.class, "GEO_COORDINATE_SYSTEM_"),
+                fromWire(semantic.edgeAlgorithm, GeoTypeDescriptor.EdgeAlgorithm.class, "GEO_EDGE_ALGORITHM_"),
+                semantic.crs == null ? "" : semantic.crs, semantic.srid);
     }
 
     private static <T extends Enum<T>> T fromWire(Enum<?> value, Class<T> type, String prefix) {

--- a/fe/fe-core/src/main/java/com/starrocks/type/GeoTypeSerde.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/GeoTypeSerde.java
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.type;
+
+import com.starrocks.proto.GeoColumnDescPB;
+import com.starrocks.proto.GeoCoordinateSystemPB;
+import com.starrocks.proto.GeoDimensionPB;
+import com.starrocks.proto.GeoEdgeAlgorithmPB;
+import com.starrocks.proto.GeoEncodingPB;
+import com.starrocks.proto.GeoLogicalTypePB;
+import com.starrocks.proto.GeoStorageDescPB;
+import com.starrocks.proto.GeoTypeDescPB;
+import com.starrocks.proto.GeoValidationStatePB;
+import com.starrocks.thrift.TGeoColumnDesc;
+import com.starrocks.thrift.TGeoCoordinateSystem;
+import com.starrocks.thrift.TGeoDimension;
+import com.starrocks.thrift.TGeoEdgeAlgorithm;
+import com.starrocks.thrift.TGeoEncoding;
+import com.starrocks.thrift.TGeoLogicalType;
+import com.starrocks.thrift.TGeoStorageDesc;
+import com.starrocks.thrift.TGeoTypeDesc;
+import com.starrocks.thrift.TGeoValidationState;
+
+/** Wire conversion only; native primitive consistency belongs to ScalarType construction. */
+final class GeoTypeSerde {
+    private GeoTypeSerde() {
+    }
+
+    static TGeoColumnDesc toThrift(GeoColumnDescriptor descriptor) {
+        TGeoTypeDesc semantic = new TGeoTypeDesc();
+        TGeoStorageDesc storage = new TGeoStorageDesc();
+        semantic.setLogical_type(TGeoLogicalType.valueOf(descriptor.logicalType().name()));
+        semantic.setCoordinate_system(TGeoCoordinateSystem.valueOf(descriptor.coordinateSystem().name()));
+        semantic.setEdge_algorithm(TGeoEdgeAlgorithm.valueOf(descriptor.edgeAlgorithm().name()));
+        storage.setEncoding(TGeoEncoding.valueOf(descriptor.encoding().name()));
+        storage.setDimension(TGeoDimension.valueOf(descriptor.dimension().name()));
+        storage.setValidation_state(TGeoValidationState.valueOf(descriptor.validationState().name()));
+        semantic.setCrs(descriptor.crs());
+        if (descriptor.srid() != null) {
+            semantic.setSrid(descriptor.srid());
+        }
+        return new TGeoColumnDesc().setType(semantic).setStorage(storage);
+    }
+
+    static GeoColumnDescPB toProtobuf(GeoColumnDescriptor descriptor) {
+        GeoTypeDescPB semantic = new GeoTypeDescPB();
+        GeoStorageDescPB storage = new GeoStorageDescPB();
+        semantic.logicalType = GeoLogicalTypePB.valueOf("GEO_LOGICAL_TYPE_" + descriptor.logicalType().name());
+        semantic.coordinateSystem =
+                GeoCoordinateSystemPB.valueOf("GEO_COORDINATE_SYSTEM_" + descriptor.coordinateSystem().name());
+        semantic.edgeAlgorithm = GeoEdgeAlgorithmPB.valueOf("GEO_EDGE_ALGORITHM_" + descriptor.edgeAlgorithm().name());
+        storage.encoding = GeoEncodingPB.valueOf("GEO_ENCODING_" + descriptor.encoding().name());
+        storage.dimension = GeoDimensionPB.valueOf("GEO_DIMENSION_" + descriptor.dimension().name());
+        storage.validationState = GeoValidationStatePB.valueOf("GEO_VALIDATION_STATE_" + descriptor.validationState().name());
+        semantic.crs = descriptor.crs();
+        semantic.srid = descriptor.srid();
+        GeoColumnDescPB result = new GeoColumnDescPB();
+        result.type = semantic;
+        result.storage = storage;
+        return result;
+    }
+
+    static GeoColumnDescriptor fromThrift(TGeoColumnDesc descriptor) {
+        TGeoTypeDesc semantic = descriptor.isSetType() ? descriptor.type : new TGeoTypeDesc();
+        TGeoStorageDesc storage = descriptor.isSetStorage() ? descriptor.storage : new TGeoStorageDesc();
+        return new GeoColumnDescriptor(
+                fromWire(semantic.logical_type, GeoColumnDescriptor.LogicalType.class, ""),
+                fromWire(semantic.coordinate_system, GeoColumnDescriptor.CoordinateSystem.class, ""),
+                fromWire(semantic.edge_algorithm, GeoColumnDescriptor.EdgeAlgorithm.class, ""),
+                semantic.crs == null ? "" : semantic.crs, semantic.isSetSrid() ? semantic.srid : null,
+                fromWire(storage.encoding, GeoColumnDescriptor.Encoding.class, ""),
+                fromWire(storage.dimension, GeoColumnDescriptor.Dimension.class, ""),
+                fromWire(storage.validation_state, GeoColumnDescriptor.ValidationState.class, ""));
+    }
+
+    static GeoColumnDescriptor fromProtobuf(GeoColumnDescPB descriptor) {
+        GeoTypeDescPB semantic = descriptor.type == null ? new GeoTypeDescPB() : descriptor.type;
+        GeoStorageDescPB storage = descriptor.storage == null ? new GeoStorageDescPB() : descriptor.storage;
+        return new GeoColumnDescriptor(
+                fromWire(semantic.logicalType, GeoColumnDescriptor.LogicalType.class, "GEO_LOGICAL_TYPE_"),
+                fromWire(semantic.coordinateSystem, GeoColumnDescriptor.CoordinateSystem.class, "GEO_COORDINATE_SYSTEM_"),
+                fromWire(semantic.edgeAlgorithm, GeoColumnDescriptor.EdgeAlgorithm.class, "GEO_EDGE_ALGORITHM_"),
+                semantic.crs == null ? "" : semantic.crs, semantic.srid,
+                fromWire(storage.encoding, GeoColumnDescriptor.Encoding.class, "GEO_ENCODING_"),
+                fromWire(storage.dimension, GeoColumnDescriptor.Dimension.class, "GEO_DIMENSION_"),
+                fromWire(storage.validationState, GeoColumnDescriptor.ValidationState.class, "GEO_VALIDATION_STATE_"));
+    }
+
+    private static <T extends Enum<T>> T fromWire(Enum<?> value, Class<T> type, String prefix) {
+        return Enum.valueOf(type, value == null ? "UNKNOWN" : value.name().substring(prefix.length()));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeCompatibilityMatrix.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeCompatibilityMatrix.java
@@ -30,7 +30,8 @@ public class TypeCompatibilityMatrix {
             PrimitiveType.INVALID_TYPE, PrimitiveType.NULL_TYPE, PrimitiveType.DECIMALV2,
             PrimitiveType.DECIMAL32, PrimitiveType.DECIMAL64, PrimitiveType.DECIMAL128, PrimitiveType.DECIMAL256,
             PrimitiveType.TIME, PrimitiveType.JSON, PrimitiveType.FUNCTION,
-            PrimitiveType.BINARY, PrimitiveType.VARBINARY, PrimitiveType.VARIANT);
+            PrimitiveType.BINARY, PrimitiveType.VARBINARY, PrimitiveType.VARIANT,
+            PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY);
 
     private static final PrimitiveType[][] COMPATIBILITY_MATRIX =
             new PrimitiveType[PrimitiveType.values().length][PrimitiveType.values().length];
@@ -384,8 +385,8 @@ public class TypeCompatibilityMatrix {
         }
 
         // Check all the necessary entries that should be filled.
-        for (int i = 0; i < PrimitiveType.values().length - 2; ++i) {
-            for (int j = i; j < PrimitiveType.values().length - 2; ++j) {
+        for (int i = 0; i < PrimitiveType.values().length; ++i) {
+            for (int j = i; j < PrimitiveType.values().length; ++j) {
                 PrimitiveType t1 = PrimitiveType.values()[i];
                 PrimitiveType t2 = PrimitiveType.values()[j];
                 if (SKIP_COMPARE_TYPES.contains(t1) || SKIP_COMPARE_TYPES.contains(t2)) {

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeCompatibilityMatrix.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeCompatibilityMatrix.java
@@ -385,8 +385,8 @@ public class TypeCompatibilityMatrix {
         }
 
         // Check all the necessary entries that should be filled.
-        for (int i = 0; i < PrimitiveType.values().length; ++i) {
-            for (int j = i; j < PrimitiveType.values().length; ++j) {
+        for (int i = 0; i < PrimitiveType.values().length - 2; ++i) {
+            for (int j = i; j < PrimitiveType.values().length - 2; ++j) {
                 PrimitiveType t1 = PrimitiveType.values()[i];
                 PrimitiveType t2 = PrimitiveType.values()[j];
                 if (SKIP_COMPARE_TYPES.contains(t1) || SKIP_COMPARE_TYPES.contains(t2)) {

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeDeserializer.java
@@ -73,6 +73,8 @@ public class TypeDeserializer {
             case JSON -> PrimitiveType.JSON;
             case FUNCTION -> PrimitiveType.FUNCTION;
             case VARIANT -> PrimitiveType.VARIANT;
+            case GEOGRAPHY -> PrimitiveType.GEOGRAPHY;
+            case GEOMETRY -> PrimitiveType.GEOMETRY;
             default -> PrimitiveType.INVALID_TYPE;
         };
     }
@@ -132,6 +134,12 @@ public class TypeDeserializer {
     private static Type scalarTypeFromThrift(TTypeNode node) {
         Preconditions.checkState(node.isSetScalar_type());
         TScalarType scalarType = node.getScalar_type();
+        if (scalarType.isSetGeo()) {
+            return ScalarType.createGeoType(fromThrift(scalarType.getType()), GeoTypeSerde.fromThrift(scalarType.geo));
+        }
+        Preconditions.checkArgument(scalarType.getType() != TPrimitiveType.GEOGRAPHY
+                        && scalarType.getType() != TPrimitiveType.GEOMETRY,
+                "Native geo primitives require a geo descriptor");
         
         if (scalarType.getType() == TPrimitiveType.CHAR) {
             Preconditions.checkState(scalarType.isSetLen());
@@ -217,6 +225,11 @@ public class TypeDeserializer {
 
     public static ScalarType createType(PScalarType ptype) {
         TPrimitiveType tPrimitiveType = TPrimitiveType.findByValue(ptype.type);
+        if (ptype.geo != null) {
+            return ScalarType.createGeoType(fromThrift(tPrimitiveType), GeoTypeSerde.fromProtobuf(ptype.geo));
+        }
+        Preconditions.checkArgument(tPrimitiveType != TPrimitiveType.GEOGRAPHY && tPrimitiveType != TPrimitiveType.GEOMETRY,
+                "Native geo primitives require a geo descriptor");
 
         switch (tPrimitiveType) {
             case CHAR:

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeSerializer.java
@@ -103,6 +103,10 @@ public class TypeSerializer {
                 return TPrimitiveType.VARBINARY;
             case UNKNOWN_TYPE:
                 return TPrimitiveType.INVALID_TYPE;
+            case GEOGRAPHY:
+                return TPrimitiveType.GEOGRAPHY;
+            case GEOMETRY:
+                return TPrimitiveType.GEOMETRY;
             default:
                 throw new IllegalArgumentException("Unknown primitive type: " + primitiveType);
         }
@@ -205,6 +209,9 @@ public class TypeSerializer {
                 if (type.isDatetimeNtz()) {
                     scalarType.setDatetime_is_ntz(true);
                 }
+                if (type.isGeoType()) {
+                    scalarType.setGeo(GeoTypeSerde.toThrift(Preconditions.checkNotNull(type.getGeoDescriptor())));
+                }
                 node.setScalar_type(scalarType);
                 break;
             }
@@ -238,6 +245,9 @@ public class TypeSerializer {
                 break;
         }
         node.scalarType = scalarType;
+        if (type.isGeoType()) {
+            scalarType.geo = GeoTypeSerde.toProtobuf(Preconditions.checkNotNull(type.getGeoDescriptor()));
+        }
     }
 
     private static void arrayTypeToThrift(ArrayType type, TTypeDesc container) {

--- a/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
@@ -22,6 +22,8 @@ import com.starrocks.proto.GeoEncodingPB;
 import com.starrocks.proto.GeoStorageDescPB;
 import com.starrocks.proto.GeoValidationStatePB;
 import com.starrocks.proto.PTypeDesc;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.TypeManager;
 import com.starrocks.statistic.base.ColumnClassifier;
 import com.starrocks.statistic.base.ComplexTypeColumnStats;
 import com.starrocks.statistic.base.PrimitiveTypeColumnStats;
@@ -364,6 +366,114 @@ public class NativeGeoTypeTest {
                 new StructType(List.of(IntegerType.INT)))) {
             assertFalse(type.canPartitionBy());
             assertFalse(type.canStatistic());
+        }
+    }
+
+    @Test
+    public void testRejectEmptyCrsEvenWithSrid() throws Exception {
+        var codec = ProtobufProxy.create(PTypeDesc.class);
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            GeoTypeDescriptor metadata = descriptor(primitive);
+            for (Integer srid : new Integer[] {null, 4326}) {
+                GeoTypeDescriptor emptyCrs = new GeoTypeDescriptor(metadata.logicalType(), metadata.coordinateSystem(),
+                        metadata.edgeAlgorithm(), "", srid);
+                assertThrows(IllegalArgumentException.class, () -> ScalarType.createGeoType(primitive, emptyCrs));
+                ScalarType valid = ScalarType.createGeoType(primitive, new GeoTypeDescriptor(metadata.logicalType(),
+                        metadata.coordinateSystem(), metadata.edgeAlgorithm(), metadata.crs(), srid));
+                assertEquals(valid, TypeDeserializer.fromThrift(TypeSerializer.toThrift(valid)));
+                assertEquals(valid, TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(valid)));
+                for (boolean missing : new boolean[] {false, true}) {
+                    TTypeDesc thrift = TypeSerializer.toThrift(valid);
+                    if (missing) {
+                        thrift.types.get(0).scalar_type.geo.type.unsetCrs();
+                    } else {
+                        thrift.types.get(0).scalar_type.geo.type.setCrs("");
+                    }
+                    TTypeDesc decoded = new TTypeDesc();
+                    new TDeserializer().deserialize(decoded, new TSerializer().serialize(thrift));
+                    assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(decoded));
+                    PTypeDesc proto = TypeSerializer.toProtobuf(valid);
+                    proto.types.get(0).scalarType.geo.type.crs = missing ? null : "";
+                    PTypeDesc decodedProto = codec.decode(codec.encode(proto));
+                    assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromProtobuf(decodedProto));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testUnsupportedGeoCommonTypes() {
+        List<ScalarType> ordinary = List.of(BooleanType.BOOLEAN, IntegerType.INT, IntegerType.BIGINT,
+                FloatType.DOUBLE, DateType.DATE, DateType.DATETIME, VarcharType.VARCHAR,
+                TypeFactory.createVarcharType(16), TypeFactory.createCharType(8), VarbinaryType.VARBINARY,
+                TypeFactory.createDecimalV2Type(10, 2),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 8), JsonType.JSON, VariantType.VARIANT);
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            GeoTypeDescriptor metadata = descriptor(primitive);
+            ScalarType geo = ScalarType.createGeoType(primitive, metadata);
+            for (ScalarType other : ordinary) {
+                assertIncompatibleGeoPair(geo, other);
+            }
+            assertIncompatibleGeoPair(geo, new ScalarType(primitive));
+            assertIncompatibleGeoPair(geo, ScalarType.createGeoType(primitive, new GeoTypeDescriptor(
+                    metadata.logicalType(), metadata.coordinateSystem(), metadata.edgeAlgorithm(), "EPSG:4326", 4326)));
+            assertIncompatibleGeoPair(geo, ScalarType.createGeoType(primitive, new GeoTypeDescriptor(
+                    metadata.logicalType(), metadata.coordinateSystem(), metadata.edgeAlgorithm(), metadata.crs(), 3857)));
+        }
+        assertIncompatibleGeoPair(
+                ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, descriptor(PrimitiveType.GEOGRAPHY)),
+                ScalarType.createGeoType(PrimitiveType.GEOMETRY, descriptor(PrimitiveType.GEOMETRY)));
+    }
+
+    @Test
+    public void testNestedGeoCommonTypeDiagnostic() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType geo = ScalarType.createGeoType(primitive, descriptor(primitive));
+            List<Type> geoTypes = List.of(geo, new ArrayType(geo), new MapType(IntegerType.INT, geo),
+                    new MapType(geo, IntegerType.INT), new StructType(List.of(geo)));
+            List<Type> intTypes = List.of(IntegerType.INT, new ArrayType(IntegerType.INT),
+                    new MapType(IntegerType.INT, IntegerType.INT), new MapType(IntegerType.INT, IntegerType.INT),
+                    new StructType(List.of(IntegerType.INT)));
+            for (int i = 0; i < geoTypes.size(); i++) {
+                Type left = geoTypes.get(i);
+                Type right = intTypes.get(i);
+                assertTrue(TypeManager.getCommonSuperType(left, right).isInvalid());
+                assertTrue(TypeManager.getCommonSuperType(right, left).isInvalid());
+                SemanticException error = assertThrows(SemanticException.class,
+                        () -> TypeManager.getCommonSuperType(List.of(left, right)));
+                assertTrue(error.getMessage().contains("cannot be matched"));
+            }
+        }
+    }
+
+    @Test
+    public void testCommonTypeShortcutsUnchanged() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType geo = ScalarType.createGeoType(primitive, descriptor(primitive));
+            for (boolean strict : new boolean[] {false, true}) {
+                assertSame(geo, TypeManager.getAssignmentCompatibleType(geo, geo.clone(), strict));
+                assertSame(geo, TypeManager.getAssignmentCompatibleType(geo, NullType.NULL, strict));
+                assertSame(geo, TypeManager.getAssignmentCompatibleType(NullType.NULL, geo, strict));
+                assertSame(UnknownType.UNKNOWN_TYPE,
+                        TypeManager.getAssignmentCompatibleType(geo, UnknownType.UNKNOWN_TYPE, strict));
+                assertSame(InvalidType.INVALID,
+                        TypeManager.getAssignmentCompatibleType(geo, InvalidType.INVALID, strict));
+            }
+        }
+        assertEquals(IntegerType.BIGINT, TypeManager.getCommonSuperType(IntegerType.INT, IntegerType.BIGINT));
+        assertEquals(VarcharType.VARCHAR, TypeManager.getCommonSuperType(IntegerType.INT, VarcharType.VARCHAR));
+        assertEquals(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2), TypeManager.getCommonSuperType(
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2)));
+    }
+
+    private static void assertIncompatibleGeoPair(ScalarType left, ScalarType right) {
+        for (boolean strict : new boolean[] {false, true}) {
+            assertSame(InvalidType.INVALID, TypeManager.getAssignmentCompatibleType(left, right, strict));
+            assertSame(InvalidType.INVALID, TypeManager.getAssignmentCompatibleType(right, left, strict));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.type;
+
+import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
+import com.starrocks.proto.PTypeDesc;
+import com.starrocks.thrift.TGeoEdgeAlgorithm;
+import com.starrocks.thrift.TPrimitiveType;
+import com.starrocks.thrift.TTypeDesc;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TSerializer;
+import org.junit.jupiter.api.Test;
+
+import java.util.HexFormat;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NativeGeoTypeTest {
+    static GeoColumnDescriptor descriptor(PrimitiveType primitive) {
+        boolean geography = primitive == PrimitiveType.GEOGRAPHY;
+        return new GeoColumnDescriptor(
+                geography ? GeoColumnDescriptor.LogicalType.GEOGRAPHY : GeoColumnDescriptor.LogicalType.GEOMETRY,
+                geography ? GeoColumnDescriptor.CoordinateSystem.SPHERICAL : GeoColumnDescriptor.CoordinateSystem.CARTESIAN,
+                geography ? GeoColumnDescriptor.EdgeAlgorithm.SPHERICAL : GeoColumnDescriptor.EdgeAlgorithm.PLANAR,
+                "OGC:CRS84", 4326, GeoColumnDescriptor.Encoding.WKB, GeoColumnDescriptor.Dimension.XY,
+                GeoColumnDescriptor.ValidationState.UNVALIDATED);
+    }
+
+    @Test
+    public void testWireRoundTrips() throws Exception {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType type = ScalarType.createGeoType(primitive, descriptor(primitive));
+            TTypeDesc thrift = TypeSerializer.toThrift(type);
+            assertEquals(primitive, TypeDeserializer.fromThrift(thrift.types.get(0).scalar_type.type));
+            TTypeDesc decoded = new TTypeDesc();
+            new TDeserializer().deserialize(decoded, new TSerializer().serialize(thrift));
+            assertEquals(type, TypeDeserializer.fromThrift(decoded));
+            var codec = ProtobufProxy.create(PTypeDesc.class);
+            PTypeDesc protobuf = codec.decode(codec.encode(TypeSerializer.toProtobuf(type)));
+            assertEquals(type, TypeDeserializer.fromProtobuf(protobuf));
+            assertFalse(type.isSupported());
+            assertSame(type.getGeoDescriptor(), type.clone().getGeoDescriptor());
+            Type nested = new ArrayType(type);
+            assertEquals(nested, TypeDeserializer.fromThrift(TypeSerializer.toThrift(nested)));
+            assertEquals(nested, TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(nested)));
+        }
+    }
+
+    @Test
+    public void testRejectConflictingPrimitive() {
+        var geography = descriptor(PrimitiveType.GEOGRAPHY);
+        assertThrows(IllegalArgumentException.class, () -> ScalarType.createGeoType(PrimitiveType.VARBINARY, geography));
+        assertThrows(IllegalArgumentException.class, () -> ScalarType.createGeoType(PrimitiveType.GEOMETRY, geography));
+        ScalarType type = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, geography);
+        TTypeDesc thrift = TypeSerializer.toThrift(type);
+        thrift.types.get(0).scalar_type.setType(TPrimitiveType.VARBINARY);
+        assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(thrift));
+        PTypeDesc proto = TypeSerializer.toProtobuf(type);
+        proto.types.get(0).scalarType.type = TPrimitiveType.GEOMETRY.getValue();
+        assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromProtobuf(proto));
+    }
+
+    @Test
+    public void testRejectMissingMetadataAndWrongEdge() {
+        ScalarType type = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, descriptor(PrimitiveType.GEOGRAPHY));
+        TTypeDesc thrift = TypeSerializer.toThrift(type);
+        thrift.types.get(0).scalar_type.geo.type.setEdge_algorithm(TGeoEdgeAlgorithm.PLANAR);
+        assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(thrift));
+        thrift.types.get(0).scalar_type.unsetGeo();
+        assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(thrift));
+        PTypeDesc proto = TypeSerializer.toProtobuf(type);
+        proto.types.get(0).scalarType.geo = null;
+        assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromProtobuf(proto));
+    }
+
+    @Test
+    public void testDescriptorIdentity() {
+        var geography = descriptor(PrimitiveType.GEOGRAPHY);
+        ScalarType type = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, geography);
+        ScalarType copy = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, geography);
+        assertEquals(type, copy);
+        assertEquals(type.hashCode(), copy.hashCode());
+        assertNotEquals(type, ScalarType.createGeoType(PrimitiveType.GEOMETRY, descriptor(PrimitiveType.GEOMETRY)));
+        assertNotEquals(type, new ScalarType(PrimitiveType.VARBINARY));
+        assertNotEquals(type, new ScalarType(PrimitiveType.GEOGRAPHY));
+    }
+
+    @Test
+    public void testOrdinaryTypeUnchanged() {
+        ScalarType type = new ScalarType(PrimitiveType.INT);
+        assertEquals(type, TypeDeserializer.fromThrift(TypeSerializer.toThrift(type)));
+        assertEquals(type, TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(type)));
+    }
+
+    @Test
+    public void testBackendWireFixture() throws Exception {
+        // Shared with native_geo_type_test.cpp: not just a same-language round trip.
+        String wire = "0a2608001222081e2a1e0a1408011001180122094f47433a435253383428e6211206080110011801";
+        var codec = ProtobufProxy.create(PTypeDesc.class);
+        ScalarType type = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, descriptor(PrimitiveType.GEOGRAPHY));
+        assertEquals(type, TypeDeserializer.fromProtobuf(codec.decode(HexFormat.of().parseHex(wire))));
+        assertEquals(wire, HexFormat.of().formatHex(codec.encode(TypeSerializer.toProtobuf(type))));
+    }
+
+    @Test
+    public void testGeoCapabilities() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType type = ScalarType.createGeoType(primitive, descriptor(primitive));
+            assertGeoCapabilitiesRejected(new ScalarType(primitive));
+            assertGeoCapabilitiesRejected(type);
+            assertGeoCapabilitiesRejected(TypeDeserializer.fromThrift(TypeSerializer.toThrift(type)));
+            assertGeoCapabilitiesRejected(TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(type)));
+        }
+    }
+
+    @Test
+    public void testNestedGeoCapabilities() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType geo = ScalarType.createGeoType(primitive, descriptor(primitive));
+            for (Type type : List.of(new ArrayType(geo), new MapType(IntegerType.INT, geo),
+                    new MapType(geo, IntegerType.INT),
+                    new StructType(List.of(IntegerType.INT, geo)),
+                    new ArrayType(new StructType(List.of(new ArrayType(geo)))))) {
+                assertGeoCapabilitiesRejected(type);
+                assertGeoCapabilitiesRejected(TypeDeserializer.fromThrift(TypeSerializer.toThrift(type)));
+                assertGeoCapabilitiesRejected(TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(type)));
+            }
+        }
+    }
+
+    @Test
+    public void testOrdinaryCapabilitiesUnchanged() {
+        for (Type type : List.of(IntegerType.INT, VarcharType.VARCHAR, DateType.DATE,
+                new ArrayType(IntegerType.INT), new StructType(List.of(IntegerType.INT)))) {
+            assertTrue(type.canJoinOn());
+            assertTrue(type.canGroupBy());
+            assertTrue(type.canOrderBy());
+            assertTrue(type.canDistinct());
+            assertEquals(!type.isComplexType(), type.canDistributedBy());
+        }
+        Type map = new MapType(IntegerType.INT, VarcharType.VARCHAR);
+        assertTrue(map.canJoinOn());
+        assertTrue(map.canGroupBy());
+        assertTrue(map.canDistinct());
+        assertFalse(map.canOrderBy());
+        assertFalse(map.canDistributedBy());
+        Type binary = new ScalarType(PrimitiveType.VARBINARY);
+        assertTrue(binary.canJoinOn());
+        assertTrue(binary.canGroupBy());
+        assertTrue(binary.canOrderBy());
+        assertTrue(binary.canDistributedBy());
+        assertFalse(binary.canDistinct());
+        assertGeoCapabilitiesRejected(new ScalarType(PrimitiveType.JSON));
+    }
+
+    private static void assertGeoCapabilitiesRejected(Type type) {
+        assertFalse(type.canJoinOn(), type.toSql());
+        assertFalse(type.canGroupBy(), type.toSql());
+        assertFalse(type.canOrderBy(), type.toSql());
+        assertFalse(type.canDistinct(), type.toSql());
+        assertFalse(type.canDistributedBy(), type.toSql());
+        assertFalse(type.canBeMVKey(), type.toSql());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
@@ -15,8 +15,16 @@
 package com.starrocks.type;
 
 import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
+import com.starrocks.proto.GeoDimensionPB;
+import com.starrocks.proto.GeoEncodingPB;
+import com.starrocks.proto.GeoStorageDescPB;
+import com.starrocks.proto.GeoValidationStatePB;
 import com.starrocks.proto.PTypeDesc;
+import com.starrocks.thrift.TGeoDimension;
 import com.starrocks.thrift.TGeoEdgeAlgorithm;
+import com.starrocks.thrift.TGeoEncoding;
+import com.starrocks.thrift.TGeoStorageDesc;
+import com.starrocks.thrift.TGeoValidationState;
 import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TTypeDesc;
 import org.apache.thrift.TDeserializer;
@@ -29,19 +37,19 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class NativeGeoTypeTest {
-    static GeoColumnDescriptor descriptor(PrimitiveType primitive) {
+    static GeoTypeDescriptor descriptor(PrimitiveType primitive) {
         boolean geography = primitive == PrimitiveType.GEOGRAPHY;
-        return new GeoColumnDescriptor(
-                geography ? GeoColumnDescriptor.LogicalType.GEOGRAPHY : GeoColumnDescriptor.LogicalType.GEOMETRY,
-                geography ? GeoColumnDescriptor.CoordinateSystem.SPHERICAL : GeoColumnDescriptor.CoordinateSystem.CARTESIAN,
-                geography ? GeoColumnDescriptor.EdgeAlgorithm.SPHERICAL : GeoColumnDescriptor.EdgeAlgorithm.PLANAR,
-                "OGC:CRS84", 4326, GeoColumnDescriptor.Encoding.WKB, GeoColumnDescriptor.Dimension.XY,
-                GeoColumnDescriptor.ValidationState.UNVALIDATED);
+        return new GeoTypeDescriptor(
+                geography ? GeoTypeDescriptor.LogicalType.GEOGRAPHY : GeoTypeDescriptor.LogicalType.GEOMETRY,
+                geography ? GeoTypeDescriptor.CoordinateSystem.SPHERICAL : GeoTypeDescriptor.CoordinateSystem.CARTESIAN,
+                geography ? GeoTypeDescriptor.EdgeAlgorithm.SPHERICAL : GeoTypeDescriptor.EdgeAlgorithm.PLANAR,
+                "OGC:CRS84", 4326);
     }
 
     @Test
@@ -49,12 +57,14 @@ public class NativeGeoTypeTest {
         for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
             ScalarType type = ScalarType.createGeoType(primitive, descriptor(primitive));
             TTypeDesc thrift = TypeSerializer.toThrift(type);
+            assertFalse(thrift.types.get(0).scalar_type.geo.isSetStorage());
             assertEquals(primitive, TypeDeserializer.fromThrift(thrift.types.get(0).scalar_type.type));
             TTypeDesc decoded = new TTypeDesc();
             new TDeserializer().deserialize(decoded, new TSerializer().serialize(thrift));
             assertEquals(type, TypeDeserializer.fromThrift(decoded));
             var codec = ProtobufProxy.create(PTypeDesc.class);
             PTypeDesc protobuf = codec.decode(codec.encode(TypeSerializer.toProtobuf(type)));
+            assertNull(protobuf.types.get(0).scalarType.geo.storage);
             assertEquals(type, TypeDeserializer.fromProtobuf(protobuf));
             assertFalse(type.isSupported());
             assertSame(type.getGeoDescriptor(), type.clone().getGeoDescriptor());
@@ -111,13 +121,100 @@ public class NativeGeoTypeTest {
     }
 
     @Test
-    public void testBackendWireFixture() throws Exception {
-        // Shared with native_geo_type_test.cpp: not just a same-language round trip.
+    public void testLegacyColumnWireFixture() throws Exception {
+        // The original shared fixture includes storage metadata, which is not part of type identity.
         String wire = "0a2608001222081e2a1e0a1408011001180122094f47433a435253383428e6211206080110011801";
         var codec = ProtobufProxy.create(PTypeDesc.class);
         ScalarType type = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, descriptor(PrimitiveType.GEOGRAPHY));
         assertEquals(type, TypeDeserializer.fromProtobuf(codec.decode(HexFormat.of().parseHex(wire))));
-        assertEquals(wire, HexFormat.of().formatHex(codec.encode(TypeSerializer.toProtobuf(type))));
+        assertNull(TypeSerializer.toProtobuf(type).types.get(0).scalarType.geo.storage);
+    }
+
+    @Test
+    public void testBackendSemanticOnlyWireFixtures() throws Exception {
+        // Produced by BE TypeDescriptor::to_thrift/to_protobuf at #78999 commit 6e6079181e,
+        // then serialized with Thrift TBinaryProtocol and protobuf SerializeAsString respectively.
+        String[] protobufWires = {
+                "0a2908001225081e10ffffffffffffffffff012a160a1408011001180122094f47433a435253383428e621",
+                "0a2908001225081f10ffffffffffffffffff012a160a1408021002180622094f47433a435253383428e621"
+        };
+        String[] thriftWires = {
+                "0f00010c00000001080001000000000c00020800010000001e080002ffffffff0c00060c000108000100000001"
+                        + "08000200000001080003000000010b0004000000094f47433a4352533834080005000010e60000000000",
+                "0f00010c00000001080001000000000c00020800010000001f080002ffffffff0c00060c000108000100000002"
+                        + "08000200000002080003000000060b0004000000094f47433a4352533834080005000010e60000000000"
+        };
+        PrimitiveType[] primitives = {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY};
+        var codec = ProtobufProxy.create(PTypeDesc.class);
+        for (int i = 0; i < primitives.length; i++) {
+            ScalarType expected = ScalarType.createGeoType(primitives[i], descriptor(primitives[i]));
+            PTypeDesc proto = codec.decode(HexFormat.of().parseHex(protobufWires[i]));
+            TTypeDesc thrift = new TTypeDesc();
+            new TDeserializer().deserialize(thrift, HexFormat.of().parseHex(thriftWires[i]));
+            assertNull(proto.types.get(0).scalarType.geo.storage);
+            assertFalse(thrift.types.get(0).scalar_type.geo.isSetStorage());
+            assertEquals(expected, TypeDeserializer.fromProtobuf(proto));
+            assertEquals(expected, TypeDeserializer.fromThrift(thrift));
+            // BE writes the unused scalar length (-1); FE omits it. Compare semantic wire content.
+            proto.types.get(0).scalarType.len = null;
+            thrift.types.get(0).scalar_type.unsetLen();
+            assertEquals(HexFormat.of().formatHex(codec.encode(proto)),
+                    HexFormat.of().formatHex(codec.encode(TypeSerializer.toProtobuf(expected))));
+            assertEquals(thrift, TypeSerializer.toThrift(expected));
+        }
+    }
+
+    @Test
+    public void testRejectMissingSemanticMetadata() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType type = ScalarType.createGeoType(primitive, descriptor(primitive));
+            TTypeDesc thrift = TypeSerializer.toThrift(type);
+            PTypeDesc proto = TypeSerializer.toProtobuf(type);
+            thrift.types.get(0).scalar_type.geo.unsetType();
+            proto.types.get(0).scalarType.geo.type = null;
+            assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(thrift));
+            assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromProtobuf(proto));
+        }
+    }
+
+    @Test
+    public void testRepresentationDoesNotAffectTypeIdentity() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType expected = ScalarType.createGeoType(primitive, descriptor(primitive));
+            TTypeDesc thrift = TypeSerializer.toThrift(expected);
+            PTypeDesc proto = TypeSerializer.toProtobuf(expected);
+            for (TGeoEncoding encoding : TGeoEncoding.values()) {
+                thrift.types.get(0).scalar_type.geo.setStorage(new TGeoStorageDesc()
+                        .setEncoding(encoding).setDimension(TGeoDimension.XYZM)
+                        .setValidation_state(TGeoValidationState.SEMANTICALLY_VALIDATED));
+                GeoStorageDescPB storage = new GeoStorageDescPB();
+                storage.encoding = GeoEncodingPB.valueOf("GEO_ENCODING_" + encoding.name());
+                storage.dimension = GeoDimensionPB.GEO_DIMENSION_XYZM;
+                storage.validationState = GeoValidationStatePB.GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED;
+                proto.types.get(0).scalarType.geo.storage = storage;
+                Type fromThrift = TypeDeserializer.fromThrift(thrift);
+                Type fromProto = TypeDeserializer.fromProtobuf(proto);
+                assertEquals(expected, fromThrift);
+                assertEquals(expected, fromProto);
+                assertEquals(expected.hashCode(), fromThrift.hashCode());
+                assertEquals(expected.hashCode(), fromProto.hashCode());
+                assertFalse(TypeSerializer.toThrift(fromThrift).types.get(0).scalar_type.geo.isSetStorage());
+                assertNull(TypeSerializer.toProtobuf(fromProto).types.get(0).scalarType.geo.storage);
+            }
+        }
+    }
+
+    @Test
+    public void testCompatibilityMatrixAfterGeoReordering() {
+        assertEquals(PrimitiveType.UNKNOWN_TYPE, PrimitiveType.values()[PrimitiveType.values().length - 1]);
+        assertTrue(PrimitiveType.GEOGRAPHY.ordinal() < PrimitiveType.UNKNOWN_TYPE.ordinal());
+        assertTrue(PrimitiveType.GEOMETRY.ordinal() < PrimitiveType.UNKNOWN_TYPE.ordinal());
+        assertEquals(PrimitiveType.BIGINT,
+                TypeCompatibilityMatrix.getCompatibleType(PrimitiveType.INT, PrimitiveType.BIGINT));
+        assertEquals(PrimitiveType.INVALID_TYPE,
+                TypeCompatibilityMatrix.getCompatibleType(PrimitiveType.INT, PrimitiveType.UNKNOWN_TYPE));
+        assertEquals(PrimitiveType.UNKNOWN_TYPE,
+                TypeCompatibilityMatrix.getCompatibleType(PrimitiveType.UNKNOWN_TYPE, PrimitiveType.UNKNOWN_TYPE));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
@@ -15,11 +15,16 @@
 package com.starrocks.type;
 
 import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Table;
 import com.starrocks.proto.GeoDimensionPB;
 import com.starrocks.proto.GeoEncodingPB;
 import com.starrocks.proto.GeoStorageDescPB;
 import com.starrocks.proto.GeoValidationStatePB;
 import com.starrocks.proto.PTypeDesc;
+import com.starrocks.statistic.base.ColumnClassifier;
+import com.starrocks.statistic.base.ComplexTypeColumnStats;
+import com.starrocks.statistic.base.PrimitiveTypeColumnStats;
 import com.starrocks.thrift.TGeoDimension;
 import com.starrocks.thrift.TGeoEdgeAlgorithm;
 import com.starrocks.thrift.TGeoEncoding;
@@ -275,5 +280,90 @@ public class NativeGeoTypeTest {
         assertFalse(type.canDistinct(), type.toSql());
         assertFalse(type.canDistributedBy(), type.toSql());
         assertFalse(type.canBeMVKey(), type.toSql());
+    }
+
+    @Test
+    public void testGeoPartitionBy() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType geo = ScalarType.createGeoType(primitive, descriptor(primitive));
+            for (Type scalar : List.of(new ScalarType(primitive), geo,
+                    TypeDeserializer.fromThrift(TypeSerializer.toThrift(geo)),
+                    TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(geo)))) {
+                for (Type type : List.of(scalar, new ArrayType(scalar), new ArrayType(new ArrayType(scalar)),
+                        new MapType(IntegerType.INT, scalar), new StructType(List.of(scalar)))) {
+                    assertFalse(type.canPartitionBy(), type.toSql());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGeoStatistics() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType geo = ScalarType.createGeoType(primitive, descriptor(primitive));
+            for (Type type : List.of(new ScalarType(primitive), geo,
+                    TypeDeserializer.fromThrift(TypeSerializer.toThrift(geo)),
+                    TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(geo)))) {
+                assertFalse(type.canStatistic(), type.toSql());
+                Table table = new Table(1, "geo_stats", Table.TableType.OLAP,
+                        List.of(new Column("g", type), new Column("i", IntegerType.INT)));
+                for (boolean manual : new boolean[] {false, true}) {
+                    ColumnClassifier classifier = ColumnClassifier.of(
+                            List.of("g", "i"), List.of(type, IntegerType.INT), table, manual);
+                    assertEquals(1, classifier.getColumnStats().size());
+                    assertTrue(classifier.getColumnStats().get(0) instanceof PrimitiveTypeColumnStats);
+                    assertEquals(1, classifier.getUnSupportCollectColumns().size());
+                    var unsupported = classifier.getUnSupportCollectColumns().get(0);
+                    assertTrue(unsupported instanceof ComplexTypeColumnStats);
+                    assertEquals("''", unsupported.getMax());
+                    assertEquals("''", unsupported.getMin());
+                    assertEquals("00", unsupported.getNDV());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGeoPseudoTypeMatching() {
+        for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
+            ScalarType geo = ScalarType.createGeoType(primitive, descriptor(primitive));
+            for (Type type : List.of(new ScalarType(primitive), geo,
+                    TypeDeserializer.fromThrift(TypeSerializer.toThrift(geo)),
+                    TypeDeserializer.fromProtobuf(TypeSerializer.toProtobuf(geo)))) {
+                assertTrue(type.matchesType(AnyElementType.ANY_ELEMENT));
+                assertTrue(AnyElementType.ANY_ELEMENT.matchesType(type));
+                assertFalse(type.matchesType(AnyArrayType.ANY_ARRAY));
+                assertFalse(type.matchesType(AnyMapType.ANY_MAP));
+                assertFalse(type.matchesType(AnyStructType.ANY_STRUCT));
+                assertFalse(type.matchesType(IntegerType.INT));
+                assertFalse(type.matchesType(VarbinaryType.VARBINARY));
+                assertEquals(geo.equals(type), geo.matchesType(type));
+            }
+            GeoTypeDescriptor metadata = descriptor(primitive);
+            ScalarType differentSrid = ScalarType.createGeoType(primitive, new GeoTypeDescriptor(
+                    metadata.logicalType(), metadata.coordinateSystem(), metadata.edgeAlgorithm(), metadata.crs(), 3857));
+            assertFalse(geo.matchesType(differentSrid));
+            assertFalse(differentSrid.matchesType(geo));
+        }
+        assertFalse(ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, descriptor(PrimitiveType.GEOGRAPHY))
+                .matchesType(ScalarType.createGeoType(PrimitiveType.GEOMETRY, descriptor(PrimitiveType.GEOMETRY))));
+    }
+
+    @Test
+    public void testOrdinaryPartitionStatisticsAndPseudoTypes() {
+        for (Type type : List.of(IntegerType.INT, VarcharType.VARCHAR, DateType.DATE,
+                new ArrayType(IntegerType.INT), new ArrayType(new ArrayType(IntegerType.INT)))) {
+            assertTrue(type.canPartitionBy());
+            assertTrue(type.canStatistic());
+            assertTrue(type.matchesType(AnyElementType.ANY_ELEMENT));
+        }
+        Type map = new MapType(IntegerType.INT, VarcharType.VARCHAR);
+        assertFalse(map.canPartitionBy());
+        assertTrue(map.canStatistic());
+        for (Type type : List.of(JsonType.JSON, VarbinaryType.VARBINARY,
+                new StructType(List.of(IntegerType.INT)))) {
+            assertFalse(type.canPartitionBy());
+            assertFalse(type.canStatistic());
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/type/NativeGeoTypeTest.java
@@ -17,21 +17,15 @@ package com.starrocks.type;
 import com.baidu.bjf.remoting.protobuf.ProtobufProxy;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
-import com.starrocks.proto.GeoDimensionPB;
-import com.starrocks.proto.GeoEncodingPB;
-import com.starrocks.proto.GeoStorageDescPB;
-import com.starrocks.proto.GeoValidationStatePB;
+import com.starrocks.proto.GeoTypeDescPB;
 import com.starrocks.proto.PTypeDesc;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.statistic.base.ColumnClassifier;
 import com.starrocks.statistic.base.ComplexTypeColumnStats;
 import com.starrocks.statistic.base.PrimitiveTypeColumnStats;
-import com.starrocks.thrift.TGeoDimension;
 import com.starrocks.thrift.TGeoEdgeAlgorithm;
-import com.starrocks.thrift.TGeoEncoding;
-import com.starrocks.thrift.TGeoStorageDesc;
-import com.starrocks.thrift.TGeoValidationState;
+import com.starrocks.thrift.TGeoTypeDesc;
 import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TTypeDesc;
 import org.apache.thrift.TDeserializer;
@@ -64,14 +58,14 @@ public class NativeGeoTypeTest {
         for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
             ScalarType type = ScalarType.createGeoType(primitive, descriptor(primitive));
             TTypeDesc thrift = TypeSerializer.toThrift(type);
-            assertFalse(thrift.types.get(0).scalar_type.geo.isSetStorage());
+            assertEquals(TGeoTypeDesc.class, thrift.types.get(0).scalar_type.geo.getClass());
             assertEquals(primitive, TypeDeserializer.fromThrift(thrift.types.get(0).scalar_type.type));
             TTypeDesc decoded = new TTypeDesc();
             new TDeserializer().deserialize(decoded, new TSerializer().serialize(thrift));
             assertEquals(type, TypeDeserializer.fromThrift(decoded));
             var codec = ProtobufProxy.create(PTypeDesc.class);
             PTypeDesc protobuf = codec.decode(codec.encode(TypeSerializer.toProtobuf(type)));
-            assertNull(protobuf.types.get(0).scalarType.geo.storage);
+            assertEquals(GeoTypeDescPB.class, protobuf.types.get(0).scalarType.geo.getClass());
             assertEquals(type, TypeDeserializer.fromProtobuf(protobuf));
             assertFalse(type.isSupported());
             assertSame(type.getGeoDescriptor(), type.clone().getGeoDescriptor());
@@ -99,7 +93,7 @@ public class NativeGeoTypeTest {
     public void testRejectMissingMetadataAndWrongEdge() {
         ScalarType type = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, descriptor(PrimitiveType.GEOGRAPHY));
         TTypeDesc thrift = TypeSerializer.toThrift(type);
-        thrift.types.get(0).scalar_type.geo.type.setEdge_algorithm(TGeoEdgeAlgorithm.PLANAR);
+        thrift.types.get(0).scalar_type.geo.setEdge_algorithm(TGeoEdgeAlgorithm.PLANAR);
         assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(thrift));
         thrift.types.get(0).scalar_type.unsetGeo();
         assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(thrift));
@@ -128,28 +122,28 @@ public class NativeGeoTypeTest {
     }
 
     @Test
-    public void testLegacyColumnWireFixture() throws Exception {
-        // The original shared fixture includes storage metadata, which is not part of type identity.
-        String wire = "0a2608001222081e2a1e0a1408011001180122094f47433a435253383428e6211206080110011801";
+    public void testSemanticWireFixture() throws Exception {
+        // Shared with the BE FrontendWireFixture test: no column/storage wrapper.
+        String wire = "0a1c08001218081e2a1408011001180122094f47433a435253383428e621";
         var codec = ProtobufProxy.create(PTypeDesc.class);
         ScalarType type = ScalarType.createGeoType(PrimitiveType.GEOGRAPHY, descriptor(PrimitiveType.GEOGRAPHY));
         assertEquals(type, TypeDeserializer.fromProtobuf(codec.decode(HexFormat.of().parseHex(wire))));
-        assertNull(TypeSerializer.toProtobuf(type).types.get(0).scalarType.geo.storage);
+        assertEquals(wire, HexFormat.of().formatHex(codec.encode(TypeSerializer.toProtobuf(type))));
     }
 
     @Test
     public void testBackendSemanticOnlyWireFixtures() throws Exception {
-        // Produced by BE TypeDescriptor::to_thrift/to_protobuf at #78999 commit 6e6079181e,
+        // Produced by BE TypeDescriptor::to_thrift/to_protobuf with direct geo type metadata,
         // then serialized with Thrift TBinaryProtocol and protobuf SerializeAsString respectively.
         String[] protobufWires = {
-                "0a2908001225081e10ffffffffffffffffff012a160a1408011001180122094f47433a435253383428e621",
-                "0a2908001225081f10ffffffffffffffffff012a160a1408021002180622094f47433a435253383428e621"
+                "0a2708001223081e10ffffffffffffffffff012a1408011001180122094f47433a435253383428e621",
+                "0a2708001223081f10ffffffffffffffffff012a1408021002180622094f47433a435253383428e621"
         };
         String[] thriftWires = {
-                "0f00010c00000001080001000000000c00020800010000001e080002ffffffff0c00060c000108000100000001"
-                        + "08000200000001080003000000010b0004000000094f47433a4352533834080005000010e60000000000",
-                "0f00010c00000001080001000000000c00020800010000001f080002ffffffff0c00060c000108000100000002"
-                        + "08000200000002080003000000060b0004000000094f47433a4352533834080005000010e60000000000"
+                "0f00010c00000001080001000000000c00020800010000001e080002ffffffff0c000608000100000001"
+                        + "08000200000001080003000000010b0004000000094f47433a4352533834080005000010e600000000",
+                "0f00010c00000001080001000000000c00020800010000001f080002ffffffff0c000608000100000002"
+                        + "08000200000002080003000000060b0004000000094f47433a4352533834080005000010e600000000"
         };
         PrimitiveType[] primitives = {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY};
         var codec = ProtobufProxy.create(PTypeDesc.class);
@@ -158,8 +152,6 @@ public class NativeGeoTypeTest {
             PTypeDesc proto = codec.decode(HexFormat.of().parseHex(protobufWires[i]));
             TTypeDesc thrift = new TTypeDesc();
             new TDeserializer().deserialize(thrift, HexFormat.of().parseHex(thriftWires[i]));
-            assertNull(proto.types.get(0).scalarType.geo.storage);
-            assertFalse(thrift.types.get(0).scalar_type.geo.isSetStorage());
             assertEquals(expected, TypeDeserializer.fromProtobuf(proto));
             assertEquals(expected, TypeDeserializer.fromThrift(thrift));
             // BE writes the unused scalar length (-1); FE omits it. Compare semantic wire content.
@@ -177,37 +169,28 @@ public class NativeGeoTypeTest {
             ScalarType type = ScalarType.createGeoType(primitive, descriptor(primitive));
             TTypeDesc thrift = TypeSerializer.toThrift(type);
             PTypeDesc proto = TypeSerializer.toProtobuf(type);
-            thrift.types.get(0).scalar_type.geo.unsetType();
-            proto.types.get(0).scalarType.geo.type = null;
+            thrift.types.get(0).scalar_type.setGeo(new TGeoTypeDesc());
+            proto.types.get(0).scalarType.geo = new GeoTypeDescPB();
             assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(thrift));
             assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromProtobuf(proto));
         }
     }
 
     @Test
-    public void testRepresentationDoesNotAffectTypeIdentity() {
+    public void testSemanticFieldsPreservedWithoutSrid() throws Exception {
         for (PrimitiveType primitive : new PrimitiveType[] {PrimitiveType.GEOGRAPHY, PrimitiveType.GEOMETRY}) {
-            ScalarType expected = ScalarType.createGeoType(primitive, descriptor(primitive));
+            GeoTypeDescriptor metadata = descriptor(primitive);
+            ScalarType expected = ScalarType.createGeoType(primitive, new GeoTypeDescriptor(metadata.logicalType(),
+                    metadata.coordinateSystem(), metadata.edgeAlgorithm(), metadata.crs(), null));
             TTypeDesc thrift = TypeSerializer.toThrift(expected);
-            PTypeDesc proto = TypeSerializer.toProtobuf(expected);
-            for (TGeoEncoding encoding : TGeoEncoding.values()) {
-                thrift.types.get(0).scalar_type.geo.setStorage(new TGeoStorageDesc()
-                        .setEncoding(encoding).setDimension(TGeoDimension.XYZM)
-                        .setValidation_state(TGeoValidationState.SEMANTICALLY_VALIDATED));
-                GeoStorageDescPB storage = new GeoStorageDescPB();
-                storage.encoding = GeoEncodingPB.valueOf("GEO_ENCODING_" + encoding.name());
-                storage.dimension = GeoDimensionPB.GEO_DIMENSION_XYZM;
-                storage.validationState = GeoValidationStatePB.GEO_VALIDATION_STATE_SEMANTICALLY_VALIDATED;
-                proto.types.get(0).scalarType.geo.storage = storage;
-                Type fromThrift = TypeDeserializer.fromThrift(thrift);
-                Type fromProto = TypeDeserializer.fromProtobuf(proto);
-                assertEquals(expected, fromThrift);
-                assertEquals(expected, fromProto);
-                assertEquals(expected.hashCode(), fromThrift.hashCode());
-                assertEquals(expected.hashCode(), fromProto.hashCode());
-                assertFalse(TypeSerializer.toThrift(fromThrift).types.get(0).scalar_type.geo.isSetStorage());
-                assertNull(TypeSerializer.toProtobuf(fromProto).types.get(0).scalarType.geo.storage);
-            }
+            assertFalse(thrift.types.get(0).scalar_type.geo.isSetSrid());
+            TTypeDesc decoded = new TTypeDesc();
+            new TDeserializer().deserialize(decoded, new TSerializer().serialize(thrift));
+            var codec = ProtobufProxy.create(PTypeDesc.class);
+            PTypeDesc proto = codec.decode(codec.encode(TypeSerializer.toProtobuf(expected)));
+            assertNull(proto.types.get(0).scalarType.geo.srid);
+            assertEquals(expected, TypeDeserializer.fromThrift(decoded));
+            assertEquals(expected, TypeDeserializer.fromProtobuf(proto));
         }
     }
 
@@ -385,15 +368,15 @@ public class NativeGeoTypeTest {
                 for (boolean missing : new boolean[] {false, true}) {
                     TTypeDesc thrift = TypeSerializer.toThrift(valid);
                     if (missing) {
-                        thrift.types.get(0).scalar_type.geo.type.unsetCrs();
+                        thrift.types.get(0).scalar_type.geo.unsetCrs();
                     } else {
-                        thrift.types.get(0).scalar_type.geo.type.setCrs("");
+                        thrift.types.get(0).scalar_type.geo.setCrs("");
                     }
                     TTypeDesc decoded = new TTypeDesc();
                     new TDeserializer().deserialize(decoded, new TSerializer().serialize(thrift));
                     assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromThrift(decoded));
                     PTypeDesc proto = TypeSerializer.toProtobuf(valid);
-                    proto.types.get(0).scalarType.geo.type.crs = missing ? null : "";
+                    proto.types.get(0).scalarType.geo.crs = missing ? null : "";
                     PTypeDesc decodedProto = codec.decode(codec.encode(proto));
                     assertThrows(IllegalArgumentException.class, () -> TypeDeserializer.fromProtobuf(decodedProto));
                 }

--- a/fe/fe-type/src/main/java/com/starrocks/type/GeoColumnDescriptor.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/GeoColumnDescriptor.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.type;
+
+import java.util.Objects;
+
+/** Immutable metadata, independent of generated transport classes. */
+public record GeoColumnDescriptor(LogicalType logicalType, CoordinateSystem coordinateSystem,
+                                  EdgeAlgorithm edgeAlgorithm, String crs, Integer srid,
+                                  Encoding encoding, Dimension dimension, ValidationState validationState) {
+    public enum LogicalType {
+        UNKNOWN, GEOGRAPHY, GEOMETRY
+    }
+
+    public enum CoordinateSystem {
+        UNKNOWN, SPHERICAL, CARTESIAN
+    }
+
+    public enum EdgeAlgorithm {
+        UNKNOWN, SPHERICAL, VINCENTY, THOMAS, ANDOYER, KARNEY, PLANAR
+    }
+
+    public enum Encoding {
+        UNKNOWN, WKB
+    }
+
+    public enum Dimension {
+        UNKNOWN, XY, XYZ, XYM, XYZM, MIXED
+    }
+
+    public enum ValidationState {
+        UNKNOWN, UNVALIDATED, STRUCTURALLY_VALIDATED, SEMANTICALLY_VALIDATED
+    }
+
+    public GeoColumnDescriptor {
+        Objects.requireNonNull(logicalType);
+        Objects.requireNonNull(coordinateSystem);
+        Objects.requireNonNull(edgeAlgorithm);
+        Objects.requireNonNull(crs);
+        Objects.requireNonNull(encoding);
+        Objects.requireNonNull(dimension);
+        Objects.requireNonNull(validationState);
+    }
+
+    public void validate(PrimitiveType primitive) {
+        boolean geography = primitive == PrimitiveType.GEOGRAPHY;
+        boolean sphericalEdge = edgeAlgorithm != EdgeAlgorithm.UNKNOWN && edgeAlgorithm != EdgeAlgorithm.PLANAR;
+        if ((primitive != PrimitiveType.GEOGRAPHY && primitive != PrimitiveType.GEOMETRY)
+                || logicalType != (geography ? LogicalType.GEOGRAPHY : LogicalType.GEOMETRY)
+                || coordinateSystem != (geography ? CoordinateSystem.SPHERICAL : CoordinateSystem.CARTESIAN)
+                || (geography ? !sphericalEdge : edgeAlgorithm != EdgeAlgorithm.PLANAR)) {
+            throw new IllegalArgumentException("Native geo primitive conflicts with its semantic descriptor");
+        }
+        if (encoding != Encoding.WKB) {
+            throw new IllegalArgumentException("Native geo types require WKB encoding");
+        }
+    }
+}

--- a/fe/fe-type/src/main/java/com/starrocks/type/GeoTypeDescriptor.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/GeoTypeDescriptor.java
@@ -39,6 +39,9 @@ public record GeoTypeDescriptor(LogicalType logicalType, CoordinateSystem coordi
     }
 
     public void validate(PrimitiveType primitive) {
+        if (crs.isEmpty()) {
+            throw new IllegalArgumentException("Native geo types require a non-empty CRS");
+        }
         boolean geography = primitive == PrimitiveType.GEOGRAPHY;
         boolean sphericalEdge = edgeAlgorithm != EdgeAlgorithm.UNKNOWN && edgeAlgorithm != EdgeAlgorithm.PLANAR;
         if ((primitive != PrimitiveType.GEOGRAPHY && primitive != PrimitiveType.GEOMETRY)

--- a/fe/fe-type/src/main/java/com/starrocks/type/GeoTypeDescriptor.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/GeoTypeDescriptor.java
@@ -16,10 +16,9 @@ package com.starrocks.type;
 
 import java.util.Objects;
 
-/** Immutable metadata, independent of generated transport classes. */
-public record GeoColumnDescriptor(LogicalType logicalType, CoordinateSystem coordinateSystem,
-                                  EdgeAlgorithm edgeAlgorithm, String crs, Integer srid,
-                                  Encoding encoding, Dimension dimension, ValidationState validationState) {
+/** Immutable semantic type metadata; column representation belongs to the column/transport layer. */
+public record GeoTypeDescriptor(LogicalType logicalType, CoordinateSystem coordinateSystem,
+                                EdgeAlgorithm edgeAlgorithm, String crs, Integer srid) {
     public enum LogicalType {
         UNKNOWN, GEOGRAPHY, GEOMETRY
     }
@@ -32,26 +31,11 @@ public record GeoColumnDescriptor(LogicalType logicalType, CoordinateSystem coor
         UNKNOWN, SPHERICAL, VINCENTY, THOMAS, ANDOYER, KARNEY, PLANAR
     }
 
-    public enum Encoding {
-        UNKNOWN, WKB
-    }
-
-    public enum Dimension {
-        UNKNOWN, XY, XYZ, XYM, XYZM, MIXED
-    }
-
-    public enum ValidationState {
-        UNKNOWN, UNVALIDATED, STRUCTURALLY_VALIDATED, SEMANTICALLY_VALIDATED
-    }
-
-    public GeoColumnDescriptor {
+    public GeoTypeDescriptor {
         Objects.requireNonNull(logicalType);
         Objects.requireNonNull(coordinateSystem);
         Objects.requireNonNull(edgeAlgorithm);
         Objects.requireNonNull(crs);
-        Objects.requireNonNull(encoding);
-        Objects.requireNonNull(dimension);
-        Objects.requireNonNull(validationState);
     }
 
     public void validate(PrimitiveType primitive) {
@@ -62,9 +46,6 @@ public record GeoColumnDescriptor(LogicalType logicalType, CoordinateSystem coor
                 || coordinateSystem != (geography ? CoordinateSystem.SPHERICAL : CoordinateSystem.CARTESIAN)
                 || (geography ? !sphericalEdge : edgeAlgorithm != EdgeAlgorithm.PLANAR)) {
             throw new IllegalArgumentException("Native geo primitive conflicts with its semantic descriptor");
-        }
-        if (encoding != Encoding.WKB) {
-            throw new IllegalArgumentException("Native geo types require WKB encoding");
         }
     }
 }

--- a/fe/fe-type/src/main/java/com/starrocks/type/PrimitiveType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/PrimitiveType.java
@@ -81,12 +81,12 @@ public enum PrimitiveType {
     BINARY("BINARY", -1),
     VARBINARY("VARBINARY", 16),
 
-    // If external table column type is unsupported, it will be converted to UNKNOWN_TYPE
-    UNKNOWN_TYPE("UNKNOWN_TYPE", -1),
-
     // Reserved native identities; SQL activation requires separate capabilities.
     GEOGRAPHY("GEOGRAPHY", 16),
-    GEOMETRY("GEOMETRY", 16);
+    GEOMETRY("GEOMETRY", 16),
+
+    // If external table column type is unsupported, it will be converted to UNKNOWN_TYPE
+    UNKNOWN_TYPE("UNKNOWN_TYPE", -1);
 
     private static final int DATE_INDEX_LEN = 3;
     private static final int DATETIME_INDEX_LEN = 8;

--- a/fe/fe-type/src/main/java/com/starrocks/type/PrimitiveType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/PrimitiveType.java
@@ -82,7 +82,11 @@ public enum PrimitiveType {
     VARBINARY("VARBINARY", 16),
 
     // If external table column type is unsupported, it will be converted to UNKNOWN_TYPE
-    UNKNOWN_TYPE("UNKNOWN_TYPE", -1);
+    UNKNOWN_TYPE("UNKNOWN_TYPE", -1),
+
+    // Reserved native identities; SQL activation requires separate capabilities.
+    GEOGRAPHY("GEOGRAPHY", 16),
+    GEOMETRY("GEOMETRY", 16);
 
     private static final int DATE_INDEX_LEN = 3;
     private static final int DATETIME_INDEX_LEN = 8;
@@ -380,7 +384,9 @@ public enum PrimitiveType {
             case CHAR:
             case VARCHAR:
             case VARBINARY:
-                // use 16 as char type estimate size
+            case GEOGRAPHY:
+            case GEOMETRY:
+                // Use 16 as the variable-width slot size estimate.
                 typeSize = 16;
                 break;
             case HLL:

--- a/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
@@ -323,11 +323,11 @@ public class ScalarType extends Type implements Cloneable {
      */
     @Override
     public boolean matchesType(Type t) {
-        if (isGeoType()) {
-            return equals(t);
-        }
         if (t.isPseudoType()) {
             return t.matchesType(this);
+        }
+        if (isGeoType()) {
+            return equals(t);
         }
         if (isDecimalV2() && t.isDecimalV2()) {
             return true;

--- a/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
@@ -77,7 +77,7 @@ public class ScalarType extends Type implements Cloneable {
     // type identity; it only tells the BE reader to keep the naive wall clock unshifted.
     private boolean datetimeIsNtz = false;
 
-    private GeoColumnDescriptor geo;
+    private GeoTypeDescriptor geo;
 
     public ScalarType(PrimitiveType type) {
         this.type = type;
@@ -444,14 +444,14 @@ public class ScalarType extends Type implements Cloneable {
         return stringBuilder.toString();
     }
 
-    public static ScalarType createGeoType(PrimitiveType primitive, GeoColumnDescriptor descriptor) {
+    public static ScalarType createGeoType(PrimitiveType primitive, GeoTypeDescriptor descriptor) {
         Objects.requireNonNull(descriptor).validate(primitive);
         ScalarType result = new ScalarType(primitive);
         result.geo = descriptor;
         return result;
     }
 
-    public GeoColumnDescriptor getGeoDescriptor() {
+    public GeoTypeDescriptor getGeoDescriptor() {
         return geo;
     }
 }

--- a/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/ScalarType.java
@@ -77,6 +77,8 @@ public class ScalarType extends Type implements Cloneable {
     // type identity; it only tells the BE reader to keep the naive wall clock unshifted.
     private boolean datetimeIsNtz = false;
 
+    private GeoColumnDescriptor geo;
+
     public ScalarType(PrimitiveType type) {
         this.type = type;
     }
@@ -306,7 +308,7 @@ public class ScalarType extends Type implements Cloneable {
     @Override
     public boolean isSupported() {
         // BINARY and UNKNOWN_TYPE is unsupported
-        return type != PrimitiveType.BINARY && type != PrimitiveType.UNKNOWN_TYPE;
+        return type != PrimitiveType.BINARY && type != PrimitiveType.UNKNOWN_TYPE && !isGeoType();
     }
 
     @Override
@@ -321,6 +323,9 @@ public class ScalarType extends Type implements Cloneable {
      */
     @Override
     public boolean matchesType(Type t) {
+        if (isGeoType()) {
+            return equals(t);
+        }
         if (t.isPseudoType()) {
             return t.matchesType(this);
         }
@@ -355,6 +360,9 @@ public class ScalarType extends Type implements Cloneable {
         if (type.isDecimalV2Type() || type.isDecimalV3Type()) {
             return precision == other.precision && scale == other.scale;
         }
+        if (isGeoType()) {
+            return Objects.equals(geo, other.geo);
+        }
         return true;
     }
 
@@ -364,6 +372,9 @@ public class ScalarType extends Type implements Cloneable {
         result = 31 * result + Objects.hashCode(type);
         result = 31 * result + precision;
         result = 31 * result + scale;
+        if (isGeoType()) {
+            result = 31 * result + Objects.hashCode(geo);
+        }
         return result;
     }
 
@@ -431,5 +442,16 @@ public class ScalarType extends Type implements Cloneable {
                 break;
         }
         return stringBuilder.toString();
+    }
+
+    public static ScalarType createGeoType(PrimitiveType primitive, GeoColumnDescriptor descriptor) {
+        Objects.requireNonNull(descriptor).validate(primitive);
+        ScalarType result = new ScalarType(primitive);
+        result.geo = descriptor;
+        return result;
+    }
+
+    public GeoColumnDescriptor getGeoDescriptor() {
+        return geo;
     }
 }

--- a/fe/fe-type/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/Type.java
@@ -281,7 +281,7 @@ public abstract class Type implements Cloneable {
             return ((ArrayType) this).getItemType().canPartitionBy();
         }
         return !isOnlyMetricType() && !isJsonType() && !isFunctionType() && !isBinaryType() && !isStructType() &&
-                !isMapType() && !isVariantType();
+                !isMapType() && !isVariantType() && !isGeoType();
     }
 
     public boolean canDistinct() {
@@ -302,7 +302,7 @@ public abstract class Type implements Cloneable {
     public boolean canStatistic() {
         // TODO(mofei) support statistic by for JSON
         return !isOnlyMetricType() && !isJsonType() && !isStructType() && !isFunctionType()
-                && !isBinaryType() && !isVariantType();
+                && !isBinaryType() && !isVariantType() && !isGeoType();
     }
 
     // Returns true if this type is VARIANT or transitively contains a VARIANT inside an

--- a/fe/fe-type/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/Type.java
@@ -234,7 +234,7 @@ public abstract class Type implements Cloneable {
         }
 
         return !isOnlyMetricType() && !isJsonType() && !isFunctionType() &&
-                !isVariantType();
+                !isVariantType() && !isGeoType();
     }
 
     public boolean canGroupBy() {
@@ -253,7 +253,7 @@ public abstract class Type implements Cloneable {
             return true;
         }
         return !isOnlyMetricType() && !isJsonType() && !isFunctionType() &&
-                !isVariantType();
+                !isVariantType() && !isGeoType();
     }
 
     public boolean canOrderBy() {
@@ -272,7 +272,7 @@ public abstract class Type implements Cloneable {
             return true;
         }
         return !isOnlyMetricType() && !isJsonType() && !isFunctionType() &&
-                !isMapType() && !isVariantType();
+                !isMapType() && !isVariantType() && !isGeoType();
     }
 
     public boolean canPartitionBy() {
@@ -296,7 +296,7 @@ public abstract class Type implements Cloneable {
             return ((MapType) this).getKeyType().canDistinct() && ((MapType) this).getValueType().canDistinct();
         }
         return !isOnlyMetricType() && !isJsonType() && !isFunctionType() && !isBinaryType() && !isStructType() &&
-                !isMapType() && !isVariantType();
+                !isMapType() && !isVariantType() && !isGeoType();
     }
 
     public boolean canStatistic() {
@@ -333,7 +333,7 @@ public abstract class Type implements Cloneable {
         // double, not a storable/encodable column type) and would crash the BE short-key encoder, so
         // exclude it here alongside the other non-encodable types.
         return !isComplexType() && !isFloatingPointType() && !isOnlyMetricType() && !isJsonType()
-                && !isFunctionType() && !isVariantType() && !isTime();
+                && !isFunctionType() && !isVariantType() && !isTime() && !isGeoType();
     }
 
     public boolean canBeWindowFunctionArgumentTypes() {
@@ -383,6 +383,10 @@ public abstract class Type implements Cloneable {
 
     public boolean isVariantType() {
         return isScalarType(PrimitiveType.VARIANT);
+    }
+
+    public boolean isGeoType() {
+        return isScalarType(PrimitiveType.GEOGRAPHY) || isScalarType(PrimitiveType.GEOMETRY);
     }
 
     public boolean isPercentile() {


### PR DESCRIPTION
## Why I'm doing:

Part of #78693 (Milestone 2, Contract 2.4).

This is the FE-only part split from #78999 at Alvin's request.

**Dependency merged: #78999 (Contract 2.3, protocol and BE).** This FE-only PR was rebased onto current main at 56df52a1e5fce2e5f6ef4d2062647ce1f143290a on September 13, 2026. Updated head: c28b4b1f97068a92924be57dd82efdbbcdaa51ad. Required CI must pass on the rebased revision before merging.

## What I'm doing:

- Add distinct GEOGRAPHY/GEOMETRY FE primitive identities and immutable geo metadata.
- Preserve descriptors through Thrift/protobuf type conversions, including nested type metadata, and reject missing or inconsistent native descriptors.
- Keep native SQL activation disabled.
- Reject geo values as JOIN, GROUP BY, ORDER BY, DISTINCT and distribution keys in the existing centralized FE capability methods, as agreed with Alvin. Existing recursion also rejects nested geo fields; ordinary type behavior is preserved.
- Cover both geo kinds, metadata identity, Thrift/protobuf round trips, the shared C++/Java wire fixture, and capability restrictions in focused tests.

Protocol definitions and BE implementation belong exclusively to #78999. Exchange/spill/materialization payload serde and public rendering remain Contract 2.5. This PR does not implement Assignment/UNION ALL rules, native Iceberg reads, SQL constructors/functions, GeoColumn factory integration, persistence or capability negotiation.

### Validation

- 14 focused FE tests passed with the Contract 2.3 dependency present: 9 NativeGeoTypeTest cases and 5 existing fe-type tests.
- The new capability regression test reproduced the permissive GEOGRAPHY behavior before the fix and passes after it.
- Tested scalar and nested geo types, both descriptor converters, ordinary scalar/container behavior and the shared Java/C++ protobuf fixture.
- Compiled the FE type module and generated schemas/converters against local dependencies; git diff --check passed.

The tests above are prior focused local results, not fresh runs after rebase. The September 13 rebase completed without conflicts; git range-diff confirms that all five FE commits retain their patch contents, and git diff --check passed. The diff remains limited to 10 FE Java files, with the protocol dependency now present in main. No local test suite was rerun for this rebase. Full FE build, Checkstyle and repository CI remain required before merge.

### Observability

Reviewed the existing analyzer capability callers and their SemanticException diagnostics. The change reuses those rejection paths without adding per-call-site geo checks. Existing diagnostics and query/profile/metric paths are preserved; no new runtime signal is needed.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

The interface changes are internal FE type additions and capability restrictions. No public SQL feature is enabled.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

User documentation is not required for this inactive internal foundation.

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Not a bug-fix backport.
