### PR TITLE
[BugFix] Do not fail the whole information_schema.columns scan when one table cannot be loaded

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -949,28 +949,44 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
 
         MetadataMgr metadataMgr = GlobalStateMgr.getCurrentState().getMetadataMgr();
-        Database db = metadataMgr.getDb(context, catalogName, params.db);
-
-        if (db != null) {
-            Table table = metadataMgr.getTable(context, catalogName, params.db, params.table_name);
-            if (table == null) {
+        Database db;
+        Table table;
+        try {
+            db = metadataMgr.getDb(context, catalogName, params.db);
+            if (db == null) {
                 return result;
             }
-            try {
-                Authorizer.checkAnyActionOnTableLikeObject(context, params.db, table);
-            } catch (AccessDeniedException e) {
-                return result;
-            }
-            // Only the target table's schema is read, so an intensive
-            // IS-on-db + READ-on-table lock is sufficient; it lets concurrent
-            // DDL/ALTER on other tables in the same db proceed.
-            Locker locker = new Locker();
-            locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-            try {
-                setColumnDesc(columns, table, limit, false, params.db, params.table_name);
-            } finally {
-                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
-            }
+            table = metadataMgr.getTable(context, catalogName, params.db, params.table_name);
+        } catch (Exception e) {
+            // BE scans information_schema.columns for a schema with one describeTable RPC per
+            // table. If loading one table's metadata throws (e.g. a Glue entry without a
+            // StorageDescriptor, which the Hive connector rejects), letting the exception escape
+            // becomes a thrift application error on the BE side and aborts the scan for every
+            // other table in the schema. Skip just this table, the same way
+            // InformationSchemaDataSource.generateTablesInfoResponse already does for
+            // information_schema.tables. DESC on the table itself still reports the error.
+            LOG.warn("describeTable: skip {}.{}.{}, failed to load table metadata: {}",
+                    catalogName, params.db, params.table_name, e.getMessage());
+            LOG.debug("describeTable: table metadata load failure", e);
+            return result;
+        }
+        if (table == null) {
+            return result;
+        }
+        try {
+            Authorizer.checkAnyActionOnTableLikeObject(context, params.db, table);
+        } catch (AccessDeniedException e) {
+            return result;
+        }
+        // Only the target table's schema is read, so an intensive
+        // IS-on-db + READ-on-table lock is sufficient; it lets concurrent
+        // DDL/ALTER on other tables in the same db proceed.
+        Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        try {
+            setColumnDesc(columns, table, limit, false, params.db, params.table_name);
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
         }
         return result;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -38,6 +38,7 @@ import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.rest.MetricsAction;
 import com.starrocks.load.batchwrite.BatchWriteMgr;
@@ -54,6 +55,7 @@ import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.NodeMgr;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.ast.DropTableStmt;
@@ -1379,6 +1381,37 @@ public class FrontendServiceImplTest {
         Assertions.assertEquals(2, testDefaultValue.size());
         Assertions.assertEquals("CURRENT_TIMESTAMP", testDefaultValue.get(0).getColumnDesc().getColumnDefault());
         Assertions.assertEquals("2", testDefaultValue.get(1).getColumnDesc().getColumnDefault());
+    }
+
+    @Test
+    public void testDescribeTableSkipsTableWhoseMetadataFailsToLoad() throws Exception {
+        // BE scans information_schema.columns for a schema with one describeTable RPC per table.
+        // When a connector cannot load one table (e.g. a Glue entry without a StorageDescriptor
+        // makes HiveMetadata.getTable throw StarRocksConnectorException), the RPC must answer
+        // with an empty column list instead of propagating: the thrift server would turn the
+        // exception into an application error that aborts the scan of every other table.
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
+                throw new StarRocksConnectorException("Table StorageDescriptor is null for table " + tblName);
+            }
+        };
+
+        FrontendServiceImpl impl = new FrontendServiceImpl(exeEnv);
+        TDescribeTableParams request = new TDescribeTableParams();
+        request.setDb("test");
+        request.setTable_name("broken_glue_entry");
+        TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("root");
+        userIdentity.setHost("%");
+        userIdentity.setIs_domain(false);
+        request.setCurrent_user_ident(userIdentity);
+
+        TDescribeTableResult response = impl.describeTable(request);
+        Assertions.assertNotNull(response.getColumns());
+        Assertions.assertTrue(response.getColumns().isEmpty(),
+                "a table whose metadata cannot be loaded must yield no columns instead of failing the RPC: "
+                        + response.getColumns());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

A schema-wide `information_schema.columns` query against an external (Hive/Glue) catalog fails as a whole when **one** table in that schema cannot be loaded by the connector:

```
ERROR 1064: FE RPC failure, address=TNetworkAddress(hostname=..., port=9020),
            reason=Internal error processing describeTable: BE:10007, host: unknown
```

Measured on a live 4.1.4 cluster (Hive catalog backed by AWS Glue):

| Query | Result |
| --- | --- |
| `SELECT ... FROM hive.information_schema.columns WHERE TABLE_SCHEMA = 'market'` (271 tables) | **fails, 3/3 attempts**, independent of which FE served the RPC |
| same query, `TABLE_SCHEMA = 'marketwms'` (118 tables) | ok |
| same query plus `AND TABLE_NAME = 'bm_shop'` (one table in `market`) | ok, 35 rows |
| `DESC hive.market.<t>` for each of the 271 tables | 13 s total; **exactly 10** fail with `Failed to get table [market.<t>]`, the other 261 succeed |

The FE log names the real cause. The 10 tables are Glue entries registered without a `StorageDescriptor`, which the Hive connector rejects — correctly, since a Hive table cannot be represented without one:

```
ERROR [GlueMetastoreClientDelegate.getTable():363] Unable to get table:
com.starrocks.connector.exception.StarRocksConnectorException: Table StorageDescriptor is null for table cyk_realtime_stat_canceled_region
    at com.starrocks.connector.hive.glue.converters.CatalogToHiveConverter.convertTable(CatalogToHiveConverter.java:174)
    at com.starrocks.connector.hive.glue.metastore.GlueMetastoreClientDelegate.getTable(GlueMetastoreClientDelegate.java:358)
    ...
    at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:526)
    at com.starrocks.service.FrontendServiceImpl.describeTable(FrontendServiceImpl.java:916)
```

This is not metastore throttling: 271 `GetTable` calls complete in 13 s with no slow call, and the failure is deterministic on the same 10 tables.

**Root cause.** BE scans `information_schema.columns` for a schema by issuing **one `describeTable` RPC per table**. `FrontendServiceImpl.describeTable` calls `metadataMgr.getTable()` without catching connector exceptions, so a failure to load one table's metadata escapes the thrift handler as `TApplicationException(INTERNAL_ERROR)`, and BE gives up on the whole scan. One unrepresentable Glue entry therefore hides the columns of the other 261 tables in the schema.

This is inconsistent with the sibling path in the same codebase: `information_schema.tables` (`InformationSchemaDataSource.generateTablesInfoResponse`) already wraps the per-table `getBasicTable` call in `catch (Exception e) { LOG.warn(...); }` and `continue`s. It also differs from what users see from Trino on the same Glue schema, which returns `information_schema.columns` for the 261 loadable tables and silently skips the 10 broken ones.

The impact is wider than an ad-hoc query: schema-wide `information_schema.columns` is what BI tools and JDBC drivers issue for metadata introspection, and a single stray Glue entry anywhere in the schema breaks it for everything in that schema.

## What I'm doing:

In `FrontendServiceImpl.describeTable`, wrap `getDb`/`getTable` and, when loading the table's metadata throws, log a WARN (stack at DEBUG) and answer with an **empty column list for that table** — the same treatment `generateTablesInfoResponse` already gives `information_schema.tables`. The `if (db != null) { ... }` block is flattened into early returns; the authorization check and the intensive table lock around `setColumnDesc` are unchanged.

- `DESC <broken table>` still reports the original connector error; that path does not go through this RPC.
- Loadable tables behave exactly as before; the existing `describeTable` tests cover that.
- Only the message is logged at WARN because a schema scan logs once per broken table on every run; the stack goes to DEBUG.

Not filing a separate issue — the root cause and the fix are both described here.

**Test.** `FrontendServiceImplTest#testDescribeTableSkipsTableWhoseMetadataFailsToLoad` mocks `MetadataMgr.getTable` to throw `StarRocksConnectorException("Table StorageDescriptor is null ...")` and asserts that `describeTable` returns an empty column list. With the production change reverted the exception propagates out of `describeTable`, so the test fails on unpatched code — it is a genuine regression test.

The identical patch (same two hunks) passed CI in our 4.1.4-based fork: `FrontendServiceImplTest` (66), `InformationSchemaDataSourceTest` (18) and `SetRoleInformationSchemaTest` (11) — 95 tests, 0 failures — plus the FE compile check.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

A schema-wide `information_schema.columns` query that previously failed with an RPC error now returns the columns of every table that can be loaded and omits the tables that cannot (with a WARN in `fe.warn.log` naming each skipped table). No syntax, parameter or policy change.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5

`branch-4.1`, `branch-4.0` and `branch-3.5` all have the same `describeTable` shape — one `metadataMgr.getTable()` call with only an `AccessDeniedException` catch around the authorization check — so all three are affected.

cc/ @kevincai