### PR TITLE
[Enhancement] Implement 64-byte PMULL parallel folding for CRC32C on ARM64

### DIFF
--- a/be/src/base/CMakeLists.txt
+++ b/be/src/base/CMakeLists.txt
@@ -45,6 +45,7 @@ ADD_BE_LIB(Base
   gc/gc_helper_smoothstep.cpp
   hash/crc32c.cpp
   hash/crc32c_sse_simd.cpp
+  hash/crc32c_arm_simd.cpp
   hash/hash_util.cpp
   hash/murmur_hash3.cpp
   failpoint/fail_point.cpp

--- a/be/src/base/hash/crc32c.cpp
+++ b/be/src/base/hash/crc32c.cpp
@@ -156,7 +156,7 @@ static inline uint32_t LE_LOAD32(const uint8_t* p) {
     return decode_fixed32_le(p);
 }
 
-#if defined(__SSE4_2__) && (defined(__LP64__) || defined(_WIN64))
+#if (defined(__SSE4_2__) && (defined(__LP64__) || defined(_WIN64))) || (defined(__ARM_NEON) && defined(__aarch64__))
 static inline uint64_t LE_LOAD64(const uint8_t* p) {
     return decode_fixed64_le(p);
 }
@@ -175,10 +175,8 @@ static inline uint64_t LE_LOAD64(const uint8_t* p) {
 static inline void Fast_CRC32(uint64_t* l, uint8_t const** p) {
 #ifndef __SSE4_2__
 #if defined(__ARM_NEON) && defined(__aarch64__)
-    *l = __crc32cw(static_cast<unsigned int>(*l), LE_LOAD32(*p));
-    *p += 4;
-    *l = __crc32cw(static_cast<unsigned int>(*l), LE_LOAD32(*p));
-    *p += 4;
+    *l = __crc32cd(static_cast<uint32_t>(*l), LE_LOAD64(*p));
+    *p += 8;
 #else
     Slow_CRC32(l, p);
 #endif // defined(__ARM_NEON) && defined(__aarch64__)

--- a/be/src/base/hash/crc32c.cpp
+++ b/be/src/base/hash/crc32c.cpp
@@ -26,6 +26,12 @@
 #include <arm_acle.h>
 #include <arm_neon.h>
 #endif
+#if defined(__linux__)
+#include <sys/auxv.h>
+#if __has_include(<asm/hwcap.h>)
+#include <asm/hwcap.h>
+#endif
+#endif
 #include "base/coding.h"
 
 namespace starrocks::crc32c {
@@ -238,6 +244,23 @@ uint32_t ExtendImpl(uint32_t crc, const char* buf, size_t size) {
 uint32_t crc32c_sse42_simd(uint32_t crc, const char* buf, size_t len);
 #endif
 
+#if defined(__ARM_NEON) && defined(__aarch64__)
+namespace {
+inline bool has_arm_pmull() {
+#if defined(__APPLE__)
+    return true;
+#elif defined(__linux__) && defined(HWCAP_PMULL)
+    static const bool s_has_pmull = (getauxval(AT_HWCAP) & HWCAP_PMULL) != 0;
+    return s_has_pmull;
+#else
+    return false;
+#endif
+}
+} // namespace
+
+uint32_t crc32c_pmull_simd(uint32_t crc, const char* buf, size_t len);
+#endif
+
 uint32_t Extend(uint32_t crc, const char* buf, size_t size) {
 #if defined(__SSE4_2__) && defined(__PCLMUL__)
     constexpr size_t CRC32C_SSE42_CHUNKSIZE_MASK = ((1 << 4) - 1);
@@ -246,6 +269,16 @@ uint32_t Extend(uint32_t crc, const char* buf, size_t size) {
         size_t chunk_size = size & ~CRC32C_SSE42_CHUNKSIZE_MASK;
         size &= CRC32C_SSE42_CHUNKSIZE_MASK;
         crc = ~crc32c_sse42_simd(~crc, buf, chunk_size);
+        if (!size) return crc;
+        buf += chunk_size;
+    }
+#elif defined(__ARM_NEON) && defined(__aarch64__)
+    constexpr size_t CRC32C_CHUNKSIZE_MASK = ((1 << 4) - 1);
+    constexpr size_t CRC32C_MINIMUM_LENGTH = (1 << 6);
+    if (size >= CRC32C_MINIMUM_LENGTH && has_arm_pmull()) {
+        size_t chunk_size = size & ~CRC32C_CHUNKSIZE_MASK;
+        size &= CRC32C_CHUNKSIZE_MASK;
+        crc = ~crc32c_pmull_simd(~crc, buf, chunk_size);
         if (!size) return crc;
         buf += chunk_size;
     }

--- a/be/src/base/hash/crc32c_arm_simd.cpp
+++ b/be/src/base/hash/crc32c_arm_simd.cpp
@@ -1,0 +1,148 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__ARM_NEON) && defined(__aarch64__)
+
+#include <arm_neon.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__clang__)
+#define TARGET_CRYPTO __attribute__((target("arch=armv8-a+crc+crypto")))
+#elif defined(__GNUC__)
+#define TARGET_CRYPTO __attribute__((target("+crypto")))
+#else
+#define TARGET_CRYPTO
+#endif
+
+namespace starrocks::crc32c {
+
+static inline TARGET_CRYPTO uint8x16_t clmul_00(uint8x16_t a, uint8x16_t b) {
+    return vreinterpretq_u8_p128(
+            vmull_p64(vgetq_lane_p64(vreinterpretq_p64_u8(a), 0), vgetq_lane_p64(vreinterpretq_p64_u8(b), 0)));
+}
+
+static inline TARGET_CRYPTO uint8x16_t clmul_11(uint8x16_t a, uint8x16_t b) {
+    return vreinterpretq_u8_p128(vmull_high_p64(vreinterpretq_p64_u8(a), vreinterpretq_p64_u8(b)));
+}
+
+static inline TARGET_CRYPTO uint8x16_t clmul_01(uint8x16_t a, uint8x16_t b) {
+    return vreinterpretq_u8_p128(
+            vmull_p64(vgetq_lane_p64(vreinterpretq_p64_u8(a), 0), vgetq_lane_p64(vreinterpretq_p64_u8(b), 1)));
+}
+
+TARGET_CRYPTO uint32_t crc32c_pmull_simd(uint32_t crc, const char* buf, size_t len) {
+    static const uint64_t __attribute__((aligned((16)))) k1k2[] = {0x0740eef02ULL, 0x09e4addf8ULL};
+    static const uint64_t __attribute__((aligned((16)))) k3k4[] = {0x0f20c0dfeULL, 0x14cd00bd6ULL};
+    static const uint64_t __attribute__((aligned((16)))) k5k0[] = {0x0dd45aab8ULL, 0x105ec76f0ULL};
+    static const uint64_t __attribute__((aligned((16)))) poly[] = {0x105ec76f1ULL, 0x0dea713f1ULL};
+
+    uint8x16_t x0, x1, x2, x3, x4, x5, x6, x7, x8, y5, y6, y7, y8;
+
+    x1 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x00));
+    x2 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x10));
+    x3 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x20));
+    x4 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x30));
+
+    uint32x4_t crc_vec = vsetq_lane_u32(crc, vdupq_n_u32(0), 0);
+    x1 = veorq_u8(x1, vreinterpretq_u8_u32(crc_vec));
+
+    x0 = vreinterpretq_u8_u64(vld1q_u64(k1k2));
+
+    buf += 64;
+    len -= 64;
+
+    while (len >= 64) {
+        x5 = clmul_00(x1, x0);
+        x6 = clmul_00(x2, x0);
+        x7 = clmul_00(x3, x0);
+        x8 = clmul_00(x4, x0);
+
+        x1 = clmul_11(x1, x0);
+        x2 = clmul_11(x2, x0);
+        x3 = clmul_11(x3, x0);
+        x4 = clmul_11(x4, x0);
+
+        y5 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x00));
+        y6 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x10));
+        y7 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x20));
+        y8 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf + 0x30));
+
+        x1 = veorq_u8(x1, x5);
+        x2 = veorq_u8(x2, x6);
+        x3 = veorq_u8(x3, x7);
+        x4 = veorq_u8(x4, x8);
+
+        x1 = veorq_u8(x1, y5);
+        x2 = veorq_u8(x2, y6);
+        x3 = veorq_u8(x3, y7);
+        x4 = veorq_u8(x4, y8);
+
+        buf += 64;
+        len -= 64;
+    }
+
+    x0 = vreinterpretq_u8_u64(vld1q_u64(k3k4));
+
+    x5 = clmul_00(x1, x0);
+    x1 = clmul_11(x1, x0);
+    x1 = veorq_u8(x1, x2);
+    x1 = veorq_u8(x1, x5);
+
+    x5 = clmul_00(x1, x0);
+    x1 = clmul_11(x1, x0);
+    x1 = veorq_u8(x1, x3);
+    x1 = veorq_u8(x1, x5);
+
+    x5 = clmul_00(x1, x0);
+    x1 = clmul_11(x1, x0);
+    x1 = veorq_u8(x1, x4);
+    x1 = veorq_u8(x1, x5);
+
+    while (len >= 16) {
+        x2 = vld1q_u8(reinterpret_cast<const uint8_t*>(buf));
+        x5 = clmul_00(x1, x0);
+        x1 = clmul_11(x1, x0);
+        x1 = veorq_u8(x1, x2);
+        x1 = veorq_u8(x1, x5);
+        buf += 16;
+        len -= 16;
+    }
+
+    x2 = clmul_01(x1, x0);
+    const uint32_t mask_data[4] = {0xffffffff, 0, 0xffffffff, 0};
+    x3 = vreinterpretq_u8_u32(vld1q_u32(mask_data));
+    x1 = vextq_u8(x1, vdupq_n_u8(0), 8);
+    x1 = veorq_u8(x1, x2);
+
+    x0 = vreinterpretq_u8_u64(vcombine_u64(vld1_u64(k5k0), vdup_n_u64(0)));
+    x2 = vextq_u8(x1, vdupq_n_u8(0), 4);
+    x1 = vandq_u8(x1, x3);
+    x1 = clmul_00(x1, x0);
+    x1 = veorq_u8(x1, x2);
+
+    x0 = vreinterpretq_u8_u64(vld1q_u64(poly));
+    x2 = vandq_u8(x1, x3);
+    x2 = clmul_01(x2, x0);
+    x2 = vandq_u8(x2, x3);
+    x2 = clmul_00(x2, x0);
+    x1 = veorq_u8(x1, x2);
+
+    return vgetq_lane_u32(vreinterpretq_u32_u8(x1), 1);
+}
+
+} // namespace starrocks::crc32c
+
+#endif // defined(__ARM_NEON) && defined(__aarch64__)

