### PR TITLE
[Enhancement] Enable zone-map pruning for date_trunc predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
@@ -67,7 +67,7 @@ public class FunctionCallExpr extends Expr {
 
     // TODO(yan): add more known functions which are monotonic.
     private static final ImmutableSet<String> MONOTONIC_FUNCTION_SET =
-            new ImmutableSet.Builder<String>().add(FunctionSet.YEAR).build();
+            new ImmutableSet.Builder<String>().add(FunctionSet.YEAR, FunctionSet.DATE_TRUNC).build();
 
     public boolean isAnalyticFnCall() {
         return isAnalyticFnCall;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.ast.expression;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.catalog.TableName;
 import com.starrocks.common.util.DateUtils;
@@ -44,6 +45,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.type.VarbinaryType;
+import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +56,51 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class ExprToThriftTest {
+
+    @Test
+    public void testDateTruncMonotonicity() {
+        for (Type type : List.of(DateType.DATE, DateType.DATETIME)) {
+            List<String> units = type.isDate()
+                    ? List.of("day", "week", "month", "quarter", "year")
+                    : List.of("second", "minute", "hour", "day", "week", "month", "quarter", "year");
+            for (boolean nullable : List.of(false, true)) {
+                SlotRef slot = new SlotRef(new SlotDescriptor(new SlotId(0), "ts", type, nullable));
+                for (String unit : units) {
+                    FunctionCallExpr trunc = new FunctionCallExpr(FunctionSet.DATE_TRUNC,
+                            List.of(new StringLiteral(unit), slot));
+                    trunc.setFn(ScalarFunction.createBuiltinOperator(FunctionSet.DATE_TRUNC,
+                            Lists.newArrayList(VarcharType.VARCHAR, type), type));
+                    trunc.setType(type);
+                    trunc.setOriginType(type);
+
+                    // The BE uses this flag for expression zone-map predicates. Equality is
+                    // handled by splitting it into >= and <= when both children are monotonic.
+                    Assertions.assertTrue(convert(trunc).isIs_monotonic(), type + ": " + unit);
+                    DateLiteral bound = type.isDate() ? new DateLiteral(2024, 1, 1)
+                            : new DateLiteral(2024, 1, 1, 0, 0, 0, 0);
+                    for (BinaryType op : List.of(BinaryType.EQ, BinaryType.LT, BinaryType.LE,
+                            BinaryType.GT, BinaryType.GE)) {
+                        BinaryPredicate predicate = ExprCaseFactory.withType(
+                                new BinaryPredicate(op, trunc, bound), BooleanType.BOOLEAN);
+                        TExpr thrift = ExprToThrift.treeToThrift(predicate);
+                        Assertions.assertEquals(op.isMonotonic(), thrift.getNodes().get(0).isIs_monotonic());
+                        Assertions.assertTrue(thrift.getNodes().get(1).isIs_monotonic());
+                    }
+
+                    // A non-monotonic timestamp expression must still prevent pruning.
+                    DateLiteral future = type.isDate() ? new DateLiteral(2025, 1, 1)
+                            : new DateLiteral(2025, 1, 1, 0, 0, 0, 0);
+                    BinaryPredicate condition = ExprCaseFactory.withType(
+                            new BinaryPredicate(BinaryType.LT, slot, bound), BooleanType.BOOLEAN);
+                    CaseExpr timestamp = new CaseExpr(null, List.of(new CaseWhenClause(condition, future)), slot);
+                    timestamp.setType(type);
+                    timestamp.setOriginType(type);
+                    trunc.setChild(1, timestamp);
+                    Assertions.assertFalse(convert(trunc).isIs_monotonic());
+                }
+            }
+        }
+    }
 
     @Test
     public void testExprToThriftCoverage() {


### PR DESCRIPTION
## Why I'm doing:

Predicates such as `date_trunc('day', ts) = '2026-09-10'` reach the scan as expression predicates, but `DATE_TRUNC` is missing from the FE's monotonic-function allowlist. The BE therefore cannot use the expression for zone-map pruning.

## What I'm doing:

Add `DATE_TRUNC` to the existing allowlist. Its unit is already required to be a constant by function analysis, and truncation preserves timestamp ordering. The existing recursive check still rejects non-monotonic child expressions; the BE already handles equality by deriving `>=` and `<=` zone-map predicates.

Add a serialization regression test covering DATE/DATETIME units, nullable and non-nullable columns, equality and range predicates, and a non-monotonic CASE input.

Related issue: none.

### Validation

- Confirmed the new regression fails on unmodified upstream: `DATE: day ==> expected: <true> but was: <false>`.
- With the fix, `ExprToThriftTest` passes: 2 tests, 0 failures/errors. Run in a Linux ARM64 container with JDK 17:

  ```bash
  cd fe
  FE_UT_PARALLEL=1 PYTHON=python3 mvn -B -ntp -pl fe-core -am \
    -Dtest=ExprToThriftTest -Dsurefire.failIfNoSpecifiedTests=false \
    -DfailIfNoTests=false -Djacoco.skip=true -Dmaven.clean.skip=true test
  ```

- Checked truncation ordering with synthetic NULL, minimum/maximum date, leap-day, and subsecond inputs on a local StarRocks instance. These are boundary sanity checks; the regression above verifies the changed upstream serialization path.
- `mvn -B -ntp -pl fe-core checkstyle:check`: passed with 0 violations.

### Reproducer

```sql
CREATE TABLE date_trunc_pruning (ts DATETIME NOT NULL)
DUPLICATE KEY(ts)
DISTRIBUTED BY HASH(ts) BUCKETS 1
PROPERTIES ('replication_num' = '1');

INSERT INTO date_trunc_pruning
SELECT minutes_add('2025-01-01 00:00:00', generate_series)
FROM TABLE(generate_series(0, 999999));

SET enable_query_cache = false;
EXPLAIN ANALYZE
SELECT count(*) FROM date_trunc_pruning
WHERE date_trunc('day', ts) = '2026-09-10';

DROP TABLE date_trunc_pruning;
```

Observability: reviewed the existing `RawRowsRead`, `ReadPagesNum`, and `ZoneMapIndexFilterRows` scan-profile counters. They already expose the pruning improvement and remain unchanged; no new metrics are needed.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

Eligible DATE_TRUNC predicates can prune additional pages. SQL results and configuration interfaces are unchanged.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
