### PR TITLE
[BugFix] Keep PK-range split parent aliases publishable

### DIFF
--- a/be/src/storage/lake/tablet_merger.cpp
+++ b/be/src/storage/lake/tablet_merger.cpp
@@ -3592,6 +3592,13 @@ bool uses_cloud_native_pk_index(const TabletMetadataPB& metadata) {
            metadata.persistent_index_type() == PersistentIndexTypePB::CLOUD_NATIVE;
 }
 
+// Range-distributed primary-key tablets with a separate ORDER BY persist their tablet ranges in
+// primary-key space. Those ranges cannot be converted into rowid windows over sort-key-ordered segments.
+bool routes_by_primary_key_range(const TabletMetadataPB& metadata) {
+    return metadata.has_range() && is_primary_key(metadata) && metadata.has_schema() &&
+           TabletSchema::create(metadata.schema())->has_separate_sort_key();
+}
+
 } // namespace
 
 DEFINE_FAIL_POINT(tablet_merge_after_rssid_reassign);
@@ -3602,6 +3609,16 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     if (old_tablet_metadatas.empty()) {
         return Status::InvalidArgument("No old tablet metadata to merge");
     }
+
+    // SPLIT keeps a read-only parent alias. For an ORDER BY != PRIMARY KEY layout that alias must retain
+    // the parent's whole shared segments and union the children's delete vectors: the pre-split parent did
+    // not filter those segments by the new child ranges. In particular, do not feed the PK-space range to
+    // the sort-key-based gap synthesizer below.
+    const bool primary_key_range_alias =
+            skip_sstable_merge &&
+            std::any_of(old_tablet_metadatas.begin(), old_tablet_metadatas.end(), [](const auto& metadata) {
+                return metadata != nullptr && routes_by_primary_key_range(*metadata);
+            });
 
     std::vector<TabletMergeContext> merge_contexts;
     merge_contexts.reserve(old_tablet_metadatas.size());