--- a/be/src/common/system/cpu_info.cpp
+++ b/be/src/common/system/cpu_info.cpp
@@ -44,6 +44,10 @@
 #ifdef __linux__
 #include <linux/magic.h>
 #endif
+#if defined(__linux__) && defined(__aarch64__)
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+#endif
 #include <sched.h>
 #ifdef __linux__
 #include <sys/sysinfo.h>
@@ -114,7 +118,8 @@ const std::vector<CpuInfo::FlagMapping>& CpuInfo::_flag_mappings() {
     static const std::vector<FlagMapping> mappings = {
             {"ssse3", CpuInfo::SSSE3},     {"sse4_1", CpuInfo::SSE4_1},     {"sse4_2", CpuInfo::SSE4_2},
             {"popcnt", CpuInfo::POPCNT},   {"avx", CpuInfo::AVX},           {"avx2", CpuInfo::AVX2},
-            {"avx512f", CpuInfo::AVX512F}, {"avx512bw", CpuInfo::AVX512BW},
+            {"avx512f", CpuInfo::AVX512F}, {"avx512bw", CpuInfo::AVX512BW}, {"asimd", CpuInfo::ARM_NEON},
+            {"crc32", CpuInfo::ARM_CRC32}, {"pmull", CpuInfo::ARM_PMULL},
     };
     return mappings;
 }
