### PR TITLE
[BugFix] Preserve Iceberg equality-delete rewrite state when copying scans

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalIcebergScanOperator.java
@@ -169,6 +169,7 @@ public class LogicalIcebergScanOperator extends LogicalScanOperator {
         public LogicalIcebergScanOperator.Builder withOperator(LogicalIcebergScanOperator scanOperator) {
             super.withOperator(scanOperator);
             builder.predicates = scanOperator.predicates.clone();
+            builder.fromEqDeleteRewriteRule = scanOperator.fromEqDeleteRewriteRule;
             builder.morParam = scanOperator.morParam;
             builder.tableFullMORParams = scanOperator.tableFullMORParams;
             return this;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/IcebergEqualityDeleteRewriteRuleTest.java
@@ -14,22 +14,122 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.connector.iceberg.IcebergMORParams;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.logical.LogicalIcebergScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.OptExpressionDuplicator;
 import com.starrocks.type.IntegerType;
+import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.starrocks.catalog.IcebergTable.DATA_SEQUENCE_NUMBER;
 
 public class IcebergEqualityDeleteRewriteRuleTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void testCopiedEqualityDeleteScanIsNotExpandedAgain(boolean duplicatePlan) {
+        BaseTable nativeTable = Mockito.mock(BaseTable.class, Mockito.RETURNS_DEEP_STUBS);
+        Mockito.when(nativeTable.schema()).thenReturn(new Schema(
+                Types.NestedField.required(1, "id", Types.IntegerType.get())));
+        Mockito.when(nativeTable.spec()).thenReturn(PartitionSpec.unpartitioned());
+        Mockito.when(nativeTable.operations().current().formatVersion()).thenReturn(2);
+        Snapshot snapshot = Mockito.mock(Snapshot.class);
+        Mockito.when(snapshot.summary()).thenReturn(Map.of("total-equality-deletes", "1"));
+        Mockito.when(nativeTable.snapshot(1L)).thenReturn(snapshot);
+
+        Column id = new Column("id", IntegerType.INT, true);
+        IcebergTable table = new IcebergTable(1, "source", "iceberg", null, "db", "source",
+                "", List.of(id), nativeTable, Map.of());
+        ColumnRefFactory factory = new ColumnRefFactory();
+        ColumnRefOperator idRef = factory.create("id", IntegerType.INT, true);
+        factory.updateColumnRefToColumns(idRef, id, table);
+        factory.updateColumnToRelationIds(idRef.getId(), factory.getNextRelationId());
+        LogicalIcebergScanOperator original = new LogicalIcebergScanOperator(table,
+                Map.of(idRef, id), Map.of(id, idRef), -1, null, TvrTableSnapshot.of(1L));
+        OptimizerContext context = Mockito.mock(OptimizerContext.class);
+        Mockito.when(context.getColumnRefFactory()).thenReturn(factory);
+        Mockito.when(context.getSessionVariable()).thenReturn(new SessionVariable());
+        DeleteFile deleteFile = Mockito.mock(DeleteFile.class);
+        Mockito.when(deleteFile.equalityFieldIds()).thenReturn(List.of(1));
+        Mockito.when(deleteFile.specId()).thenReturn(0);
+        MetadataMgr metadata = Mockito.mock(MetadataMgr.class);
+        Mockito.when(metadata.getDeleteFiles(Mockito.any(IcebergTable.class), Mockito.eq(1L),
+                Mockito.any(), Mockito.eq(FileContent.EQUALITY_DELETES))).thenReturn(Set.of(deleteFile));
+        GlobalStateMgr state = Mockito.mock(GlobalStateMgr.class);
+        Mockito.when(state.getMetadataMgr()).thenReturn(metadata);
+        try (MockedStatic<GlobalStateMgr> global = Mockito.mockStatic(GlobalStateMgr.class)) {
+            global.when(GlobalStateMgr::getCurrentState).thenReturn(state);
+            IcebergEqualityDeleteRewriteRule rule = new IcebergEqualityDeleteRewriteRule();
+            OptExpression input = OptExpression.create(original);
+            Assertions.assertTrue(rule.check(input, context), "the original scan must apply equality deletes");
+            OptExpression rewritten = rule.transform(input, context).get(0);
+            LogicalIcebergScanOperator withDeletes = findDataWithDeletes(rewritten);
+            Assertions.assertNotNull(withDeletes);
+            LogicalIcebergScanOperator copied = duplicatePlan
+                    ? (LogicalIcebergScanOperator) new OptExpressionDuplicator(factory, context)
+                            .duplicate(OptExpression.create(withDeletes)).getOp()
+                    : (LogicalIcebergScanOperator) OperatorBuilderFactory.build(withDeletes)
+                            .withOperator(withDeletes).build();
+
+            Assertions.assertTrue(copied.getColumnNameToColRefMap().containsKey(DATA_SEQUENCE_NUMBER));
+            Assertions.assertEquals(withDeletes.getMORParam(), copied.getMORParam());
+            Assertions.assertEquals(withDeletes.getTableFullMORParams(), copied.getTableFullMORParams());
+            // MV definition plans can already contain the equality-delete expansion when they are
+            // duplicated into a new query. Running its rewrite pass must not add the synthetic columns twice.
+            Assertions.assertDoesNotThrow(() -> {
+                OptExpression copiedInput = OptExpression.create(copied);
+                if (rule.check(copiedInput, context)) {
+                    rule.transform(copiedInput, context);
+                }
+            });
+            Assertions.assertFalse(rule.check(OptExpression.create(copied), context));
+        }
+    }
+
+    private LogicalIcebergScanOperator findDataWithDeletes(OptExpression expression) {
+        if (expression.getOp() instanceof LogicalIcebergScanOperator scan
+                && scan.getMORParam() == IcebergMORParams.DATA_FILE_WITH_EQ_DELETE) {
+            return scan;
+        }
+        for (OptExpression child : expression.getInputs()) {
+            LogicalIcebergScanOperator scan = findDataWithDeletes(child);
+            if (scan != null) {
+                return scan;
+            }
+        }
+        return null;
+    }
 
     // The LEFT ANTI JOIN that applies equality deletes must compare identity columns with null-safe
     // equals (EQ_FOR_NULL / <=>), not plain EQ: per the Iceberg spec a NULL value in a delete column


### PR DESCRIPTION
## Why I'm doing:

Copying an Iceberg scan that has already been expanded for equality deletes loses its rewrite marker. If the copied plan enters equality-delete rewriting again, the rule adds the synthetic columns a second time and throws a duplicate `$data_sequence_number` key exception. One route is an optimized materialized-view definition being duplicated into a later query optimization pass.

Related to #78927. This reproduces a copy-state defect with the same exception; I have not reproduced the report's complete view/join query or established that it takes this route.

## What I'm doing:

Preserve `fromEqDeleteRewriteRule` in `LogicalIcebergScanOperator.Builder.withOperator`, alongside the existing MOR metadata. Fresh scans retain their current behavior, and copied expanded scans are skipped by the equality-delete rewrite.

The regression performs the real equality-delete transformation, copies its data scan through either the generic operator builder or `OptExpressionDuplicator`, then checks the next rewrite pass. Both cases fail with the duplicate-column exception before the fix and pass afterward.

Existing optimizer before/after traces, timers, and exception reporting remain intact; this state-preservation fix does not need a new observability signal.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: avoid repeated equality-delete expansion of copied scans.

## Validation

On JDK 17, `run-fe-ut.sh -j 2 --test` with these four classes passed **55 tests, 0 failures/errors/skips**:

- `com.starrocks.sql.optimizer.rule.transformation.IcebergEqualityDeleteRewriteRuleTest` (3)
- `com.starrocks.sql.optimizer.rule.transformation.materialization.OptExpressionDuplicatorRangeTest` (1)
- `com.starrocks.catalog.IcebergTableTest` (14)
- `com.starrocks.planner.IcebergScanNodeTest` (37)

`mvn checkstyle:check -pl fe-core` passed with 0 violations. The regression uses mocked Iceberg metadata and the actual optimizer rewrite/duplication code; a live Iceberg cluster and the reporter's complete query were not tested.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5

Reviewed the version options and kept all backport labels unset: this change is validated on current main only. Backport targets have not been tested.