@@ -3680,7 +3697,7 @@ StatusOr<MutableTabletMetadataPtr> merge_tablet(TabletManager* tablet_manager,
     // (merge_delvecs), so the two paths cannot diverge. For non-PK tables the
     // specs stay empty, which keeps DCG coverage strict.
     std::vector<CanonicalGapSpec> gap_specs;
-    if (is_primary_key(*new_tablet_metadata)) {
+    if (is_primary_key(*new_tablet_metadata) && !primary_key_range_alias) {
         ASSIGN_OR_RETURN(gap_specs,
                          compute_synthesized_gap_specs(tablet_manager, *new_tablet_metadata, canonical_contribs));
         if (!gap_specs.empty()) {

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -20230,4 +20230,106 @@ TEST_F(LakeTabletReshardTest, test_identical_retry_cache_complete_returns_withou
     EXPECT_EQ(cached_target->SerializeAsString(), actual.at(target)->SerializeAsString());
 }
 
+// SPLIT publishes a read-only parent alias alongside its children. For a range-distributed PK tablet whose
+// ORDER BY differs from the primary key, the child ranges live in PK space and cannot be decoded as ranges
+// over the two-column physical sort key. The alias must therefore keep the shared segment whole and combine
+// the child delete vectors without attempting to synthesize a sort-key rowid gap.
+TEST_F(LakeTabletReshardTest, test_primary_key_range_split_parent_alias_unions_shared_delvecs) {
+    constexpr int64_t kNewVersion = 2;
+    const int64_t child_a = next_id();
+    const int64_t child_b = next_id();
+    const int64_t alias_tablet = next_id();
+    for (int64_t tablet_id : {child_a, child_b, alias_tablet}) {
+        prepare_tablet_dirs(tablet_id);
+    }
+
+    const std::string segment_name = "pk_range_alias_shared.dat";
+    auto make_child = [&](int64_t tablet_id, bool is_left) {
+        auto metadata = std::make_shared<TabletMetadataPB>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(1);
+        metadata->set_next_rowset_id(2);
+        set_two_column_pk_schema(metadata.get(), /*schema_id=*/9001);
+        // ORDER BY (c1, c0), while the range is encoded over PRIMARY KEY (c0).
+        metadata->mutable_schema()->add_sort_key_idxes(1);
+        metadata->mutable_schema()->add_sort_key_idxes(0);
+
+        auto* tablet_range = metadata->mutable_range();
+        if (is_left) {
+            *tablet_range->mutable_upper_bound() = generate_sort_key(100);
+            tablet_range->set_upper_bound_included(false);
+        } else {
+            *tablet_range->mutable_lower_bound() = generate_sort_key(100);
+            tablet_range->set_lower_bound_included(true);
+        }
+
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(1);
+        rowset->set_version(1);
+        rowset->set_num_rows(10);
+        rowset->set_data_size(100);
+        auto* segment = rowset->add_segment_metas();
+        segment->set_filename(segment_name);
+        segment->set_size(100);
+        segment->set_num_rows(10);
+        segment->set_shared(true);
+        stamp_physical_identity_uid(rowset, segment_name);
+
+        auto* rowset_range = rowset->mutable_range();
+        if (is_left) {
+            // Leave a leading contributor gap so the old code attempts to decode this one-value PK
+            // range as the two-value sort key and reproduces issue #12198 exactly.
+            *rowset_range->mutable_lower_bound() = generate_sort_key(90);
+            rowset_range->set_lower_bound_included(true);
+            *rowset_range->mutable_upper_bound() = generate_sort_key(100);
+            rowset_range->set_upper_bound_included(false);
+        } else {
+            *rowset_range->mutable_lower_bound() = generate_sort_key(100);
+            rowset_range->set_lower_bound_included(true);
+        }
+        return metadata;
+    };
+
+    auto meta_a = make_child(child_a, /*is_left=*/true);
+    auto meta_b = make_child(child_b, /*is_left=*/false);
+    write_two_column_segment(
+            alias_tablet, segment_name, /*num_rows=*/10, [](int key) { return key * 2; },
+            /*key_start=*/90);
+
+    DelVector delvec_a;
+    const uint32_t deleted_by_a[] = {3, 9};
+    delvec_a.init(/*version=*/10, deleted_by_a, std::size(deleted_by_a));
+    add_delvec(meta_a.get(), child_a, /*version=*/10, /*segment_id=*/1, "pk_range_alias_a.delvec", delvec_a.save());
+    DelVector delvec_b;
+    const uint32_t deleted_by_b[] = {5};
+    delvec_b.init(/*version=*/10, deleted_by_b, std::size(deleted_by_b));
+    add_delvec(meta_b.get(), child_b, /*version=*/10, /*segment_id=*/1, "pk_range_alias_b.delvec", delvec_b.save());
+
+    MergingTabletInfoPB merging;
+    merging.add_old_tablet_ids(child_a);
+    merging.add_old_tablet_ids(child_b);
+    merging.set_new_tablet_id(alias_tablet);
+    TxnInfoPB txn_info;
+    txn_info.set_txn_id(next_id());
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+    ASSIGN_OR_ABORT(auto alias,
+                    lake::merge_tablet(_tablet_manager.get(), {meta_a, meta_b}, merging, kNewVersion, txn_info,
+                                       /*skip_sstable_merge=*/true));
+
+    ASSERT_EQ(1, alias->rowsets_size());
+    ASSERT_EQ(1, alias->rowsets(0).segment_metas_size());
+    EXPECT_EQ(segment_name, alias->rowsets(0).segment_metas(0).filename());
+    EXPECT_TRUE(alias->sstable_meta().sstables().empty());
+
+    DelVector merged;
+    LakeIOOptions io_options;
+    ASSERT_OK(lake::get_del_vec(_tablet_manager.get(), *alias, alias->rowsets(0).id(), false, io_options, &merged));
+    ASSERT_NE(nullptr, merged.roaring());
+    EXPECT_EQ(3, merged.cardinality());
+    EXPECT_TRUE(merged.roaring()->contains(3));
+    EXPECT_TRUE(merged.roaring()->contains(5));
+    EXPECT_TRUE(merged.roaring()->contains(9));
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

StarRocksTest#12198 found that publishing a split of a range-distributed primary-key table with `ORDER BY != PRIMARY KEY` can fail forever with:

`Unexpected number of values in TabletRangePB bound value, expected at least: 2, actual: 1`

The one-value boundary is intentional: this table routes by its one-column primary key, while its segments are physically ordered by a two-column sort key. The failure happens later when aggregate publish rebuilds the query-side parent tablet alias from its children. Gap-delvec synthesis incorrectly interprets the children's PK-space ranges as contiguous ranges over the segment sort key.

The deterministic failure blocks the partition publish queue, so committed transactions accumulate and can exhaust `max_running_txn_num_per_db`.

## What I'm doing:

- Detect the read-only parent alias of a primary-key-range layout.
- Skip sort-key rowid-gap synthesis for that alias. The alias keeps each shared segment once and unions the child delete vectors, which reconstructs the pre-split parent view.
- Add a regression test with the production shape: one-column PK ranges, two-column physical sort key, a shared segment, a contributor gap, and distinct child delete vectors.

Observability: reviewed the aggregate-publish parent-alias latency log and the tablet merge/gap counters. The existing signals remain on the same ownership boundaries; no new state or failure mode is introduced, and the gap counter now correctly excludes a layout where a rowid gap cannot be computed.

Fixes StarRocks/StarRocksTest#12198

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

## Tests

- `python3 build-support/check_be_module_boundaries.py --mode changed --base starrocks-upstream/main --enforce-baseline-shrink`
- `python3 build-support/render_be_agents.py --check`
- Local BE CMake configuration could not start compilation because this checkout has no external Boost/thirdparty installation; TSP PR build will provide the clean compile result.