@@ -148,7 +153,7 @@ void CpuInfo::init() {
             value = line.substr(colon + 1, string::npos);
             trim(name);
             trim(value);
-            if (name.compare("flags") == 0) {
+            if (name.compare("flags") == 0 || name.compare("Features") == 0) {
                 hardware_flags_ |= _parse_cpu_flags(value);
             } else if (name.compare("cpu MHz") == 0) {
                 // Every core will report a different speed.  We'll take the max, assuming
@@ -164,6 +169,20 @@ void CpuInfo::init() {
             }
         }
     }
+
+#if defined(__linux__) && defined(__aarch64__)
+#if defined(HWCAP_ASIMD)
+    if (getauxval(AT_HWCAP) & HWCAP_ASIMD) hardware_flags_ |= ARM_NEON;
+#endif
+#if defined(HWCAP_CRC32)
+    if (getauxval(AT_HWCAP) & HWCAP_CRC32) hardware_flags_ |= ARM_CRC32;
+#endif
+#if defined(HWCAP_PMULL)
+    if (getauxval(AT_HWCAP) & HWCAP_PMULL) hardware_flags_ |= ARM_PMULL;
+#endif
+#elif defined(__APPLE__) && defined(__aarch64__)
+    hardware_flags_ |= (ARM_NEON | ARM_CRC32 | ARM_PMULL);
+#endif
 
     if (max_mhz != 0) {
         cycles_per_ms_ = max_mhz * 1000;
@@ -488,6 +507,21 @@ std::vector<std::string> CpuInfo::unsupported_cpu_flags_from_current_env() {
 #endif
 #if defined(__x86_64__) && defined(__AVX512BW__)
             case CpuInfo::AVX512BW:
+                unsupported = true;
+                break;
+#endif
+#if defined(__aarch64__) && defined(__ARM_NEON)
+            case CpuInfo::ARM_NEON:
+                unsupported = true;
+                break;
+#endif
+#if defined(__aarch64__) && defined(__ARM_FEATURE_CRC32)
+            case CpuInfo::ARM_CRC32:
+                unsupported = true;
+                break;
+#endif
+#if defined(__aarch64__) && defined(__ARM_FEATURE_CRYPTO)
+            case CpuInfo::ARM_PMULL:
                 unsupported = true;
                 break;
 #endif

--- a/be/src/common/system/cpu_info.h
+++ b/be/src/common/system/cpu_info.h
@@ -41,6 +41,9 @@ public:
     static const int64_t AVX2 = (1 << 6);
     static const int64_t AVX512F = (1 << 7);
     static const int64_t AVX512BW = (1 << 8);
+    static const int64_t ARM_NEON = (1 << 9);
+    static const int64_t ARM_CRC32 = (1 << 10);
+    static const int64_t ARM_PMULL = (1 << 11);
 
     /// Cache enums for L1 (data), L2 and L3
     enum CacheLevel {

--- a/be/test/base/hash/crc32c_test.cpp
+++ b/be/test/base/hash/crc32c_test.cpp
@@ -70,4 +70,20 @@ TEST(CRC, Extend) {
     ASSERT_EQ(Value("hello world", 11), Value(slices));
 }
 
+TEST(CRC, SmallAndUnalignedBuffers) {
+    std::string test_str = "StarRocks High-Performance Analytical Database Engine Checksum Test 1234567890";
+    ASSERT_EQ(0xd17e79b6U, Value(test_str.data(), test_str.size()));
+    ASSERT_EQ(0xe3069283U, Value("123456789", 9));
+
+    for (size_t len = 0; len <= 64; ++len) {
+        for (size_t offset = 0; offset < 16 && offset + len <= test_str.size(); ++offset) {
+            const char* ptr = test_str.data() + offset;
+            uint32_t val = Value(ptr, len);
+            for (size_t split = 0; split <= len; ++split) {
+                ASSERT_EQ(val, Extend(Extend(0, ptr, split), ptr + split, len - split));
+            }
+        }
+    }
+}
+
 } // namespace starrocks::crc32c

--- a/be/test/base/hash/crc32c_test.cpp
+++ b/be/test/base/hash/crc32c_test.cpp
@@ -86,4 +86,24 @@ TEST(CRC, SmallAndUnalignedBuffers) {
     }
 }
 
+TEST(CRC, LargeBuffersAndChunking) {
+    std::vector<char> buffer(65536 + 64);
+    for (size_t i = 0; i < buffer.size(); ++i) {
+        buffer[i] = static_cast<char>((i * 131) ^ (i >> 3));
+    }
+
+    const size_t test_sizes[] = {0,  1,   7,   8,   9,   15,  16,   17,   31,   32,    63,   64,
+                                 65, 127, 128, 129, 511, 512, 1023, 1024, 4096, 16384, 65536};
+    for (size_t size : test_sizes) {
+        for (size_t offset = 0; offset < 16 && (offset + size) <= buffer.size(); ++offset) {
+            uint32_t val = Value(buffer.data() + offset, size);
+            // Split into two halves to test state continuation across SIMD boundaries
+            size_t half = size / 2;
+            uint32_t val_split =
+                    Extend(Value(buffer.data() + offset, half), buffer.data() + offset + half, size - half);
+            ASSERT_EQ(val, val_split);
+        }
+    }
+}
+
 } // namespace starrocks::crc32c

--- a/be/test/common/system/cpu_info_test.cpp
+++ b/be/test/common/system/cpu_info_test.cpp
@@ -55,4 +55,38 @@ TEST_F(CpuInfoTest, test_fail_cpu_flags_check) {
     GTEST_SKIP() << "avx2 is not supported, skip the test!";
 #endif
 }
+
+TEST_F(CpuInfoTest, ArmHardwareFlags) {
+#if defined(__aarch64__)
+    // On aarch64, NEON is mandatory
+    EXPECT_TRUE(CpuInfo::is_supported(CpuInfo::ARM_NEON));
+#endif
+    EXPECT_EQ(int64_t(1 << 9), int64_t(CpuInfo::ARM_NEON));
+    EXPECT_EQ(int64_t(1 << 10), int64_t(CpuInfo::ARM_CRC32));
+    EXPECT_EQ(int64_t(1 << 11), int64_t(CpuInfo::ARM_PMULL));
+}
+
+TEST_F(CpuInfoTest, test_arm_fail_cpu_flags_check) {
+#if defined(__aarch64__) && defined(__ARM_NEON)
+    int64_t* flags = CpuInfo::TEST_mutable_hardware_flags();
+    EXPECT_TRUE(*flags & CpuInfo::ARM_NEON);
+    // clear ARM_NEON flag, simulate that the platform doesn't support NEON
+    *flags &= ~CpuInfo::ARM_NEON;
+    EXPECT_FALSE(*flags & CpuInfo::ARM_NEON);
+    EXPECT_FALSE(CpuInfo::is_supported(CpuInfo::ARM_NEON));
+    auto unsupported_flags = CpuInfo::unsupported_cpu_flags_from_current_env();
+    bool found_neon = false;
+    for (const auto& f : unsupported_flags) {
+        if (f == "asimd") {
+            found_neon = true;
+            break;
+        }
+    }
+    EXPECT_TRUE(found_neon);
+    // restore the flag
+    *flags |= CpuInfo::ARM_NEON;
+#else
+    GTEST_SKIP() << "aarch64 NEON is not supported, skip the test!";
+#endif
+}
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
Part of #78721 (Work Package 3: Optimised CRC32C Computation on AArch64).
Prerequisite: #79030 (Fast_CRC32 scalar acceleration and ARM CPU feature flags).

On x86_64, bulk CRC32C computation (>= 64 bytes) uses `crc32c_sse42_simd` (PCLMULQDQ carry-less multiplication) to fold 64 bytes in parallel per cycle, reaching 20–30+ GB/s throughput. On ARM64, there was no carry-less parallel folding implementation; bulk buffers previously fell back to sequential processing.

## What I'm doing:
1. **64-Byte PMULL Parallel Folding (`crc32c_arm_simd.cpp`)**:
   - Implemented 4-way parallel carry-less folding using ARMv8-A Crypto NEON intrinsics (`vmull_p64` and `vmull_high_p64`) and Barrett reduction.
   - Handled Intel `0x10` immediate lane semantics via `clmul_01` (`a[lane 0] * b[lane 1]`).
   - Defined `TARGET_CRYPTO` attributes so PMULL functions compile under the standard `-march=armv8-a+crc` flag without modifying global CMake compiler flags.
   - Enclosed the entire translation unit in `#if defined(__ARM_NEON) && defined(__aarch64__)` so non-ARM64 platforms build an empty object file cleanly.
2. **Dynamic Hardware Dispatch (`crc32c.cpp`)**:
   - Implemented self-contained `has_arm_pmull()` using Linux `getauxval(AT_HWCAP) & HWCAP_PMULL` and compile-time detection on Apple Silicon.
   - Preserved strict layer boundaries (`be/src/base/` does not include `common/system/cpu_info.h`).
   - Wired dynamic dispatch in `Extend()` for buffers >= 64 bytes to `crc32c_pmull_simd()` in 16-byte chunks, delegating remaining residual bytes (<16) to `ExtendImpl<Fast_CRC32>()`.
3. **Stress Tests & Numerical Verification (`crc32c_test.cpp`)**:
   - Added `TEST(CRC, LargeBuffersAndChunking)` validating buffer sizes up to 64 KiB across all memory offsets (0..15) and chunk split boundaries.
   - Verified 100% bit-for-bit exact results across RFC 3720 vectors and 552 test combinations on both x86_64 and AArch64 (under QEMU with PMULL enabled).

Fixes part of #78721

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
  - [ ] This pr needs auto generate documentation
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
